### PR TITLE
[octaveh5] correct section title and underlining in rst doc

### DIFF
--- a/doc/source/modules/io/octaveh5.rst
+++ b/doc/source/modules/io/octaveh5.rst
@@ -1,11 +1,10 @@
 
 .. currentmodule:: silx.io
 
-:mod:`silx.io.octaveh5`: h5py-like API to SpecFile
-------------------------------------------------
+:mod:`silx.io.octaveh5`: Octave HDF5 compatibility
+---------------------------------------------------
 
 .. automodule:: silx.io.octaveh5
     :members:
     :show-inheritance:
     :undoc-members:
-    :special-members: __getitem__, __len__, __contains__


### PR DESCRIPTION
Sphinx was raising a warning due to the underlining being shorter than the title