### PR TITLE
Add octaveh5 file and the corresponding unit tests.

### DIFF
--- a/doc/source/modules/io/index.rst
+++ b/doc/source/modules/io/index.rst
@@ -9,6 +9,7 @@
    
    configdict.rst
    dictdump.rst
+   octaveh5.rst
    specfile.rst
    specfilewrapper.rst
    spech5.rst

--- a/doc/source/modules/io/octaveh5.rst
+++ b/doc/source/modules/io/octaveh5.rst
@@ -1,0 +1,11 @@
+
+.. currentmodule:: silx.io
+
+:mod:`silx.io.octaveh5`: h5py-like API to SpecFile
+------------------------------------------------
+
+.. automodule:: silx.io.octaveh5
+    :members:
+    :show-inheritance:
+    :undoc-members:
+    :special-members: __getitem__, __len__, __contains__

--- a/silx/gui/plot/test/testPlotTools.py
+++ b/silx/gui/plot/test/testPlotTools.py
@@ -77,6 +77,7 @@ class TestPositionInfo(TestCaseQt):
         self.qWaitForWindowExposed(self.plot)
         self.mouseMove(self.plot, pos=(1, 1))
         self.qapp.processEvents()
+        self.qWait(100)
 
     def tearDown(self):
         self.plot.setAttribute(qt.Qt.WA_DeleteOnClose)
@@ -105,6 +106,7 @@ class TestPositionInfo(TestCaseQt):
             # Move mouse to center
             self.mouseMove(self.plot)
             self.qapp.processEvents()
+            self.qWait(100)
 
     def testDefaultConverters(self):
         """Test PositionInfo with default converters"""

--- a/silx/io/octaveh5.py
+++ b/silx/io/octaveh5.py
@@ -39,7 +39,6 @@ import os.path
 import logging
 logger = logging.getLogger(__name__)
 import numpy as np
-from silx.gui import qt
 
 try:
     import h5py
