### PR TITLE
Make h5py an optional dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
     - pip install --pre --find-links dist/ --trusted-host www.edna-site.org --find-links http://www.edna-site.org/pub/wheelhouse/ silx
 
     # Install h5py for silx.io tests
-    - pip install h5py
+    - "pip install --pre --trusted-host www.edna-site.org --find-links http://www.edna-site.org/pub/wheelhouse/ h5py"
 
     # Print Python info
     - python ci/info_platform.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,9 @@ script:
     # Install from source package
     - pip install --pre --find-links dist/ --trusted-host www.edna-site.org --find-links http://www.edna-site.org/pub/wheelhouse/ silx
 
+    # Install h5py for silx.io tests
+    - pip install h5py
+
     # Print Python info
     - python ci/info_platform.py
     - pip freeze

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -70,7 +70,7 @@ test_script:
     - "pip install matplotlib"
 
     # Install h5py for silx.io tests
-    - "pip install h5py"
+    - "pip install --pre --trusted-host www.edna-site.org --find-links http://www.edna-site.org/pub/wheelhouse/ h5py"
 
     # Install the generated wheel package to test it
     - "pip install --pre --find-links dist/ --trusted-host www.edna-site.org --find-links http://www.edna-site.org/pub/wheelhouse/ silx"

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -69,6 +69,9 @@ test_script:
     - "pip install --pre --trusted-host www.edna-site.org --find-links http://www.edna-site.org/pub/wheelhouse/ %QT_BINDINGS%"
     - "pip install matplotlib"
 
+    # Install h5py for silx.io tests
+    - "pip install h5py"
+
     # Install the generated wheel package to test it
     - "pip install --pre --find-links dist/ --trusted-host www.edna-site.org --find-links http://www.edna-site.org/pub/wheelhouse/ silx"
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@
 # ###########################################################################*/
 
 __authors__ = ["Jérôme Kieffer", "Thomas Vincent"]
-__date__ = "16/03/2016"
+__date__ = "29/04/2016"
 __license__ = "MIT"
 
 
@@ -404,7 +404,7 @@ cmdclass['debian_src'] = sdist_debian
 
 setup_kwargs = config.todict()
 
