### PR TITLE
[array_like] fix double transposition issue

### DIFF
--- a/silx/utils/array_like.py
+++ b/silx/utils/array_like.py
@@ -305,7 +305,8 @@ class ListOfImages(object):
         the same images but with a different :attr:`transposition`.
 
         :param list[int] transposition: List/tuple of dimension numbers in the
-            wanted order
+            wanted order.
+            If ``None`` (default), reverse the dimensions.
         :return: new :class:`ListOfImages` object
         """
         # by default, reverse the dimensions
@@ -314,6 +315,14 @@ class ListOfImages(object):
 
         return ListOfImages(self.images,
                             transposition)
+
+    @property
+    def T(self):
+        """
+        Same as self.transpose()
+
+        :return: DatasetView with dimensions reversed."""
+        return self.transpose()
 
     def __getitem__(self, item):
         """Handle a subset of numpy indexing with regards to the dimension
@@ -557,7 +566,8 @@ class DatasetView(object):
         The returned object refers to
         the same dataset but with a different :attr:`transposition`.
 
-        :param list[int] transposition: List of dimension numbers in the wanted order
+        :param list[int] transposition: List of dimension numbers in the wanted order.
+            If ``None`` (default), reverse the dimensions.
         :return: Transposed DatasetView
         """
         # by default, reverse the dimensions
@@ -566,3 +576,11 @@ class DatasetView(object):
 
         return DatasetView(self.dataset,
                            transposition)
+
+    @property
+    def T(self):
+        """
+        Same as self.transpose()
+
+        :return: DatasetView with dimensions reversed."""
+        return self.transpose()

--- a/silx/utils/array_like.py
+++ b/silx/utils/array_like.py
@@ -313,6 +313,11 @@ class ListOfImages(object):
         if transposition is None:
             transposition = list(reversed(self.transposition))
 
+        # If this ListOfImages is already transposed, sort new transposition
+        # relative to old transposition
+        elif list(self.transposition) != list(range(self.ndim)):
+            transposition = [self.transposition[i] for i in transposition]
+
         return ListOfImages(self.images,
                             transposition)
 
@@ -573,6 +578,11 @@ class DatasetView(object):
         # by default, reverse the dimensions
         if transposition is None:
             transposition = list(reversed(self.transposition))
+
+        # If this DatasetView is already transposed, sort new transposition
+        # relative to old transposition
+        elif list(self.transposition) != list(range(self.ndim)):
+            transposition = [self.transposition[i] for i in transposition]
 
         return DatasetView(self.dataset,
                            transposition)

--- a/silx/utils/test/test_array_like.py
+++ b/silx/utils/test/test_array_like.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "22/12/2016"
+__date__ = "09/01/2017"
 
 try:
     import h5py
@@ -88,6 +88,12 @@ class TestTransposedDatasetView(unittest.TestCase):
         self.assertEqual(a.shape, self.original_shape)
         self._testSize(a)
 
+        # reversing the dimensions twice results in no change
+        rtrans = list(reversed(range(self.ndim)))
+        self.assertTrue(numpy.array_equal(
+                a,
+                a.transpose(rtrans).transpose(rtrans)))
+
         for i in range(a.shape[0]):
             for j in range(a.shape[1]):
                 for k in range(a.shape[2]):
@@ -139,6 +145,12 @@ class TestTransposedDatasetView(unittest.TestCase):
                     corresponding_original_value = self.h5f["volume"][sorted_indices]
                     self.assertEqual(viewed_value,
                                      corresponding_original_value)
+
+        # reversing the dimensions twice results in no change
+        rtrans = list(reversed(range(self.ndim)))
+        self.assertTrue(numpy.array_equal(
+                a,
+                a.transpose(rtrans).transpose(rtrans)))
 
     def testTransposition012(self):
         """transposition = (0, 1, 2)
@@ -210,6 +222,17 @@ class TestTransposedListOfImages(unittest.TestCase):
                     self.assertEqual(self.images[i][j, k],
                                      a[i, j, k])
 
+        # reversing the dimensions twice results in no change
+        rtrans = list(reversed(range(self.ndim)))
+        self.assertTrue(numpy.array_equal(
+                a,
+                a.transpose(rtrans).transpose(rtrans)))
+
+        # test .T property
+        self.assertTrue(numpy.array_equal(
+                a.T,
+                a.transpose(rtrans)))
+
     def _testTransposition(self, transposition):
         """test transposed dataset
 
@@ -255,6 +278,17 @@ class TestTransposedListOfImages(unittest.TestCase):
                     corresponding_original_value = self.images[sorted_indices[0]][sorted_indices[1:]]
                     self.assertEqual(viewed_value,
                                      corresponding_original_value)
+
+        # reversing the dimensions twice results in no change
+        rtrans = list(reversed(range(self.ndim)))
+        self.assertTrue(numpy.array_equal(
+                a,
+                a.transpose(rtrans).transpose(rtrans)))
+
+        # test .T property
+        self.assertTrue(numpy.array_equal(
+                a.T,
+                a.transpose(rtrans)))
 
     def testTransposition012(self):
         """transposition = (0, 1, 2)


### PR DESCRIPTION
Fix a problem when transposing a view that was already transposed (#495). Add tests for this issue.
Implement `.T` as an alias for `.transpose()`.