### PR TITLE
Use StackViewer as a view for the DataViewer

### DIFF
--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -69,7 +69,7 @@ Example::
 
 __authors__ = ["P. Knobel", "H. Payno"]
 __license__ = "MIT"
-__date__ = "04/01/2016"
+__date__ = "06/01/2017"
 
 import numpy
 
@@ -155,6 +155,12 @@ class StackView(qt.QMainWindow):
                  copy=True, save=True, print_=True, control=False,
                  position=None, mask=True):
         qt.QMainWindow.__init__(self, parent)
+        if parent is not None:
+            # behave as a widget
+            self.setWindowFlags(qt.Qt.Widget)
+        else:
+            self.setWindowTitle('StackView')
+
         self._stack = None
         """Loaded stack of images, as a 3D array or 3D dataset"""
         self.__transposed_view = None

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -302,6 +302,13 @@ class StackView(qt.QMainWindow):
         self._browser.setRange(0, self.__transposed_view.shape[0] - 1)
         self._browser.setValue(0)
 
+    def setFrameNumber(self, number):
+        """Set the frame selection to a specific value\
+
+        :param int number: Number of the frame
+        """
+        self._browser.setValue(number)
+
     def __updateFrameNumber(self, index):
         """Update the current image displayed
 

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -203,16 +203,25 @@ class StackView(qt.QMainWindow):
         self._browser.valueChanged[int].connect(self.__updateFrameNumber)
         self._browser.setEnabled(False)
 
-        planeSelection = PlanesWidget(self._plot)
-        planeSelection.sigPlaneSelectionChanged.connect(self.__setPerspective)
+        self.__planeSelection = PlanesWidget(self._plot)
+        self.__planeSelection.sigPlaneSelectionChanged.connect(self.__setPerspective)
 
         layout = qt.QGridLayout()
         layout.addWidget(self._plot, 0, 0, 1, 2)
-        layout.addWidget(planeSelection, 1, 0)
+        layout.addWidget(self.__planeSelection, 1, 0)
         layout.addWidget(self._browser, 1, 1)
 
         central_widget.setLayout(layout)
         self.setCentralWidget(central_widget)
+
+    def setOptionVisible(self, isVisible):
+        """
+        Set the visibility of the browsing options.
+
+        :param bool isVisible: True to have the options visible, else False
+        """
+        self._browser.setVisible(isVisible)
+        self.__planeSelection.setVisible(isVisible)
 
     def _imagePlotCB(self, eventDict):
         """Callback for plot events.

--- a/silx/gui/widgets/DataViewer.py
+++ b/silx/gui/widgets/DataViewer.py
@@ -60,7 +60,7 @@ class DataView(object):
         """Returns the mode id"""
         return self.__modeId
 
-    def axiesNames(self):
+    def axesNames(self):
         """Returns names of the expected axes of the view"""
         return []
 
@@ -128,7 +128,7 @@ class DataView(object):
 class _EmptyView(DataView):
     """Dummy view to display nothing"""
 
-    def axiesNames(self):
+    def axesNames(self):
         return []
 
     def createWidget(self, parent):
@@ -145,7 +145,7 @@ class _Plot1dView(DataView):
         super(_Plot1dView, self).__init__(parent, modeId)
         self.__resetZoomNextTime = True
 
-    def axiesNames(self):
+    def axesNames(self):
         return ["y"]
 
     def createWidget(self, parent):
@@ -186,7 +186,7 @@ class _Plot2dView(DataView):
         super(_Plot2dView, self).__init__(parent, modeId)
         self.__resetZoomNextTime = True
 
-    def axiesNames(self):
+    def axesNames(self):
         return ["y", "x"]
 
     def createWidget(self, parent):
@@ -228,7 +228,7 @@ class _Plot2dView(DataView):
 class _ArrayView(DataView):
     """View displaying data using a 2d table"""
 
-    def axiesNames(self):
+    def axesNames(self):
         return ["col", "row"]
 
     def createWidget(self, parent):
@@ -264,7 +264,7 @@ class _StackView(DataView):
         super(_StackView, self).__init__(parent, modeId)
         self.__resetZoomNextTime = True
 
-    def axiesNames(self):
+    def axesNames(self):
         return ["depth", "y", "x"]
 
     def customAxisNames(self):
@@ -280,7 +280,7 @@ class _StackView(DataView):
         from silx.gui import plot
         widget = plot.StackView(parent=parent)
         widget.setKeepDataAspectRatio(True)
-        widget.setLabels(self.axiesNames())
+        widget.setLabels(self.axesNames())
         # hide default option panel
         widget.setOptionVisible(False)
         return widget
@@ -316,7 +316,7 @@ class _TextView(DataView):
 
     __format = "%g"
 
-    def axiesNames(self):
+    def axesNames(self):
         return []
 
     def createWidget(self, parent):
@@ -374,7 +374,7 @@ class _TextView(DataView):
 class _RecordView(DataView):
     """View displaying data using text"""
 
