### PR TITLE
[Plot] Add enter/leave events to 

### DIFF
--- a/silx/gui/plot/BackendMatplotlib.py
+++ b/silx/gui/plot/BackendMatplotlib.py
@@ -902,6 +902,8 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
         self.mpl_connect('button_release_event', self._onMouseRelease)
         self.mpl_connect('motion_notify_event', self._onMouseMove)
         self.mpl_connect('scroll_event', self._onMouseWheel)
+        self.mpl_connect('axes_enter_event', self._onMouseEnter)
+        self.mpl_connect('axes_leave_event', self._onMouseLeave)
 
     def postRedisplay(self):
         self._sigPostRedisplay.emit()
@@ -937,6 +939,12 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
 
     def _onMouseWheel(self, event):
         self._plot.onMouseWheel(event.x, event.y, event.step)
+
+    def _onMouseEnter(self, event):
+        self._plot.onMouseEnter(event.x, event.y)
+
+    def _onMouseLeave(self, event):
+        self._plot.onMouseLeave(event.x, event.y)
 
     # picking
 

--- a/silx/gui/plot/Interaction.py
+++ b/silx/gui/plot/Interaction.py
@@ -39,10 +39,10 @@ with transitions on left button press/release:
                    self.goto('active')
 
        class Active(State):
-           def enter(self):
+           def enterState(self):
                print('Enabled')  # Handle enter active state here
 
-           def leave(self):
+           def leaveState(self):
                print('Disabled')  # Handle leave active state here
 
            def onRelease(self, x, y, btn):
@@ -116,14 +116,14 @@ class State(object):
     def goto(self, state, *args, **kwargs):
         """Performs a transition to a new state.
 
-        Extra arguments are passed to the :meth:`enter` method of the
+        Extra arguments are passed to the :meth:`enterState` method of the
         new state.
 
         :param str state: The name of the state to go to.
         """
         self.machine._goto(state, *args, **kwargs)
 
-    def enter(self, *args, **kwargs):
+    def enterState(self, *args, **kwargs):
         """Called when the state machine enters this state.
 
         Arguments are those provided to the :meth:`goto` method that
@@ -131,7 +131,7 @@ class State(object):
         """
         pass
 
-    def leave(self):
+    def leaveState(self):
         """Called when the state machine leaves this state
         (i.e., when :meth:`goto` is called).
         """
@@ -149,7 +149,8 @@ class StateMachine(object):
     def __init__(self, states, initState, *args, **kwargs):
         """Create a state machine controller with an initial state.
 
-        Extra arguments are passed to the enter method of the initState.
+        Extra arguments are passed to the :meth:`enterState` method
+        of the initState.
 
         :param states: All states of the state machine
         :type states: dict of: {str name: State subclass}
@@ -158,12 +159,12 @@ class StateMachine(object):
         self.states = states
 
         self.state = self.states[initState](self)
-        self.state.enter(*args, **kwargs)
+        self.state.enterState(*args, **kwargs)
 
     def _goto(self, state, *args, **kwargs):
-        self.state.leave()
+        self.state.leaveState()
         self.state = self.states[state](self)
-        self.state.enter(*args, **kwargs)
+        self.state.enterState(*args, **kwargs)
 
     def handleEvent(self, eventName, *args, **kwargs):
         """Process an event with the state machine.
@@ -231,7 +232,7 @@ class ClickOrDrag(StateMachine):
                 self.goto('idle')
 
     class ClickOrDrag(State):
-        def enter(self, x, y):
+        def enterState(self, x, y):
             self.initPos = x, y
 
         def onMove(self, x, y):
@@ -246,7 +247,7 @@ class ClickOrDrag(StateMachine):
                 self.goto('idle')
 
     class Drag(State):
-        def enter(self, initPos, curPos):
+        def enterState(self, initPos, curPos):
             self.initPos = initPos
             self.machine.beginDrag(*initPos)
             self.machine.drag(*curPos)

--- a/silx/gui/plot/Plot.py
+++ b/silx/gui/plot/Plot.py
@@ -2728,6 +2728,24 @@ class Plot(object):
             self._eventHandler.handleEvent(
                 'wheel', xPixel, yPixel, angleInDegrees)
 
+    def onMouseEnter(self, xPixel, yPixel):
+        """Handle mouse enter plot area event.
+
+        :param float xPixel: X mouse position in pixels
+        :param float yPixel: Y mouse position in pixels
+        """
+        self._eventHandler.handleEvent(
+            'enter', xPixel, yPixel)
+
+    def onMouseLeave(self, xPixel, yPixel):
+        """Handle mouse leave plot area event.
+
+        :param float xPixel: X mouse position in pixels
+        :param float yPixel: Y mouse position in pixels
+        """
+        self._eventHandler.handleEvent(
+            'leave', xPixel, yPixel)
+
     # Interaction modes #
 
     def getInteractiveMode(self):

--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -425,7 +425,7 @@ class SelectPolygon(Select):
                 return True
 
     class Select(State):
-        def enter(self, x, y):
+        def enterState(self, x, y):
             dataPos = self.machine.plot.pixelToData(x, y)
             assert dataPos is not None
             self._firstPos = dataPos
@@ -573,7 +573,7 @@ class Select2Points(Select):
                 return True
 
     class Start(State):
-        def enter(self, x, y):
+        def enterState(self, x, y):
             self.machine.beginSelect(x, y)
 
         def onMove(self, x, y):
@@ -585,7 +585,7 @@ class Select2Points(Select):
                 return True
 
     class Select(State):
-        def enter(self, x, y):
+        def enterState(self, x, y):
             self.onMove(x, y)
 
         def onMove(self, x, y):
@@ -706,7 +706,7 @@ class Select1Point(Select):
                 return True
 
     class Select(State):
-        def enter(self, x, y):
+        def enterState(self, x, y):
             self.onMove(x, y)
 
         def onMove(self, x, y):
@@ -1149,7 +1149,7 @@ class FocusManager(StateMachine):
             self._processEvent('wheel', x, y, angle)
 
     class Focus(State):
-        def enter(self, eventHandler, btn):
+        def enterState(self, eventHandler, btn):
             self.eventHandler = eventHandler
             self.focusBtns = set((btn,))
 


### PR DESCRIPTION
This PR adds events to the interaction state machine when the mouse enters/leaves the plot area.
To handle them, add onEnter(x, y)/onLeave(x, y) methods to the interaction state machine.
To avoid confusion, previously existing methods enter/leave called when a state is entered/leaved has been renamed enterState/leaveState.
Closes #338 