### PR TITLE
Add parentheses around the file extension of the filters

### DIFF
--- a/silx/gui/plot/PlotActions.py
+++ b/silx/gui/plot/PlotActions.py
@@ -500,35 +500,35 @@ class SaveAction(_PlotAction):
     """
     # TODO find a way to make the filter list selectable and extensible
 
-    SNAPSHOT_FILTERS = ('Plot Snapshot PNG *.png', 'Plot Snapshot JPEG *.jpg')
+    SNAPSHOT_FILTERS = ('Plot Snapshot PNG (*.png)', 'Plot Snapshot JPEG (*.jpg)')
 
     # Dict of curve filters with CSV-like format
     # Using ordered dict to guarantee filters order
     # Note: '%.18e' is numpy.savetxt default format
     CURVE_FILTERS_TXT = OrderedDict((
-        ('Curve as Raw ASCII *.txt',
+        ('Curve as Raw ASCII (*.txt)',
          {'fmt': '%.18e', 'delimiter': ' ', 'header': False}),
-        ('Curve as ";"-separated CSV *.csv',
+        ('Curve as ";"-separated CSV (*.csv)',
          {'fmt': '%.18e', 'delimiter': ';', 'header': True}),
-        ('Curve as ","-separated CSV *.csv',
-         {'fmt': '%.18e', 'delimiter': ',', 'header': True}),
-        ('Curve as tab-separated CSV *.csv',
+        ('Curve as ","-separated CSV (*.csv)',
+            {'fmt': '%.18e', 'delimiter': ',', 'header': True}),
+        ('Curve as tab-separated CSV (*.csv)',
          {'fmt': '%.18e', 'delimiter': '\t', 'header': True}),
-        ('Curve as OMNIC CSV *.csv',
+        ('Curve as OMNIC CSV (*.csv)',
          {'fmt': '%.7E', 'delimiter': ',', 'header': False}),
-        ('Curve as SpecFile *.dat',
+        ('Curve as SpecFile (*.dat)',
          {'fmt': '%.7g', 'delimiter': '', 'header': False})
     ))
 
-    CURVE_FILTER_NPY = 'Curve as NumPy binary file *.npy'
+    CURVE_FILTER_NPY = 'Curve as NumPy binary file (*.npy)'
 
     CURVE_FILTERS = list(CURVE_FILTERS_TXT.keys()) + [CURVE_FILTER_NPY]
 
-    ALL_CURVES_FILTERS = ("All curves as SpecFile *.dat", )
+    ALL_CURVES_FILTERS = ("All curves as SpecFile (*.dat", )
 
-    IMAGE_FILTER_EDF = 'Image as EDF *.edf'
-    IMAGE_FILTER_TIFF = 'Image as TIFF *.tif'
-    IMAGE_FILTER_NUMPY = 'Image as NumPy binary file *.npy'
+    IMAGE_FILTER_EDF = 'Image as EDF (*.edf)'
+    IMAGE_FILTER_TIFF = 'Image as TIFF (*.tif)'
+    IMAGE_FILTER_NUMPY = 'Image as NumPy binary file (*.npy)'
     IMAGE_FILTERS = (IMAGE_FILTER_EDF, IMAGE_FILTER_TIFF, IMAGE_FILTER_NUMPY)
 
     def __init__(self, plot, parent=None):

--- a/silx/gui/plot/PlotActions.py
+++ b/silx/gui/plot/PlotActions.py
@@ -48,7 +48,7 @@ from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent"]
 __license__ = "MIT"
-__date__ = "12/04/2016"
+__date__ = "30/08/2016"
 
 
 from collections import OrderedDict

--- a/silx/gui/plot/PlotActions.py
+++ b/silx/gui/plot/PlotActions.py
@@ -511,7 +511,7 @@ class SaveAction(_PlotAction):
         ('Curve as ";"-separated CSV (*.csv)',
          {'fmt': '%.18e', 'delimiter': ';', 'header': True}),
         ('Curve as ","-separated CSV (*.csv)',
-            {'fmt': '%.18e', 'delimiter': ',', 'header': True}),
+         {'fmt': '%.18e', 'delimiter': ',', 'header': True}),
         ('Curve as tab-separated CSV (*.csv)',
          {'fmt': '%.18e', 'delimiter': '\t', 'header': True}),
         ('Curve as OMNIC CSV (*.csv)',
@@ -524,7 +524,7 @@ class SaveAction(_PlotAction):
 
     CURVE_FILTERS = list(CURVE_FILTERS_TXT.keys()) + [CURVE_FILTER_NPY]
 
-    ALL_CURVES_FILTERS = ("All curves as SpecFile (*.dat", )
+    ALL_CURVES_FILTERS = ("All curves as SpecFile (*.dat"), )
 
     IMAGE_FILTER_EDF = 'Image as EDF (*.edf)'
     IMAGE_FILTER_TIFF = 'Image as TIFF (*.tif)'

--- a/silx/gui/plot/PlotActions.py
+++ b/silx/gui/plot/PlotActions.py
@@ -524,7 +524,7 @@ class SaveAction(_PlotAction):
 
     CURVE_FILTERS = list(CURVE_FILTERS_TXT.keys()) + [CURVE_FILTER_NPY]
 
-    ALL_CURVES_FILTERS = ("All curves as SpecFile (*.dat"), )
+    ALL_CURVES_FILTERS = ("All curves as SpecFile (*.dat)", )
 
     IMAGE_FILTER_EDF = 'Image as EDF (*.edf)'
     IMAGE_FILTER_TIFF = 'Image as TIFF (*.tif)'


### PR DESCRIPTION
A "cosmetic" fix that surrounds the filter's extension with parentheses, similar to other software, e.g. Qt Designer.