### PR TITLE
[Plot] Fix pan with arrow keys disabled at start-up.

### DIFF
--- a/silx/gui/plot/ImageView.py
+++ b/silx/gui/plot/ImageView.py
@@ -955,6 +955,7 @@ def main(argv=None):
         mainWindow.addToolBar(multiFrameToolbar)
 
     mainWindow.show()
+    mainWindow.setFocus(qt.Qt.OtherFocusReason)
 
     return app.exec_()
 

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -152,6 +152,9 @@ class PlotWidget(qt.QMainWindow, Plot.Plot):
         else:
             _logger.warning("Plot backend does not support widget")
 
+        self.setFocusPolicy(qt.Qt.StrongFocus)
+        self.setFocus(qt.Qt.OtherFocusReason)
+
     def notify(self, event, **kwargs):
         """Override :meth:`Plot.notify` to send Qt signals."""
         eventDict = kwargs.copy()


### PR DESCRIPTION
Closes #291 
setFocus in `__init__` and in `main()` of ImageView.