### PR TITLE
Double fix README encoding issue

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ On Linux, to install silx with pip, you must install numpy first.
 
 Unofficial Debian8 packages are available at http://www.silx.org/pub/debian/
 CentOS rpm packages are provided by Max IV at the following url: http://pubrepo.maxiv.lu.se/rpm/el7/x86_64/
-Arch Linux (AUR) packages are also available: https://aur.archlinux.org/packages/python-silx
+Arch Linux (AUR) packages are also available: https://aur.archlinux.org/packages/python-silx
 
 On Windows, pre-compiled binaries (aka Python wheels) are available for Python 2.7 and 3.5.
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # coding: utf8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2016 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -82,7 +82,7 @@ def get_version():
 
 def get_readme():
     dirname = os.path.dirname(os.path.abspath(__file__))
-    with open(os.path.join(dirname, "README.rst"), "r") as fp:
+    with io.open(os.path.join(dirname, "README.rst"), "r", encoding="utf-8") as fp:
         long_description = fp.read()
     return long_description
 


### PR DESCRIPTION
Remove non-breakable space from README.rst, specify encoding=utf-8 in setup.py when reading README.RST
Addresses #601