### PR TITLE
[Gui] Add loadUi to qt.py

### DIFF
--- a/copyright
+++ b/copyright
@@ -19,6 +19,11 @@ Files: silx/gui/plot/MPLColormap.py
 Copyright: Nathaniel J. Smith, Stefan van der Walt, Eric Firing
 License: CC0
 
+Files: silx/gui/_pyside_dynamic.py
+Copyright: 2011 Sebastian Wiesner <lunaryorn@gmail.com>
+           Modifications by Charl Botha <cpbotha@vxlabs.com>
+License: MIT
+
 License: MIT
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/silx/gui/_pyside_dynamic.py
+++ b/silx/gui/_pyside_dynamic.py
@@ -66,9 +66,10 @@ class UiLoader(QUiLoader):
         instance of the top-level class in the user interface to load, or a
         subclass thereof.
 
-        ``customWidgets`` is a dictionary mapping from class name to class object
-        for widgets that you've promoted in the Qt Designer interface. Usually,
-        this should be done by calling registerCustomWidget on the QUiLoader, but
+        ``customWidgets`` is a dictionary mapping from class name to class
+        object for widgets that you've promoted in the Qt Designer
+        interface. Usually, this should be done by calling
+        registerCustomWidget on the QUiLoader, but
         with PySide 1.1.2 on Ubuntu 12.04 x86_64 this causes a segfault.
 
         ``parent`` is the parent object of this loader.
@@ -95,15 +96,18 @@ class UiLoader(QUiLoader):
                 widget = QUiLoader.createWidget(self, class_name, parent, name)
 
             else:
-                # if not in the list of availableWidgets, must be a custom widget
+                # if not in the list of availableWidgets,
+                # must be a custom widget
                 # this will raise KeyError if the user has not supplied the
                 # relevant class_name in the dictionary, or TypeError, if
                 # customWidgets is None
                 try:
                     widget = self.customWidgets[class_name](parent)
 
-                except (TypeError, KeyError) as e:
-                    raise Exception('No custom widget ' + class_name + ' found in customWidgets param of UiLoader __init__.')
+                except (TypeError, KeyError):
+                    raise Exception('No custom widget ' + class_name +
+                                    ' found in customWidgets param of' +
+                                    'UiLoader __init__.')
 
             if self.baseinstance:
                 # set an attribute for the new child widget on the base
@@ -112,7 +116,7 @@ class UiLoader(QUiLoader):
 
                 # this outputs the various widget names, e.g.
                 # sampleGraphicsView, dockWidget, samplesTableView etc.
-                #print(name)
+                # print(name)
 
             return widget
 
@@ -185,4 +189,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/silx/gui/_pyside_dynamic.py
+++ b/silx/gui/_pyside_dynamic.py
@@ -1,5 +1,7 @@
-#!/usr/bin/python2
 # -*- coding: utf-8 -*-
+
+# Taken from: https://gist.github.com/cpbotha/1b42a20c8f3eb9bb7cb8
+
 # Copyright (c) 2011 Sebastian Wiesner <lunaryorn@gmail.com>
 # Modifications by Charl Botha <cpbotha@vxlabs.com>
 # * customWidgets support (registerCustomWidget() causes segfault in

--- a/silx/gui/_pyside_dynamic.py
+++ b/silx/gui/_pyside_dynamic.py
@@ -38,6 +38,7 @@
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 
+import logger
 import os
 import sys
 
@@ -45,7 +46,8 @@ from PySide.QtCore import Slot, QMetaObject
 from PySide.QtUiTools import QUiLoader
 from PySide.QtGui import QApplication, QMainWindow, QMessageBox
 
-SCRIPT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
+
+_logger = logging.getLogger(__name__)
 
 
 class UiLoader(QUiLoader):
@@ -123,8 +125,7 @@ class UiLoader(QUiLoader):
             return widget
 
 
