### PR TITLE
[plot3d] Handle missing PyOpenGL or QtOpenGL

### DIFF
--- a/doc/source/modules/gui/plot3d/index.rst
+++ b/doc/source/modules/gui/plot3d/index.rst
@@ -51,6 +51,8 @@ Widgets gallery
 Public modules
 --------------
 
+The following sub-modules are available:
+
 .. toctree::
    :maxdepth: 2
 
@@ -60,6 +62,10 @@ Public modules
    sfviewparamtree.rst
    toolbars.rst
    actions.rst
+
+The :mod:`silx.gui.plot3d` package provides the following function:
+
+.. autofunction:: isAvailable
 
 Sample code
 -----------

--- a/doc/source/modules/gui/plot3d/index.rst
+++ b/doc/source/modules/gui/plot3d/index.rst
@@ -63,9 +63,6 @@ The following sub-modules are available:
    toolbars.rst
    actions.rst
 
-The :mod:`silx.gui.plot3d` package provides the following function:
-
-.. autofunction:: isAvailable
 
 Sample code
 -----------

--- a/silx/gui/data/DataViewer.py
+++ b/silx/gui/data/DataViewer.py
@@ -38,7 +38,6 @@ import logging
 import silx.io
 from silx.gui import qt
 from silx.gui.data.NumpyAxesSelector import NumpyAxesSelector
-import silx.gui.plot3d
 
 
 try:
@@ -235,9 +234,12 @@ class _Plot3dView(DataView):
 
     def __init__(self, parent, modeId):
         super(_Plot3dView, self).__init__(parent, modeId)
-        if not silx.gui.plot3d.isAvailable():
+        try:
+            import silx.gui.plot3d
+        except ImportError:
             _logger.warning("Plot3dView is not available")
-            raise ImportError("silx.gui.plot3d is not available")
+            _logger.debug("Backtrace", exc_info=True)
+            raise
         self.__resetZoomNextTime = True
 
     def axesNames(self):

--- a/silx/gui/data/DataViewer.py
+++ b/silx/gui/data/DataViewer.py
@@ -38,6 +38,7 @@ import logging
 import silx.io
 from silx.gui import qt
 from silx.gui.data.NumpyAxesSelector import NumpyAxesSelector
+import silx.gui.plot3d
 
 
 try:
@@ -234,9 +235,7 @@ class _Plot3dView(DataView):
 
     def __init__(self, parent, modeId):
         super(_Plot3dView, self).__init__(parent, modeId)
-        try:
-            import OpenGL  # noqa
-        except:
+        if not silx.gui.plot3d.isAvailable():
             _logger.warning("Plot3dView is not available")
             _logger.debug("Backtrace", exc_info=True)
             raise

--- a/silx/gui/data/DataViewer.py
+++ b/silx/gui/data/DataViewer.py
@@ -237,8 +237,7 @@ class _Plot3dView(DataView):
         super(_Plot3dView, self).__init__(parent, modeId)
         if not silx.gui.plot3d.isAvailable():
             _logger.warning("Plot3dView is not available")
-            _logger.debug("Backtrace", exc_info=True)
-            raise
+            raise ImportError("silx.gui.plot3d is not available")
         self.__resetZoomNextTime = True
 
     def axesNames(self):

--- a/silx/gui/plot3d/__init__.py
+++ b/silx/gui/plot3d/__init__.py
@@ -30,3 +30,35 @@ from __future__ import absolute_import
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "05/01/2017"
+
+
+import logging as _logging
+
+from .. import qt as _qt
+
+try:
+    import OpenGL as _OpenGL
+except ImportError:
+    _OpenGL = None
+
+
+_logger = _logging.getLogger(__name__)
+
+
+if not _qt.HAS_OPENGL:
+    _logger.warning(
+        'Qt.QtOpenGL is not available: silx.gui.plot3d modules will fail.')
+
+if _OpenGL is None:
+    _logger.warning(
+        'PyOpenGL is not installed: silx.gui.plot3d modules will fail')
+
+
+def isAvailable():
+    """Returns True if plot3d functionality is available, False otherwise.
+
+    This function checks for PyOpenGL and QtOpenGL availability.
+    The availability of OpenGL 2.1 (required by plot3d) is not checked here.
+
+    :rtype: bool"""
+    return _OpenGL is not None and _qt.HAS_OPENGL

