### PR TITLE
[Plot] Fix leave event not generate for fast mouse movement

### DIFF
--- a/silx/gui/plot/BackendMatplotlib.py
+++ b/silx/gui/plot/BackendMatplotlib.py
@@ -902,8 +902,6 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
         self.mpl_connect('button_release_event', self._onMouseRelease)
         self.mpl_connect('motion_notify_event', self._onMouseMove)
         self.mpl_connect('scroll_event', self._onMouseWheel)
-        self.mpl_connect('axes_enter_event', self._onMouseEnter)
-        self.mpl_connect('axes_leave_event', self._onMouseLeave)
 
     def postRedisplay(self):
         self._sigPostRedisplay.emit()
@@ -940,11 +938,9 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
     def _onMouseWheel(self, event):
         self._plot.onMouseWheel(event.x, event.y, event.step)
 
-    def _onMouseEnter(self, event):
-        self._plot.onMouseEnter(event.x, event.y)
-
-    def _onMouseLeave(self, event):
-        self._plot.onMouseLeave(event.x, event.y)
+    def leaveEvent(self, event):
+        """QWidget event handler"""
+        self._plot.onMouseLeaveWidget()
 
     # picking
 

--- a/silx/gui/plot/Plot.py
+++ b/silx/gui/plot/Plot.py
@@ -266,6 +266,7 @@ class Plot(object):
     def __init__(self, parent=None, backend=None):
         self._autoreplot = False
         self._dirty = False
+        self._cursorInPlot = False
 
         if backend is None:
             backend = self.defaultBackend
@@ -2686,6 +2687,11 @@ class Plot(object):
         inXPixel, inYPixel = self._isPositionInPlotArea(xPixel, yPixel)
         isCursorInPlot = inXPixel == xPixel and inYPixel == yPixel
 
+        if self._cursorInPlot != isCursorInPlot:
+            self._cursorInPlot = isCursorInPlot
+            self._eventHandler.handleEvent(
+                'enter' if self._cursorInPlot else 'leave')
+
         if isCursorInPlot:
             # Signal mouse move event
             dataPos = self.pixelToData(inXPixel, inYPixel)
@@ -2728,23 +2734,11 @@ class Plot(object):
             self._eventHandler.handleEvent(
                 'wheel', xPixel, yPixel, angleInDegrees)
 
-    def onMouseEnter(self, xPixel, yPixel):
-        """Handle mouse enter plot area event.
-
-        :param float xPixel: X mouse position in pixels
-        :param float yPixel: Y mouse position in pixels
-        """
-        self._eventHandler.handleEvent(
-            'enter', xPixel, yPixel)
-
-    def onMouseLeave(self, xPixel, yPixel):
-        """Handle mouse leave plot area event.
-
-        :param float xPixel: X mouse position in pixels
-        :param float yPixel: Y mouse position in pixels
-        """
-        self._eventHandler.handleEvent(
-            'leave', xPixel, yPixel)
+    def onMouseLeaveWidget(self):
+        """Handle mouse leave widget event."""
+        if self._cursorInPlot:
+            self._cursorInPlot = False
+            self._eventHandler.handleEvent('leave')
 
     # Interaction modes #
 


### PR DESCRIPTION
This PR uses Qt mouse leave and move events rather than matplotlib enter/leave events to trigger enter/leave events in state machine.
This avoids missing leave events when there is no mouse move event in the outer part of the plot.