-def loadUi(uifile, baseinstance=None, customWidgets=None,
-           workingDirectory=None):
+def loadUi(uifile, baseinstance=None, package=None, resource_suffix=None):
     """
     Dynamically load a user interface from the given ``uifile``.
 
@@ -139,55 +140,21 @@ def loadUi(uifile, baseinstance=None, customWidgets=None,
     cannot load a ``QMainWindow`` UI file with a plain
     :class:`~PySide.QtGui.QWidget` as ``baseinstance``.
 
-    ``customWidgets`` is a dictionary mapping from class name to class object
-    for widgets that you've promoted in the Qt Designer interface. Usually,
-    this should be done by calling registerCustomWidget on the QUiLoader, but
-    with PySide 1.1.2 on Ubuntu 12.04 x86_64 this causes a segfault.
-
     :method:`~PySide.QtCore.QMetaObject.connectSlotsByName()` is called on the
     created user interface, so you can implemented your slots according to its
     conventions in your widget class.
 
-    Return ``baseinstance``, if ``baseinstance`` is not ``None``.  Otherwise
+    Return ``baseinstance``, if ``baseinstance`` is not ``None``. Otherwise
     return the newly created instance of the user interface.
     """
+    if package is not None:
+        _logger.warning(
+            "loadUi package parameter not implemented with PySide")
+    if resource_suffix is not None:
+        _logger.warning(
+            "loadUi resource_suffix parameter not implemented with PySide")
 
-    loader = UiLoader(baseinstance, customWidgets)
-
-    if workingDirectory is not None:
-        loader.setWorkingDirectory(workingDirectory)
-
+    loader = UiLoader(baseinstance)
     widget = loader.load(uifile)
     QMetaObject.connectSlotsByName(widget)
     return widget
-
-
-class MainWindow(QMainWindow):
-
-    def __init__(self, parent=None):
-        QMainWindow.__init__(self, parent)
-        loadUi(os.path.join(SCRIPT_DIRECTORY, 'mainwindow.ui'), self)
-
-    @Slot(bool)
-    def on_clickMe_clicked(self, is_checked):
-        if is_checked:
-            message = self.trUtf8(b'I am checked now.')
-        else:
-            message = self.trUtf8(b'I am unchecked now.')
-        QMessageBox.information(self, self.trUtf8(b'You clicked me'), message)
-
-    @Slot()
-    def on_actionHello_triggered(self):
-        QMessageBox.information(self, self.trUtf8(b'Hello world'),
-                                self.trUtf8(b'Greetings to the world.'))
-
-
-def main():
-    app = QApplication(sys.argv)
-    window = MainWindow()
-    window.show()
-    app.exec_()
-
-
-if __name__ == '__main__':
-    main()

