### PR TITLE
Fix #91 (spec_date_to_iso8601)

### DIFF
--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -514,7 +514,7 @@ def spec_date_to_iso8601(date, zone=None):
         >>> spec_date_to_iso8601("Sat 2015/03/14 03:53:50")
         '2015-03-14T03:53:50'
     """
-    months = ['Jan', 'Feb', 'Mar', 'Apr', 'Jun', 'Jul',
+    months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul',
               'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
     days = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 


### PR DESCRIPTION
Fix for #91
 Added unit tests for spec_date_to_iso8601.
**Nominal** tests only.
The **zone** keyword is **not** tested. I haven't added tests for the **error** cases either.
I checked that the new tests fail with the previous version of the function.

BTW the function only works if the provided spec dates are in english (Mon, Apr, Aug, Sun, ....). Are we sure this will always be the case?