### PR TITLE
Add a requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@
 numpy
 h5py                      # For silx.io
 ipython                   # For silx.gui.console
+qt_console                # For silx.gui.console
 matplotlib >= 1.2.0       # For silx.gui.plot
 # PyQt4, PyQt5 or PySide  # For silx.gui
 
@@ -15,8 +16,6 @@ matplotlib >= 1.2.0       # For silx.gui.plot
 # Try to install a Qt binding from a wheel
 # This is no available for all configurations
 
-PyQt5; python_version == '3.5'
-
-# Extra wheels available for Windows
+# Require PyQt5 except on Windows with Python2.7
+PyQt5; sys_platform != 'win32' and python_version != '2.7'
 PyQt4; sys_platform == 'win32' and python_version == '2.7'  # From silx.org
-PySide; sys_platform == 'win32' and python_version != '3.5' and python_version != '2.7'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,22 @@
+# List all dependencies of silx
+# Requires pip >= 8.0
+
+--trusted-host www.silx.org
+--find-links http://www.silx.org/pub/wheelhouse/
+--only-binary h5py,PyQt4,PyQt5,PySide
+
+numpy
+h5py                      # For silx.io
+ipython                   # For silx.gui.console
+matplotlib >= 1.2.0       # For silx.gui.plot
+# PyQt4, PyQt5 or PySide  # For silx.gui
+
+
+# Try to install a Qt binding from a wheel
+# This is no available for all configurations
+
+PyQt5; python_version == '3.5'
+
+# Extra wheels available for Windows
+PyQt4; sys_platform == 'win32' and python_version == '2.7'  # From silx.org
+PySide; sys_platform == 'win32' and python_version != '3.5' and python_version != '2.7'

--- a/silx/gui/qt.py
+++ b/silx/gui/qt.py
@@ -66,22 +66,22 @@ elif 'PyQt4' in sys.modules:
 
 else:  # Then try Qt bindings
     try:
-        import PyQt4  # noqa
+        import PyQt5  # noqa
     except ImportError:
         try:
-            import PySide  # noqa
+            import PyQt4  # noqa
         except ImportError:
             try:
-                import PyQt5  # noqa
+                import PySide  # noqa
             except ImportError:
                 raise ImportError(
                     'No Qt wrapper found. Install PyQt4, PyQt5 or PySide.')
             else:
-                BINDING = 'PyQt5'
+                BINDING = 'PySide'
         else:
-            BINDING = 'PySide'
+            BINDING = 'PyQt4'
     else:
-        BINDING = 'PyQt4'
+        BINDING = 'PyQt5'
 
 
 if BINDING == 'PyQt4':


### PR DESCRIPTION
List all project's dependencies.
Closes #101 

Some points to discuss:
- If a wheel is available for PyQt/PySide it installs it, otherwise it does not install PyQt/PySide. Do we want that?
  Alternative 1: Do not put pyqt/pyside in requirements.txt and add a requirements-qt.txt for this.
  Alternative 2: Choose one e.g., PyQt5 and enforces it (in requirements.txt only)
- if h5py is not installed and no wheel is available, it will not be installed