### PR TITLE
Fix shortcut context

### DIFF
--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -607,6 +607,7 @@ class MaskToolsWidget(qt.QWidget):
             ' <b>B</b>')
         self.browseAction.setCheckable(True)
         self.browseAction.triggered.connect(self._activeBrowseMode)
+        self.addAction(self.browseAction)
 
         self.rectAction = qt.QAction(
             icons.getQIcon('shape-rectangle'), 'Rectangle selection', None)
@@ -615,6 +616,7 @@ class MaskToolsWidget(qt.QWidget):
         self.rectAction.setShortcut(qt.QKeySequence(qt.Qt.Key_R))
         self.rectAction.setCheckable(True)
         self.rectAction.triggered.connect(self._activeRectMode)
+        self.addAction(self.rectAction)
 
         self.polygonAction = qt.QAction(
             icons.getQIcon('shape-polygon'), 'Polygon selection', None)
@@ -625,6 +627,7 @@ class MaskToolsWidget(qt.QWidget):
             'Right-click to place the last corner')
         self.polygonAction.setCheckable(True)
         self.polygonAction.triggered.connect(self._activePolygonMode)
+        self.addAction(self.polygonAction)
 
         self.pencilAction = qt.QAction(
             icons.getQIcon('draw-pencil'), 'Pencil tool', None)
@@ -633,6 +636,7 @@ class MaskToolsWidget(qt.QWidget):
             'Pencil tool: (Un)Mask using a pencil <b>P</b>')
         self.pencilAction.setCheckable(True)
         self.pencilAction.triggered.connect(self._activePencilMode)
+        self.addAction(self.polygonAction)
 
         self.drawActionGroup = qt.QActionGroup(self)
         self.drawActionGroup.setExclusive(True)

--- a/silx/gui/plot/PlotActions.py
+++ b/silx/gui/plot/PlotActions.py
@@ -51,7 +51,7 @@ from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "25/11/2016"
+__date__ = "26/01/2017"
 
 
 from collections import OrderedDict
@@ -171,6 +171,7 @@ class ZoomInAction(PlotAction):
             triggered=self._actionTriggered,
             checkable=False, parent=parent)
         self.setShortcut(qt.QKeySequence.ZoomIn)
+        self.setShortcutContext(qt.Qt.WidgetShortcut)
 
     def _actionTriggered(self, checked=False):
         _applyZoomToPlot(self.plot, 1.1)
@@ -190,6 +191,7 @@ class ZoomOutAction(PlotAction):
             triggered=self._actionTriggered,
             checkable=False, parent=parent)
         self.setShortcut(qt.QKeySequence.ZoomOut)
+        self.setShortcutContext(qt.Qt.WidgetShortcut)
 
     def _actionTriggered(self, checked=False):
         _applyZoomToPlot(self.plot, 1. / 1.1)
@@ -559,6 +561,7 @@ class SaveAction(PlotAction):
             triggered=self._actionTriggered,
             checkable=False, parent=parent)
         self.setShortcut(qt.QKeySequence.Save)
+        self.setShortcutContext(qt.Qt.WidgetShortcut)
 
     def _errorMessage(self, informativeText=''):
         """Display an error message."""
@@ -865,6 +868,7 @@ class PrintAction(PlotAction):
             triggered=self.printPlot,
             checkable=False, parent=parent)
         self.setShortcut(qt.QKeySequence.Print)
+        self.setShortcutContext(qt.Qt.WidgetShortcut)
 
     @property
     def printer(self):
@@ -959,6 +963,7 @@ class CopyAction(PlotAction):
             triggered=self.copyPlot,
             checkable=False, parent=parent)
         self.setShortcut(qt.QKeySequence.Copy)
+        self.setShortcutContext(qt.Qt.WidgetShortcut)
 
     def copyPlot(self):
         """Copy plot content to the clipboard as a bitmap."""

--- a/silx/gui/plot/PlotToolButtons.py
+++ b/silx/gui/plot/PlotToolButtons.py
@@ -34,7 +34,7 @@ The following QToolButton are available:
 
 __authors__ = ["V. Valls", "H. Payno"]
 __license__ = "MIT"
-__date__ = "05/01/2016"
+__date__ = "26/01/2017"
 
 
 import logging
@@ -278,4 +278,3 @@ class ProfileToolButton(PlotToolButton):
 
     def computeProfileIn2D(self):
         self._profileDimensionChanged(2)
-

--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -30,7 +30,7 @@ It provides the plot API fully defined in :class:`.Plot`.
 
 __authors__ = ["V.A. Sole", "T. Vincent"]
 __license__ = "MIT"
-__date__ = "25/01/2017"
+__date__ = "26/01/2017"
 
 import collections
 import logging
@@ -115,6 +115,7 @@ class PlotWindow(PlotWidget):
 
         self.resetZoomAction = self.group.addAction(PlotActions.ResetZoomAction(self))
         self.resetZoomAction.setVisible(resetzoom)
+        self.addAction(self.resetZoomAction)
 
         self.zoomInAction = PlotActions.ZoomInAction(self)
         self.addAction(self.zoomInAction)
