### PR TITLE
Delete temporary pyc files created during import in tests

### DIFF
--- a/silx/math/fit/test/test_fitmanager.py
+++ b/silx/math/fit/test/test_fitmanager.py
@@ -181,6 +181,9 @@ class TestFitmanager(unittest.TestCase):
             fd.write(custom_function_definition)
             fd.close()
             fit.loadtheories(tmpfile)
+            tmpfile_pyc = os.path.exists(os.path.join(tmpDir, 'customfun.pyc'))
+            if os.path.exists(tmpfile_pyc):
+                os.unlink(tmpfile_pyc)
             os.unlink(tmpfile)
 
         fit.settheory('my fit theory')
@@ -225,6 +228,9 @@ class TestFitmanager(unittest.TestCase):
             fd.write(old_custom_function_definition)
             fd.close()
             fit.loadtheories(tmpfile)
+            tmpfile_pyc = os.path.exists(os.path.join(tmpDir, 'oldcustomfun.pyc'))
+            if os.path.exists(tmpfile_pyc):
+                os.unlink(tmpfile_pyc)
             os.unlink(tmpfile)
 
         fit.settheory('my fit theory')

--- a/silx/math/fit/test/test_fitmanager.py
+++ b/silx/math/fit/test/test_fitmanager.py
@@ -181,7 +181,7 @@ class TestFitmanager(unittest.TestCase):
             fd.write(custom_function_definition)
             fd.close()
             fit.loadtheories(tmpfile)
-            tmpfile_pyc = os.path.exists(os.path.join(tmpDir, 'customfun.pyc'))
+            tmpfile_pyc = os.path.join(tmpDir, 'customfun.pyc')
             if os.path.exists(tmpfile_pyc):
                 os.unlink(tmpfile_pyc)
             os.unlink(tmpfile)
@@ -228,7 +228,7 @@ class TestFitmanager(unittest.TestCase):
             fd.write(old_custom_function_definition)
             fd.close()
             fit.loadtheories(tmpfile)
-            tmpfile_pyc = os.path.exists(os.path.join(tmpDir, 'oldcustomfun.pyc'))
+            tmpfile_pyc = os.path.join(tmpDir, 'oldcustomfun.pyc')
             if os.path.exists(tmpfile_pyc):
                 os.unlink(tmpfile_pyc)
             os.unlink(tmpfile)


### PR DESCRIPTION
Delete temporary pyc files automatically created during import in tests.