--- a/silx/gui/plot3d/__init__.py
+++ b/silx/gui/plot3d/__init__.py
@@ -24,41 +24,22 @@
 # ###########################################################################*/
 """
 This package provides widgets displaying 3D content based on OpenGL.
+
+It depends on PyOpenGL and QtOpenGL.
 """
 from __future__ import absolute_import
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "05/01/2017"
+__date__ = "18/01/2017"
 
-
-import logging as _logging
 
 from .. import qt as _qt
+
+if not _qt.HAS_OPENGL:
+    raise ImportError('Qt.QtOpenGL is not available')
 
 try:
     import OpenGL as _OpenGL
 except ImportError:
-    _OpenGL = None
-
-
-_logger = _logging.getLogger(__name__)
-
-
-if not _qt.HAS_OPENGL:
-    _logger.warning(
-        'Qt.QtOpenGL is not available: silx.gui.plot3d modules will fail.')
-
-if _OpenGL is None:
-    _logger.warning(
-        'PyOpenGL is not installed: silx.gui.plot3d modules will fail')
-
-
-def isAvailable():
-    """Returns True if plot3d functionality is available, False otherwise.
-
-    This function checks for PyOpenGL and QtOpenGL availability.
-    The availability of OpenGL 2.1 (required by plot3d) is not checked here.
-
-    :rtype: bool"""
-    return _OpenGL is not None and _qt.HAS_OPENGL
+    raise ImportError('PyOpenGL is not installed')

--- a/silx/gui/plot3d/test/__init__.py
+++ b/silx/gui/plot3d/test/__init__.py
@@ -33,6 +33,8 @@ import logging
 import os
 import unittest
 
+import silx.gui.plot3d
+
 
 _logger = logging.getLogger(__name__)
 
@@ -40,24 +42,7 @@ _logger = logging.getLogger(__name__)
 def suite():
     test_suite = unittest.TestSuite()
 
-    try:
-        import OpenGL
-    except ImportError:
-        OpenGL = None
-
-    if OpenGL is None:  # PyOpenGL is not available
-        _logger.warning(
-            'silx.gui.plot3d tests disabled (PyOpenGL not installed)')
-
-        class SkipPlot3DTest(unittest.TestCase):
-            def runTest(self):
-                self.skipTest(
-                    'silx.gui.plot3d tests disabled (PyOpenGL not installed)')
-
-        test_suite.addTest(SkipPlot3DTest())
-        return test_suite
-
-    elif os.environ.get('WITH_GL_TEST', 'True') == 'False':
+    if os.environ.get('WITH_GL_TEST', 'True') == 'False':
         # Explicitly disabled tests
         _logger.warning(
             "silx.gui.plot3d tests disabled (WITH_GL_TEST=False)")
@@ -66,6 +51,18 @@ def suite():
             def runTest(self):
                 self.skipTest(
                     "silx.gui.plot3d tests disabled (WITH_GL_TEST=False)")
+
+        test_suite.addTest(SkipPlot3DTest())
+        return test_suite
+
+    elif not silx.gui.plot3d.isAvailable():
+        _logger.warning('silx.gui.plot3d tests disabled '
+                        '(PyOpenGL or QtOpenGL not installed)')
+
+        class SkipPlot3DTest(unittest.TestCase):
+            def runTest(self):
+                self.skipTest('silx.gui.plot3d tests disabled '
+                              '(PyOpenGL or QtOpenGL not installed)')
 
         test_suite.addTest(SkipPlot3DTest())
         return test_suite

--- a/silx/gui/plot3d/test/__init__.py
+++ b/silx/gui/plot3d/test/__init__.py
@@ -33,8 +33,6 @@ import logging
 import os
 import unittest
 
-import silx.gui.plot3d
-
 
 _logger = logging.getLogger(__name__)
 
@@ -55,19 +53,7 @@ def suite():
         test_suite.addTest(SkipPlot3DTest())
         return test_suite
 
