### PR TITLE
Support ellipsis to reach scalar from spech5 datasets

### DIFF
--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -181,7 +181,7 @@ from .specfile import SpecFile
 
 __authors__ = ["P. Knobel", "D. Naudet"]
 __license__ = "MIT"
-__date__ = "15/12/2016"
+__date__ = "19/12/2016"
 
 logging.basicConfig()
 logger1 = logging.getLogger(__name__)
@@ -731,7 +731,9 @@ class SpecH5Dataset(object):
 
     def __getitem__(self, item):
         if not isinstance(self.value, numpy.ndarray):
-            if item == Ellipsis or item == tuple():
+            if item == Ellipsis:
+                return numpy.array(self.value)
+            elif item == tuple():
                 return self.value
             else:
                 raise ValueError("Scalar can only be reached with an ellipsis or an empty tuple")

--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -181,7 +181,7 @@ from .specfile import SpecFile
 
 __authors__ = ["P. Knobel", "D. Naudet"]
 __license__ = "MIT"
-__date__ = "03/10/2016"
+__date__ = "15/12/2016"
 
 logging.basicConfig()
 logger1 = logging.getLogger(__name__)
@@ -730,6 +730,11 @@ class SpecH5Dataset(object):
         return len(self.value)
 
     def __getitem__(self, item):
+        if not isinstance(self.value, numpy.ndarray):
+            if item == Ellipsis or item == tuple():
+                return self.value
+            else:
+                raise ValueError("Scalar can only be reached with an ellipsis or an empty tuple")
         return self.value.__getitem__(item)
 
     def __getslice__(self, i, j):

--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -749,7 +749,7 @@ class SpecH5Dataset(object):
     def __dir__(self):
         attrs = set(dir(self.value) +
                     ["value", "name", "parent", "file",
-                     "attrs",  "shape", "dtype", "size",
+                     "attrs", "shape", "dtype", "size",
                      "h5py_class"])
         return sorted(attrs)
 
@@ -914,7 +914,7 @@ def _dataset_builder(name, specfileh5, parent_group):
         array_like = "\n".join(scan.file_header)
 
     elif scan_header_data_pattern.match(name):
-        #array_like = _fixed_length_strings(scan.scan_header)
+        # array_like = _fixed_length_strings(scan.scan_header)
         array_like = "\n".join(scan.scan_header)
 
     elif positioners_data_pattern.match(name):


### PR DESCRIPTION
This PR allow to use `[...]` or `[()]` to reach a scalar value, while `.value` is deprecated.

I am using `[...]` for scalar in `h5py.Dataset`, and the h5py documentation contains:

> To retrieve the contents of a scalar dataset, you can use the same syntax as in NumPy: result = dset[()]. In other words, index into the dataset using an empty tuple.`


Here is the result:
```
In [1]: import silx.io

In [2]: a = silx.io.open("../data/SpecFile/nofhdr.dat")

In [3]: a["1.1/title"][()]
Out[3]: '1  ascan  ss1vo -4.55687 -0.556875  40 0.2'

In [4]: a["1.1/title"][...]
Out[4]: '1  ascan  ss1vo -4.55687 -0.556875  40 0.2'
```