--- a/silx/gui/_pyside_dynamic.py
+++ b/silx/gui/_pyside_dynamic.py
@@ -1,0 +1,188 @@
+#!/usr/bin/python2
+# -*- coding: utf-8 -*-
+# Copyright (c) 2011 Sebastian Wiesner <lunaryorn@gmail.com>
+# Modifications by Charl Botha <cpbotha@vxlabs.com>
+# * customWidgets support (registerCustomWidget() causes segfault in
+#   pyside 1.1.2 on Ubuntu 12.04 x86_64)
+# * workingDirectory support in loadUi
+
+# found this here:
+# https://github.com/lunaryorn/snippets/blob/master/qt4/designer/pyside_dynamic.py
+
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+
+"""
+    How to load a user interface dynamically with PySide.
+
+    .. moduleauthor::  Sebastian Wiesner  <lunaryorn@gmail.com>
+"""
+
+from __future__ import (print_function, division, unicode_literals,
+                        absolute_import)
+
+import os
+import sys
+
+from PySide.QtCore import Slot, QMetaObject
+from PySide.QtUiTools import QUiLoader
+from PySide.QtGui import QApplication, QMainWindow, QMessageBox
+
+SCRIPT_DIRECTORY = os.path.dirname(os.path.abspath(__file__))
+
+
+class UiLoader(QUiLoader):
+    """
+    Subclass :class:`~PySide.QtUiTools.QUiLoader` to create the user interface
+    in a base instance.
+
+    Unlike :class:`~PySide.QtUiTools.QUiLoader` itself this class does not
+    create a new instance of the top-level widget, but creates the user
+    interface in an existing instance of the top-level class.
+
+    This mimics the behaviour of :func:`PyQt4.uic.loadUi`.
+    """
+
+    def __init__(self, baseinstance, customWidgets=None):
+        """
+        Create a loader for the given ``baseinstance``.
+
+        The user interface is created in ``baseinstance``, which must be an
+        instance of the top-level class in the user interface to load, or a
+        subclass thereof.
+
+        ``customWidgets`` is a dictionary mapping from class name to class object
+        for widgets that you've promoted in the Qt Designer interface. Usually,
+        this should be done by calling registerCustomWidget on the QUiLoader, but
+        with PySide 1.1.2 on Ubuntu 12.04 x86_64 this causes a segfault.
+
+        ``parent`` is the parent object of this loader.
+        """
+
+        QUiLoader.__init__(self, baseinstance)
+        self.baseinstance = baseinstance
+        self.customWidgets = customWidgets
+
+    def createWidget(self, class_name, parent=None, name=''):
+        """
+        Function that is called for each widget defined in ui file,
+        overridden here to populate baseinstance instead.
+        """
+
+        if parent is None and self.baseinstance:
+            # supposed to create the top-level widget, return the base instance
+            # instead
+            return self.baseinstance
+
+        else:
+            if class_name in self.availableWidgets():
+                # create a new widget for child widgets
+                widget = QUiLoader.createWidget(self, class_name, parent, name)
+
+            else:
+                # if not in the list of availableWidgets, must be a custom widget
+                # this will raise KeyError if the user has not supplied the
+                # relevant class_name in the dictionary, or TypeError, if
+                # customWidgets is None
+                try:
+                    widget = self.customWidgets[class_name](parent)
+
+                except (TypeError, KeyError) as e:
+                    raise Exception('No custom widget ' + class_name + ' found in customWidgets param of UiLoader __init__.')
+
+            if self.baseinstance:
+                # set an attribute for the new child widget on the base
+                # instance, just like PyQt4.uic.loadUi does.
+                setattr(self.baseinstance, name, widget)
+
+                # this outputs the various widget names, e.g.
+                # sampleGraphicsView, dockWidget, samplesTableView etc.
+                #print(name)
+
+            return widget
+
+
+def loadUi(uifile, baseinstance=None, customWidgets=None,
+           workingDirectory=None):
+    """
+    Dynamically load a user interface from the given ``uifile``.
+
+    ``uifile`` is a string containing a file name of the UI file to load.
+
+    If ``baseinstance`` is ``None``, the a new instance of the top-level widget
+    will be created.  Otherwise, the user interface is created within the given
+    ``baseinstance``.  In this case ``baseinstance`` must be an instance of the
+    top-level widget class in the UI file to load, or a subclass thereof.  In
+    other words, if you've created a ``QMainWindow`` interface in the designer,
+    ``baseinstance`` must be a ``QMainWindow`` or a subclass thereof, too.  You
+    cannot load a ``QMainWindow`` UI file with a plain
+    :class:`~PySide.QtGui.QWidget` as ``baseinstance``.
+
+    ``customWidgets`` is a dictionary mapping from class name to class object
+    for widgets that you've promoted in the Qt Designer interface. Usually,
+    this should be done by calling registerCustomWidget on the QUiLoader, but
+    with PySide 1.1.2 on Ubuntu 12.04 x86_64 this causes a segfault.
+
+    :method:`~PySide.QtCore.QMetaObject.connectSlotsByName()` is called on the
+    created user interface, so you can implemented your slots according to its
+    conventions in your widget class.
+
+    Return ``baseinstance``, if ``baseinstance`` is not ``None``.  Otherwise
+    return the newly created instance of the user interface.
+    """
+
+    loader = UiLoader(baseinstance, customWidgets)
+
+    if workingDirectory is not None:
+        loader.setWorkingDirectory(workingDirectory)
+
+    widget = loader.load(uifile)
+    QMetaObject.connectSlotsByName(widget)
+    return widget
+
+
+class MainWindow(QMainWindow):
+
+    def __init__(self, parent=None):
+        QMainWindow.__init__(self, parent)
+        loadUi(os.path.join(SCRIPT_DIRECTORY, 'mainwindow.ui'), self)
+
+    @Slot(bool)
+    def on_clickMe_clicked(self, is_checked):
+        if is_checked:
+            message = self.trUtf8(b'I am checked now.')
+        else:
+            message = self.trUtf8(b'I am unchecked now.')
+        QMessageBox.information(self, self.trUtf8(b'You clicked me'), message)
+
+    @Slot()
+    def on_actionHello_triggered(self):
+        QMessageBox.information(self, self.trUtf8(b'Hello world'),
+                                self.trUtf8(b'Greetings to the world.'))
+
+
+def main():
+    app = QApplication(sys.argv)
+    window = MainWindow()
+    window.show()
+    app.exec_()
+
+
+if __name__ == '__main__':
+    main()
+

