### PR TITLE
[plot] Add more formats to plot SaveAction

### DIFF
--- a/silx/gui/_utils.py
+++ b/silx/gui/_utils.py
@@ -35,6 +35,7 @@ __license__ = "MIT"
 __date__ = "16/01/2017"
 
 
+import sys
 import numpy
 
 from . import qt

--- a/silx/gui/_utils.py
+++ b/silx/gui/_utils.py
@@ -1,0 +1,99 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This module provides convenient functions to use with Qt objects.
+
+It provides conversion between numpy and QImage.
+"""
+
+from __future__ import division
+
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "16/01/2017"
+
+
+import numpy
+
+from . import qt
+
+
+def convertArrayToQImage(image):
+    """Convert an array-like RGB888 image to a QImage.
+
+    The created QImage is using a copy of the array data.
+
+    Limitation: Only supports RGB888 format.
+
+    :param image: Array-like image data
+    :type image: numpy.ndarray of uint8 of dimension HxWx3
+    :return: Corresponding Qt image
+    :rtype: QImage
+    """
+    # Possible extension: add a format argument to support more formats
+
+    image = numpy.array(image, copy=False, order='C', dtype=numpy.uint8)
+
+    height, width, depth = image.shape
+    assert depth == 3
+
+    qimage = qt.QImage(
+        image.data,
+        width,
+        height,
+        image.strides[0],  # bytesPerLine
+        qt.QImage.Format_RGB888)
+
+    return qimage.copy()  # Making a copy of the image and its data
+
+
+def convertQImageToArray(image):
+    """Convert a RGB888 QImage to a numpy array.
+
+    Limitation: Only supports RGB888 format.
+    If QImage is not RGB888 it gets converted to this format.
+
+    :param QImage: The QImage to convert.
+    :return: The image array
+    :rtype: numpy.ndarray of uint8 of shape HxWx3
+    """
+    # Possible extension: avoid conversion to support more formats
+
+    if image.format() != qt.QImage.Format_RGB888:
+        # Convert to RGB888 if needed
+        image = image.convertToFormat(qt.QImage.Format_RGB888)
+
+    ptr = image.bits()
+    if qt.BINDING != 'PySide':
+        ptr.setsize(image.byteCount())
+        if qt.BINDING == 'PyQt4' and sys.version_info[0] == 2:
+            ptr = ptr.asstring()
+
+    array = numpy.fromstring(ptr, dtype=numpy.uint8)
+
+    # Lines are 32 bits aligned: remove padding bytes
+    array = array.reshape(image.height(), -1)[:, :image.width() * 3]
+    array.shape = image.height(), image.width(), 3
+    return array

--- a/silx/gui/plot/Colors.py
+++ b/silx/gui/plot/Colors.py
@@ -22,14 +22,24 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-"""Color conversion function and dictionary."""
+"""Color conversion function, color dictionary and colormap tools."""
 
 __authors__ = ["V.A. Sole", "T. VINCENT"]
 __license__ = "MIT"
-__date__ = "17/10/2016"
+__date__ = "16/01/2017"
 
+
+import logging
 
 import numpy
+
+import matplotlib.colors
+import matplotlib.cm
+
+from . import MPLColormap
+
+
+_logger = logging.getLogger(__name__)
 
 
 COLORDICT = {}
@@ -65,7 +75,7 @@ def rgba(color, colorDict=None):
     It also convert RGB(A) values from uint8 to float in [0, 1] and
     accept a QColor as color argument.
 
-    :param str code: The color code to conver
+    :param str color: The color to convert
     :param dict colorDict: A dictionary of color name conversion to color code
     :returns: RGBA colors as floats in [0., 1.]
     :rtype: tuple
@@ -130,3 +140,156 @@ def cursorColorForColormap(colormapName):
     :rtype: str
     """
     return _COLORMAP_CURSOR_COLORS.get(colormapName, 'black')
