### PR TITLE
[CI] Appveyor switch to Pro plane

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,5 +80,5 @@ See the `copyright file <https://github.com/silx-kit/silx/blob/master/copyright>
 
 .. |Travis Status| image:: https://travis-ci.org/silx-kit/silx.svg?branch=master
    :target: https://travis-ci.org/silx-kit/silx
-.. |Appveyor Status| image:: https://ci.appveyor.com/api/projects/status/mc7r6xwsgpbcdvgr/branch/master?svg=true
-   :target: https://ci.appveyor.com/project/kif/silx
+.. |Appveyor Status| image:: https://ci.appveyor.com/api/projects/status/qgox9ei0wxwfagrb/branch/master?svg=true
+   :target: https://ci.appveyor.com/project/ESRF/silx

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -1,5 +1,5 @@
 os:
-    - Visual Studio 2015
+    - Visual Studio 2015 - GCE
 
 cache:
     - '%LOCALAPPDATA%\pip\Cache'


### PR DESCRIPTION
This PR enables use of the Pro Appveyor plane:

- change appveyor badge in README
- Use a specific worker (required for now to download from silx.org)