### PR TITLE
Feature h5 load API

### DIFF
--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -164,10 +164,16 @@ from .specfile import SpecFile
 
 __authors__ = ["P. Knobel", "D. Naudet"]
 __license__ = "MIT"
-__date__ = "15/09/2016"
+__date__ = "20/09/2016"
 
 logging.basicConfig()
 logger1 = logging.getLogger(__name__)
+
+try:
+    import h5py
+except ImportError:
+    logger1.debug("Module h5py optional.", exc_info=True)
+
 
 string_types = (basestring,) if sys.version_info[0] == 2 else (str,)  # noqa
 
@@ -665,6 +671,11 @@ class SpecH5Dataset(numpy.ndarray):
         self.file = getattr(obj, 'file', None)
         self.attrs = getattr(obj, 'attrs', None)
 
+    @property
+    def h5py_class(self):
+        """h5py class which is mimicked by this class"""
+        return h5py.Dataset
+
 
 class SpecH5LinkToDataset(SpecH5Dataset):
     """Special :class:`SpecH5Dataset` representing a link to a dataset. It
@@ -874,6 +885,11 @@ class SpecH5Group(object):
         if name != "/":
             scan_key = _get_scan_key_in_name(name)
             self._scan = self.file._sf[scan_key]
+
+    @property
+    def h5py_class(self):
+        """h5py class which is mimicked by this class"""
+        return h5py.Group
 
     @property
     def parent(self):
@@ -1177,3 +1193,7 @@ class SpecH5(SpecH5Group):
                 self.filename == other.filename and
                 self.keys() == other.keys())
 
+    @property
+    def h5py_class(self):
+        """h5py class which is mimicked by this class"""
+        return h5py.File

--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -1229,6 +1229,13 @@ class SpecH5(SpecH5Group):
         """
         return self._sf.keys()
 
+    def close(self):
+        """Close the object, and free up associated resources.
+
+        After calling this method, attempts to use the object may fail.
+        """
+        self._sf = None
+
     def __repr__(self):
         return '<SpecH5 "%s" (%d members)>' % (self.filename, len(self))
 

--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -987,6 +987,10 @@ class SpecH5Group(object):
         for key in self.keys():
             yield key
 
+    def items(self):
+        for key in self.keys():
+            yield key, self[key]
+
     def __len__(self):
         """Return number of members,subgroups and datasets, attached to this
          group.

--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -164,7 +164,7 @@ from .specfile import SpecFile
 
 __authors__ = ["P. Knobel", "D. Naudet"]
 __license__ = "MIT"
-__date__ = "20/09/2016"
+__date__ = "27/09/2016"
 
 logging.basicConfig()
 logger1 = logging.getLogger(__name__)
@@ -172,6 +172,7 @@ logger1 = logging.getLogger(__name__)
 try:
     import h5py
 except ImportError:
+    h5py = None
     logger1.debug("Module h5py optional.", exc_info=True)
 
 
@@ -673,7 +674,15 @@ class SpecH5Dataset(numpy.ndarray):
 
     @property
     def h5py_class(self):
-        """h5py class which is mimicked by this class"""
+        """Return h5py class which is mimicked by this class:
+        :class:`h5py.dataset`.
+
+        Accessing this attribute if :mod:`h5py` is not installed causes
+        an ``ImportError`` to be raised
+        """
+        if h5py is None:
+            raise ImportError("Cannot return h5py.Dataset class, " +
+                              "unable to import h5py module")
         return h5py.Dataset
 
 
@@ -888,7 +897,15 @@ class SpecH5Group(object):
 
     @property
     def h5py_class(self):
-        """h5py class which is mimicked by this class"""
+        """Return h5py class which is mimicked by this class:
+        :class:`h5py.Group`.
+
+        Accessing this attribute if :mod:`h5py` is not installed causes
+        an ``ImportError`` to be raised
+        """
+        if h5py is None:
+            raise ImportError("Cannot return h5py.Group class, " +
+                              "unable to import h5py module")
         return h5py.Group
 
     @property
@@ -962,6 +979,33 @@ class SpecH5Group(object):
                 self.name == other.name and
                 self.file.filename == other.file.filename and
                 self.keys() == other.keys())
+
+    def get(self, name, default=None, getclass=False, getlink=False):
+        """Retrieve an item by name, or a default value if name does not
+        point to an existing item.
+
+        :param name str: name of the item
+        :param default: Default value returned if the name is not found
+        :param bool getclass: if *True*, the returned object is the class of
+            the item, instead of the item instance.
+        :param bool getlink: Not implemented. This method always returns
+            an instance of the original class of the requested item (or
+            just the class, if *getclass* is *True*)
+        :return: The requested item, or its class if *getclass* is *True*,
+            or the specified *default* value if the group does not contain
+            an item with the requested name.
+        """
+        if name not in self:
+            return default
+
+        if getlink:
+            logger1.warning("getlink is not implemented. " +
+                            "It has no effect on SpecH5Group.get()")
+
+        if getclass:
+            return self[name].__class__
+
+        return self[name]
 
     def __getitem__(self, key):
         """Return a :class:`SpecH5Group` or a :class:`SpecH5Dataset`