+
+
+_CMAPS = {}  # Store additional colormaps
+
+
+def getMPLColormap(name):
+    """Returns matplotlib colormap corresponding to given name
+
+    :param str name: The name of the colormap
+    :return: The corresponding colormap
+    :rtype: matplolib.colors.Colormap
+    """
+    if not _CMAPS:  # Lazy initialization of own colormaps
+        cdict = {'red': ((0.0, 0.0, 0.0),
+                         (1.0, 1.0, 1.0)),
+                 'green': ((0.0, 0.0, 0.0),
+                           (1.0, 0.0, 0.0)),
+                 'blue': ((0.0, 0.0, 0.0),
+                          (1.0, 0.0, 0.0))}
+        _CMAPS['red'] = matplotlib.colors.LinearSegmentedColormap(
+            'red', cdict, 256)
+
+        cdict = {'red': ((0.0, 0.0, 0.0),
+                         (1.0, 0.0, 0.0)),
+                 'green': ((0.0, 0.0, 0.0),
+                           (1.0, 1.0, 1.0)),
+                 'blue': ((0.0, 0.0, 0.0),
+                          (1.0, 0.0, 0.0))}
+        _CMAPS['green'] = matplotlib.colors.LinearSegmentedColormap(
+            'green', cdict, 256)
+
+        cdict = {'red': ((0.0, 0.0, 0.0),
+                         (1.0, 0.0, 0.0)),
+                 'green': ((0.0, 0.0, 0.0),
+                           (1.0, 0.0, 0.0)),
+                 'blue': ((0.0, 0.0, 0.0),
+                          (1.0, 1.0, 1.0))}
+        _CMAPS['blue'] = matplotlib.colors.LinearSegmentedColormap(
+            'blue', cdict, 256)
+
+        # Temperature as defined in spslut
+        cdict = {'red': ((0.0, 0.0, 0.0),
+                         (0.5, 0.0, 0.0),
+                         (0.75, 1.0, 1.0),
+                         (1.0, 1.0, 1.0)),
+                 'green': ((0.0, 0.0, 0.0),
+                           (0.25, 1.0, 1.0),
+                           (0.75, 1.0, 1.0),
+                           (1.0, 0.0, 0.0)),
+                 'blue': ((0.0, 1.0, 1.0),
+                          (0.25, 1.0, 1.0),
+                          (0.5, 0.0, 0.0),
+                          (1.0, 0.0, 0.0))}
+        # but limited to 256 colors for a faster display (of the colorbar)
+        _CMAPS['temperature'] = \
+            matplotlib.colors.LinearSegmentedColormap(
+                'temperature', cdict, 256)
+
+        # reversed gray
+        cdict = {'red': ((0.0, 1.0, 1.0),
+                         (1.0, 0.0, 0.0)),
+                 'green': ((0.0, 1.0, 1.0),
+                           (1.0, 0.0, 0.0)),
+                 'blue': ((0.0, 1.0, 1.0),
+                          (1.0, 0.0, 0.0))}
+
+        _CMAPS['reversed gray'] = \
+            matplotlib.colors.LinearSegmentedColormap(
+                'yerg', cdict, 256)
+
+    if name in _CMAPS:
+        return _CMAPS[name]
+    elif hasattr(MPLColormap, name):  # viridis and sister colormaps
+        return getattr(MPLColormap, name)
+    else:
+        # matplotlib built-in
+        return matplotlib.cm.get_cmap(name)
+
+
+def getMPLScalarMappable(colormap, data=None):
+    """Returns matplotlib ScalarMappable corresponding to colormap
+
+    :param dict colormap: The colormap to convert
+    :param numpy.ndarray data:
+        The data on which the colormap is applied.
+        If provided, it is used to compute autoscale.
+    :return: matplotlib object corresponding to colormap
+    :rtype: matplotlib.cm.ScalarMappable
+    """
+    assert colormap is not None
+
+    if colormap['name'] is not None:
+        cmap = getMPLColormap(colormap['name'])
+
+    else:  # No name, use custom colors
+        if 'colors' not in colormap:
+            raise ValueError(
+                'addImage: colormap no name nor list of colors.')
+        colors = numpy.array(colormap['colors'], copy=True)
+        assert len(colors.shape) == 2
+        assert colors.shape[-1] in (3, 4)
+        if colors.dtype == numpy.uint8:
+            # Convert to float in [0., 1.]
+            colors = colors.astype(numpy.float32) / 255.
+        cmap = matplotlib.colors.ListedColormap(colors)
+
+    if colormap['normalization'].startswith('log'):
+        vmin, vmax = None, None
+        if not colormap['autoscale']:
+            if colormap['vmin'] > 0.:
+                vmin = colormap['vmin']
+            if colormap['vmax'] > 0.:
+                vmax = colormap['vmax']
+
+            if vmin is None or vmax is None:
+                _logger.warning('Log colormap with negative bounds, ' +
+                                'changing bounds to positive ones.')
+            elif vmin > vmax:
+                _logger.warning('Colormap bounds are inverted.')
+                vmin, vmax = vmax, vmin
+
+        # Set unset/negative bounds to positive bounds
+        if (vmin is None or vmax is None) and data is not None:
+            finiteData = data[numpy.isfinite(data)]
+            posData = finiteData[finiteData > 0]
+            if vmax is None:
+                # 1. as an ultimate fallback
+                vmax = posData.max() if posData.size > 0 else 1.
+            if vmin is None:
+                vmin = posData.min() if posData.size > 0 else vmax
+            if vmin > vmax:
+                vmin = vmax
+
+        norm = matplotlib.colors.LogNorm(vmin, vmax)
+
+    else:  # Linear normalization
+        if colormap['autoscale']:
+            if data is None:
+                vmin, vmax = None, None
+            else:
+                finiteData = data[numpy.isfinite(data)]
+                vmin = finiteData.min()
+                vmax = finiteData.max()
+        else:
+            vmin = colormap['vmin']
+            vmax = colormap['vmax']
+            if vmin > vmax:
+                _logger.warning('Colormap bounds are inverted.')
+                vmin, vmax = vmax, vmin
+
+        norm = matplotlib.colors.Normalize(vmin, vmax)
+
+    return matplotlib.cm.ScalarMappable(norm=norm, cmap=cmap)

