### PR TITLE
Fix deadlock on gui tests

### DIFF
--- a/silx/sx/__init__.py
+++ b/silx/sx/__init__.py
@@ -57,17 +57,6 @@ else:
 
 
 if not _IS_NOTEBOOK:  # Load Qt and widgets only if running from console
-    # Debian8 support:
-    # IPython < 3.2.2 does not check if PyQt5 is loaded,
-    # force silx to use PyQt4 or PySide if available.
-    import IPython
-    if IPython.__version__ < '3.2.2':
-        try:
-            import PyQt4
-        except ImportError:
-            import PySide
-    del IPython  # clean-up namespace
-
     from silx.gui import qt
 
     if hasattr(_sys, 'ps1'):  # If from console, make sure QApplication runs

--- a/silx/test/__init__.py
+++ b/silx/test/__init__.py
@@ -54,14 +54,16 @@ def suite():
     from ..utils import test as test_utils
 
     test_suite = unittest.TestSuite()
+    # test sx first cause qui tests load ipython module
+    test_suite.addTest(test_sx.suite())
+    test_suite.addTest(test_gui.suite())
+    # then test no-gui tests
     test_suite.addTest(test_version.suite())
     test_suite.addTest(test_resources.suite())
-    test_suite.addTest(test_gui.suite())
     test_suite.addTest(test_utils.suite())
     test_suite.addTest(test_io.suite())
     test_suite.addTest(test_math.suite())
     test_suite.addTest(test_image.suite())
-    test_suite.addTest(test_sx.suite())
     return test_suite
 
 

--- a/silx/test/test_sx.py
+++ b/silx/test/test_sx.py
@@ -70,9 +70,10 @@ elif os.environ.get('WITH_QT_TEST', 'True') == 'False':
 else:
     # Import here to avoid loading QT if tests are disabled
 
-    from silx import sx
     from silx.gui import qt
+    # load TestCaseQt before sx
     from silx.gui.test.utils import TestCaseQt
+    from silx import sx
 
     class SXTest(TestCaseQt):
         """Test the sx module"""


### PR DESCRIPTION
It looks to fix a dead lock occured at the end of run_tests on Windows PyQt5.

- A deprecated ipython import is removed
- Order import to be sure the first QApplication is created by the tests (and not by sx module)
- Execute sx tests before gui tests

It looks to fix the issue on our new Windows laptop, but it is difficult to know if it change anything.