### PR TITLE
[Plot] Makes sure Qt window is activated and on top for tests

### DIFF
--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -32,7 +32,7 @@ __date__ = "30/03/2016"
 import doctest
 import unittest
 
-from silx.gui.testutils import qWaitForWindowExposed
+from silx.gui.testutils import qWaitForWindowExposedAndActivate
 from silx.gui import qt
 from silx.gui.plot import ColormapDialog
 
@@ -47,7 +47,7 @@ def _tearDownQt(docTest):
     Checks that dialog widget is displayed
     """
     dialogWidget = docTest.globs['dialog']
-    qWaitForWindowExposed(dialogWidget)
+    qWaitForWindowExposedAndActivate(dialogWidget)
     dialogWidget.setAttribute(qt.Qt.WA_DeleteOnClose)
     dialogWidget.close()
     del dialogWidget

--- a/silx/gui/plot/test/testPlotTools.py
+++ b/silx/gui/plot/test/testPlotTools.py
@@ -35,7 +35,7 @@ import unittest
 
 from silx.testutils import ParametricTestCase, test_logging
 from silx.gui.testutils import (
-    qWaitForWindowExposed, TestCaseQt, getQToolButtonFromAction)
+    qWaitForWindowExposedAndActivate, TestCaseQt, getQToolButtonFromAction)
 from silx.gui import qt
 from silx.gui.plot import PlotWindow, PlotTools
 
@@ -50,7 +50,7 @@ def _tearDownDocTest(docTest):
     Checks that plot widget is displayed
     """
     plot = docTest.globs['plot']
-    qWaitForWindowExposed(plot)
+    qWaitForWindowExposedAndActivate(plot)
     plot.setAttribute(qt.Qt.WA_DeleteOnClose)
     plot.close()
     del plot

--- a/silx/gui/plot/test/testPlotWindow.py
+++ b/silx/gui/plot/test/testPlotWindow.py
@@ -33,7 +33,7 @@ import doctest
 import unittest
 
 from silx.gui.testutils import TestCaseQt, getQToolButtonFromAction
-# from silx.gui.testutils import qWaitForWindowExposed
+# from silx.gui.testutils import qWaitForWindowExposedAndActivate
 
 from silx.gui import qt
 from silx.gui.plot import PlotWindow
@@ -54,7 +54,7 @@ def _tearDownQt(docTest):
     for obj in docTest.globs.values():
         if isinstance(obj, PlotWindow):
             # Commented out as it takes too long
-            # qWaitForWindowExposed(obj)
+            # qWaitForWindowExposedAndActivate(obj)
             obj.setAttribute(qt.Qt.WA_DeleteOnClose)
             obj.close()
             del obj

--- a/silx/gui/testutils.py
+++ b/silx/gui/testutils.py
@@ -61,6 +61,26 @@ else:
     qWaitForWindowExposed = QTest.qWaitForWindowExposed
 
 
+def qWaitForWindowExposedAndActivate(window, timeout=None):
+    """Waits until the window is shown in the screen.
+
+    It also activates the window and raises it.
+
+    See QTest.qWaitForWindowExposed for details.
+    """
+    if timeout is None:
+        result = qWaitForWindowExposed(window)
+    else:
+        result = qWaitForWindowExposed(window, timeout)
+
+    if result:
+        # Makes sure window is active and on top
+        window.activateWindow()
+        window.raise_()
+
+    return result
+
+
 # Placeholder for QApplication
 _qapp = None
 
@@ -277,10 +297,7 @@ class TestCaseQt(unittest.TestCase):
 
         See QTest.qWaitForWindowExposed for details.
         """
-        if timeout is None:
-            result = qWaitForWindowExposed(window)
-        else:
-            result = qWaitForWindowExposed(window, timeout)
+        result = qWaitForWindowExposedAndActivate(window, timeout)
 
         if self.TIMEOUT_WAIT:
             QTest.qWait(self.TIMEOUT_WAIT)


### PR DESCRIPTION
Activate window and raise it to top when waiting for it to be exposed.
Closes #133