### PR TITLE
Update Qt test to support Qt5

### DIFF
--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -35,7 +35,9 @@ import numpy
 
 from silx.gui.test.utils import TestCaseQt
 
+from silx.gui import qt
 from silx.gui.plot import PlotWidget
+
 
 SIZE = 1024
 """Size of the test image"""
@@ -57,6 +59,8 @@ class _PlotWidgetTest(TestCaseQt):
         self.qWaitForWindowExposed(self.plot)
 
     def tearDown(self):
+        self.plot.setAttribute(qt.Qt.WA_DeleteOnClose)
+        self.plot.close()
         del self.plot
         super(_PlotWidgetTest, self).tearDown()
 


### PR DESCRIPTION
- Close and delete PlotWidget in tests.
- Init a list of exisiting widgets that are not under silx control before running the tests.
  Then use this list when checking if tests are leaking widgets.