### PR TITLE
Make ConfigDict ordered

### DIFF
--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -279,11 +279,14 @@ def dump(ddict, ffile, fmat="json"):
 def load(ffile, fmat="json"):
     """Load dictionary from a file
 
+    When loading from a JSON or INI file, an OrderedDict is returned to
+    preserve the values' insertion order.
+
     :param ffile: File name or file-like object with a ``read`` method
     :param fmat: Input format: ``json``, ``hdf5`` or ``ini``
         Loading from a HDF5 file requires `h5py <http://www.h5py.org/>`_ to be
         installed.
-    :return: Dictionary
+    :return: Dictionary (ordered dictionary for JSON and INI)
     """
     if not hasattr(ffile, "read"):
         f = open(ffile, "r")

--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -25,6 +25,7 @@
 by text strings to following file formats: `HDF5, INI, JSON`
 """
 
+from collections import OrderedDict
 import json
 import logging
 import numpy
@@ -42,7 +43,7 @@ from .configdict import ConfigDict
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "03/05/2016"
+__date__ = "25/05/2016"
 
 logger = logging.getLogger(__name__)
 
@@ -292,7 +293,7 @@ def load(ffile, fmat="json"):
         fname = ffile.name
 
     if fmat.lower() == "json":
-        return json.load(f)
+        return json.load(f, object_pairs_hook=OrderedDict)
     if fmat.lower() in ["hdf5", "h5"]:
         if h5py_missing:
             logger.error("Cannot load from HDF5 format, missing h5py library")

--- a/silx/io/test/test_dictdump.py
+++ b/silx/io/test/test_dictdump.py
@@ -25,8 +25,9 @@
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "29/04/2016"
+__date__ = "24/05/2016"
 
+from collections import OrderedDict
 import numpy
 import os
 import tempfile
@@ -59,13 +60,12 @@ city_attrs["Europe"]["France"]["Tourcoing"]["area"]
 @unittest.skipIf(h5py_missing, "Could not import h5py")
 class TestDictToH5(unittest.TestCase):
     def setUp(self):
-        fd, self.h5_fname = tempfile.mkstemp(text=False)
-        # Close and delete (we just want the name)
-        os.close(fd)
-        os.unlink(self.h5_fname)
+        self.tempdir = tempfile.mkdtemp()
+        self.h5_fname = os.path.join(self.tempdir, "cityattrs.h5")
 
     def tearDown(self):
         os.unlink(self.h5_fname)
+        os.rmdir(self.tempdir)
 
     def testH5CityAttrs(self):
         filters = {'compression': "gzip", 'shuffle': True,
@@ -176,6 +176,38 @@ class TestDictToIni(unittest.TestCase):
             else:
                 self.assertEqual(read, original,
                             "Read <%s> instead of <%s>" % (read, original))
+
+    def testConfigDictOrder(self):
+        """Ensure order is preserved when dictionary is
+        written to file and read back."""
+        test_dict = {'banana': 3, 'apple': 4, 'pear': 1, 'orange': 2}
+        # sort by key
+        test_ordered_dict1 = OrderedDict(sorted(test_dict.items(),
+                                                key=lambda t: t[0]))
+        # sort by value
+        test_ordered_dict2 = OrderedDict(sorted(test_dict.items(),
+                                                key=lambda t: t[1]))
+        # add the two ordered dict as sections of a third ordered dict
+        test_ordered_dict3 = OrderedDict()
+        test_ordered_dict3["section1"] = test_ordered_dict1
+        test_ordered_dict3["section2"] = test_ordered_dict2
+
+        # write to ini and read back as a ConfigDict (inherits OrderedDict)
+        dump(test_ordered_dict3,
+             self.ini_fname, fmat="ini")
+        read_instance = ConfigDict()
+        read_instance.read(self.ini_fname)
+
+        # loop through original and read-back dictionaries,
+        # test identical order for key/value pairs
+        for orig_key, section in zip(test_ordered_dict3.keys(),
+                                     read_instance.keys()):
+            self.assertEqual(orig_key, section)
+            for orig_key2, read_key in zip(test_ordered_dict3[section].keys(),
+                                           read_instance[section].keys()):
+                self.assertEqual(orig_key2, read_key)
+                self.assertEqual(test_ordered_dict3[section][orig_key2],
+                                 read_instance[section][read_key])
 
 
 def suite():


### PR DESCRIPTION
 - Make `ConfigDict` an OrderedDict. This results in internal changes only, it does not affect the API. Files written with previous versions of  `ConfigDict` can still be read back. The relative order of values in a section is preserved, and the relative order of sub-sections in a section is preserved, but due to the output file format we cannot preserve the relative order between a value and a sub-section in a section (subsections are written after all top level values) 

 - Update docstrings.