### PR TITLE
[gui] Widget signature (parent=None as first param)

### DIFF
--- a/doc/source/Tutorials/fit.rst
+++ b/doc/source/Tutorials/fit.rst
@@ -1,4 +1,5 @@
 
+.. _fit-tutorial:
 
 Fit tools
 ---------
@@ -156,12 +157,10 @@ A third approach to improve our fit is to define uncertainties for the data.
 The larger the uncertainty on a data sample, the smaller its weight will be
 in the least-square problem.
 
-In our case, we don't have obvious uncertainties associated to our data, altough we could
-try to figure out the uncertainties due to numerical rounding errors by closely
-looking at how floating point values are stored.
-
-A common approach that requires less work is to use the square-root of the data values
-as their uncertainty value. Let's try it:
+In our case, we do not know the uncertainties associated to our data. We could
+determine the uncertainties due to numerical rounding errors, but let's just use
+a common approach that requires less work: use the square-root of the data values
+as their uncertainty value:
 
 .. code-block:: python
 
@@ -185,7 +184,7 @@ This results in a great improvement::
        a=2.400000, b=-10.000000, c=15.200000, d=-24.600000, e=150.000000
 
 The resulting fit is perfect. The very large ``y`` values with their very large
-associated uncertainties have been ignored, for all practical purposes. The fit
+associated uncertainties have been practicaly rejected from the fit process. The fit
 converged even faster than with the solution of limiting the ``x`` range to
 0 -- 100.
 
@@ -331,8 +330,9 @@ Pseudo-Voigt functions or hypermet tailing functions.
 
 The :meth:`loadtheories` method can also be used to load user defined
 functions. Instead of a module, a path to a Python source file can be given
-as a parameter. This source file must adhere to certain conventions, explained
-in the documentation of :mod:`silx.math.fit.fittheories`.
+as a parameter. This source file must adhere to certain conventions, as explained
+in the documentation of :mod:`silx.math.fit.fittheories` and
+:mod:`silx.math.fit.fittheory.FitTheory`.
 
 Subtracting a background
 ************************
@@ -455,8 +455,8 @@ performing a smoothing prior to the strip computation.
 See the `PyMca documentation <http://pymca.sourceforge.net/stripbackground.html>`_
 for more information on the strip background.
 
-To configure the strip background model of :class:`FitManager`, use :meth:`configure`
-to modify the following parameters:
+To configure the strip background model of :class:`FitManager`, use its :meth:`configure`
+method to modify the following parameters:
 
  - *StripWidth*: strip width parameter *w*, mentionned earlier
  - *StripNIterations*: number of iterations

--- a/doc/source/modules/gui/fit/index.rst
+++ b/doc/source/modules/gui/fit/index.rst
@@ -8,16 +8,16 @@
 
 Snapshot of the widgets:
 
-.. |imgFitWidget1| image:: ../../../Tutorials/img/fitwidget1.png
+.. |imgFitWidget4| image:: ../../../Tutorials/img/fitwidget4.png
    :height: 150px
    :align: middle
 
-.. |imgFitWidget2| image:: ../../../Tutorials/img/fitwidget2.png
+.. |imgFitWidget3| image:: ../../../Tutorials/img/fitwidget3.png
    :height: 150px
    :align: middle
 
 =================== ===================
-|imgFitWidget1|     |imgFitWidget2|
+|imgFitWidget4|     |imgFitWidget3|
 :class:`FitWidget`  Fit configuration
 =================== ===================
 

--- a/doc/source/modules/math/fit/index.rst
+++ b/doc/source/modules/math/fit/index.rst
@@ -19,4 +19,6 @@
 
 For a graphical fit widget, see :mod:`silx.gui.fit.FitWidget`.
 
+For a tutorial on using the various fit related modules, see :ref:`fit-tutorial` .
+
 

--- a/silx/gui/console.py
+++ b/silx/gui/console.py
@@ -138,7 +138,9 @@ class IPythonWidget(RichIPythonWidget):
        the console.
     """
 
-    def __init__(self, custom_banner=None, *args, **kwargs):
+    def __init__(self, parent=None, custom_banner=None, *args, **kwargs):
+        if parent is not None:
+            kwargs["parent"] = parent
         super(IPythonWidget, self).__init__(*args, **kwargs)
         if custom_banner is not None:
             self.banner = custom_banner
@@ -179,8 +181,8 @@ class IPythonDockWidget(qt.QDockWidget):
     :param parent: Parent :class:`qt.QMainWindow` containing this
         :class:`qt.QDockWidget`
     """
