### PR TITLE
[Plot] plot widgets have parent=None first + addImage origin and scale support float

### DIFF
--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -78,10 +78,10 @@ _logger = logging.getLogger(__name__)
 class _FloatEdit(qt.QLineEdit):
     """Field to edit a float value.
 
-    :param float value: The value to set the QLineEdit to.
     :param parent: See :class:`QLineEdit`
+    :param float value: The value to set the QLineEdit to.
     """
-    def __init__(self, value=None, parent=None):
+    def __init__(self, parent=None, value=None):
         qt.QLineEdit.__init__(self, parent)
         self.setValidator(qt.QDoubleValidator())
         self.setAlignment(qt.Qt.AlignRight)
@@ -103,8 +103,8 @@ class _FloatEdit(qt.QLineEdit):
 class ColormapDialog(qt.QDialog):
     """A QDialog widget to set the colormap.
 
-    :param str title: The QDialog title
     :param parent: See :class:`QDialog`
+    :param str title: The QDialog title
     """
 
     sigColormapChanged = qt.Signal(dict)
@@ -114,7 +114,7 @@ class ColormapDialog(qt.QDialog):
     This dict can be used with :class:`Plot`.
     """
 
-    def __init__(self, title="Colormap Dialog", parent=None):
+    def __init__(self, parent=None, title="Colormap Dialog"):
         qt.QDialog.__init__(self, parent)
         self.setWindowTitle(title)
 
@@ -172,14 +172,14 @@ class ColormapDialog(qt.QDialog):
         formLayout.addRow('Range:', self._rangeAutoscaleButton)
 
         # Min row
-        self._minValue = _FloatEdit(1.)
+        self._minValue = _FloatEdit(value=1.)
         self._minValue.setEnabled(False)
         self._minValue.textEdited.connect(self._minMaxTextEdited)
         self._minValue.editingFinished.connect(self._minEditingFinished)
         formLayout.addRow('\tMin:', self._minValue)
 
         # Max row
-        self._maxValue = _FloatEdit(10.)
+        self._maxValue = _FloatEdit(value=10.)
         self._maxValue.setEnabled(False)
         self._maxValue.textEdited.connect(self._minMaxTextEdited)
         self._maxValue.editingFinished.connect(self._maxEditingFinished)

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -499,13 +499,13 @@ class CurvesROIDockWidget(qt.QDockWidget):
 
     It makes the link between the CurvesROIWidget and the PlotWindow.
 
+    :param parent: See :class:`QDockWidget`
     :param plot: :class:`.PlotWindow` instance on which to operate
     :param name: See :class:`QDockWidget`
-    :param parent: See :class:`QDockWidget`
     """
     sigROISignal = qt.Signal(object)
 
-    def __init__(self, plot, name=None, parent=None):
+    def __init__(self, parent=None, plot=None, name=None):
         super(CurvesROIDockWidget, self).__init__(name, parent)
 
         assert plot is not None

--- a/silx/gui/plot/ImageView.py
+++ b/silx/gui/plot/ImageView.py
@@ -298,7 +298,7 @@ class ImageView(PlotWindow):
 
         self._initWidgets(backend)
 
-        self.profile = ProfileToolBar(self)
+        self.profile = ProfileToolBar(plot=self)
         """"Profile tools attached to this plot.
 
         See :class:`silx.gui.plot.PlotTools.ProfileToolBar`
@@ -800,7 +800,7 @@ class ImageViewMainWindow(ImageView):
         self.setGraphTitle('Image')
 
         # Add toolbars and status bar
-        self.addToolBar(qt.Qt.BottomToolBarArea, LimitsToolBar(self))
+        self.addToolBar(qt.Qt.BottomToolBarArea, LimitsToolBar(plot=self))
 
         self.statusBar()
 

--- a/silx/gui/plot/LegendSelector.py
+++ b/silx/gui/plot/LegendSelector.py
@@ -934,11 +934,11 @@ class LegendsDockWidget(qt.QDockWidget):
 
     It makes the link between the LegendListView widget and the PlotWindow.
 
-    :param plot: :class:`.PlotWindow` instance on which to operate
     :param parent: See :class:`QDockWidget`
+    :param plot: :class:`.PlotWindow` instance on which to operate
     """
 
-    def __init__(self, plot, parent=None):
+    def __init__(self, parent=None, plot=None):
         assert plot is not None
         self._plotRef = weakref.ref(plot)
         self._isConnected = False  # True if widget connected to plot signals

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -326,7 +326,7 @@ class MaskToolsWidget(qt.QWidget):
 
     _maxLevelNumber = 255
 
