### PR TITLE
[Plot] Fix not possible to hide toolbar tool buttons

### DIFF
--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -33,7 +33,7 @@ import time
 import unittest
 import tempfile
 import numpy
-from decorator import contextmanager
+from contextlib import contextmanager
 from silx.gui import qt
 from silx.gui import testutils
 from silx.gui import hdf5

--- a/silx/gui/plot/PlotToolButtons.py
+++ b/silx/gui/plot/PlotToolButtons.py
@@ -47,7 +47,7 @@ class PlotToolButton(qt.QToolButton):
     """A QToolButton connected to a :class:`.PlotWidget`.
     """
 
-    def __init__(self, plot=None, parent=None):
+    def __init__(self, parent=None, plot=None):
         super(PlotToolButton, self).__init__(parent)
         self._plot = None
         if plot is not None:
@@ -97,7 +97,7 @@ class AspectToolButton(PlotToolButton):
     STATE = None
     """Lazy loaded states used to feed AspectToolButton"""
 
-    def __init__(self, plot=None, parent=None):
+    def __init__(self, parent=None, plot=None):
         if self.STATE is None:
             self.STATE = {}
             # dont keep ration
@@ -109,7 +109,7 @@ class AspectToolButton(PlotToolButton):
             self.STATE[True, "state"] = "Aspect ration is kept"
             self.STATE[True, "action"] = "Keep data aspect ratio"
 
-        super(AspectToolButton, self).__init__(plot, parent)
+        super(AspectToolButton, self).__init__(parent=parent, plot=plot)
 
         keepAction = self._createAction(True)
         keepAction.triggered.connect(self.keepDataAspectRatio)
@@ -163,7 +163,7 @@ class YAxisOriginToolButton(PlotToolButton):
     STATE = None
     """Lazy loaded states used to feed YAxisOriginToolButton"""
 
-    def __init__(self, plot=None, parent=None):
+    def __init__(self, parent=None, plot=None):
         if self.STATE is None:
             self.STATE = {}
             # is down
@@ -175,7 +175,7 @@ class YAxisOriginToolButton(PlotToolButton):
             self.STATE[True, "state"] = "Y-axis is oriented upward"
             self.STATE[True, "action"] = "Orient Y-axis upward"
 
-        super(YAxisOriginToolButton, self).__init__(plot, parent)
+        super(YAxisOriginToolButton, self).__init__(parent=parent, plot=plot)
 
         upwardAction = self._createAction(True)
         upwardAction.triggered.connect(self.setYAxisUpward)

--- a/silx/gui/plot/test/testPlotWindow.py
+++ b/silx/gui/plot/test/testPlotWindow.py
@@ -114,16 +114,16 @@ class TestPlotWindow(TestCaseQt):
 
     def testToolAspectRatio(self):
         self.plot.toolBar()
-        self.plot._keepAspectRatio.keepDataAspectRatio()
+        self.plot.keepDataAspectRatioButton.keepDataAspectRatio()
         self.assertTrue(self.plot.isKeepDataAspectRatio())
-        self.plot._keepAspectRatio.dontKeepDataAspectRatio()
+        self.plot.keepDataAspectRatioButton.dontKeepDataAspectRatio()
         self.assertFalse(self.plot.isKeepDataAspectRatio())
 
     def testToolYAxisOrigin(self):
         self.plot.toolBar()
-        self.plot._yAxisInverted.setYAxisUpward()
+        self.plot.yAxisInvertedButton.setYAxisUpward()
         self.assertFalse(self.plot.isYAxisInverted())
-        self.plot._yAxisInverted.setYAxisDownward()
+        self.plot.yAxisInvertedButton.setYAxisDownward()
         self.assertTrue(self.plot.isYAxisInverted())
 
 


### PR DESCRIPTION
This PR:

- Closes #344 : aspect ratio and y axis orientation can be hidden as before
- Closes #345 : Replace non standard decorator module by contextlib
- Change PlotToolButton constructor parameters to have parent as first argument