### PR TITLE
handling of default parameters for save1D

### DIFF
--- a/silx/io/test/test_utils.py
+++ b/silx/io/test/test_utils.py
@@ -44,7 +44,7 @@ else:
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "29/04/2016"
+__date__ = "06/09/2016"
 
 
 expected_spec1 = r"""#F .*
@@ -74,13 +74,19 @@ expected_csv = r"""Abscissa;Ordinate1;Ordinate2
 3;6\.00;9\.00e\+00
 """
 
+expected_csv2 = r"""x;y0;y1
+1;4\.00;7\.00e\+00
+2;5\.00;8\.00e\+00
+3;6\.00;9\.00e\+00
+"""
+
 class TestSave(unittest.TestCase):
     """Test saving curves as SpecFile:
     """
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
         self.spec_fname = os.path.join(self.tempdir, "savespec.dat")
-        self.csv_fname = os.path.join(self.tempdir, "savecsv.dat")
+        self.csv_fname = os.path.join(self.tempdir, "savecsv.csv")
         self.npy_fname = os.path.join(self.tempdir, "savenpy.npy")
 
         self.x = [1, 2, 3]
@@ -166,6 +172,18 @@ class TestSave(unittest.TestCase):
         actual_spec = specf.read()
         specf.close()
         self.assertRegexpMatches(actual_spec, expected_spec2)
+
+    def test_save_csv_no_labels(self):
+        """Save csv using save(), with autoheader=True but
+        xlabel=None and ylabels=None
+        This is a non-regression test for bug #223"""
+        save1D(self.csv_fname, self.x, self.y,
+               autoheader=True, fmt=["%d", "%.2f", "%.2e"])
+
+        csvf = open(self.csv_fname)
+        actual_csv = csvf.read()
+        csvf.close()
+        self.assertRegexpMatches(actual_csv, expected_csv2)
 
 
 def assert_match_any_string_in_list(test, pattern, list_of_strings):

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -41,7 +41,7 @@ else:
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "29/04/2016"
+__date__ = "06/09/2016"
 
 
 logger = logging.getLogger(__name__)
@@ -67,7 +67,7 @@ def save1D(fname, x, y, xlabel=None, ylabels=None, filetype=None,
         to be saved.
     :param filetype: Filetype: ``"spec", "csv", "txt", "ndarray"``.
         If ``None``, filetype is detected from file name extension
-        (``.dat, .csv, .txt, .npy``)
+        (``.dat, .csv, .txt, .npy``).
     :param xlabel: Abscissa label
     :param ylabels: List of `y` labels
     :param fmt: Format string for data. You can specify a short format
@@ -119,11 +119,29 @@ def save1D(fname, x, y, xlabel=None, ylabels=None, filetype=None,
         fileext = os.path.splitext(outfname)[1]
         if fileext in exttypes:
             filetype = exttypes[fileext]
+        else:
+            raise IOError("File type unspecified and could not be " +
+                          "inferred from file extension (not in " +
+                          "txt, dat, csv, npy)")
     else:
         filetype = filetype.lower()
 
     if filetype not in available_formats:
         raise IOError("File type %s is not supported" % (filetype))
+
+    # default column headers
+    if xlabel is None:
+        xlabel = "x"
+    if ylabels is None:
+        if len(numpy.array(y).shape) > 1:
+            ylabels = ["y%d" % i for i in range(len(y))]
+        else:
+            ylabels = ["y"]
+    elif isinstance(ylabels, (list, tuple)):
+        # if ylabels is provided as a list, every element must
+        # be a string
+        ylabels = [ylabels[i] if ylabels[i] is not None else "y%d" % i
+                   for i in range(len(ylabels))]
 
     if filetype.lower() == "spec":
         y_array = numpy.asarray(y)


### PR DESCRIPTION
Additional fix for #223. 
#225 fixed the issue only when `save1D` is called by a PlotWindow, by making sure xlabel or ylabel is never None.
This PR fixes the problem by setting default labels when `autoheader==True` and labels are `None` (or unspecified). 