### PR TITLE
[plot] resetZoom with data margins and keep aspect ratio on

### DIFF
--- a/silx/gui/plot/BackendBase.py
+++ b/silx/gui/plot/BackendBase.py
@@ -473,7 +473,7 @@ class BackendBase(object):
         """
         raise NotImplementedError()
 
-    def pixelToData(self, x, y, axis, check=True):
+    def pixelToData(self, x, y, axis, check):
         """Convert a position in pixels in the widget to a position in
         the data space.
 

--- a/silx/gui/plot/BackendMatplotlib.py
+++ b/silx/gui/plot/BackendMatplotlib.py
@@ -564,6 +564,9 @@ class BackendMatplotlib(BackendBase.BackendBase):
                 xmin, xmax, ymin, ymax, ymin2, ymax2))
 
             if self.isKeepDataAspectRatio():
+                # Use limits with margins to keep ratio
+                xmin, xmax, ymin, ymax = newLimits[:4]
+
                 # Compute bbox wth figure aspect ratio
                 figW, figH = self.fig.get_size_inches()
                 figureRatio = figH / figW
@@ -571,14 +574,14 @@ class BackendMatplotlib(BackendBase.BackendBase):
                 dataRatio = (ymax - ymin) / (xmax - xmin)
                 if dataRatio < figureRatio:
                     # Increase y range
-                    ycenter = 0.5 * (newLimits[3] + newLimits[2])
+                    ycenter = 0.5 * (ymax + ymin)
                     yrange = (xmax - xmin) * figureRatio
                     newLimits[2] = ycenter - 0.5 * yrange
                     newLimits[3] = ycenter + 0.5 * yrange
 
                 elif dataRatio > figureRatio:
                     # Increase x range
-                    xcenter = 0.5 * (newLimits[1] + newLimits[0])
+                    xcenter = 0.5 * (xmax + xmin)
                     xrange_ = (ymax - ymin) / figureRatio
                     newLimits[0] = xcenter - 0.5 * xrange_
                     newLimits[1] = xcenter + 0.5 * xrange_


### PR DESCRIPTION
This PR fixes an issue with Plot.resetZoom method with data margins and keep aspect ratio on: Closes #452