@@ -125,28 +126,35 @@ class PlotWindow(PlotWidget):
         self.xAxisAutoScaleAction = self.group.addAction(
             PlotActions.XAxisAutoScaleAction(self))
         self.xAxisAutoScaleAction.setVisible(autoScale)
+        self.addAction(self.xAxisAutoScaleAction)
 
         self.yAxisAutoScaleAction = self.group.addAction(
             PlotActions.YAxisAutoScaleAction(self))
         self.yAxisAutoScaleAction.setVisible(autoScale)
+        self.addAction(self.yAxisAutoScaleAction)
 
         self.xAxisLogarithmicAction = self.group.addAction(
             PlotActions.XAxisLogarithmicAction(self))
         self.xAxisLogarithmicAction.setVisible(logScale)
+        self.addAction(self.xAxisLogarithmicAction)
 
         self.yAxisLogarithmicAction = self.group.addAction(
             PlotActions.YAxisLogarithmicAction(self))
         self.yAxisLogarithmicAction.setVisible(logScale)
+        self.addAction(self.yAxisLogarithmicAction)
 
         self.gridAction = self.group.addAction(
             PlotActions.GridAction(self, gridMode='both'))
         self.gridAction.setVisible(grid)
+        self.addAction(self.gridAction)
 
         self.curveStyleAction = self.group.addAction(PlotActions.CurveStyleAction(self))
         self.curveStyleAction.setVisible(curveStyle)
+        self.addAction(self.curveStyleAction)
 
         self.colormapAction = self.group.addAction(PlotActions.ColormapAction(self))
         self.colormapAction.setVisible(colormap)
+        self.addAction(self.colormapAction)
 
         self.keepDataAspectRatioButton = PlotToolButtons.AspectToolButton(
             parent=self, plot=self)
@@ -172,15 +180,19 @@ class PlotWindow(PlotWidget):
 
         self.copyAction = self.group.addAction(PlotActions.CopyAction(self))
         self.copyAction.setVisible(copy)
+        self.addAction(self.copyAction)
 
         self.saveAction = self.group.addAction(PlotActions.SaveAction(self))
         self.saveAction.setVisible(save)
+        self.addAction(self.saveAction)
 
         self.printAction = self.group.addAction(PlotActions.PrintAction(self))
         self.printAction.setVisible(print_)
+        self.addAction(self.printAction)
 
         self.fitAction = self.group.addAction(PlotActions.FitAction(self))
         self.fitAction.setVisible(fit)
+        self.addAction(self.fitAction)
 
         # lazy loaded actions needed by the controlButton menu
         self._consoleAction = None

--- a/silx/gui/plot3d/Plot3DActions.py
+++ b/silx/gui/plot3d/Plot3DActions.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import, division
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "10/01/2017"
+__date__ = "26/01/2017"
 
 
 import logging
@@ -92,6 +92,7 @@ class CopyAction(Plot3DAction):
         self.setToolTip('Copy a snapshot of the 3D scene to the clipboard')
         self.setCheckable(False)
         self.setShortcut(qt.QKeySequence.Copy)
+        self.setShortcutContext(qt.Qt.WidgetShortcut)
         self.triggered[bool].connect(self._triggered)
 
     def _triggered(self, checked=False):
@@ -118,6 +119,7 @@ class SaveAction(Plot3DAction):
         self.setToolTip('Save a snapshot of the 3D scene')
         self.setCheckable(False)
         self.setShortcut(qt.QKeySequence.Save)
+        self.setShortcutContext(qt.Qt.WidgetShortcut)
         self.triggered[bool].connect(self._triggered)
 
     def _triggered(self, checked=False):
@@ -171,6 +173,7 @@ class PrintAction(Plot3DAction):
         self.setToolTip('Print a snapshot of the 3D scene')
         self.setCheckable(False)
         self.setShortcut(qt.QKeySequence.Print)
+        self.setShortcutContext(qt.Qt.WidgetShortcut)
         self.triggered[bool].connect(self._triggered)
 
     def getPrinter(self):

--- a/silx/gui/plot3d/Plot3DActions.py
+++ b/silx/gui/plot3d/Plot3DActions.py
@@ -33,7 +33,6 @@ __date__ = "26/01/2017"
 
 import logging
 import os
-import sys
 import weakref
 
 import numpy

--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -28,13 +28,14 @@ from __future__ import absolute_import
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "15/09/2016"
+__date__ = "26/01/2017"
 
 
 import logging
 
 from silx.gui import qt
 from silx.gui.plot.Colors import rgba
+from silx.gui.plot3d import Plot3DActions
 from .._utils import convertArrayToQImage
 
 from .glutils import gl
@@ -102,6 +103,8 @@ class Plot3DWidget(qt.QGLWidget):
         self.setMouseTracking(True)
 
         self.setFocusPolicy(qt.Qt.StrongFocus)
+        self._copyAction = Plot3DActions.CopyAction(parent=self, plot3d=self)
+        self.addAction(self._copyAction)
         self.setFocus(qt.Qt.OtherFocusReason)
 
         self._updating = False  # True if an update is requested

