### PR TITLE
[Plot] Fix addMarker + change text position if symbol is None

### DIFF
--- a/silx/gui/plot/BackendMatplotlib.py
+++ b/silx/gui/plot/BackendMatplotlib.py
@@ -453,7 +453,6 @@ class BackendMatplotlib(BackendBase.BackendBase):
                   symbol, constraint, overlay):
         legend = "__MARKER__" + legend
 
-        # TODO issues with text placement when changing limits..
         if x is not None and y is not None:
             line = self.ax.plot(x, y, label=legend,
                                 linestyle=" ",
@@ -464,12 +463,18 @@ class BackendMatplotlib(BackendBase.BackendBase):
             if text is not None:
                 xtmp, ytmp = self.ax.transData.transform_point((x, y))
                 inv = self.ax.transData.inverted()
-                xtmp, ytmp = inv.transform_point((xtmp, ytmp + 15))
-                text = " " + text
+                xtmp, ytmp = inv.transform_point((xtmp, ytmp))
+
+                if symbol is None:
+                    valign = 'baseline'
+                else:
+                    valign = 'top'
+                    text = "  " + text
+
                 line._infoText = self.ax.text(x, ytmp, text,
                                               color=color,
                                               horizontalalignment='left',
-                                              verticalalignment='top')
+                                              verticalalignment=valign)
 
         elif x is not None:
             line = self.ax.axvline(x, label=legend, color=color)

--- a/silx/gui/plot/Plot.py
+++ b/silx/gui/plot/Plot.py
@@ -1068,7 +1068,7 @@ class Plot(object):
         See :meth:`addMarker` for argument documentation.
         """
         if legend is None:
-            legend = "Unnamed Marker"
+            legend = "Unnamed Marker 0"
             i = 1
             while legend in self._markers:
                 legend = "Unnamed Marker %d" % i

--- a/silx/gui/plot/Plot.py
+++ b/silx/gui/plot/Plot.py
@@ -1068,7 +1068,8 @@ class Plot(object):
         See :meth:`addMarker` for argument documentation.
         """
         if legend is None:
-            i = 0
+            legend = "Unnamed Marker"
+            i = 1
             while legend in self._markers:
                 legend = "Unnamed Marker %d" % i
                 i += 1

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -329,6 +329,24 @@ class TestPlotMarker(_PlotWidgetTest):
 
         self.plot.resetZoom()
 
+    def testPlotMarkerWithoutLegend(self):
+        self.plot.setGraphTitle('Markers without legend')
+        self.plot.setYAxisInverted(True)
+
+        # Markers without legend
+        self.plot.addMarker(10, 10)
+        self.plot.addMarker(10, 20)
+        self.plot.addMarker(40, 50, text='test', symbol=None)
+        self.plot.addMarker(40, 50, text='test', symbol='+')
+        self.plot.addXMarker(25)
+        self.plot.addXMarker(35)
+        self.plot.addXMarker(45, text='test')
+        self.plot.addYMarker(55)
+        self.plot.addYMarker(65)
+        self.plot.addYMarker(75, text='test')
+
+        self.plot.resetZoom()
+
 
 # TestPlotItem ################################################################
 


### PR DESCRIPTION
This PR updates and fix plot addMarker method:

- When symbol is None the text is placed at the x,y position, closes #282
- Fix marker text placement incorrect when zooming
- Fix bug when legend was not provided