### PR TITLE
[Plot] Fix data range not correct when some curves are hidden

### DIFF
--- a/silx/gui/plot/Plot.py
+++ b/silx/gui/plot/Plot.py
@@ -397,23 +397,24 @@ class Plot(object):
         xMax = yMaxLeft = yMaxRight = float('nan')
 
         for _curve, info in self._curves.items():
-            # using numpy's separate min and max is faster than
-            # a pure python minmax.
-            if info['xmin'] is not None:
-                xMin = numpy.nanmin([xMin, info['xmin']])
-            if info['xmax'] is not None:
-                xMax = numpy.nanmax([xMax, info['xmax']])
+            if _curve not in self._hiddenCurves:
+                # using numpy's separate min and max is faster than
+                # a pure python minmax.
+                if info['xmin'] is not None:
+                    xMin = numpy.nanmin([xMin, info['xmin']])
+                if info['xmax'] is not None:
+                    xMax = numpy.nanmax([xMax, info['xmax']])
 
-            if info['params']['yaxis'] == 'left':
-                if info['ymin'] is not None:
-                    yMinLeft = numpy.nanmin([yMinLeft, info['ymin']])
-                if info['ymax'] is not None:
-                    yMaxLeft = numpy.nanmax([yMaxLeft, info['ymax']])
-            else:
-                if info['ymin'] is not None:
-                    yMinRight = numpy.nanmin([yMinRight, info['ymin']])
-                if info['ymax'] is not None:
-                    yMaxRight = numpy.nanmax([yMaxRight, info['ymax']])
+                if info['params']['yaxis'] == 'left':
+                    if info['ymin'] is not None:
+                        yMinLeft = numpy.nanmin([yMinLeft, info['ymin']])
+                    if info['ymax'] is not None:
+                        yMaxLeft = numpy.nanmax([yMaxLeft, info['ymax']])
+                else:
+                    if info['ymin'] is not None:
+                        yMinRight = numpy.nanmin([yMinRight, info['ymin']])
+                    if info['ymax'] is not None:
+                        yMaxRight = numpy.nanmax([yMaxRight, info['ymax']])
 
         if not self.isXAxisLogarithmic() and not self.isYAxisLogarithmic():
             for _image, info in self._images.items():
@@ -1190,6 +1191,7 @@ class Plot(object):
             self.addCurve(curve['x'], curve['y'], legend, resetzoom=False,
                           **curve['params'])
 
+        self._invalidateDataRange()
         self._setDirtyPlot()
 
     # Remove

--- a/silx/gui/plot/test/testPlot.py
+++ b/silx/gui/plot/test/testPlot.py
@@ -365,6 +365,19 @@ class TestPlotRanges(ParametricTestCase):
                                 msg='{0} != {1}'.format(dataRange.y, yRange))
                 self.assertIsNone(dataRange.yright)
 
+    def testDataRangeHiddenCurve(self):
+        """curves with a hidden curve"""
+        plot = Plot(backend='none')
+        plot.addCurve((0, 1), (0, 1), legend='shown')
+        plot.addCurve((0, 1, 2), (5, 5, 5), legend='hidden')
+        range1 = plot.getDataRange()
+        self.assertEqual(range1.x, (0, 2))
+        self.assertEqual(range1.y, (0, 5))
+        plot.hideCurve('hidden')
+        range2 = plot.getDataRange()
+        self.assertEqual(range2.x, (0, 1))
+        self.assertEqual(range2.y, (0, 1))
+
 
 class TestPlotGetCurveImage(unittest.TestCase):
     """Test of plot getCurve and getImage methods"""


### PR DESCRIPTION
Hidden curves were taken into account by Plot.getDataRange.
This PR does not take them into account for the data range and marks the data range as dirty when a curve is hidden or shown.

Closes #414