--- a/silx/gui/plot/PlotActions.py
+++ b/silx/gui/plot/PlotActions.py
@@ -70,6 +70,7 @@ import numpy
 
 from .. import icons
 from .. import qt
+from .._utils import convertArrayToQImage
 from . import Colors
 from .ColormapDialog import ColormapDialog
 from ._utils import applyZoomToPlot as _applyZoomToPlot
@@ -721,19 +722,8 @@ class SaveAction(PlotAction):
             scalarMappable = Colors.getMPLScalarMappable(colormap, data)
             rgbaImage = scalarMappable.to_rgba(data, bytes=True)
 
-            # Convert to RGB image
-            image = numpy.ascontiguousarray(rgbaImage[:, :, :3],
-                                            dtype=numpy.uint8)
-
-            height, width = image.shape[:2]
-            bytesPerLine = image.strides[0]
-            # Warning: qimage is NOT copying image data
-            qimage = qt.QImage(
-                image.data,
-                width,
-                height,
-                bytesPerLine,
-                qt.QImage.Format_RGB888)
+            # Convert RGB QImage
+            qimage = convertArrayToQImage(rgbaImage[:, :, :3])
 
             if nameFilter == self.IMAGE_FILTER_RGB_PNG:
                 fileFormat = 'PNG'

--- a/silx/gui/plot/PlotActions.py
+++ b/silx/gui/plot/PlotActions.py
@@ -501,7 +501,11 @@ class SaveAction(PlotAction):
     """
     # TODO find a way to make the filter list selectable and extensible
 
-    SNAPSHOT_FILTERS = ('Plot Snapshot PNG (*.png)', 'Plot Snapshot JPEG (*.jpg)')
+    SNAPSHOT_FILTER_SVG = 'Plot Snapshot as SVG (*.svg)'
+
+    SNAPSHOT_FILTERS = ('Plot Snapshot as PNG (*.png)',
+                        'Plot Snapshot as JPEG (*.jpg)',
+                        SNAPSHOT_FILTER_SVG)
 
     # Dict of curve filters with CSV-like format
     # Using ordered dict to guarantee filters order
@@ -557,15 +561,19 @@ class SaveAction(PlotAction):
         :return: False if format is not supported or save failed,
                  True otherwise.
         """
-        if hasattr(qt.QPixmap, "grabWidget"):
-            # Qt 4
-            pixmap = qt.QPixmap.grabWidget(self.plot.getWidgetHandle())
+        if nameFilter == self.SNAPSHOT_FILTER_SVG:
+            self.plot.saveGraph(filename, fileFormat='svg')
+
         else:
-            # Qt 5
-            pixmap = self.plot.getWidgetHandle().grab()
-        if not pixmap.save(filename):
-            self._errorMessage()
-            return False
+            if hasattr(qt.QPixmap, "grabWidget"):
+                # Qt 4
+                pixmap = qt.QPixmap.grabWidget(self.plot.getWidgetHandle())
+            else:
+                # Qt 5
+                pixmap = self.plot.getWidgetHandle().grab()
+            if not pixmap.save(filename):
+                self._errorMessage()
+                return False
         return True
 
     def _saveCurve(self, filename, nameFilter):

--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -35,6 +35,7 @@ import logging
 
 from silx.gui import qt
 from silx.gui.plot.Colors import rgba
+from .._utils import convertArrayToQImage
 
 from .glutils import gl
 from .scene import interaction, primitives, transform
@@ -267,11 +268,7 @@ class Plot3DWidget(qt.QGLWidget):
             self.makeCurrent()
             image = self.window.grab(qt.QGLContext.currentContext())
 
-        height, width = image.shape[:2]
-        bytesPerLine = image.strides[0]
-        qimage = qt.QImage(
-            image.data, width, height, bytesPerLine, qt.QImage.Format_RGB888)
-        return qimage.copy(qimage.rect())  # Return a copy
+        return convertArrayToQImage(image)
 
     def wheelEvent(self, event):
         xpixel = event.x() * self._devicePixelRatio