@@ -1196,4 +1240,7 @@ class SpecH5(SpecH5Group):
     @property
     def h5py_class(self):
         """h5py class which is mimicked by this class"""
+        if h5py is None:
+            raise ImportError("Cannot return h5py.File class, " +
+                              "unable to import h5py module")
         return h5py.File

--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -164,7 +164,7 @@ from .specfile import SpecFile
 
 __authors__ = ["P. Knobel", "D. Naudet"]
 __license__ = "MIT"
-__date__ = "27/09/2016"
+__date__ = "03/10/2016"
 
 logging.basicConfig()
 logger1 = logging.getLogger(__name__)
@@ -1002,7 +1002,7 @@ class SpecH5Group(object):
             pass
 
         if getclass:
-            return self[name].__class__
+            return self[name].h5py_class
 
         return self[name]
 

--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -998,9 +998,8 @@ class SpecH5Group(object):
         if name not in self:
             return default
 
-        if getlink:
-            logger1.warning("getlink is not implemented. " +
-                            "It has no effect on SpecH5Group.get()")
+        if getlink and getclass:
+            pass
 
         if getclass:
             return self[name].__class__

--- a/silx/io/test/test_spech5.py
+++ b/silx/io/test/test_spech5.py
@@ -34,6 +34,11 @@ from functools import partial
 from ..spech5 import (SpecH5, SpecH5Group,
                       SpecH5Dataset, spec_date_to_iso8601)
 
+try:
+    import h5py
+except ImportError:
+    h5py = None
+
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
 __date__ = "30/08/2016"
@@ -259,6 +264,24 @@ class TestSpecH5(unittest.TestCase):
         self.assertEqual(self.sfh5["25.1/start_time"],
                          b"2015-03-14T03:53:50")
 
