### PR TITLE
Fix fabioh5 with special TIFF

### DIFF
--- a/silx/gui/data/RecordTableView.py
+++ b/silx/gui/data/RecordTableView.py
@@ -35,7 +35,7 @@ from .TextFormatter import TextFormatter
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "20/01/2017"
+__date__ = "24/01/2017"
 
 
 class _MultiLineItem(qt.QItemDelegate):
@@ -204,6 +204,10 @@ class RecordTableModel(qt.QAbstractTableModel):
     def headerData(self, section, orientation, role=qt.Qt.DisplayRole):
         """Returns the 0-based row or column index, for display in the
         horizontal and vertical headers"""
+        if section == -1:
+            # PyQt4 send -1 when there is columns but no rows
+            return None
+
         if role == qt.Qt.DisplayRole:
             if orientation == qt.Qt.Vertical:
                 return str(section)

--- a/silx/io/fabioh5.py
+++ b/silx/io/fabioh5.py
@@ -737,6 +737,10 @@ class FabioReader(object):
                 converted.append(c)
                 types.add(c.dtype)
 
+        if has_none and len(types) == 0:
+            # That's a list of none values
+            return numpy.array([0] * len(values), numpy.int8)
+
         result_type = numpy.result_type(*types)
 
         if issubclass(result_type.type, numpy.string_):

--- a/silx/io/fabioh5.py
+++ b/silx/io/fabioh5.py
@@ -821,11 +821,13 @@ class FabioReader(object):
         try:
             value = int(value)
             dtype = numpy.min_scalar_type(value)
+            assert dtype.kind != "O"
             return dtype.type(value)
         except ValueError:
             try:
                 value = float(value)
                 dtype = numpy.min_scalar_type(value)
+                assert dtype.kind != "O"
                 return dtype.type(value)
             except ValueError:
                 return numpy.string_(value)


### PR DESCRIPTION
Some file header from FabIO provide python object from headers, while most of format provide key-value as string-string.

This patch convert most of python object to numpy object.

It fix the issue #580 from PiRK.