### PR TITLE
Disable doctest for PlotTools because of exotic error message

### DIFF
--- a/silx/gui/plot/test/testPlotTools.py
+++ b/silx/gui/plot/test/testPlotTools.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "28/04/2016"
+__date__ = "12/07/2016"
 
 
 import doctest
@@ -55,13 +55,16 @@ def _tearDownDocTest(docTest):
     plot.close()
     del plot
 
-positionInfoTestSuite = doctest.DocTestSuite(
-    PlotTools, tearDown=_tearDownDocTest,
-    optionflags=doctest.ELLIPSIS)
-"""Test suite of tests from PlotTools docstrings.
-
-Test PositionInfo and ProfileToolBar docstrings.
-"""
+# Disable doctest because of
+# "NameError: name 'numpy' is not defined"
+#
+# positionInfoTestSuite = doctest.DocTestSuite(
+#     PlotTools, tearDown=_tearDownDocTest,
+#     optionflags=doctest.ELLIPSIS)
+# """Test suite of tests from PlotTools docstrings.
+#
+# Test PositionInfo and ProfileToolBar docstrings.
+# """
 
 
 class TestPositionInfo(TestCaseQt):
@@ -215,7 +218,7 @@ class TestProfileToolBar(TestCaseQt, ParametricTestCase):
 
 def suite():
     test_suite = unittest.TestSuite()
-    test_suite.addTest(positionInfoTestSuite)
+    # test_suite.addTest(positionInfoTestSuite)
     for testClass in (TestPositionInfo, TestProfileToolBar):
         test_suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(
             testClass))


### PR DESCRIPTION
On some systems, a "NameError: name 'numpy' is not defined" is raised when running tests using code from PlotTools docstrings.
These docstring tests are duplicate of the test suites in testPlotTools.py, so this removal does not affect test coverage of real code.
It affects test coverage of docstrings, so this issue should still be investigated.