+    def testGet(self):
+        """Test :meth:`SpecH5Group.get`"""
+        # default value of param *default* is None
+        self.assertIsNone(self.sfh5.get("toto"))
+        self.assertEqual(self.sfh5["25.1"].get("toto", default=-3),
+                         -3)
+
+        self.assertEqual(self.sfh5.get("/1.1/start_time", default=-3),
+                         b"2016-02-11T09:55:20")
+
+        self.assertIs(self.sfh5["1.1"].get("start_time", getclass=True),
+                      SpecH5Dataset)
+        self.assertIs(self.sfh5["1.1"].get("instrument", getclass=True),
+                      SpecH5Group)
+
+        # spech5 does not define external link, so there is no way
+        # a group can *get* a SpecH5 class
+
     def testGetItemGroup(self):
         group = self.sfh5["25.1"]["instrument"]
         self.assertEqual(group["positioners"].keys(),
@@ -270,6 +293,22 @@ class TestSpecH5(unittest.TestCase):
     def testGetitemSpecH5(self):
         self.assertEqual(self.sfh5["/1.2/instrument/positioners"],
                          self.sfh5["1.2"]["instrument"]["positioners"])
+
+    @unittest.skipIf(h5py is None, "test requires h5py (not installed)")
+    def testH5pyClass(self):
+        """Test :attr:`h5py_class` returns the corresponding h5py class
+        (h5py.File, h5py.Group, h5py.Dataset)"""
+        a_file = self.sfh5
+        self.assertIs(a_file.h5py_class,
+                      h5py.File)
+
+        a_group = self.sfh5["/1.2/measurement"]
+        self.assertIs(a_group.h5py_class,
+                      h5py.Group)
+
+        a_dataset = self.sfh5["/1.1/instrument/positioners/Sslit1 HOff"]
+        self.assertIs(a_dataset.h5py_class,
+                      h5py.Dataset)
 
     def testHeader(self):
         # File header has 10 lines

--- a/silx/io/test/test_spech5.py
+++ b/silx/io/test/test_spech5.py
@@ -41,7 +41,7 @@ except ImportError:
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "30/08/2016"
+__date__ = "03/10/2016"
 
 sftext = """#F /tmp/sf.dat
 #E 1455180875
@@ -274,10 +274,14 @@ class TestSpecH5(unittest.TestCase):
         self.assertEqual(self.sfh5.get("/1.1/start_time", default=-3),
                          b"2016-02-11T09:55:20")
 
+    def testGetClass(self):
+        """Test :meth:`SpecH5Group.get`"""
+        if h5py is None:
+            self.skipTest("h5py is not available")
         self.assertIs(self.sfh5["1.1"].get("start_time", getclass=True),
-                      SpecH5Dataset)
+                      h5py.Dataset)
         self.assertIs(self.sfh5["1.1"].get("instrument", getclass=True),
-                      SpecH5Group)
+                      h5py.Group)
 
         # spech5 does not define external link, so there is no way
         # a group can *get* a SpecH5 class

--- a/silx/io/test/test_utils.py
+++ b/silx/io/test/test_utils.py
@@ -31,7 +31,7 @@ import shutil
 import tempfile
 import unittest
 
-from ..utils import savespec, save1D, load
+from .. import utils
 
 try:
     import h5py
@@ -105,7 +105,7 @@ class TestSave(unittest.TestCase):
         shutil.rmtree(self.tempdir)
 
     def test_save_csv(self):
-        save1D(self.csv_fname, self.x, self.y,
+        utils.save1D(self.csv_fname, self.x, self.y,
                xlabel=self.xlab, ylabels=self.ylabs,
                filetype="csv", fmt=["%d", "%.2f", "%.2e"],
                csvdelim=";", autoheader=True)
@@ -120,7 +120,7 @@ class TestSave(unittest.TestCase):
         """npy file is saved with numpy.save after building a numpy array
         and converting it to a named record array"""
         npyf = open(self.npy_fname, "wb")
-        save1D(npyf, self.x, self.y,
+        utils.save1D(npyf, self.x, self.y,
                xlabel=self.xlab, ylabels=self.ylabs)
         npyf.close()
 
@@ -134,7 +134,7 @@ class TestSave(unittest.TestCase):
 
     def test_savespec_filename(self):
         """Save SpecFile using savespec()"""
-        savespec(self.spec_fname, self.x, self.y[0], xlabel=self.xlab,
+        utils.savespec(self.spec_fname, self.x, self.y[0], xlabel=self.xlab,
                  ylabel=self.ylabs[0], fmt=["%d", "%.2f"], close_file=True,
                  scan_number=1)
 
@@ -148,12 +148,12 @@ class TestSave(unittest.TestCase):
         """Save SpecFile using savespec(), passing a file handle"""
         # first savespec: open, write file header, save y[0] as scan 1,
         #                 return file handle
-        specf = savespec(self.spec_fname, self.x, self.y[0], xlabel=self.xlab,
+        specf = utils.savespec(self.spec_fname, self.x, self.y[0], xlabel=self.xlab,
                          ylabel=self.ylabs[0], fmt=["%d", "%.2f"],
                          close_file=False)
 
         # second savespec: save y[1] as scan 2, close file
-        savespec(specf, self.x, self.y[1], xlabel=self.xlab,
+        utils.savespec(specf, self.x, self.y[1], xlabel=self.xlab,
                  ylabel=self.ylabs[1], fmt=["%d", "%.2f"],
                  write_file_header=False, close_file=True,
                  scan_number=2)
@@ -166,7 +166,7 @@ class TestSave(unittest.TestCase):
 
     def test_save_spec(self):
         """Save SpecFile using save()"""
-        save1D(self.spec_fname, self.x, self.y, xlabel=self.xlab,
+        utils.save1D(self.spec_fname, self.x, self.y, xlabel=self.xlab,
                ylabels=self.ylabs, filetype="spec", fmt=["%d", "%.2f"])
 
         specf = open(self.spec_fname)
@@ -178,7 +178,7 @@ class TestSave(unittest.TestCase):
         """Save csv using save(), with autoheader=True but
         xlabel=None and ylabels=None
         This is a non-regression test for bug #223"""
-        save1D(self.csv_fname, self.x, self.y,
+        utils.save1D(self.csv_fname, self.x, self.y,
                autoheader=True, fmt=["%d", "%.2f", "%.2e"])
 
         csvf = open(self.csv_fname)
@@ -260,7 +260,7 @@ class TestLoad(unittest.TestCase):
         h5.close()
 
         # load it
-        f = load(tmp.name)
+        f = utils.load(tmp.name)
         self.assertIsNotNone(f)
         self.assertIsInstance(f, h5py.File)
 
@@ -272,7 +272,7 @@ class TestLoad(unittest.TestCase):
                        fmt=["%d", "%.2f"], close_file=True, scan_number=1)
 
         # load it
-        f = load(tmp.name)
+        f = utils.load(tmp.name)
         self.assertIsNotNone(f)
         self.assertEquals(f.h5py_class, h5py.File)
 
@@ -283,11 +283,11 @@ class TestLoad(unittest.TestCase):
         tmp.close()
 
         # load it
-        self.assertRaises(IOError, load, tmp.name)
+        self.assertRaises(IOError, utils.load, tmp.name)
 
     def testNotExists(self):
         # load it
-        self.assertRaises(IOError, load, "#$.")
+        self.assertRaises(IOError, utils.load, "#$.")
 
 
 def suite():

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -41,7 +41,7 @@ else:
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "15/09/2016"
+__date__ = "27/09/2016"
 
 
 logger = logging.getLogger(__name__)
@@ -159,7 +159,7 @@ def save1D(fname, x, y, xlabel=None, ylabels=None, filetype=None,
         # Other curves
         for i in range(1, y_array.shape[0]):
             specf = savespec(specf, x, y_array[i], xlabel, ylabels[i],
-                             fmt=fmt, scan_number=i+1, mode="w",
+                             fmt=fmt, scan_number=i + 1, mode="w",
                              write_file_header=False, close_file=False)
         # close file if we created it
         if not hasattr(fname, "write"):
@@ -360,3 +360,33 @@ def h5ls(h5group, lvl=0):
         h5f.close()
 
     return h5repr
+
+
+def load(filename):
+    """
+    Load a file as an `h5py.File`-like object.
+
+    Format supported:
+    - h5 files, if `h5py` module is installed
+    - Spec files if `SpecFile` module is installed
+
+    :param str filename: A filename
+    :raises: IOError if the file can't be loaded as an h5py.File like object
+    :rtype: h5py.File
+    """
+    if not os.path.isfile(filename):
+        raise IOError("Filename '%s' must be a file path" % filename)
+
+    if not h5py_missing:
+        if h5py.is_hdf5(filename):
+            return h5py.File(filename)
+
+    try:
+        from . import spech5
+        return spech5.SpecH5(filename)
+    except ImportError:
+        logger.debug("spech5 can't be loaded.", exc_info=True)
+    except IOError:
+        logger.debug("File '%s' can't be read as spec file.", filename, exc_info=True)
+
+    raise IOError("File '%s' can't be read as HDF5" % filename)


### PR DESCRIPTION
Provide a generic loading API for HDF5-like files. It supports h5 files and spec files.

- Create `load` API
- Create `h5py_class` method to flag mimicked objects with the referenced class
