### PR TITLE
[spectoh5] Fix critical bug when writing SpecH5Dataset to HDF5

### DIFF
--- a/silx/io/spectoh5.py
+++ b/silx/io/spectoh5.py
@@ -160,9 +160,9 @@ def write_spec_to_h5(specfile, h5file, h5path='/',
             if overwrite_data or not member_initially_exists:
                 # fancy arguments don't apply to scalars (shape==())
                 if obj.shape == ():
-                    ds = h5f.create_dataset(h5_name, data=obj)
+                    ds = h5f.create_dataset(h5_name, data=obj.value)
                 else:
-                    ds = h5f.create_dataset(h5_name, data=obj,
+                    ds = h5f.create_dataset(h5_name, data=obj.value,
                                             **create_dataset_args)
             else:
                 ds = h5f[h5_name]

--- a/silx/io/test/test_spectoh5.py
+++ b/silx/io/test/test_spectoh5.py
@@ -41,7 +41,7 @@ else:
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "18/05/2016"
+__date__ = "05/10/2016"
 
 
 sftext = """#F /tmp/sf.dat
@@ -128,6 +128,14 @@ class TestConvertSpecHDF5(unittest.TestCase):
             array_equal(self.h5f["/1.2/measurement/mca_1/data"],
                         self.h5f["/foo/bar/spam/1.2/measurement/mca_1/data"])
         )
+
+    def testTitle(self):
+        """Test the value of a dataset"""
+        title12 = self.h5f["/1.2/title"].value
+        if sys.version > '3.0':
+            title12 = title12.decode()
+        self.assertEqual(title12,
+                         "1 aaaaaa")
 
     def testAttrs(self):
         # Test root group (file) attributes


### PR DESCRIPTION
Now that SpecH5Dataset is no longer a numpy array, we need to write the `.value` attribute to HDF5, and not the dataset itself.