-    def __init__(self, plot, parent=None):
+    def __init__(self, parent=None, plot=None):
         self._defaultColors = numpy.ones((self._maxLevelNumber+1), dtype=numpy.bool)  # register if the user as force a color for the corresponding mask level
         self._overlayColors = numpy.zeros((self._maxLevelNumber+1, 3), dtype=numpy.float32)  # overlays colors setted by the user
 
@@ -1254,17 +1254,17 @@ class MaskToolsDockWidget(qt.QDockWidget):
 
     For integration in a :class:`PlotWindow`.
 
+    :param parent: See :class:`QDockWidget`
     :param plot: The PlotWidget this widget is operating on
     :paran str name: The title of this widget
-    :param parent: See :class:`QDockWidget`
     """
 
-    def __init__(self, plot, name='Mask', parent=None):
+    def __init__(self, parent=None, plot=None, name='Mask'):
         super(MaskToolsDockWidget, self).__init__(parent)
         self.setWindowTitle(name)
 
         self.layout().setContentsMargins(0, 0, 0, 0)
-        self.setWidget(MaskToolsWidget(plot))
+        self.setWidget(MaskToolsWidget(plot=plot))
         self.dockLocationChanged.connect(self._dockLocationChanged)
         self.topLevelChanged.connect(self._topLevelChanged)
 

--- a/silx/gui/plot/Plot.py
+++ b/silx/gui/plot/Plot.py
@@ -198,7 +198,7 @@ __license__ = "MIT"
 __date__ = "23/02/2016"
 
 
-from collections import OrderedDict, namedtuple
+from collections import Iterable, OrderedDict, namedtuple
 import logging
 
 import numpy
@@ -706,11 +706,15 @@ class Plot(object):
         :param str ylabel: Y axis label to show when this curve is active,
                            or None to keep default axis label.
         :param origin: (origin X, origin Y) of the data.
+                       It is possible to pass a single float if both
+                       coordinates are equal.
                        Default: (0., 0.)
-        :type origin: 2-tuple of float
+        :type origin: float or 2-tuple of float
         :param scale: (scale X, scale Y) of the data.
-                       Default: (1., 1.)
-        :type scale: 2-tuple of float
+                      It is possible to pass a single float if both
+                      coordinates are equal.
+                      Default: (1., 1.)
+        :type scale: float or 2-tuple of float
         :param bool resetzoom: True (the default) to reset the zoom.
         :returns: The key string identify this image
         """
@@ -743,10 +747,16 @@ class Plot(object):
         data = numpy.asarray(data)
 
         if origin is not None:
-            origin = float(origin[0]), float(origin[1])
+            if isinstance(origin, Iterable):
+                origin = float(origin[0]), float(origin[1])
+            else:  # single value origin
+                origin = float(origin), float(origin)
 
         if scale is not None:
-            scale = float(scale[0]), float(scale[1])
+            if isinstance(scale, Iterable):
+                scale = float(scale[0]), float(scale[1])
+            else:  # single value scale
+                scale = float(scale), float(scale)
 
         if z is not None:
             z = int(z)

--- a/silx/gui/plot/PlotTools.py
+++ b/silx/gui/plot/PlotTools.py
@@ -78,7 +78,7 @@ class PositionInfo(qt.QWidget):
     >>> import numpy
     >>> from silx.gui.plot.PlotTools import PositionInfo
 