-    def __init__(self, available_vars=None, custom_banner=None,
-                 title="Console", parent=None):
+    def __init__(self, parent=None, available_vars=None, custom_banner=None,
+                 title="Console"):
         super(IPythonDockWidget, self).__init__(title, parent)
 
         self.ipyconsole = IPythonWidget(custom_banner=custom_banner)

--- a/silx/gui/fit/FitConfig.py
+++ b/silx/gui/fit/FitConfig.py
@@ -188,8 +188,9 @@ class ConstraintsPage(qt.QGroupBox):
     """Checkable QGroupBox widget filled with QCheckBox widgets,
     to configure the fit estimation for standard fit theories.
     """
-    def __init__(self, title="Set constraints", parent=None):
-        super(ConstraintsPage, self).__init__(title, parent)
+    def __init__(self, parent=None, title="Set constraints"):
+        super(ConstraintsPage, self).__init__(parent)
+        self.setTitle(title)
         self.setToolTip("Disable 'Set constraints' to remove all " +
                         "constraints on all fit parameters")
         self.setCheckable(True)
@@ -346,10 +347,10 @@ class SearchPage(qt.QWidget):
 
 
 class BackgroundPage(qt.QGroupBox):
-    def __init__(self,
-                 title="Subtract strip background prior to estimation",
-                 parent=None):
-        super(BackgroundPage, self).__init__(title, parent)
+    def __init__(self, parent=None,
+                 title="Subtract strip background prior to estimation"):
+        super(BackgroundPage, self).__init__(parent)
+        self.setTitle(title)
         self.setCheckable(True)
         self.setToolTip(
             "The strip algorithm strips away peaks to compute the " +

--- a/silx/io/configdict.py
+++ b/silx/io/configdict.py
@@ -267,7 +267,7 @@ class OptionStr(str):
         """Return a list or a numpy array.
 
         Any string containing a comma (``,``) character will be interpreted
-        as a list: for instance ``-1, Hello World, 3.0``, or ``"2.0,``
+        as a list: for instance ``-1, Hello World, 3.0``, or ``2.0,``
 
         The format for numpy arrays is a blank space delimited list of values
         between square brackets: ``[ 1.3 2.2 3.1 ]``, or

--- a/silx/io/specfilewrapper.py
+++ b/silx/io/specfilewrapper.py
@@ -240,7 +240,7 @@ class scandata(Scan):  # noqa
         - :meth:`data` becomes a method returning an array, instead of just
           an array
         - :meth:`mca`: becomes a method returning an array, instead of
-          a :class:`silx.io.specfile.Scan` object
+          a :class:`silx.io.specfile.MCA` object
         - :meth:`header`: becomes a method returning a list of **scan**
           header lines (or a list of a single header line, if a key is
           specified), instead of just a list of all header lines
@@ -361,7 +361,8 @@ class scandata(Scan):  # noqa
     def mca(self, number):
         """Return one MCA spectrum
 
-        :param number: MCA number (1-based index)"""
+        :param number: MCA number (1-based index)
+        :rtype: 1D numpy array"""
         # in the base class, mca is an object that can be indexed (but 0-based)
         return super(scandata, self).mca[number - 1]
 

--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -63,7 +63,7 @@ Specfile data structure exposed by this API:
           …
 
 ``file_header`` and ``scan_header`` are the raw headers as they
-appear in the original file, as a string of lines separated by ``\n`` characters.
+appear in the original file, as a string of lines separated by newline (``\\n``) characters.
 
 The title is the content of the ``#S`` scan header line without the leading
 ``#S`` (e.g ``"1  ascan  ss1vo -4.55687 -0.556875  40 0.2"``).


### PR DESCRIPTION
Put `parent=None` as first parameter in widgets of `silx.gui.console` and `silx.gui.fit.FitConfig`.

Closes #280 _First parameter of widget must be parent widget_ 

I also fixed  minor documentation typos in this PR. It would be preferable to merge this prior to the coming release.