-    def axiesNames(self):
+    def axesNames(self):
         return ["data"]
 
     def createWidget(self, parent):
@@ -528,7 +528,7 @@ class DataViewer(qt.QFrame):
         """
         previous = self.__numpySelection.blockSignals(True)
         self.__numpySelection.clear()
-        axisNames = self.__currentView.axiesNames()
+        axisNames = self.__currentView.axesNames()
         if len(axisNames) > 0:
             self.__useAxisSelection = True
             self.__axisSelection.setVisible(True)

--- a/silx/gui/widgets/DataViewer.py
+++ b/silx/gui/widgets/DataViewer.py
@@ -64,6 +64,20 @@ class DataView(object):
         """Returns names of the expected axes of the view"""
         return []
 
+    def customAxisNames(self):
+        """Returns names of axes which can be custom by the user and provided
+        to the view."""
+        return []
+
+    def setCustomAxisValue(self, name, value):
+        """
+        Set the value of a custom axis
+
+        :param str name: Name of the custom axis
+        :param int value: Value of the custom axis
+        """
+        pass
+
     def getWidget(self):
         """Returns the widget hold in the view and displaying the data.
 
@@ -389,6 +403,7 @@ class DataViewer(qt.QFrame):
         self.__numpySelection = NumpyAxesSelector(self)
         self.__numpySelection.selectedAxisChanged.connect(self.__numpyAxisChanged)
         self.__numpySelection.selectionChanged.connect(self.__numpySelectionChanged)
+        self.__numpySelection.customAxisChanged.connect(self.__numpyCustomAxisChanged)
 
         self.setLayout(qt.QVBoxLayout(self))
         self.layout().addWidget(self.__stack, 1)
@@ -446,6 +461,11 @@ class DataViewer(qt.QFrame):
         if view is not None:
             view.clear()
 
+    def __numpyCustomAxisChanged(self, name, value):
+        view = self.__currentView
+        if view is not None:
+            view.setCustomAxisValue(name, value)
+
     def __updateNumpySelectionAxis(self):
         """
         Update the numpy-selector according to the needed axis names
@@ -457,6 +477,7 @@ class DataViewer(qt.QFrame):
             self.__useAxisSelection = True
             self.__axisSelection.setVisible(True)
             self.__numpySelection.setAxisNames(axisNames)
+            self.__numpySelection.setCustomAxis(self.__currentView.customAxisNames())
             self.__numpySelection.setData(self.__data)
         else:
             self.__useAxisSelection = False

--- a/silx/gui/widgets/DataViewerSelector.py
+++ b/silx/gui/widgets/DataViewerSelector.py
@@ -64,6 +64,7 @@ class DataViewerSelector(qt.QWidget):
         buttons[DataViewer.ARRAY_MODE] = ("Raw", "view-raw")
         buttons[DataViewer.RECORD_MODE] = ("Raw", "view-raw")
         buttons[DataViewer.TEXT_MODE] = ("Text", "view-text")
+        buttons[DataViewer.STACK_MODE] = ("Image stack", "view-2d-stack")
 
         for modeId, state in buttons.items():
             text, iconName = state

--- a/silx/gui/widgets/test/test_dataviewer.py
+++ b/silx/gui/widgets/test/test_dataviewer.py
@@ -24,7 +24,7 @@
 # ###########################################################################*/
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "06/01/2017"
+__date__ = "10/01/2017"
 
 import unittest
 import numpy
@@ -84,6 +84,13 @@ class AbstractDataViewerTests(TestCaseQt):
         widget.setData(data)
         self.assertEqual(DataViewer.PLOT2D_MODE, widget.displayMode())
 
+    def test_plot_3d_data(self):
+        data = numpy.arange(3 ** 3)
+        data.shape = [3] * 3
+        widget = self.create_widget()
+        widget.setData(data)
+        self.assertEqual(DataViewer.STACK_MODE, widget.displayMode())
+
     def test_array_1d_data(self):
         data = numpy.array(["aaa"] * (3 ** 1))
         data.shape = [3] * 1
@@ -99,7 +106,7 @@ class AbstractDataViewerTests(TestCaseQt):
         self.assertEqual(DataViewer.ARRAY_MODE, widget.displayMode())
 
     def test_array_4d_data(self):
-        data = numpy.arange(3 ** 4)
+        data = numpy.array(["aaa"] * (3 ** 4))
         data.shape = [3] * 4
         widget = self.create_widget()
         widget.setData(data)


### PR DESCRIPTION
This pull request provide the stack view in the data viewer

It contains few changes on the StackView to be able to integrate it
- Switch StackView as a widget if it is defined with a parent (the code is a copy-paste from other plot widget)
- A method to hide the default browser and axes selector (this information is already provided by the DataViewer)
- And a method to programatically set the visible frame

There is few changes on the DataViewer
- Be able to name an available axes and custom its value at the same time
