### PR TITLE
[plot] Create the console widget only when required

### DIFF
--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -310,31 +310,30 @@ class PlotWindow(PlotWidget):
         will handle toggling the visibility of the console widget.
         """
         if not hasattr(self, '_consoleAction'):
-            self._consoleAction = qt.QAction('Console', self.controlButton)
+            self._consoleAction = qt.QAction('Console', self)
             self._consoleAction.setCheckable(True)
             if IPythonDockWidget is not None:
-                self._consoleAction.toggled.connect(self._initializeConsole)
+                self._consoleAction.toggled.connect(self._toggleConsoleVisibility)
             else:
                 self._consoleAction.setEnabled(False)
         return self._consoleAction
 
-    def _initializeConsole(self):
-        """Create IPythonDockWidget, show it, update :attr:`_consoleAction`
-        to connect its `toggled` signal to
-        :meth:`_consoleDockWidget.setVisible`."""
-        available_vars = {"plt": self}
-        banner = "The variable 'plt' is available. Use the 'whos' "
-        banner += "and 'help(plt)' commands for more information.\n\n"
-        self._consoleDockWidget = IPythonDockWidget(
-            available_vars=available_vars,
-            custom_banner=banner,
-            parent=self)
-        self._introduceNewDockWidget(self._consoleDockWidget)
-        self._consoleDockWidget.show()
-        self._consoleDockWidget.visibilityChanged.connect(self._consoleAction.setChecked)
+    def _toggleConsoleVisibility(self, is_checked=False):
+        """Create IPythonDockWidget if needed,
+        show it or hide it."""
+        # create widget if needed (first call)
+        if not hasattr(self, '_consoleDockWidget'):
+            available_vars = {"plt": self}
+            banner = "The variable 'plt' is available. Use the 'whos' "
+            banner += "and 'help(plt)' commands for more information.\n\n"
+            self._consoleDockWidget = IPythonDockWidget(
+                available_vars=available_vars,
+                custom_banner=banner,
+                parent=self)
+            self._introduceNewDockWidget(self._consoleDockWidget)
+            self._consoleDockWidget.visibilityChanged.connect(self._consoleAction.setChecked)
 
-        self._consoleAction.toggled.disconnect(self._initializeConsole)
-        self._consoleAction.toggled.connect(self._consoleDockWidget.setVisible)
+        self._consoleDockWidget.setVisible(is_checked)
 
     @property
     def crosshairAction(self):

--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2016 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-"""A :class:`.PlotWidget` with additionnal toolbars.
+"""A :class:`.PlotWidget` with additional toolbars.
 
 The :class:`PlotWindow` is a subclass of :class:`.PlotWidget`.
 It provides the plot API fully defined in :class:`.Plot`.
@@ -30,7 +30,7 @@ It provides the plot API fully defined in :class:`.Plot`.
 
 __authors__ = ["V.A. Sole", "T. Vincent"]
 __license__ = "MIT"
-__date__ = "13/12/2016"
+__date__ = "10/01/2017"
 
 import collections
 import logging
@@ -303,22 +303,38 @@ class PlotWindow(PlotWidget):
         return bool(self.maskToolsDockWidget.setSelectionMask(mask))
 
     @property
-    def consoleDockWidget(self):
-        """DockWidget with IPython console (lazy-loaded)."""
-        if not hasattr(self, '_consoleDockWidget'):
-            available_vars = {"plt": self}
-            banner = "The variable 'plt' is available. Use the 'whos' "
-            banner += "and 'help(plt)' commands for more information.\n\n"
+    def consoleAction(self):
+        """QAction handling the IPython console instantiation the first time
+        the user clicks the "Console" menu button.
+        The following clicks, after initialization is done,
+        will handle toggling the visibility of the console widget.
+        """
+        if not hasattr(self, '_consoleAction'):
+            self._consoleAction = qt.QAction('Console', self.controlButton)
+            self._consoleAction.setCheckable(True)
             if IPythonDockWidget is not None:
-                self._consoleDockWidget = IPythonDockWidget(
-                    available_vars=available_vars,
-                    custom_banner=banner,
-                    parent=self)
-                self._consoleDockWidget.hide()
-                self._introduceNewDockWidget(self._consoleDockWidget)
+                self._consoleAction.toggled.connect(self._initializeConsole)
             else:
-                self._consoleDockWidget = None
-        return self._consoleDockWidget
+                self._consoleAction.setEnabled(False)
+        return self._consoleAction
+
+    def _initializeConsole(self):
+        """Create IPythonDockWidget, show it, update :attr:`_consoleAction`
+        to connect its `toggled` signal to
+        :meth:`_consoleDockWidget.setVisible`."""
+        available_vars = {"plt": self}
+        banner = "The variable 'plt' is available. Use the 'whos' "
+        banner += "and 'help(plt)' commands for more information.\n\n"
+        self._consoleDockWidget = IPythonDockWidget(
+            available_vars=available_vars,
+            custom_banner=banner,
+            parent=self)
+        self._introduceNewDockWidget(self._consoleDockWidget)
+        self._consoleDockWidget.show()
+        self._consoleDockWidget.visibilityChanged.connect(self._consoleAction.setChecked)
+
+        self._consoleAction.toggled.disconnect(self._initializeConsole)
+        self._consoleAction.toggled.connect(self._consoleDockWidget.setVisible)
 
     @property
     def crosshairAction(self):
@@ -387,12 +403,7 @@ class PlotWindow(PlotWidget):
         controlMenu.addAction(self.legendsDockWidget.toggleViewAction())
         controlMenu.addAction(self.roiAction)
         controlMenu.addAction(self.maskAction)
-        if self.consoleDockWidget is not None:
-            controlMenu.addAction(self.consoleDockWidget.toggleViewAction())
-        else:
-            disabledConsoleAction = controlMenu.addAction('Console')
-            disabledConsoleAction.setCheckable(True)
-            disabledConsoleAction.setEnabled(False)
+        controlMenu.addAction(self.consoleAction)
 
         controlMenu.addSeparator()
         controlMenu.addAction(self.crosshairAction)


### PR DESCRIPTION
Create the console widget only after the corresponding menu is clicked, not when the menu is populated.

Closes #499 