### PR TITLE
[PeriodicTable] mostly documentation

### DIFF
--- a/doc/source/modules/gui/widgets/periodictable.rst
+++ b/doc/source/modules/gui/widgets/periodictable.rst
@@ -28,5 +28,10 @@ Data model
 ++++++++++
 
 .. autoclass:: silx.gui.widgets.PeriodicTable.PeriodicTableItem
-   :members:
+    :members:
+
+
+.. autoclass:: silx.gui.widgets.PeriodicTable.ColoredPeriodicTableItem
+    :members:
+    :show-inheritance:
 

--- a/silx/gui/widgets/PeriodicTable.py
+++ b/silx/gui/widgets/PeriodicTable.py
@@ -28,6 +28,8 @@
 Example of usage
 ----------------
 
+This example uses the widgets with the standard builtin elements list.
+
 .. code-block:: python
 
     from silx.gui import qt
@@ -70,6 +72,49 @@ Example of usage
     w.show()
     a.exec_()
 
+
+The second example explains how to define custom elements.
+
+.. code-block:: python
+
+    from silx.gui import qt
+    from silx.gui.widgets.PeriodicTable import PeriodicTable, \
+        PeriodicCombo, PeriodicList
+    from silx.gui.widgets.PeriodicTable import PeriodicTableItem
+
+    # subclass PeriodicTableItem
+    class MyPeriodicTableItem(PeriodicTableItem):
+        "New item with added mass number and number of protons"
+        def __init__(self, symbol, Z, A, col, row, name, mass,
+                     subcategory="", bgcolor=None):
+            PeriodicTableItem.__init__(
+                    self, symbol, Z, col, row, name, mass,
+                    subcategory, bgcolor)
+
+            self.A = A
+            "Mass number (neutrons + protons)"
+
+            self.num_neutrons = A - Z
+            "Number of neutrons"
+
+    # build your list of elements
+    my_elements = [MyPeriodicTableItem("H", 1, 1, 1, 1, "hydrogen",
+                                       1.00800, "diatomic nonmetal"),
+                   MyPeriodicTableItem("He", 2, 4, 18, 1, "helium",
+                                        4.0030, "noble gas"),
+                   # etc ...
+                   ]
+
+    app = qt.QApplication([])
+
+    ptable = PeriodicTable(elements=my_elements, selectable=True)
+    ptable.show()
+
+    def click_table(item):
+        print("New table click, mass number:", item.A)
+
+    ptable.sigElementClicked.connect(click_table)
+    app.exec_()
 
 """
 

--- a/silx/gui/widgets/PeriodicTable.py
+++ b/silx/gui/widgets/PeriodicTable.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2016 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -75,7 +75,7 @@ Example of usage
 
 __authors__ = ["E. Papillon", "V.A. Sole", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "05/12/2016"
+__date__ = "26/01/2017"
 
 from collections import OrderedDict
 import logging
@@ -547,7 +547,8 @@ class PeriodicTable(qt.QWidget):
         self.sigElementClicked.emit(item)
 
     def getSelection(self):
-        """Return a list of symbols for selected elements
+        """Return a list of selected elements, as a list of :class:`PeriodicTableItem`
+        objects.
 
         :return: Selected items
         :rtype: list(PeriodicTableItem)
@@ -634,8 +635,7 @@ class PeriodicCombo(qt.QComboBox):
         """Get selected element
 
         :return: Selected element
-        :rtype: :class:`PeriodicTableItem` object. This object can be unpacked as a list
-            ``[symbol, Z, col, row, name, mass]``
+        :rtype: PeriodicTableItem
         """
         return _defaultTableItems[self.currentIndex()]
 
@@ -714,7 +714,10 @@ class PeriodicList(qt.QTreeWidget):
 
     def getSelection(self):
         """Get a list of selected elements, as a list of :class:`PeriodicTableItem`
-        objects."""
+        objects.
+
+        :return: Selected elements
+        :rtype: list(PeriodicTableItem)"""
         return [_defaultTableItems[idx] for idx in range(len(self.tree_items))
                 if self.tree_items[idx].isSelected()]
 

--- a/silx/gui/widgets/PeriodicTable.py
+++ b/silx/gui/widgets/PeriodicTable.py
@@ -564,6 +564,12 @@ class PeriodicTable(qt.QWidget):
         :param list(str) symbols: List of symbols of elements to be selected
             (e.g. *["Fe", "Hg", "Li"]*)
         """
+        # accept list of PeriodicTableItems as input, because getSelection
+        # returns these objects and it makes sense to have getter and setter
+        # use same type of data
+        if isinstance(symbols[0], PeriodicTableItem):
+            symbols = [elmt.symbol for elmt in symbols]
+
         for (e, b) in self._eltButtons.items():
             b.setSelected(e in symbols)
         self.sigSelectionChanged.emit(self.getSelection())
@@ -644,6 +650,9 @@ class PeriodicCombo(qt.QComboBox):
 
         :param symbol: Symbol of element to be selected
         """
+        # accept PeriodicTableItem for getter/setter consistency
+        if isinstance(symbol, PeriodicTableItem):
+            symbol = symbol.symbol
         symblist = [elmt.symbol for elmt in _defaultTableItems]
         self.setCurrentIndex(symblist.index(symbol))
 
@@ -721,12 +730,15 @@ class PeriodicList(qt.QTreeWidget):
         return [_defaultTableItems[idx] for idx in range(len(self.tree_items))
                 if self.tree_items[idx].isSelected()]
 
-    # setSelection is a bad idea (name of a QTreeWidget method)
+    # setSelection is a bad name (name of a QTreeWidget method)
     def setSelectedElements(self, symbolList):
         """
 
         :param symbolList: List of atomic symbols ["H", "He", "Li"...]
             to be selected in the widget
         """
+        # accept PeriodicTableItem for getter/setter consistency
+        if isinstance(symbolList[0], PeriodicTableItem):
+            symbolList = [elmt.symbol for elmt in symbolList]
         for idx in range(len(self.tree_items)):
             self.tree_items[idx].setSelected(_defaultTableItems[idx].symbol in symbolList)

--- a/silx/gui/widgets/test/test_periodictable.py
+++ b/silx/gui/widgets/test/test_periodictable.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -48,10 +48,10 @@ class TestPeriodicTable(TestCaseQt):
         self.assertTrue(pt.selectable)
 
     def testCustomElements(self):
-        PTI = PeriodicTable.PeriodicTableItem
+        PTI = PeriodicTable.ColoredPeriodicTableItem
         my_items = [
             PTI("Xx", 42, 43, 44, "xaxatorium", 1002.2,
-                bgcolor=qt.QColor(qt.Qt.red)),
+                bgcolor="#FF0000"),
             PTI("Yy", 25, 22, 44, "yoyotrium", 8.8)
         ]
 
@@ -64,7 +64,7 @@ class TestPeriodicTable(TestCaseQt):
         self.assertEqual(selection[0].Z, 42)
         self.assertEqual(selection[0].col, 43)
         self.assertAlmostEqual(selection[0].mass, 1002.2)
-        self.assertEqual(selection[0].bgcolor,
+        self.assertEqual(qt.QColor(selection[0].bgcolor),
                          qt.QColor(qt.Qt.red))
 
         self.assertTrue(pt.isElementSelected("Xx"))


### PR DESCRIPTION
Add example in documentation to explain adding of custom data to elements.

Make `bgcolor` attribute a simple RGB string rather than a `QColor`

Closes #558 