### PR TITLE
[Plot] Fix display of negative values with log scales

### DIFF
--- a/silx/gui/plot/BackendMatplotlib.py
+++ b/silx/gui/plot/BackendMatplotlib.py
@@ -159,6 +159,11 @@ class BackendMatplotlib(BackendBase.BackendBase):
             else:
                 errorbarColor = color
 
+            # On Debian 7 at least, Nx1 array yerr does not seems supported
+            if (yerror is not None and yerror.ndim == 2 and
+                    yerror.shape[1] == 1 and len(x) != 1):
+                yerror = numpy.ravel(yerror)
+
             errorbars = axes.errorbar(x, y, label=legend,
                                       xerr=xerror, yerr=yerror,
                                       linestyle=' ', color=errorbarColor)

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -603,6 +603,40 @@ class TestPlotCurveLog(_PlotWidgetTest, ParametricTestCase):
                            replace=False, resetzoom=True,
                            color='green', linestyle="-", symbol='o')
 
+    def testPlotCurveErrorLogXY(self):
+        self.plot.setXAxisLogarithmic(True)
+        self.plot.setYAxisLogarithmic(True)
+
+        # Every second error leads to negative number
+        errors = numpy.ones_like(self.xData)
+        errors[::2] = self.xData[::2] + 1
+
+        tests = [  # name, xerror, yerror
+            ('xerror=3', 3, None),
+            ('xerror=N array', errors, None),
+            ('xerror=Nx1 array', errors.reshape(len(errors), 1), None),
+            ('xerror=2xN array', numpy.array((errors, errors)), None),
+            ('yerror=6', None, 6),
+            ('yerror=N array', None, errors ** 2),
+            ('yerror=Nx1 array', None, (errors ** 2).reshape(len(errors), 1)),
+            ('yerror=2xN array', None, numpy.array((errors, errors)) ** 2),
+        ]
+
+        for name, xError, yError in tests:
+            with self.subTest(name):
+                self.plot.setGraphTitle(name)
+                self.plot.addCurve(self.xData, self.yData,
+                                   legend=name,
+                                   xerror=xError, yerror=yError,
+                                   replace=False, resetzoom=True,
+                                   color='green', linestyle="-", symbol='o')
+
+                self.qapp.processEvents()
+
+                self.plot.clear()
+                self.plot.resetZoom()
+                self.qapp.processEvents()
+
     def testPlotCurveToggleLog(self):
         """Add a curve with negative data and toggle log axis"""
         arange = numpy.arange(1000) + 1


### PR DESCRIPTION
This PR fix display of negative values with log scale.
It replace values <= 0 with nan to show discontinuities.
It also filter xerror and yerror values if any of those is spanning error bars below 0 but changing those to nan.

Values stored with curves remains unchanged.

Closes #330