### PR TITLE
Fix errors in SIFT tests

### DIFF
--- a/silx/image/sift/test/test_gaussian.py
+++ b/silx/image/sift/test/test_gaussian.py
@@ -121,7 +121,7 @@ class TestGaussian(unittest.TestCase):
         """
         Calculate a 1D gaussian using pyopencl.
         This is the same as scipy.signal.gaussian
-    
+
         :param sigma: width of the gaussian
         :param size: can be calculated as 1 + 2 * 4sigma
         """
@@ -133,7 +133,7 @@ class TestGaussian(unittest.TestCase):
                                                   g_gpu.data,  # __global     float     *data,
                                                   numpy.float32(sigma),  # const        float     sigma,
                                                   numpy.int32(size))  # const        int     SIZE
-        sum_data = pyopencl.array.sum(g_gpu, dtype=numpy.float32, queue=cls.queue)
+        sum_data = pyopencl.array.sum(g_gpu, dtype=numpy.dtype(numpy.float32), queue=cls.queue)
         evt2 = cls.kernels["preprocess"].divide_cst(cls.queue, (size,), (1,),
                                                     g_gpu.data,  # __global     float     *data,
                                                     sum_data.data,  # const        float     sigma,
@@ -150,7 +150,7 @@ class TestGaussian(unittest.TestCase):
         Calculate a 1D gaussian using pyopencl.
         This is the same as scipy.signal.gaussian.
         Only one kernel to
-    
+
         :param sigma: width of the gaussian
         :param size: can be calculated as 1 + 2 * 4sigma
         """

--- a/silx/image/sift/test/test_matching.py
+++ b/silx/image/sift/test/test_matching.py
@@ -47,6 +47,11 @@ except ImportError:
     scipy = None
 else:
     import scipy.misc, scipy.ndimage
+try:
+    import feature
+except:
+    feature = None
+
 
 # for Python implementation of tested functions
 # from test_image_functions import
@@ -99,6 +104,7 @@ class TestMatching(unittest.TestCase):
         self.mat = None
         self.program = None
 
+    @unittest.skipIf(feature is None, "no feature module")
     def test_matching(self):
         '''
         tests keypoints matching kernel

--- a/silx/image/sift/test/test_matching.py
+++ b/silx/image/sift/test/test_matching.py
@@ -47,10 +47,6 @@ except ImportError:
     scipy = None
 else:
     import scipy.misc, scipy.ndimage
-try:
-    import feature
-except:
-    feature = None
 
 
 # for Python implementation of tested functions
@@ -104,7 +100,6 @@ class TestMatching(unittest.TestCase):
         self.mat = None
         self.program = None
 
-    @unittest.skipIf(feature is None, "no feature module")
     def test_matching(self):
         '''
         tests keypoints matching kernel

--- a/silx/image/sift/utils.py
+++ b/silx/image/sift/utils.py
@@ -94,6 +94,22 @@ def matching_correction(matching):
     '''
     N = matching.shape[0]
     # solving normals equations for least square fit
+    #
+    # We correct for linear transformations, mapping points (x, y)
+    # to points (x', y') :
+    #
+    #   x' = a*x + b*y + c
+    #   y' = d*x + e*y + f
+    #
+    # where the parameters a, ..., f  determine the linear transformation.
+    # The equivalent matrix form is
+    #
+    #   x1  y1  1   0   0   0           a       x1'
+    #   0   0   0   x1  y1  1           b       y1'
+    #   x2  y2  1   0   0   0     x     c   =   x2'
+    #   0   0   0   x2  y2  1           d       y2'
+    #       . . . . . .                 e       .
+    #                                   f       .
     X = numpy.zeros((2 * N, 6))
     X[::2, 2:] = 1, 0, 0, 0
     X[::2, 0] = matching.x[:, 0]
@@ -105,10 +121,13 @@ def matching_correction(matching):
     y = numpy.zeros((2 * N, 1))
     y[::2, 0] = matching.x[:, 1]
     y[1::2, 0] = matching.y[:, 1]
-    A = numpy.dot(X.transpose(), X)
-    sol = numpy.dot(numpy.linalg.inv(A), numpy.dot(X.transpose(), y))
-#    sol = numpy.dot(numpy.linalg.pinv(X),y) #pseudo-inverse is slower
-#    MSE = numpy.linalg.norm(y - numpy.dot(X,sol))**2/N #Mean Squared Error, if needed
+
+    # A = numpy.dot(X.transpose(), X)
+    # sol = numpy.dot(numpy.linalg.inv(A), numpy.dot(X.transpose(), y))
+    # sol = numpy.dot(numpy.linalg.pinv(X),y) #pseudo-inverse is slower but numerically stable
+    # MSE = numpy.linalg.norm(y - numpy.dot(X,sol))**2/N #Mean Squared Error, if needed
+
+    sol, sqmse, rnk, svals = numpy.linalg.lstsq(X, y)
     return sol
 
 


### PR DESCRIPTION
This PR fixes two errors with the sift tests:
- Fix error with array.sum() for new versions of pyopencl
- Do not perform test_matching if there is no "feature" module

Also, another (equivalent but more numerically stable) least squares routine is used for the linear alignment.