-install_requires = ["numpy", "h5py"]
+install_requires = ["numpy"]
 setup_requires = ["numpy"]
 
 setup_kwargs.update(

--- a/silx/io/__init__.py
+++ b/silx/io/__init__.py
@@ -1,0 +1,36 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""I/O modules"""
+
+__authors__ = ["P. Knobel"]
+__license__ = "MIT"
+__date__ = "29/04/2016"
+
+
+import logging
+
+
+# Init logging once for the whole module
+logging.basicConfig()

--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -42,7 +42,7 @@ from .configdict import ConfigDict
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "29/04/2016"
+__date__ = "03/05/2016"
 
 logger = logging.getLogger(__name__)
 
@@ -84,9 +84,12 @@ def dicttoh5(treedict, h5file, h5path='/',
 
     If a dictionary value is a sub-dictionary, a group is created. If it is
     any other data type, it is cast into a numpy array and written as a
-    :mod:`h5py` dataset.
+    :mod:`h5py` dataset. Dictionary keys must be strings and cannot contain
+    the ``/`` character.
 
-    Dictionary keys must be strings and cannot contain the ``/`` character.
+    .. note::
+
+        This function requires `h5py <http://www.h5py.org/>`_ to be installed.
 
     :param treedict: Nested dictionary/tree structure with strings as keys
          and array-like objects as leafs. The ``"/"`` character is not allowed
@@ -174,10 +177,15 @@ def h5todict(h5file, path="/"):
     """Read HDF5 file and return a nested dictionary with the complete file
     structure and all data.
 
-    .. warning:: If you write a dictionary to a HDF5 file with 
+    .. note:: This function requires `h5py <http://www.h5py.org/>`_ to be
+        installed.
+
+    .. note:: If you write a dictionary to a HDF5 file with 
         :func:`dicttoh5` and then read it back with :func:`h5todict`, data
         types are not preserved. All values are cast to numpy arrays before
-        being written to file, and they are read back as numpy arrays.
+        being written to file, and they are read back as numpy arrays (or
+        scalars). In some cases, you may find that a list of heterogeneous
+        data types is converted to a numpy array of strings.
 
     :param h5file: File name or :class:`h5py.File` object
     :return: dict
@@ -250,7 +258,9 @@ def dump(ddict, ffile, fmat="json"):
 
     :param ddict: Dictionary with string keys
     :param ffile: File name or file-like object with a ``write`` method
-    :param fmat: Output format: ``json``, ``hdf5`` or ``ini``
+    :param fmat: Output format: ``"json"``, ``"hdf5"`` or ``"ini"``.
+        Dumping to a HDF5 file requires `h5py <http://www.h5py.org/>`_ to be
+        installed.
     """
     if fmat.lower() == "json":
         dicttojson(ddict, ffile)
@@ -270,6 +280,8 @@ def load(ffile, fmat="json"):
 
     :param ffile: File name or file-like object with a ``read`` method
     :param fmat: Input format: ``json``, ``hdf5`` or ``ini``
+        Loading from a HDF5 file requires `h5py <http://www.h5py.org/>`_ to be
+        installed.
     :return: Dictionary
     """
     if not hasattr(ffile, "read"):

--- a/silx/io/spectoh5.py
+++ b/silx/io/spectoh5.py
@@ -23,18 +23,24 @@
 #############################################################################*/
 """This module provides functions to convert a SpecFile into a HDF5 file"""
 
-import h5py
 import logging
+logger = logging.getLogger(__name__)
+
 import re
+
+try:
+    import h5py
+except ImportError as e:
+    logger.error("Module " + __name__ + " requires h5py")
+    raise e
+
 from .spech5 import SpecH5, SpecH5Group, SpecH5Dataset, \
      SpecH5LinkToGroup, SpecH5LinkToDataset
 
+
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "30/03/2016"
-
-logger = logging.getLogger(__name__)
-# logger.setLevel(logging.DEBUG)
+__date__ = "29/04/2016"
 
 
 def write_spec_to_h5(specfile, h5file, h5path='/',

--- a/silx/io/spectoh5.py
+++ b/silx/io/spectoh5.py
@@ -21,7 +21,11 @@
 # THE SOFTWARE.
 #
 #############################################################################*/
-"""This module provides functions to convert a SpecFile into a HDF5 file"""
+"""This module provides functions to convert a SpecFile into a HDF5 file.
+
+.. note:: These functions depend on the `h5py <http://www.h5py.org/>`_ 
+    library, which is not a mandatory dependency for `silx`.
+"""
 
 import logging
 logger = logging.getLogger(__name__)
@@ -40,7 +44,7 @@ from .spech5 import SpecH5, SpecH5Group, SpecH5Dataset, \
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "29/04/2016"
+__date__ = "03/05/2016"
 
 
 def write_spec_to_h5(specfile, h5file, h5path='/',

--- a/silx/io/test/test_dictdump.py
+++ b/silx/io/test/test_dictdump.py
@@ -25,13 +25,18 @@
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "28/04/2016"
+__date__ = "29/04/2016"
 
-import h5py
 import numpy
 import os
 import tempfile
 import unittest
+
+try:
+    import h5py
+    h5py_missing = False
+except ImportError:
+    h5py_missing = True
 
 from collections import defaultdict
 
@@ -51,6 +56,7 @@ city_attrs["Europe"]["France"]["Grenoble"]["coordinates"] = [45.1830, 5.7196]
 city_attrs["Europe"]["France"]["Tourcoing"]["area"]
 
 
+@unittest.skipIf(h5py_missing, "Could not import h5py")
 class TestDictToH5(unittest.TestCase):
     def setUp(self):
         fd, self.h5_fname = tempfile.mkstemp(text=False)
@@ -170,7 +176,6 @@ class TestDictToIni(unittest.TestCase):
             else:
                 self.assertEqual(read, original,
                             "Read <%s> instead of <%s>" % (read, original))
-
 
 
 def suite():

--- a/silx/io/test/test_specfile.py
+++ b/silx/io/test/test_specfile.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "24/03/2016"
+__date__ = "29/04/2016"
 
 import gc
 import locale
@@ -115,8 +115,6 @@ try:
     locale.setlocale(locale.LC_NUMERIC, 'de_DE.utf8')
 except locale.Error:
     try_DE = False
-    logger1.warning("de_DE.utf8 locale not installed on your system. " +
-                    "An important i18n test will be skipped.")
 else:
     try_DE = True
     locale.setlocale(locale.LC_NUMERIC, loc)

--- a/silx/io/test/test_spectoh5.py
+++ b/silx/io/test/test_spectoh5.py
@@ -24,19 +24,24 @@
 """Tests for SpecFile to HDF5 converter"""
 
 import gc
-import h5py
 from numpy import array_equal
 import os
 import sys
 import tempfile
 import unittest
 
-from ..spech5 import SpecH5
-from ..spectoh5 import convert, write_spec_to_h5
+try:
+    import h5py
+except ImportError:
+    h5py_missing = True
+else:
+    h5py_missing = False
+    from ..spech5 import SpecH5
+    from ..spectoh5 import convert, write_spec_to_h5
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "04/04/2016"
+__date__ = "29/04/2016"
 
 
 sftext = """#F /tmp/sf.dat
@@ -83,6 +88,7 @@ sftext = """#F /tmp/sf.dat
 """
 
 
+@unittest.skipIf(h5py_missing, "Could not import h5py")
 class TestConvertSpecHDF5(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/silx/io/test/test_utils.py
+++ b/silx/io/test/test_utils.py
@@ -23,7 +23,7 @@
 #############################################################################*/
 """Tests for utils module"""
 
-import h5py
+
 import numpy
 import os
 import re
@@ -32,12 +32,19 @@ import tempfile
 import unittest
 
 from ..utils import savespec, save1D
-from ..utils import h5ls
+
+try:
+    import h5py
+except ImportError:
+    h5py_missing = True
+else:
+    h5py_missing = False
+    from ..utils import h5ls
 
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "11/04/2016"
+__date__ = "29/04/2016"
 
 
 expected_spec1 = r"""#F .*
@@ -168,6 +175,7 @@ def assert_match_any_string_in_list(test, pattern, list_of_strings):
     return False
 
 
+@unittest.skipIf(h5py_missing, "Could not import h5py")
 class TestH5Ls(unittest.TestCase):
     """Test displaying the following HDF5 file structure:
 

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -88,7 +88,7 @@ def save1D(fname, x, y, xlabel=None, ylabels=None, filetype=None,
         ``footer`` strings, to mark them as comments. Default: ``#``.
     :param autoheader: In `CSV` or `txt`, ``True`` causes the first header
          line to be written as a standard CSV header line with column labels
-         separated by the specified CSV delimiter.
+         separated by the specified CSV delimiter.
 
     When saving to Specfile format, each curve is saved as a separate scan
     with two data columns (``x`` and ``y``).
@@ -240,11 +240,11 @@ def savespec(specfile, x, y, xlabel="X", ylabel="Y", fmt="%.7g",
         or a list of two different format strings (e.g. ``["%d", "%.7g"]``).
         Default is ``"%.7g"``.
     :param scan_number: Scan number (default 1).
-    :param mode: Mode for opening file: ``w`` (default), ``a``,  ``r+``,
+    :param mode: Mode for opening file: ``w`` (default), ``a``,  ``r+``,
         ``w+``, ``a+``. This parameter is only relevant if ``specfile`` is a
         path.
-    :param write_file_header: If True, write a file header before writing the
-        scan (``#F`` and ``#D`` line).
+    :param write_file_header: If ``True``, write a file header before writing
+        the scan (``#F`` and ``#D`` line).
     :param close_file: If ``True``, close the file after saving curve.
     :return: ``None`` if ``close_file`` is ``True``, else return the file
         handle.
@@ -312,6 +312,9 @@ def h5ls(h5group, lvl=0):
             +fieldE
                 <HDF5 dataset "x": shape (256, 256), type "<f4">
                 <HDF5 dataset "y": shape (256, 256), type "<f4">
+
+    .. note:: This function requires `h5py <http://www.h5py.org/>`_ to be
+        installed.
     """
     if h5py_missing:
         logger.error("h5ls requires h5py")

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -23,15 +23,28 @@
 #############################################################################*/
 """ I/O utility functions"""
 
-import h5py
 import numpy
 import os.path
 import sys
 import time
 
+import logging
+
+try:
+    import h5py
+except ImportError as e:
+    h5py_missing = True
+    h5py_import_error = e
+else:
+    h5py_missing = False
+
+
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "11/04/2016"
+__date__ = "29/04/2016"
+
+
+logger = logging.getLogger(__name__)
 
 string_types = (basestring,) if sys.version_info[0] == 2 else (str,)
 
@@ -300,6 +313,10 @@ def h5ls(h5group, lvl=0):
                 <HDF5 dataset "x": shape (256, 256), type "<f4">
                 <HDF5 dataset "y": shape (256, 256), type "<f4">
     """
+    if h5py_missing:
+        logger.error("h5ls requires h5py")
+        raise h5py_import_error
+
     repr = ''
     if isinstance(h5group, (h5py.File, h5py.Group)):
         h5f = h5group


### PR DESCRIPTION
- removed `h5py` from install requirements in `setup.py`
- added `@skipIf(…)` for tests requiring `h5py`
- added error message logging and `ImportError` raising when trying to use a module or function requiring `h5py`
- added a line in Travis and AppVeyor config files to manually install `h5py` and keep running the tests, as it is no considered a mandatory dependency when running `pip install silx`