@@ -58,8 +57,8 @@ class Octaveh5():
     """  
 
     def __init__(self, octave_targetted_version=3.8):
-            self.file = None
-            self.octave_targetted_version = octave_targetted_version
+        self.file = None
+        self.octave_targetted_version = octave_targetted_version
 
     def open(self, h5file, mode='r'):
         """Open the h5 file which has been write by octave"""
@@ -81,6 +80,7 @@ class Octaveh5():
         if self.file == None : 
             info = "No file currently open"
             logger.info(info)
+            return
 
         data_dict= {}
 
@@ -104,6 +104,8 @@ class Octaveh5():
         if self.file == None : 
             info = "No file currently open"
             logger.info(info)
+            return
+
         # write
         group_l1 = self.file.create_group(struct_name)
         group_l1.attrs['OCTAVE_GLOBAL'] = np.uint8(1)

--- a/silx/io/octaveh5.py
+++ b/silx/io/octaveh5.py
@@ -1,0 +1,134 @@
+# coding: utf-8
+#/*##########################################################################
+# Copyright (C) 2016 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#############################################################################*/
+"""
+Python h5 module and octave h5 module have differente ways to deal without
+h5 files.
+This module is used to make the link between octave and python using such files.
+(python is using a dictionnay and octave a struct )
+
+This module provides to prepare fasttomo input as HDF5 file.
+
+.. note:: These functions depend on the `h5py <http://www.h5py.org/>`_ 
+    library, which is not a mandatory dependency for `silx`.
+"""
+
+import sys
+import os.path
+
+import logging
+logger = logging.getLogger(__name__)
+import numpy as np
+from silx.gui import qt
+
+try:
+    import h5py
+except ImportError as e:
+    logger.error("Module " + __name__ + " requires h5py")
+    raise e
+
+__authors__ = ["C. Nemoz", "H. Payno"]
+__license__ = "MIT"
+__date__ = "25/05/2016"
+
+
+class Octaveh5():
+    """
+    This class allows communication between octave and python using hdf5 format.
+    """  
+
+    def __init__(self, octave_targetted_version=3.8):
+            self.file = None
+            self.octave_targetted_version = octave_targetted_version
+
+    def open(self, h5file, mode='r'):
+        """Open the h5 file which has been write by octave"""
+        try:
+            self.file = h5py.File(h5file, mode)
+            return self
+        except:
+            if mode == 'a' : 
+                reason = "\n %s: Can t find or create " % h5file
+            else :
+                reason = "\n %s: File not found" % h5file
+            self.file = None
+
+            logger.info(reason)
+            return
+
+    def get(self, struct_name):
+        """Read octave equivalent structures in hdf5 file"""   
+        if self.file == None : 
+            info = "No file currently open"
+            logger.info(info)
+
+        data_dict= {}
+
+        grr=(self.file[struct_name].items()[1])[1]
+        try:
+            gr_level2=grr.items()
+        except:
+            reason = "no gr_level2"
+            return
+
+        for key, val in dict(gr_level2).iteritems():
+            data_dict[str(key)] = (val.items()[1])[1].value
+
+            # In the case Octave have added a 0 at the end
+            if (val.items()[0])[1].value == 'sq_string' and self.octave_targetted_version < 3.8 :
+                data_dict[str(key)] = data_dict[str(key)][:-1]
+
+        return data_dict
+
+    def write(self, struct_name, data_dict):
+        if self.file == None : 
+            info = "No file currently open"
+            logger.info(info)
+        # write
+        group_l1 = self.file.create_group(struct_name)
+        group_l1.attrs['OCTAVE_GLOBAL'] = np.uint8(1)
+        group_l1.attrs['OCTAVE_NEW_FORMAT'] = np.uint8(1)
+        data_l1 = group_l1.create_dataset("type", data=np.string0('scalar struct'), dtype="|S14")
+        group_l2 = group_l1.create_group('value')
+        for ftparams in data_dict:
+            group_l3 = group_l2.create_group(ftparams)
+            group_l3.attrs['OCTAVE_NEW_FORMAT'] = np.uint8(1)
+            if type(data_dict[ftparams]) == str:
+                data_l2 = group_l3.create_dataset("type",(), data=np.string0('sq_string'), dtype="|S10")
+                if self.octave_targetted_version < 3.8 :
+                    data_l3 = group_l3.create_dataset("value", data=np.string0(data_dict[ftparams]+'0'))
+                else :
+                    data_l3 = group_l3.create_dataset("value", data=np.string0(data_dict[ftparams]))
+            else:
+                data_l2 = group_l3.create_dataset("type",(), data=np.string0('scalar'), dtype="|S7")
+                data_l3 = group_l3.create_dataset("value", data=data_dict[ftparams])
+
+    def close(self):
+        """Close the file after calling read function"""
+        if self.file :
+            self.file.close()
+
+    def __del__(self):
+        self.close()
+
+        

--- a/silx/io/test/__init__.py
+++ b/silx/io/test/__init__.py
@@ -33,6 +33,7 @@ from .test_specfilewrapper import suite as test_specfilewrapper_suite
 from .test_dictdump import suite as test_dictdump_suite
 from .test_spech5 import suite as test_spech5_suite
 from .test_spectoh5 import suite as test_spectoh5_suite
+from .test_octaveh5 import suite as test_octaveh5_suite
 from .test_utils import suite as test_utils_suite
 
 
@@ -43,5 +44,6 @@ def suite():
     test_suite.addTest(test_specfilewrapper_suite())
     test_suite.addTest(test_spech5_suite())
     test_suite.addTest(test_spectoh5_suite())
+    test_suite.addTest(test_octaveh5_suite())
     test_suite.addTest(test_utils_suite())
     return test_suite

--- a/silx/io/test/test_octaveh5.py
+++ b/silx/io/test/test_octaveh5.py
@@ -1,0 +1,169 @@
+# coding: utf-8
+#/*##########################################################################
+# Copyright (C) 2016 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+#############################################################################*/
+"""
+Tests for the octaveh5 module
+"""
+
+__authors__ = ["C. Nemoz", "H. Payno"]
+__license__ = "MIT"
+__date__ = "12/07/2016"
+
+import unittest
+import os
+import tempfile
+
+try:
+    import h5py
+except ImportError:
+    h5py_missing = True
+else:
+    h5py_missing = False
+
+from ..octaveh5 import Octaveh5
+
+
+@unittest.skipIf(h5py_missing, "Could not import h5py")
+class TestOctaveH5(unittest.TestCase):
+    @staticmethod
+    def _get_struct_FT():
+        return { 
+            'NO_CHECK': 0.0, 'SHOWSLICE': 1.0, 'DOTOMO': 1.0, 'DATABASE': 0.0, 'ANGLE_OFFSET': 0.0, 
+            'VOLSELECTION_REMEMBER': 0.0, 'NUM_PART': 4.0, 'VOLOUTFILE': 0.0, 'RINGSCORRECTION': 0.0, 
+            'DO_TEST_SLICE': 1.0, 'ZEROOFFMASK': 1.0, 'VERSION': 'fastomo3 version 2.0', 
+            'CORRECT_SPIKES_THRESHOLD': 0.040000000000000001, 'SHOWPROJ': 0.0, 'HALF_ACQ': 0.0, 
+            'ANGLE_OFFSET_VALUE': 0.0, 'FIXEDSLICE': 'middle', 'VOLSELECT': 'total' }
+    @staticmethod
+    def _get_struct_PYHSTEXE():
+        return {
+            'EXE': 'PyHST2_2015d', 'VERBOSE': 0.0, 'OFFV': 'PyHST2_2015d', 'TOMO': 0.0, 
+            'VERBOSE_FILE': 'pyhst_out.txt', 'DIR': '/usr/bin/', 'OFFN': 'pyhst2'}
+
+    @staticmethod
+    def _get_struct_FTAXIS():
+        return {
+            'POSITION_VALUE': 12345.0, 'COR_ERROR': 0.0, 'FILESDURINGSCAN': 0.0, 'PLOTFIGURE': 1.0,
+            'DIM1': 0.0, 'OVERSAMPLING': 5.0, 'TO_THE_CENTER': 1.0, 'POSITION': 'fixed', 
+            'COR_POSITION': 0.0, 'HA': 0.0 }
+            
+    @staticmethod
+    def _get_struct_PAGANIN():
+        return {
+            'MKEEP_MASK': 0.0, 'UNSHARP_SIGMA': 0.80000000000000004, 'DILATE': 2.0, 'UNSHARP_COEFF': 3.0, 
+            'MEDIANR': 4.0, 'DB': 500.0, 'MKEEP_ABS': 0.0, 'MODE': 0.0, 'THRESHOLD': 0.5, 
+            'MKEEP_BONE': 0.0, 'DB2': 100.0, 'MKEEP_CORR': 0.0, 'MKEEP_SOFT': 0.0 }
+
+    @staticmethod
+    def _get_struct_BEAMGEO():
+        return {'DIST': 55.0, 'SY': 0.0, 'SX': 0.0, 'TYPE': 'p'}
+
+
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()        
+        self.test_3_6_fname = os.path.join(self.tempdir, "silx_tmp_t00_octaveTest_3_6.h5")
+        self.test_3_8_fname = os.path.join(self.tempdir, "silx_tmp_t00_octaveTest_3_8.h5")
+
+    def tearDown(self):
+        if os.path.isfile(self.test_3_6_fname):
+            os.unlink(self.test_3_6_fname)
+        if os.path.isfile(self.test_3_8_fname):
+            os.unlink(self.test_3_8_fname)
+
+    def testWritedIsReaded(self):
+        """
+        Simple test to write and reaf the structure compatible with the octave h5 using structure.
+        This test is for # test for octave version > 3.8
+        """   
+        writer = Octaveh5()
+
+        writer.open(self.test_3_8_fname, 'a')
+        # step 1 writing the file
+        writer.write('FT', self._get_struct_FT())
+        writer.write('PYHSTEXE', self._get_struct_PYHSTEXE())
+        writer.write('FTAXIS', self._get_struct_FTAXIS())
+        writer.write('PAGANIN', self._get_struct_PAGANIN())
+        writer.write('BEAMGEO', self._get_struct_BEAMGEO())
+        writer.close()
+
+        # step 2 reading the file
+        reader = Octaveh5().open(self.test_3_8_fname)
+        #  2.1 check FT
+        data_readed = reader.get('FT')
+        self.assertEqual(data_readed, self._get_struct_FT() )
+        #  2.2 check PYHSTEXE
+        data_readed = reader.get('PYHSTEXE')
+        self.assertEqual(data_readed, self._get_struct_PYHSTEXE() )
+        #  2.3 check FTAXIS
+        data_readed = reader.get('FTAXIS')
+        self.assertEqual(data_readed, self._get_struct_FTAXIS() )
+        #  2.4 check PAGANIN
+        data_readed = reader.get('PAGANIN')
+        self.assertEqual(data_readed, self._get_struct_PAGANIN() )
+        #  2.5 check BEAMGEO
+        data_readed = reader.get('BEAMGEO')
+        self.assertEqual(data_readed, self._get_struct_BEAMGEO() )
+        reader.close()
+
+    def testWritedIsReadedOldOctaveVersion(self):
+        """The same test as testWritedIsReaded but for octave version < 3.8
+        """
+        # test for octave version < 3.8
+        writer = Octaveh5(3.6)
+
+        writer.open(self.test_3_6_fname, 'a')
+
+        # step 1 writing the file
+        writer.write('FT', self._get_struct_FT())
+        writer.write('PYHSTEXE', self._get_struct_PYHSTEXE())
+        writer.write('FTAXIS', self._get_struct_FTAXIS())
+        writer.write('PAGANIN', self._get_struct_PAGANIN())
+        writer.write('BEAMGEO', self._get_struct_BEAMGEO())
+        writer.close()
+
+        # step 2 reading the file
+        reader = Octaveh5(3.6).open(self.test_3_6_fname)
+        #  2.1 check FT
+        data_readed = reader.get('FT')
+        self.assertEqual(data_readed, self._get_struct_FT() )
+        #  2.2 check PYHSTEXE
+        data_readed = reader.get('PYHSTEXE')
+        self.assertEqual(data_readed, self._get_struct_PYHSTEXE() )
+        #  2.3 check FTAXIS
+        data_readed = reader.get('FTAXIS')
+        self.assertEqual(data_readed, self._get_struct_FTAXIS() )
+        #  2.4 check PAGANIN
+        data_readed = reader.get('PAGANIN')
+        self.assertEqual(data_readed, self._get_struct_PAGANIN() )
+        #  2.5 check BEAMGEO
+        data_readed = reader.get('BEAMGEO')
+        self.assertEqual(data_readed, self._get_struct_BEAMGEO() )
+        reader.close()
+
+def suite():
+    test_suite = unittest.TestSuite()
+    test_suite.addTest(
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestOctaveH5))
+    return test_suite
+
+if __name__ == '__main__':
+    unittest.main(defaultTest="suite")


### PR DESCRIPTION
A simple class to make communication between Octave and Python (using hdf5 structures).
Mainly developed by CaptainNemoz.
For Octave version < 3.8 we need to add a small hack to make sure we don t loose information (adding an extra character for sq_string values )