--- a/silx/gui/plot3d/_font.py
+++ b/silx/gui/plot3d/_font.py
@@ -33,6 +33,7 @@ import logging
 import sys
 import numpy
 from silx.gui import qt
+from silx.gui._utils import convertQImageToArray
 
 
 _logger = logging.getLogger(__name__)
@@ -117,14 +118,7 @@ def rasterText(text, font, size=-1, weight=-1, italic=False):
     painter.drawText(bounds, qt.Qt.TextExpandTabs, text)
     painter.end()
 
-    # RGB QImage to numpy array
-    ptr = image.bits()
-    if qt.BINDING != 'PySide':
-        ptr.setsize(image.byteCount())
-        if qt.BINDING == 'PyQt4' and sys.version_info[0] == 2:
-            ptr = ptr.asstring()
-    array = numpy.fromstring(ptr, dtype=numpy.uint8)
-    array.shape = image.height(), image.width(), 3
+    array = convertQImageToArray(image)
 
     # RGB to R
     array = numpy.ascontiguousarray(array[:, :, 0])

--- a/silx/gui/test/__init__.py
+++ b/silx/gui/test/__init__.py
@@ -75,6 +75,7 @@ def suite():
     from . import test_qt
     from . import test_console
     from . import test_icons
+    from . import test_utils
 
     test_suite.addTest(test_qt.suite())
     test_suite.addTest(test_plot.suite())
@@ -84,4 +85,5 @@ def suite():
     test_suite.addTest(test_console.suite())
     test_suite.addTest(test_icons.suite())
     test_suite.addTest(test_plot3d.suite())
+    test_suite.addTest(test_utils.suite())
     return test_suite

--- a/silx/gui/test/test_utils.py
+++ b/silx/gui/test/test_utils.py
@@ -1,0 +1,77 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Test of utils module."""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "16/01/2017"
+
+
+import unittest
+
+import numpy
+
+from silx.gui import qt
+from silx.gui.test.utils import TestCaseQt
+
+from silx.gui import _utils
+
+
+class TestQImageConversion(TestCaseQt):
+    """Tests conversion of QImage to/from numpy array."""
+
+    def testConvertArrayToQImage(self):
+        """Test conversion of numpy array to QImage"""
+        image = numpy.ones((3, 3, 3), dtype=numpy.uint8)
+        qimage = _utils.convertArrayToQImage(image)
+
+        self.assertEqual(qimage.height(), image.shape[0])
+        self.assertEqual(qimage.width(), image.shape[1])
+        self.assertEqual(qimage.format(), qt.QImage.Format_RGB888)
+
+        color = qt.QColor(1, 1, 1).rgb()
+        self.assertEqual(qimage.pixel(1, 1), color)
+
+    def testConvertQImageToArray(self):
+        """Test conversion of QImage to numpy array"""
+        qimage = qt.QImage(3, 3, qt.QImage.Format_RGB888)
+        qimage.fill(1)
+        image = _utils.convertQImageToArray(qimage)
+
+        self.assertEqual(qimage.height(), image.shape[0])
+        self.assertEqual(qimage.width(), image.shape[1])
+        self.assertEqual(image.shape[2], 3)
+        self.assertTrue(numpy.all(numpy.equal(image, (0, 0, 1))))
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    test_suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(
+        TestQImageConversion))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/silx/gui/test/test_utils.py
+++ b/silx/gui/test/test_utils.py
@@ -57,13 +57,13 @@ class TestQImageConversion(TestCaseQt):
     def testConvertQImageToArray(self):
         """Test conversion of QImage to numpy array"""
         qimage = qt.QImage(3, 3, qt.QImage.Format_RGB888)
-        qimage.fill(1)
+        qimage.fill(0x010101)
         image = _utils.convertQImageToArray(qimage)
 
         self.assertEqual(qimage.height(), image.shape[0])
         self.assertEqual(qimage.width(), image.shape[1])
         self.assertEqual(image.shape[2], 3)
-        self.assertTrue(numpy.all(numpy.equal(image, (0, 0, 1))))
+        self.assertTrue(numpy.all(numpy.equal(image, 1)))
 
 
 def suite():


### PR DESCRIPTION
In the SaveAction:

- Add save of plot as SVG, closes #503
- Add save of active image with colormap applied as RGB in PNG and TIFF, closes #437

This PR also contains some refactoring:
- New module: silx.gui._utils with QImage<->numpy.array
- Moved colormap functions from matplotlib backend to silx.gui.Colors
