### PR TITLE
Bump Cython version

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # List of silx development dependencies
 # Those ARE NOT required for installation, at runtime or to build from source (except for the doc)
 
-Cython >= 0.18  # To regenerate .c/.cpp files from .pyx
-Sphinx          # To build the documentation in doc/
-lxml            # For test coverage in run_test.py
-coverage        # For test coverage in run_test.py
+Cython >= 0.21.1  # To regenerate .c/.cpp files from .pyx
+Sphinx            # To build the documentation in doc/
+lxml              # For test coverage in run_test.py
+coverage          # For test coverage in run_test.py

--- a/setup.py
+++ b/setup.py
@@ -255,7 +255,7 @@ USE_OPENMP = check_openmp()
 # Cython support #
 # ############## #
 
-CYTHON_MIN_VERSION = '0.18'
+CYTHON_MIN_VERSION = '0.21.1'
 
 
 def check_cython():


### PR DESCRIPTION
This PR bumps minimal version of Cython to 0.21.1 (as in Debian 8)
Closes #354 