### PR TITLE
[install doc]emphasize importance of Python 64-bit

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -38,7 +38,7 @@ Tools for reading and writing HDF5 files depend on the following package:
 Build dependencies
 ++++++++++++++++++
 
-In addition to run-time dependencies, building *silx* requires a C/C++ compiler, `numpy <http://www.numpy.org/>`_ and `cython <http://cython.org>`_ (optional).
+In addition to run-time dependencies, building *silx* requires a C/C++ compiler, `numpy <httinp://www.numpy.org/>`_ and `cython <http://cython.org>`_ (optional).
 
 On Windows it is recommended to use Python 3.5, because with previous versions of Python, it might be difficult to compile the extensions.
 
@@ -125,8 +125,10 @@ read the following sections.
 Installing Python
 +++++++++++++++++
 
-Download and install Python from `python.org <https://www.python.org/downloads/>`_.
-We recommend you to install the 64bits version of Python as the 32bits version is limited to 2 GB of memory.
+Download and install Python from `python.org <https://www.python.org/downloads/>`_. 
+
+We recommend that you install the 64bits version of Python, which is not the default version suggested on the Python website. The 32bits version is limited to 2 GB of memory, and also we don't provide a silx wheel for it. This means that you would have to install silx from its sources, which requires you to install a C compiler first.
+
 We also encourage you to use Python 3.5 or newer.
 
 Configure Python as explained on `docs.python.org

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -38,7 +38,7 @@ Tools for reading and writing HDF5 files depend on the following package:
 Build dependencies
 ++++++++++++++++++
 
-In addition to run-time dependencies, building *silx* requires a C/C++ compiler, `numpy <httinp://www.numpy.org/>`_ and `cython <http://cython.org>`_ (optional).
+In addition to run-time dependencies, building *silx* requires a C/C++ compiler, `numpy <http://www.numpy.org/>`_ and `cython <http://cython.org>`_ (optional).
 
 On Windows it is recommended to use Python 3.5, because with previous versions of Python, it might be difficult to compile the extensions.
 


### PR DESCRIPTION
This is my suggestion to emphasize the importance of python 64 on Windows. But I don't think most windows users will read it, especially if they already have python installed.