--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -105,7 +105,6 @@ class Plot3DWidget(qt.QGLWidget):
         self.setFocusPolicy(qt.Qt.StrongFocus)
         self._copyAction = Plot3DActions.CopyAction(parent=self, plot3d=self)
         self.addAction(self._copyAction)
-        self.setFocus(qt.Qt.OtherFocusReason)
 
         self._updating = False  # True if an update is requested
 

--- a/silx/gui/plot3d/Plot3DWindow.py
+++ b/silx/gui/plot3d/Plot3DWindow.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "15/09/2016"
+__date__ = "26/01/2017"
 
 
 from silx.gui import qt
@@ -55,6 +55,7 @@ class Plot3DWindow(qt.QMainWindow):
         toolbar = Plot3DToolBar(parent=self)
         toolbar.setPlot3DWidget(self._plot3D)
         self.addToolBar(toolbar)
+        self.addActions(toolbar.actions())
 
     def getPlot3DWidget(self):
         """Get the :class:`Plot3DWidget` of this window"""

--- a/silx/gui/widgets/TableWidget.py
+++ b/silx/gui/widgets/TableWidget.py
@@ -50,7 +50,7 @@ creating the widgets, or later by calling their :meth:`enableCut` and
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "23/11/2016"
+__date__ = "26/01/2017"
 
 
 import sys
@@ -90,7 +90,7 @@ class CopySelectedCellsAction(qt.QAction):
         super(CopySelectedCellsAction, self).__init__(table)
         self.setText("Copy selection")
         self.setToolTip("Copy selected cells into the clipboard.")
-        self.setShortcut(qt.QKeySequence('Ctrl+C'))
+        self.setShortcut(qt.QKeySequence.Copy)
         self.triggered.connect(self.copyCellsToClipboard)
         self.table = table
         self.cut = False
@@ -207,7 +207,7 @@ class CutSelectedCellsAction(CopySelectedCellsAction):
     def __init__(self, table):
         super(CutSelectedCellsAction, self).__init__(table)
         self.setText("Cut selection")
-        self.setShortcut(qt.QKeySequence('Ctrl+X'))
+        self.setShortcut(qt.QKeySequence.Cut)
         # cutting is already implemented in CopySelectedCellsAction (but
         # it is disabled), we just need to enable it
         self.cut = True
@@ -270,7 +270,7 @@ class PasteCellsAction(qt.QAction):
         super(PasteCellsAction, self).__init__(table)
         self.table = table
         self.setText("Paste")
-        self.setShortcut(qt.QKeySequence('Ctrl+V'))
+        self.setShortcut(qt.QKeySequence.Paste)
         self.setToolTip("Paste data. The selected cell is the top-left" +
                         "corner of the paste area.")
         self.triggered.connect(self.pasteCellFromClipboard)

--- a/silx/gui/widgets/TableWidget.py
+++ b/silx/gui/widgets/TableWidget.py
@@ -483,4 +483,3 @@ if __name__ == "__main__":
     tableview.show()
 
     app.exec_()
-

--- a/silx/gui/widgets/TableWidget.py
+++ b/silx/gui/widgets/TableWidget.py
@@ -91,6 +91,7 @@ class CopySelectedCellsAction(qt.QAction):
         self.setText("Copy selection")
         self.setToolTip("Copy selected cells into the clipboard.")
         self.setShortcut(qt.QKeySequence.Copy)
+        self.setShortcutContext(qt.Qt.WidgetShortcut)
         self.triggered.connect(self.copyCellsToClipboard)
         self.table = table
         self.cut = False
@@ -208,6 +209,7 @@ class CutSelectedCellsAction(CopySelectedCellsAction):
         super(CutSelectedCellsAction, self).__init__(table)
         self.setText("Cut selection")
         self.setShortcut(qt.QKeySequence.Cut)
+        self.setShortcutContext(qt.Qt.WidgetShortcut)
         # cutting is already implemented in CopySelectedCellsAction (but
         # it is disabled), we just need to enable it
         self.cut = True
@@ -271,6 +273,7 @@ class PasteCellsAction(qt.QAction):
         self.table = table
         self.setText("Paste")
         self.setShortcut(qt.QKeySequence.Paste)
+        self.setShortcutContext(qt.Qt.WidgetShortcut)
         self.setToolTip("Paste data. The selected cell is the top-left" +
                         "corner of the paste area.")
         self.triggered.connect(self.pasteCellFromClipboard)


### PR DESCRIPTION
Change context of shortcut ctrl-c, ctrl-v... only when the expected widget have the focus. Else all shortcut of all widget are overwriten, and it is not possible anymore to copy a single text.

- Tested on the Plot2d and it's status bar of the plot2d (arrow keys too)
- Tested on the Plot3D and its toolbar (arrow keys too)
- Tested on the ArrayTableView
- Mask tools was tested (the action context for them was not changed)

But the last commit can be problematic for people who use it. I remove a `setFocus`. It do not have to be there, but maybe there was a good reason for that?