-    elif not silx.gui.plot3d.isAvailable():
-        _logger.warning('silx.gui.plot3d tests disabled '
-                        '(PyOpenGL or QtOpenGL not installed)')
-
-        class SkipPlot3DTest(unittest.TestCase):
-            def runTest(self):
-                self.skipTest('silx.gui.plot3d tests disabled '
-                              '(PyOpenGL or QtOpenGL not installed)')
-
-        test_suite.addTest(SkipPlot3DTest())
-        return test_suite
-
-    # Import here to avoid loading PyOpenGL if tests are disabled
+    # Import here to avoid loading modules if tests are disabled
 
     # from ..glutils import test as test_glutils
     from ..scene import test as test_scene

--- a/silx/gui/qt/_qt.py
+++ b/silx/gui/qt/_qt.py
@@ -60,6 +60,9 @@ QtBinding = None  # noqa
 HAS_SVG = False
 """True if Qt provides support for Scalable Vector Graphics (QtSVG)."""
 
+HAS_OPENGL = False
+"""True if Qt provides support for OpenGL (QtOpenGL)."""
+
 # First check for an already loaded wrapper
 if 'PySide.QtCore' in sys.modules:
     BINDING = 'PySide'
@@ -111,6 +114,9 @@ if BINDING == 'PyQt4':
         from PyQt4.QtOpenGL import *  # noqa
     except ImportError:
         _logger.info("PyQt4.QtOpenGL not available")
+        HAS_OPENGL = False
+    else:
+        HAS_OPENGL = True
 
     try:
         from PyQt4.QtSvg import *  # noqa
@@ -140,6 +146,9 @@ elif BINDING == 'PySide':
         from PySide.QtOpenGL import *  # noqa
     except ImportError:
         _logger.info("PySide.QtOpenGL not available")
+        HAS_OPENGL = False
+    else:
+        HAS_OPENGL = True
 
     try:
         from PySide.QtSvg import *  # noqa
@@ -167,7 +176,10 @@ elif BINDING == 'PyQt5':
     try:
         from PyQt5.QtOpenGL import *  # noqa
     except ImportError:
-        _logger.info("PyQt5.QtOpenGL not available")
+        _logger.info("PySide.QtOpenGL not available")
+        HAS_OPENGL = False
+    else:
+        HAS_OPENGL = True
 
     try:
         from PyQt5.QtSvg import *  # noqa

--- a/silx/gui/test/__init__.py
+++ b/silx/gui/test/__init__.py
@@ -71,7 +71,6 @@ def suite():
     from ..fit import test as test_fit
     from ..hdf5 import test as test_hdf5
     from ..widgets import test as test_widgets
-    from ..plot3d import test as test_plot3d
     from ..data import test as test_data
     from . import test_qt
     # Console tests disabled due to corruption of python environment
@@ -80,6 +79,22 @@ def suite():
     from . import test_icons
     from . import test_utils
 
+    try:
+        from ..plot3d.test import suite as test_plot3d_suite
+
+    except ImportError:
+        _logger.warning(
+            'silx.gui.plot3d tests disabled '
+            '(PyOpenGL or QtOpenGL not installed)')
+
+        class SkipPlot3DTest(unittest.TestCase):
+            def runTest(self):
+                self.skipTest('silx.gui.plot3d tests disabled '
+                              '(PyOpenGL or QtOpenGL not installed)')
+
+        test_plot3d_suite = SkipPlot3DTest
+
+
     test_suite.addTest(test_qt.suite())
     test_suite.addTest(test_plot.suite())
     test_suite.addTest(test_fit.suite())
@@ -87,7 +102,7 @@ def suite():
     test_suite.addTest(test_widgets.suite())
     # test_suite.addTest(test_console.suite())   # see issue #538 on github
     test_suite.addTest(test_icons.suite())
-    test_suite.addTest(test_plot3d.suite())
     test_suite.addTest(test_data.suite())
     test_suite.addTest(test_utils.suite())
+    test_suite.addTest(test_plot3d_suite())
     return test_suite


### PR DESCRIPTION
This PR adds a function to check if plot3d can run (i.e., PyOpenGL and QtOpenGL are available).
This function is used by plot3d tests and DataViewer.

Closes #532, closes #540 