### PR TITLE
[sift] handle dtypes uint64 and float64

### DIFF
--- a/silx/image/sift/plan.py
+++ b/silx/image/sift/plan.py
@@ -455,10 +455,7 @@ class SiftPlan(object):
                 # A preprocessing kernel double_to_float exists, but is commented (RUNS ONLY ON GPU WITH FP64)
                 # TODO: benchmark this kernel vs the current pure CPU format conversion with numpy.float32
                 #       and uncomment it if it proves faster (dubious, because of data transfer bottleneck)
-                if isinstance(image, pyopencl.array.Array):
-                    evt = pyopencl.enqueue_copy(self.queue, self.buffers[0].data, numpy.float32(image.data))
-                else:
-                    evt = pyopencl.enqueue_copy(self.queue, self.buffers[0].data, numpy.float32(image))
+                evt = pyopencl.enqueue_copy(self.queue, self.buffers[0].data, image.astype(numpy.float32))
                 if self.profile:
                     self.events.append(("copy H->D", evt))
             elif (len(image.shape) == 3) and (image.dtype == numpy.uint8) and (self.RGB):

--- a/silx/resources/opencl/sift/preprocess.cl
+++ b/silx/resources/opencl/sift/preprocess.cl
@@ -89,7 +89,7 @@ u16_to_float(__global unsigned short  *array_int,
 /**
  * \brief cast values of an array of uint32 into a float output array.
  *
- * :param array_int:    Pointer to global memory with the input data as unsigned16 array
+ * :param array_int:    Pointer to global memory with the input data as unsigned32 array
  * :param array_float:  Pointer to global memory with the output data as float array
  * :param IMAGE_W:        Width of the image
  * :param IMAGE_H:         Height of the image
@@ -105,6 +105,28 @@ u32_to_float(__global unsigned int  *array_int,
     if ((get_global_id(0)<IMAGE_W) && (get_global_id(1) < IMAGE_H)){
     	int i = get_global_id(0) + IMAGE_W * get_global_id(1);
     	array_float[i]=(float)array_int[i];
+    }
+}//end kernel
+
+/**
+ * \brief cast values of an array of uint64 into a float output array.
+ *
+ * :param array_int:    Pointer to global memory with the input data as unsigned64 array
+ * :param array_float:  Pointer to global memory with the output data as float array
+ * :param IMAGE_W:        Width of the image
+ * :param IMAGE_H:         Height of the image
+ */
+__kernel void
+u64_to_float(__global unsigned long  *array_int,
+             __global float *array_float,
+             const int IMAGE_W,
+             const int IMAGE_H
+)
+{
+    //Global memory guard for padding
+    if ((get_global_id(0)<IMAGE_W) && (get_global_id(1) < IMAGE_H)){
+        int i = get_global_id(0) + IMAGE_W * get_global_id(1);
+        array_float[i]=(float)array_int[i];
     }
 }//end kernel
 


### PR DESCRIPTION
It would be preferable to handle image with these 2 dtypes, as numpy uses them as default in some situations. For example, when attempting naive conversion from RGB to black and white:

- numpy.sum(..., axis=-1) on RGB images (shape=(h, w, 3), dtype=uint8) returns uint64
- numpy.mean(..., axis=-1) on uint8 returns float64