### PR TITLE
Test verbosity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ matplotlib >= 1.2.0       # For silx.gui.plot
 # This is no available for all configurations
 
 # Require PyQt5 except on Windows with Python2.7
-PyQt5; sys_platform != 'win32' and python_version != '2.7'
+PyQt5; sys_platform != 'win32' or python_version != '2.7'
 PyQt4; sys_platform == 'win32' and python_version == '2.7'  # From silx.org

--- a/run_tests.py
+++ b/run_tests.py
@@ -320,7 +320,12 @@ else:
         unittest.defaultTestLoader.loadTestsFromNames(options.test_name))
 
 
-if runner.run(test_suite).wasSuccessful():
+result = runner.run(test_suite)
+for test, reason in result.skipped:
+    logger.warning('Skipped %s (%s): %s',
+                   test.id(), test.shortDescription() or '', reason)
+
+if result.wasSuccessful():
     logger.info("Test suite succeeded")
     exit_status = 0
 else:

--- a/run_tests.py
+++ b/run_tests.py
@@ -235,7 +235,9 @@ parser.add_argument("-m", "--memprofile", dest="memprofile",
                     help="Report memory profiling")
 parser.add_argument("-v", "--verbose", default=0,
                     action="count", dest="verbose",
-                    help="Increase verbosity")
+                    help="Increase verbosity. Option -v prints additional " +
+                         "INFO messages. Use -vv for full verbosity, " +
+                         "including debug messages and test help strings.")
 default_test_name = "%s.test.suite" % PROJECT_NAME
 parser.add_argument("test_name", nargs='*',
                     default=(default_test_name,),
@@ -243,13 +245,17 @@ parser.add_argument("test_name", nargs='*',
 options = parser.parse_args()
 sys.argv = [sys.argv[0]]
 
-
+# test_verbosity could be set to 0 by default
+# (print only total number of tests and the global result)
+test_verbosity = 1
 if options.verbose == 1:
     logging.root.setLevel(logging.INFO)
     logger.info("Set log level: INFO")
+    test_verbosity = 1
 elif options.verbose > 1:
     logging.root.setLevel(logging.DEBUG)
     logger.info("Set log level: DEBUG")
+    test_verbosity = 2
 
 
 if options.coverage:
@@ -295,7 +301,7 @@ PROJECT_PATH = module.__path__[0]
 if options.memprofile:
     runner = ProfileTestRunner()
 else:
-    runner = unittest.TextTestRunner()
+    runner = unittest.TextTestRunner(verbosity=test_verbosity)
 
 logger.warning("Test %s %s from %s",
                PROJECT_NAME, PROJECT_VERSION, PROJECT_PATH)

--- a/run_tests.py
+++ b/run_tests.py
@@ -245,13 +245,11 @@ parser.add_argument("test_name", nargs='*',
 options = parser.parse_args()
 sys.argv = [sys.argv[0]]
 
-# test_verbosity could be set to 0 by default
-# (print only total number of tests and the global result)
+
 test_verbosity = 1
 if options.verbose == 1:
     logging.root.setLevel(logging.INFO)
     logger.info("Set log level: INFO")
-    test_verbosity = 1
 elif options.verbose > 1:
     logging.root.setLevel(logging.DEBUG)
     logger.info("Set log level: DEBUG")


### PR DESCRIPTION
Addresses #136

My current change https://github.com/silx-kit/silx/commit/d6cbd0334e7583332828443b2a5def12b6607a02 does not modify the previous behavior of printing dots for successful tests, `s` for skipped tests, `E` for errors and `F` for failures.  It just adds the option to increase the verbosity of the tests themselves (not only the logging verbosity) with option -vv.

The test verbosity parameter can be:

- 0 (quiet): you just get the total numbers of tests executed and the global result
- 1 (default): you get the same plus a dot for every successful test or a F for every failure
- 2 (verbose): you get the help string of every test and the result

To summarize:
 
- `python run_tests.py` sets `logging` level to _WARNING_ and `unittest.TextTestRunner` verbosity to _1_
- `python run_tests.py` sets `logging` level to _INFO_ and `unittest.TextTestRunner` verbosity to _1_
-  `python run_tests.py` sets `logging` level to _DEBUG_ and `unittest.TextTestRunner` verbosity to _2_