-    >>> position = PositionInfo(plot, converters=[
+    >>> position = PositionInfo(plot=plot, converters=[
     ...     ('Radius', lambda x, y: numpy.sqrt(x*x + y*y)),
     ...     ('Angle', lambda x, y: numpy.degrees(numpy.arctan2(y, x)))])
 
@@ -95,7 +95,8 @@ class PositionInfo(qt.QWidget):
     :param parent: Parent widget
     """
 
-    def __init__(self, plot, converters=None, parent=None):
+    def __init__(self, parent=None, plot=None, converters=None):
+        assert plot is not None
         self._plotRef = weakref.ref(plot)
 
         super(PositionInfo, self).__init__(parent)
@@ -210,9 +211,9 @@ class PositionInfo(qt.QWidget):
 class LimitsToolBar(qt.QToolBar):
     """QToolBar displaying and controlling the limits of a :class:`PlotWidget`.
 
+    :param parent: See :class:`QToolBar`.
     :param plot: :class:`PlotWidget` instance on which to operate.
     :param str title: See :class:`QToolBar`.
-    :param parent: See :class:`QToolBar`.
     """
 
     class _FloatEdit(qt.QLineEdit):
@@ -231,7 +232,7 @@ class LimitsToolBar(qt.QToolBar):
         def setValue(self, value):
             self.setText('%g' % value)
 
-    def __init__(self, plot, title='Limits', parent=None):
+    def __init__(self, parent=None, plot=None, title='Limits'):
         super(LimitsToolBar, self).__init__(title, parent)
         assert plot is not None
         self._plot = plot
@@ -321,7 +322,7 @@ class ProfileToolBar(qt.QToolBar):
     >>> from silx.gui import qt
 
     >>> plot = PlotWindow()  # Create a PlotWindow
-    >>> toolBar = ProfileToolBar(plot)  # Create a profile toolbar for the plot
+    >>> toolBar = ProfileToolBar(plot=plot)  # Create a profile toolbar
     >>> plot.addToolBar(toolBar)  # Add it to plot
     >>> plot.show()  # To display the PlotWindow with the profile toolbar
 
@@ -335,8 +336,8 @@ class ProfileToolBar(qt.QToolBar):
 
     _POLYGON_LEGEND = '__ProfileToolBar_ROI_Polygon'
 
-    def __init__(self, plot, profileWindow=None,
-                 title='Profile Selection', parent=None):
+    def __init__(self, parent=None, plot=None, profileWindow=None,
+                 title='Profile Selection'):
         super(ProfileToolBar, self).__init__(title, parent)
         assert plot is not None
         self.plot = plot

--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -205,7 +205,8 @@ class PlotWindow(PlotWidget):
                     converters = position
                 else:
                     converters = None
-                self.positionWidget = PositionInfo(self, converters=converters)
+                self.positionWidget = PositionInfo(
+                    plot=self, converters=converters)
                 self.positionWidget.autoSnapToActiveCurve = True
 
                 hbox.addWidget(self.positionWidget)
@@ -230,7 +231,7 @@ class PlotWindow(PlotWidget):
     def legendsDockWidget(self):
         """DockWidget with Legend panel (lazy-loaded)."""
         if not hasattr(self, '_legendsDockWidget'):
-            self._legendsDockWidget = LegendsDockWidget(self)
+            self._legendsDockWidget = LegendsDockWidget(plot=self)
             self._legendsDockWidget.hide()
             self._introduceNewDockWidget(self._legendsDockWidget)
         return self._legendsDockWidget
@@ -240,7 +241,7 @@ class PlotWindow(PlotWidget):
         """DockWidget with curves' ROI panel (lazy-loaded)."""
         if not hasattr(self, '_curvesROIDockWidget'):
             self._curvesROIDockWidget = CurvesROIDockWidget(
-                self, name='Regions Of Interest')
+                plot=self, name='Regions Of Interest')
             self._curvesROIDockWidget.hide()
             self._introduceNewDockWidget(self._curvesROIDockWidget)
         return self._curvesROIDockWidget
@@ -254,7 +255,8 @@ class PlotWindow(PlotWidget):
     def maskToolsDockWidget(self):
         """DockWidget with image mask panel (lazy-loaded)."""
         if not hasattr(self, '_maskToolsDockWidget'):
-            self._maskToolsDockWidget = MaskToolsDockWidget(self, name='Mask')
+            self._maskToolsDockWidget = MaskToolsDockWidget(
+                plot=self, name='Mask')
             self._maskToolsDockWidget.hide()
             self._introduceNewDockWidget(self._maskToolsDockWidget)
         return self._maskToolsDockWidget
@@ -433,7 +435,7 @@ class Plot2D(PlotWindow):
         self.setGraphXLabel('Columns')
         self.setGraphYLabel('Rows')
 
-        self.profile = ProfileToolBar(self)
+        self.profile = ProfileToolBar(plot=self)
         """"Profile tools attached to this plot.
 
         See :class:`silx.gui.plot.PlotTools.ProfileToolBar`

--- a/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/silx/gui/plot/test/testCurvesROIWidget.py
@@ -54,7 +54,7 @@ class TestCurvesROIWidget(TestCaseQt):
         self.plot.show()
         self.qWaitForWindowExposed(self.plot)
 
-        self.widget = CurvesROIWidget.CurvesROIDockWidget(self.plot, 'TEST')
+        self.widget = CurvesROIWidget.CurvesROIDockWidget(plot=self.plot, name='TEST')
         self.widget.show()
         self.qWaitForWindowExposed(self.widget)
 

--- a/silx/gui/plot/test/testMaskToolsWidget.py
+++ b/silx/gui/plot/test/testMaskToolsWidget.py
@@ -52,7 +52,7 @@ class TestMaskToolsWidget(TestCaseQt):
         super(TestMaskToolsWidget, self).setUp()
         self.plot = PlotWindow()
 
-        self.widget = MaskToolsWidget.MaskToolsDockWidget(self.plot, 'TEST')
+        self.widget = MaskToolsWidget.MaskToolsDockWidget(plot=self.plot, name='TEST')
         self.plot.addDockWidget(qt.Qt.BottomDockWidgetArea, self.widget)
 
         self.plot.show()

--- a/silx/gui/plot/test/testPlotTools.py
+++ b/silx/gui/plot/test/testPlotTools.py
@@ -110,12 +110,13 @@ class TestPositionInfo(TestCaseQt):
 
     def testDefaultConverters(self):
         """Test PositionInfo with default converters"""
-        positionWidget = PlotTools.PositionInfo(self.plot)
+        positionWidget = PlotTools.PositionInfo(plot=self.plot)
         self._test(positionWidget, ('X', 'Y'))
 
     def testCustomConverters(self):
         """Test PositionInfo with custom converters"""
-        positionWidget = PlotTools.PositionInfo(self.plot, converters=[
+        positionWidget = PlotTools.PositionInfo(plot=self.plot,
+                                                converters=[
             ('Coords', lambda x, y: (int(x), int(y))),
             ('Radius', lambda x, y: numpy.sqrt(x * x + y * y)),
             ('Angle', lambda x, y: numpy.degrees(numpy.arctan2(y, x)))])
@@ -127,7 +128,8 @@ class TestPositionInfo(TestCaseQt):
             raise RuntimeError()
 
         positionWidget = PlotTools.PositionInfo(
-            self.plot, converters=[('Exception', raiseException)])
+            plot=self.plot,
+            converters=[('Exception', raiseException)])
         self._test(positionWidget, ['Exception'], error=2)
 
 

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -120,7 +120,7 @@ class TestPlotWidget(_PlotWidgetTest):
         checkLimits(expectedYLim=(1., 10.), expectedRatio=defaultRatio)
 
 
-class TestPlotImage(_PlotWidgetTest):
+class TestPlotImage(_PlotWidgetTest, ParametricTestCase):
     """Basic tests for addImage"""
 
     def setUp(self):
@@ -196,6 +196,46 @@ class TestPlotImage(_PlotWidgetTest):
                            origin=(DATA_2D.shape[0], 0),
                            replace=False, resetzoom=False)
         self.plot.resetZoom()
+
+    def testImageOriginScale(self):
+        """Test of image with different origin and scale"""
+        self.plot.setGraphTitle('origin and scale')
+
+        tests = [  # (origin, scale)
+            ((10, 20), (1, 1)),
+            ((10, 20), (-1, -1)),
+            ((-10, 20), (2, 1)),
+            ((10, -20), (-1, -2)),
+            (100, 2),
+            (-100, (1, 1)),
+            ((10, 20), 2),
+            ]
+
+        for origin, scale in tests:
+            with self.subTest(origin=origin, scale=scale):
+                self.plot.addImage(DATA_2D, origin=origin, scale=scale)
+                xmin, xmax = self.plot.getGraphXLimits()
+                ymin, ymax = self.plot.getGraphYLimits()
+
+                try:
+                    ox, oy = origin
+                except TypeError:
+                    ox, oy = origin, origin
+                try:
+                    sx, sy = scale
+                except TypeError:
+                    sx, sy = scale, scale
+
+                xbounds = ox, ox + DATA_2D.shape[1] * sx
+                self.assertEqual(xmin, min(xbounds))
+                self.assertEqual(xmax, max(xbounds))
+
+                ybounds = oy, oy + DATA_2D.shape[0] * sy
+                self.assertEqual(ymin, min(ybounds))
+                self.assertEqual(ymax, max(ybounds))
+
+                self.plot.clear()
+                self.plot.resetZoom()
 
 
 class TestPlotCurve(_PlotWidgetTest):


### PR DESCRIPTION
This PR:
- Changes parameter order of plot widgets arguments to have parent first: Related to #280 
- Adds support of single float value for addImage origin and scale arguments: Closes #290 