### PR TITLE
Call resetZoom on addCurve in order to respect user interface.

### DIFF
--- a/silx/gui/widgets/DataViewer.py
+++ b/silx/gui/widgets/DataViewer.py
@@ -29,7 +29,7 @@ from __future__ import division
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "10/01/2017"
+__date__ = "12/01/2017"
 
 import numpy
 import numbers
@@ -161,7 +161,7 @@ class _Plot1dView(DataView):
                                   x=range(len(data)),
                                   y=data,
                                   resetzoom=self.__resetZoomNextTime)
-        self.__resetZoomNextTime = False
+        self.__resetZoomNextTime = True
 
     def getDataPriority(self, data):
         if data is None:


### PR DESCRIPTION
Closes #515 

DataViewer behavior is correct with images (when dimensions change there is a zoom reset and it is not the case when we are on the same dimensions).