### PR TITLE
Fix bug (use file_header_dict instead of file_header to get date)

### DIFF
--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -691,7 +691,7 @@ def _dataset_builder(name, specfileh5, parent_group):
         elif "D" in scan.file_header_dict:
             logger1.warn("No #D line in scan header. " +
                          "Using file header for start_time.")
-            array_like = spec_date_to_iso8601(scan.file_header["D"])
+            array_like = spec_date_to_iso8601(scan.file_header_dict["D"])
         else:
             logger1.warn("No #D line in header. " +
                          "Using current system time for start_time.")


### PR DESCRIPTION
This fixes a bug causing a `TypeError:  list indices must be integers, not str` when opening a specfile with no scan header.