### PR TITLE
[StackView] Make getStack return same object set in setStack

### DIFF
--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -69,7 +69,7 @@ Example::
 
 __authors__ = ["P. Knobel", "H. Payno"]
 __license__ = "MIT"
-__date__ = "04/01/2016"
+__date__ = "10/01/2016"
 
 import numpy
 
@@ -376,7 +376,36 @@ class StackView(qt.QMainWindow):
         self.sigStackChanged.emit(stack.size)
 
     def getStack(self, copy=True, returnNumpyArray=False):
-        """Get the stack of images, as a 3D array or dataset.
+        """Get the original stack of images, as a 3D array or dataset.
+
+        The output has the form: [data, params]
+        where params is a dictionary containing display parameters.
+
+        :param bool copy: If True (default), then the object is copied
+            and returned as a numpy array.
+            Else, a reference to original data is returned, if possible.
+            If the original data is not a numpy array and parameter
+            returnNumpyArray is True, a copy will be made anyway.
+        :param bool returnNumpyArray: If True, the returned object is
+            guaranteed to be a numpy array.
+        :return: Stack of images and parameters.
+        :rtype: (numpy.ndarray, dict)
+        """
+        if self.getActiveImage() is None:
+            return None
+        _img, _legend, _info, _pixmap, params = self.getActiveImage()
+        if returnNumpyArray or copy:
+            return numpy.array(self._stack, copy=copy), params
+
+        # if a list of 2D arrays was cast into a ListOfImages,
+        # return the original list
+        if isinstance(self._stack, ListOfImages):
+            return self._stack.images, params
+
+        return self._stack, params
+
+    def getCurrentView(self, copy=True, returnNumpyArray=False):
+        """Get the stack of images, it is currently displayed.
 
         The first index of the returned stack is always the image
         index. If the perspective has been changed in the widget since the

--- a/silx/gui/plot/test/testStackView.py
+++ b/silx/gui/plot/test/testStackView.py
@@ -76,7 +76,9 @@ class TestStackView(TestCaseQt):
 
     def testSetStackPerspective(self):
         self.stackview.setStack(self.mystack, perspective=1)
-        my_trans_stack, params = self.stackview.getStack()
+        # my_orig_stack, params = self.stackview.getStack()
+        my_trans_stack, params = self.stackview.getCurrentView()
+
         # get stack returns the transposed data, depending on the perspective
         self.assertEqual(my_trans_stack.shape,
                          (self.mystack.shape[1], self.mystack.shape[0], self.mystack.shape[2]))
@@ -87,20 +89,29 @@ class TestStackView(TestCaseQt):
         loi = [self.mystack[i] for i in range(self.mystack.shape[0])]
 
         self.stackview.setStack(loi)
+        my_orig_stack, params = self.stackview.getStack(returnNumpyArray=True)
         my_trans_stack, params = self.stackview.getStack(returnNumpyArray=True)
         self.assertEqual(my_trans_stack.shape, self.mystack.shape)
         self.assertTrue(numpy.array_equal(self.mystack,
                                           my_trans_stack))
+        self.assertTrue(numpy.array_equal(self.mystack,
+                                          my_orig_stack))
         self.assertIsInstance(my_trans_stack, numpy.ndarray)
 
         self.stackview.setStack(loi, perspective=2)
-        my_trans_stack, params = self.stackview.getStack(copy=False)
+        my_orig_stack, params = self.stackview.getStack(copy=False)
+        my_trans_stack, params = self.stackview.getCurrentView(copy=False)
+        # getStack(copy=False) must return the object set in setStack
+        self.assertIs(my_orig_stack, loi)
+        # getCurrentView(copy=False) returns a ListOfImages whose .images
+        # attr is the original data
         self.assertEqual(my_trans_stack.shape,
                          (self.mystack.shape[2], self.mystack.shape[0], self.mystack.shape[1]))
         self.assertTrue(numpy.array_equal(numpy.array(my_trans_stack),
                                           numpy.transpose(self.mystack, axes=(2, 0, 1))))
         self.assertIsInstance(my_trans_stack,
                               ListOfImages)  # returnNumpyArray=False by default in getStack
+        self.assertIs(my_trans_stack.images, loi)
 
 
 class TestStackViewMainWindow(TestCaseQt):
@@ -134,7 +145,7 @@ class TestStackViewMainWindow(TestCaseQt):
 
     def testSetStackPerspective(self):
         self.stackview.setStack(self.mystack, perspective=1)
-        my_trans_stack, params = self.stackview.getStack()
+        my_trans_stack, params = self.stackview.getCurrentView()
         # get stack returns the transposed data, depending on the perspective
         self.assertEqual(my_trans_stack.shape,
                          (self.mystack.shape[1], self.mystack.shape[0], self.mystack.shape[2]))


### PR DESCRIPTION
Make getStack return the original data, no matter what the current view is.

Add getCurrentView() method to: return the view currently displayed in the widget.