--- a/silx/gui/_pyside_dynamic.py
+++ b/silx/gui/_pyside_dynamic.py
@@ -38,7 +38,7 @@
 from __future__ import (print_function, division, unicode_literals,
                         absolute_import)
 
-import logger
+import logging
 import os
 import sys
 

--- a/silx/gui/qt.py
+++ b/silx/gui/qt.py
@@ -131,6 +131,8 @@ if BINDING == 'PyQt4':
     else:
         HAS_SVG = True
 
+    from PyQt4.uic import loadUi  # noqa
+
     Signal = pyqtSignal
 
     Property = pyqtProperty
@@ -158,6 +160,9 @@ elif BINDING == 'PySide':
     else:
         HAS_SVG = True
 
+    # Import loadUi wrapper for PySide
+    from ._pyside_dynamic import loadUi  # noqa
+
 elif BINDING == 'PyQt5':
     _logger.debug('Using PyQt5 bindings')
 
@@ -180,6 +185,8 @@ elif BINDING == 'PyQt5':
         HAS_SVG = False
     else:
         HAS_SVG = True
+
+    from PyQt5.uic import loadUi  # noqa
 
     Signal = pyqtSignal
 

--- a/silx/gui/test/test_qt.py
+++ b/silx/gui/test/test_qt.py
@@ -26,10 +26,14 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "16/02/2016"
+__date__ = "12/09/2016"
 
 
+import os.path
 import unittest
+
+from silx.testutils import temp_dir
+from silx.gui.testutils import TestCaseQt
 
 from silx.gui import qt
 
@@ -43,10 +47,96 @@ class TestQtWrapper(unittest.TestCase):
         self.assertTrue(obj is not None)
 
 
+class TestLoadUi(TestCaseQt):
+    """Test loadUi function"""
+
+    TEST_UI = """<?xml version="1.0" encoding="UTF-8"?>
+    <ui version="4.0">
+     <class>MainWindow</class>
+     <widget class="QMainWindow" name="MainWindow">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>293</width>
+        <height>296</height>
+       </rect>
+      </property>
+      <property name="windowTitle">
+       <string>Test loadUi</string>
+      </property>
+      <widget class="QWidget" name="centralwidget">
+       <widget class="QPushButton" name="pushButton">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>10</y>
+          <width>89</width>
+          <height>27</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Button 1</string>
+        </property>
+       </widget>
+       <widget class="QPushButton" name="pushButton_2">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>50</y>
+          <width>89</width>
+          <height>27</height>
+         </rect>
+        </property>
+        <property name="text">
+         <string>Button 2</string>
+        </property>
+       </widget>
+      </widget>
+      <widget class="QMenuBar" name="menubar">
+       <property name="geometry">
+        <rect>
+         <x>0</x>
+         <y>0</y>
+         <width>293</width>
+         <height>25</height>
+        </rect>
+       </property>
+      </widget>
+      <widget class="QStatusBar" name="statusbar"/>
+     </widget>
+     <resources/>
+     <connections/>
+    </ui>
+    """
+
+    def testLoadUi(self):
+        """Create a QMainWindow from an ui file"""
+        with temp_dir() as tmp:
+            uifile = os.path.join(tmp, "test.ui")
+
+            # write file
+            with open(uifile, mode='w') as f:
+                f.write(self.TEST_UI)
+
+            class TestMainWindow(qt.QMainWindow):
+                def __init__(self, parent=None):
+                    super(TestMainWindow, self).__init__(parent)
+                    qt.loadUi(uifile, self)
+
+            testMainWindow = TestMainWindow()
+            testMainWindow.show()
+            self.qWaitForWindowExposed(testMainWindow)
+
+            testMainWindow.setAttribute(qt.Qt.WA_DeleteOnClose)
+            testMainWindow.close()
+
+
 def suite():
     test_suite = unittest.TestSuite()
-    test_suite.addTest(
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestQtWrapper))
+    for TestCaseCls in (TestQtWrapper, TestLoadUi):
+        test_suite.addTest(
+            unittest.defaultTestLoader.loadTestsFromTestCase(TestCaseCls))
     return test_suite
 
 


### PR DESCRIPTION
This PR adds uic.loadUi to qt.py.
For PySide, it provides an alternative implementation which only has the 2 first arguments of loadUi implemented (and warnings when the 2 last are set).

Closes #230 