### PR TITLE
Fix index issue in leastsq()

### DIFF
--- a/silx/math/fit/leastsq.py
+++ b/silx/math/fit/leastsq.py
@@ -789,8 +789,8 @@ def _get_sigma_parameters(parameters, sigma0, constraints):
             sigma_par [i] = sigma0[n_free]
             n_free += 1
         elif constraints[i][0] == CQUOTED:
-            pmax = max(constraints [1] [i], constraints [2] [i])
-            pmin = min(constraints [1] [i], constraints [2] [i])
+            pmax = max(constraints [i][1], constraints [i][2])
+            pmin = min(constraints [i][1], constraints [i][2])
             # A = 0.5 * (pmax + pmin)
             B = 0.5 * (pmax - pmin)
             if (B > 0) & (parameters [i] < pmax) & (parameters [i] > pmin):

--- a/silx/math/fit/leastsq.py
+++ b/silx/math/fit/leastsq.py
@@ -714,6 +714,7 @@ def chisq_alpha_beta(model, parameters, x, y, weight, constraints=None,
     else:
         return chisq, alpha, beta
 
+
 def _get_parameters(parameters, constraints):
     """
     Apply constraints to input parameters.
@@ -758,6 +759,7 @@ def _get_parameters(parameters, constraints):
             newparam[i] = constraints[i][2]-newparam[int(constraints[i][1])]
     return newparam
 
+
 def _get_sigma_parameters(parameters, sigma0, constraints):
     """
     Internal function propagating the uncertainty on the actually fitted parameters and related parameters to the
@@ -766,9 +768,10 @@ def _get_sigma_parameters(parameters, sigma0, constraints):
     Parameters
     ----------
         parameters : 1D sequence of length equal to the number of free parameters N
-            The parameters acually used in the fitting process.
+            The parameters actually used in the fitting process.
         sigma0 : 1D sequence of length N
-            The independent variable where the data is measured.
+            Uncertainties calculated as the square-root of the diagonal of
+            the covariance matrix
         constraints : The set of constraints applied in the fitting process
     """
     # 0 = Free       1 = Positive     2 = Quoted
@@ -777,7 +780,7 @@ def _get_sigma_parameters(parameters, sigma0, constraints):
         return sigma0
     n_free = 0
     sigma_par = numpy.zeros(parameters.shape, numpy.float)
-    for i in range(len(constraints [0])):
+    for i in range(len(constraints)):
         if constraints[i][0] == CFREE:
             sigma_par [i] = sigma0[n_free]
             n_free += 1
@@ -797,7 +800,7 @@ def _get_sigma_parameters(parameters, sigma0, constraints):
                 sigma_par [i] = parameters[i]
         elif abs(constraints[i][0]) == CFIXED:
             sigma_par[i] = parameters[i]
-    for i in range(len(constraints [0])):
+    for i in range(len(constraints)):
         if constraints[i][0] == CFACTOR:
             sigma_par [i] = constraints[i][2]*sigma_par[int(constraints[i][1])]
         elif constraints[i][0] == CDELTA:

--- a/silx/math/test/test_fit.py
+++ b/silx/math/test/test_fit.py
@@ -249,74 +249,43 @@ class Test_leastsq(unittest.TestCase):
                                                           fittedpar[i])
                 self.assertTrue(test_condition, msg)
 
-    def testDataWithNaN(self):
-        parameters_actual = [10.5, 2, 1000.0, 20., 15]
-        x = numpy.arange(10000.).reshape(1000, 10)
+    def testUncertainties(self):
+        """Test for validity of uncertainties in returned full-output
+        dictionary. This is a non-regression test for pull request #197"""
+        parameters_actual = [10.5, 2, 1000.0, 20., 15, 2001.0, 30.1, 16]
+        x = numpy.arange(10000.)
         y = self.gauss(x, *parameters_actual)
-        sigma = numpy.sqrt(y)
-        parameters_estimate = [0.0, 1.0, 900.0, 25., 10]
-        model_function = self.gauss
-        x[500] = numpy.inf
-        # check default behavior
-        try:
-            self.instance(model_function, x, y,
-                          parameters_estimate,
-                          sigma=sigma)
-        except ValueError:
-            info = "%s" % sys.exc_info()[1]
-            self.assertTrue("array must not contain inf" in info)
+        parameters_estimate = [0.0, 1.0, 900.0, 25., 10., 1500., 20., 2.0]
 
-        # check requested behavior
-        try:
-            self.instance(model_function, x, y,
-                          parameters_estimate,
-                          sigma=sigma,
-                          check_finite=True)
-        except ValueError:
-            info = "%s" % sys.exc_info()[1]
-            self.assertTrue("array must not contain inf" in info)
+        # test that uncertainties are not 0.
+        fittedpar, cov, infodict = self.instance(self.gauss, x, y, parameters_estimate,
+                                                 full_output=True)
+        uncertainties = infodict["uncertainties"]
+        self.assertEqual(len(uncertainties), len(parameters_actual))
+        self.assertEqual(len(uncertainties), len(fittedpar))
+        for uncertainty in uncertainties:
+            self.assertNotAlmostEqual(uncertainty, 0.)
 
-        fittedpar, cov = self.instance(model_function, x, y,
-                                       parameters_estimate,
-                                       sigma=sigma,
-                                       check_finite=False)
-        test_condition = numpy.allclose(parameters_actual, fittedpar)
-        if not test_condition:
-            msg = "Unsuccessfull fit\n"
-            for i in range(len(fittedpar)):
-                msg += "Expected %g obtained %g\n" % (parameters_actual[i],
-                                                      fittedpar[i])
-            self.assertTrue(test_condition, msg)
-
-        # testing now with ydata containing NaN
-        x = numpy.arange(10000.).reshape(1000, 10)
-        y[500] = numpy.nan
-        fittedpar, cov = self.instance(model_function, x, y,
-                                       parameters_estimate,
-                                       sigma=sigma,
-                                       check_finite=False)
-
-        test_condition = numpy.allclose(parameters_actual, fittedpar)
-        if not test_condition:
-            msg = "Unsuccessfull fit\n"
-            for i in range(len(fittedpar)):
-                msg += "Expected %g obtained %g\n" % (parameters_actual[i],
-                                                      fittedpar[i])
-            self.assertTrue(test_condition, msg)
-
-        # testing now with sigma containing NaN
-        sigma[300] = numpy.nan
-        fittedpar, cov = self.instance(model_function, x, y,
-                                       parameters_estimate,
-                                       sigma=sigma,
-                                       check_finite=False)
-        test_condition = numpy.allclose(parameters_actual, fittedpar)
-        if not test_condition:
-            msg = "Unsuccessfull fit\n"
-            for i in range(len(fittedpar)):
-                msg += "Expected %g obtained %g\n" % (parameters_actual[i],
-                                                      fittedpar[i])
-            self.assertTrue(test_condition, msg)
+        # set constraint FIXED for half the parameters.
+        # This should cause leastsq to return 100% uncertainty.
+        parameters_estimate = [10.6, 2.1, 1000.1, 20.1, 15.1, 2001.1, 30.2, 16.1]
+        CFIXED = 3
+        CFREE = 0
+        constraints = []
+        for i in range(len(parameters_estimate)):
+            if i % 2:
+                constraints.append([CFIXED, 0, 0])
+            else:
+                constraints.append([CFREE, 0, 0])
+        fittedpar, cov, infodict = self.instance(self.gauss, x, y, parameters_estimate,
+                                                 constraints=constraints,
+                                                 full_output=True)
+        uncertainties = infodict["uncertainties"]
+        for i in range(len(parameters_estimate)):
+            if i % 2:
+                # test that all FIXED parameters have 100% uncertainty
+                self.assertAlmostEqual(uncertainties[i],
+                                       parameters_estimate[i])
 
 
 test_cases = (Test_leastsq,)


### PR DESCRIPTION
The uncertainties calculation for `infodict['uncertainty']` had a loop on the wrong range, the length of the second dimension of `constraints` instead of the first dimension.   `constraints` has been transposed when it was included in _silx_.