### PR TITLE
Update project documentation process + Fix of HDF5 tree documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -34,7 +34,13 @@ os.environ["PYTHONPATH"] = source_dir + os.pathsep + os.environ.get("PYTHONPATH"
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.coverage', 'sphinx.ext.mathjax', 'sphinx.ext.viewcode']
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.coverage',
+    'sphinx.ext.mathjax',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.doctest'
+]
 
 autodoc_member_order = 'bysource'
 
@@ -245,3 +251,6 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 # texinfo_show_urls = 'footnote'
+
+# Do not test code in >>> by default
+doctest_test_doctest_blocks = ''

--- a/doc/source/modules/gui/hdf5/getting_started.rst
+++ b/doc/source/modules/gui/hdf5/getting_started.rst
@@ -17,7 +17,16 @@ Import and create your tree view
 
 HDF5 widgets are all exposed by the package `silx.gui.hdf5`.
 
-.. code-block:: python
+.. testsetup:: *
+
+   from silx.gui import qt
+   app = qt.QApplication([])
+   import silx.gui.hdf5
+   treeview = silx.gui.hdf5.Hdf5TreeView()
+   header = treeview.header()
+   model = treeview.findHdf5TreeModel()
+
+.. testcode::
 
    import silx.gui.hdf5
    treeview = silx.gui.hdf5.Hdf5TreeView()
@@ -27,7 +36,7 @@ Custom your tree view
 
 The tree view can be customized to be sorted by default.
 
-.. code-block:: python
+.. testcode::
 
    # Sort content of files by time or name
    treeview.setSortingEnabled(True)
@@ -36,7 +45,7 @@ The model can be customized to support mouse interaction.
 A convenient method :meth:`Hdf5TreeView.findHdf5TreeModel` returns the main
 HDF5 model used through proxy models.
 
-.. code-block:: python
+.. testcode::
 
    model = treeview.findHdf5TreeModel()
 
@@ -49,7 +58,7 @@ HDF5 model used through proxy models.
 The tree view is also provided with a custom header which help to choose
 visible columns.
 
-.. code-block:: python
+.. testcode::
 
    header = treeview.header()
 
@@ -112,7 +121,7 @@ The callback receives a :class:`Hdf5ContextMenuEvent` every time the user
 requests the context menu. The event contains :class:`H5Node` objects which wrap
 h5py objects with extra information.
 
-.. code-block:: python
+.. testcode::
 
    def my_action_callback(obj):
       # do what you want
@@ -160,7 +169,7 @@ The :class:`Hdf5TreeView` widget provides default Qt signals inherited from
 The method :meth:`Hdf5TreeView.selectedH5Nodes` returns an iterator of :class:`H5Node`
 objects which wrap h5py objects with extra information.
 
-.. code-block:: python
+.. testcode::
 
    def my_callback(index):
        objects = list(treeview.selectedH5Nodes())

--- a/doc/source/modules/gui/hdf5/getting_started.rst
+++ b/doc/source/modules/gui/hdf5/getting_started.rst
@@ -79,8 +79,8 @@ and dataset as it is.
 .. code-block:: python
 
    import h5py
-   h5 = h5py.File("test.py")
-   
+   h5 = h5py.File("test.h5")
+
    # We can use file
    model.insertH5pyObject(h5)
 
@@ -116,15 +116,17 @@ h5py objects with extra information.
 
    def my_action_callback(obj):
       # do what you want
+      pass
 
    def my_callback(event):
-      objects = event.source().selectedH5Nodes()
+      objects = list(event.source().selectedH5Nodes())
       obj = objects[0]  # for single selection
 
+      menu = event.menu()
       if obj.ntype is h5py.Dataset:
-         action = qt.QAction("My funky action on datasets only")
+         action = qt.QAction("My funky action on datasets only", menu)
          action.triggered.connect(lambda: my_action_callback(obj))
-         event.menu().addAction(action)
+         menu.addAction(action)
 
    treeview.addContextMenuCallback(my_callback)
 
@@ -155,10 +157,13 @@ The :class:`Hdf5TreeView` widget provides default Qt signals inherited from
       was pressed on is specified by index. The signal is only emitted when the
       index is valid.
 
+The method :meth:`Hdf5TreeView.selectedH5Nodes` returns an iterator of :class:`H5Node`
+objects which wrap h5py objects with extra information.
+
 .. code-block:: python
 
    def my_callback(index):
