### PR TITLE
[Gui] Change the way to probe already loaded Qt binding

### DIFF
--- a/silx/gui/qt.py
+++ b/silx/gui/qt.py
@@ -72,13 +72,13 @@ HAS_SVG = False
 """True if Qt provides support for Scalable Vector Graphics (QtSVG)."""
 
 # First check for an already loaded wrapper
-if 'PySide' in sys.modules:
+if 'PySide.QtCore' in sys.modules:
     BINDING = 'PySide'
 
-elif 'PyQt5' in sys.modules:
+elif 'PyQt5.QtCore' in sys.modules:
     BINDING = 'PyQt5'
 
-elif 'PyQt4' in sys.modules:
+elif 'PyQt4.QtCore' in sys.modules:
     BINDING = 'PyQt4'
 
 else:  # Then try Qt bindings


### PR DESCRIPTION
One can do `import PyQt4, PyQt5` without any trouble, so probe for Py*.QtCore module which cannot be loaded from different bindings.

This should close #415 ... though I could not reproduce the original issue....