### PR TITLE
[Plot] Add default argument for getCurve and getImage

### DIFF
--- a/silx/gui/plot/Plot.py
+++ b/silx/gui/plot/Plot.py
@@ -1702,36 +1702,61 @@ class Plot(object):
                                curve['params']['info'] or {}, curve['params']))
         return output
 
-    def getCurve(self, legend):
-        """Return the data and info of a specific curve.
+    def getCurve(self, legend=None):
+        """Get the data and info of a specific curve.
 
-        It returns None in case of not having the curve.
+        It returns None in case no matching curve is found.
 
         Warning: Returned values MUST not be modified.
         Make a copy if you need to modify them.
 
-        :param str legend: legend associated to the curve
+        :param str legend:
+            The legend identifying the curve.
+            If not provided or None (the default), the active curve is returned
+            or if there is no active curve, the lastest updated curve that is
+            not hidden.
+            is returned if there are curves in the plot.
         :return: None or list [x, y, legend, parameters]
         """
-        if legend in self._curves:
+        if legend is None:
+            legend = self.getActiveCurve(just_legend=True)
+            if legend is None and self._curves:
+                # There is no active curve, but there is some curves:
+                # get one that is not hidden
+                for curveLegend in reversed(list(self._curves.keys())):
+                    if curveLegend not in self._hiddenCurves:
+                        legend = curveLegend
+                        break
+
+        if legend is not None and legend in self._curves:
             curve = self._curves[legend]
             return (curve['x'], curve['y'], legend,
                     curve['params']['info'] or {}, curve['params'])
         else:
             return None
 
-    def getImage(self, legend):
-        """Return the data and info of a specific image.
+    def getImage(self, legend=None):
+        """Get the data and info of a specific image.
 
-        It returns None in case of not having an active curve.
+        It returns None in case no matching image is found.
 
         Warning: Returned values MUST not be modified.
         Make a copy if you need to modify them.
 
-        :param str legend: legend associated to the curve
+        :param str legend:
+            The legend identifying the image.
+            If not provided or None (the default), the active image is returned
+            or if there is no active image, the lastest updated image
+            is returned if there are images in the plot.
         :return: None or list [image, legend, info, pixmap, params]
         """
-        if legend in self._images:
+        if legend is None:
+            legend = self.getActiveImage(just_legend=True)
+            if legend is None and self._images:
+                # There is no active image, but there is some images: get one
+                legend = list(self._images.keys())[-1]
+
+        if legend is not None and legend in self._images:
             image = self._images[legend]
             return (image['data'], legend, image['params']['info'] or {},
                     image['pixmap'], image['params'])

--- a/silx/gui/plot/test/testPlot.py
+++ b/silx/gui/plot/test/testPlot.py
@@ -367,12 +367,86 @@ class TestPlotRanges(ParametricTestCase):
                 self.assertIsNone(dataRange.yright)
 
 
+class TestPlotGetCurveImage(unittest.TestCase):
+    """Test of plot getCurve and getImage methods"""
+
+    def testGetCurve(self):
+        """Plot.getCurve and Plot.getActiveCurve tests"""
+
+        plot = Plot(backend='none')
+
+        # No curve
+        curve = plot.getCurve()
+        self.assertIsNone(curve)  # No curve
+
+        plot.setActiveCurveHandling(True)
+        plot.addCurve(x=(0, 1), y=(0, 1), legend='curve 0')
+        plot.addCurve(x=(0, 1), y=(0, 1), legend='curve 1')
+        plot.addCurve(x=(0, 1), y=(0, 1), legend='curve 2')
+
+        # Active curve
+        active = plot.getActiveCurve()
+        self.assertEqual(active[2], 'curve 0')  # Test curve legend
+        curve = plot.getCurve()
+        self.assertEqual(curve[2], 'curve 0')  # Test curve legend
+
+        # No active curve and curves
+        plot.setActiveCurveHandling(False)
+        active = plot.getActiveCurve()
+        self.assertIsNone(active)  # No active curve
+        curve = plot.getCurve()
+        self.assertEqual(curve[2], 'curve 2')  # Last added curve
+
+        # Last curve hidden
+        plot.hideCurve('curve 2', True)
+        curve = plot.getCurve()
+        self.assertEqual(curve[2], 'curve 1')  # Last added curve
+
+        # All curves hidden
+        plot.hideCurve('curve 1', True)
+        plot.hideCurve('curve 0', True)
+        curve = plot.getCurve()
+        self.assertIsNone(curve)
+
+    def testGetImage(self):
+        """Plot.getImage and Plot.getActiveImage tests"""
+
+        plot = Plot(backend='none')
+
+        # No image
+        image = plot.getImage()
+        self.assertIsNone(image)
+
+        plot.addImage(((0, 1), (2, 3)), legend='image 0', replace=False)
+        plot.addImage(((0, 1), (2, 3)), legend='image 1', replace=False)
+
+        # Active image
+        active = plot.getActiveImage()
+        self.assertEqual(active[1], 'image 0')  # Test image legend
+        image = plot.getImage()
+        self.assertEqual(image[1], 'image 0')  # Test image legend
+
+        # No active image
+        plot.addImage(((0, 1), (2, 3)), legend='image 2', replace=False)
+        plot.setActiveImage(None)
+        active = plot.getActiveImage()
+        self.assertIsNone(active)
+        image = plot.getImage()
+        self.assertEqual(image[1], 'image 2')  # Test image legend
+
+        # Active image
+        plot.setActiveImage('image 1')
+        active = plot.getActiveImage()
+        self.assertEqual(active[1], 'image 1')
+        image = plot.getImage()
+        self.assertEqual(image[1], 'image 1')  # Test image legend
+
+
 def suite():
     test_suite = unittest.TestSuite()
-    test_suite.addTest(
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestPlot))
-    test_suite.addTest(
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestPlotRanges))
+    for TestClass in (TestPlot, TestPlotRanges, TestPlotGetCurveImage):
+        test_suite.addTest(
+            unittest.defaultTestLoader.loadTestsFromTestCase(TestClass))
     return test_suite
 
 


### PR DESCRIPTION
This PR adds possibility to call getCurve and getImage withou argument, which returns the active curve|image if available, else the last updated (and visible) curve|image.
It adds a few tests for getCurve, getActiveCurve, getImage, getActiveImage
Closes #244