-       objects = treeview.selectedH5Nodes()
+       objects = list(treeview.selectedH5Nodes())
        obj = objects[0]  # for single selection
 
        print(obj)
@@ -176,7 +181,8 @@ The :class:`Hdf5TreeView` widget provides default Qt signals inherited from
        if obj.ntype is h5py.Dataset:
            print(obj.dtype)
            print(obj.shape)
-           print(obj.value)
+           print(obj.value)        # create a copy of data of the dataset
+           print(obj.h5py_object)  # reference to the Hdf5 dataset (or group)
 
    treeview.clicked.connect(my_callback)
 

--- a/setup.py
+++ b/setup.py
@@ -172,7 +172,7 @@ except ImportError:
 
         def run(self):
             raise RuntimeError(
-                'Sphinx is required to build the documentation.\n'
+                'Sphinx is required to build or test the documentation.\n'
                 'Please install Sphinx (http://www.sphinx-doc.org).')
 
 if sphinx is not None:

--- a/setup.py
+++ b/setup.py
@@ -210,9 +210,36 @@ else:
 
 cmdclass['build_doc'] = BuildDocCommand
 
+# ################### #
+# test_doc command    #
+# ################### #
+
+if sphinx is not None:
+    class TestDocCommand(BuildDoc):
+        """Target to test the documentation using sphynx doctest.
 
         http://www.sphinx-doc.org/en/1.4.8/ext/doctest.html
+        """
 
+        def run(self):
+            # make sure the python path is pointing to the newly built
+            # code so that the documentation is built on this and not a
+            # previously installed version
+
+            build = self.get_finalized_command('build')
+            sys.path.insert(0, os.path.abspath(build.build_lib))
+
+            # Build the Users Guide in HTML and TeX format
+            for builder in ['doctest']:
+                self.builder = builder
+                self.builder_target_dir = os.path.join(self.build_dir, builder)
+                self.mkpath(self.builder_target_dir)
+                BuildDoc.run(self)
+            sys.path.pop(0)
+else:
+    TestDocCommand = SphinxExpectedCommand
+
+cmdclass['test_doc'] = TestDocCommand
 
 # ############## #
 # OpenMP support #

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@
 # ###########################################################################*/
 
 __authors__ = ["Jérôme Kieffer", "Thomas Vincent"]
-__date__ = "04/10/2016"
+__date__ = "16/11/2016"
 __license__ = "MIT"
 
 
@@ -151,7 +151,7 @@ cmdclass['test'] = PyTest
 
 
 # ################### #
-# build_doc commandes #
+# build_doc command   #
 # ################### #
 
 try:
@@ -159,9 +159,9 @@ try:
     import sphinx.util.console
     sphinx.util.console.color_terminal = lambda: False
     from sphinx.setup_command import BuildDoc
-
 except ImportError:
-    class build_doc(Command):
+    sphinx = None
+    class SphinxExpectedCommand(Command):
         user_options = []
 
         def initialize_options(self):
@@ -175,9 +175,8 @@ except ImportError:
                 'Sphinx is required to build the documentation.\n'
                 'Please install Sphinx (http://www.sphinx-doc.org).')
 
-else:
-    # i.e. if sphinx:
-    class build_doc(BuildDoc):
+if sphinx is not None:
+    class BuildDocCommand(BuildDoc):
 
         def run(self):
             # make sure the python path is pointing to the newly built
@@ -200,15 +199,19 @@ else:
 #                         shutil.copy(src, idst)
 
             # Build the Users Guide in HTML and TeX format
-            for builder in ('html', 'latex'):
+            for builder in ['html', 'latex']:
                 self.builder = builder
                 self.builder_target_dir = os.path.join(self.build_dir, builder)
                 self.mkpath(self.builder_target_dir)
                 BuildDoc.run(self)
             sys.path.pop(0)
+else:
+    BuildDocCommand = SphinxExpectedCommand
+
+cmdclass['build_doc'] = BuildDocCommand
 
 
-cmdclass['build_doc'] = build_doc
+        http://www.sphinx-doc.org/en/1.4.8/ext/doctest.html
 
 
 # ############## #


### PR DESCRIPTION
- HDF5 tree documentation
   - Fix wrong documentation
   - Add extra information to point H5Node documentation
   - Add comment and difference between obj.h5py_object and obj.value
   - Use testcode and testsetup for some tests
- Use `sphinx.ext.doctest`
- Add `test_doc` as a new `setup.py` target