### PR TITLE
Add links to Max IV Fedora repository

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,11 +27,12 @@ To install silx locally, run::
  
     pip install silx --user
 
-On Linux, to install silx with pip, you must install numpy first.
+On Linux, to install silx with pip, you must install numpy first. Unofficial packages for different distributions are available::
 
-Unofficial Debian8 packages are available at http://www.silx.org/pub/debian/
-CentOS rpm packages are provided by Max IV at the following url: http://pubrepo.maxiv.lu.se/rpm/el7/x86_64/
-Arch Linux (AUR) packages are also available: https://aur.archlinux.org/packages/python-silx
+- Unofficial Debian8 packages are available at http://www.silx.org/pub/debian/
+- CentOS 7 rpm packages are provided by Max IV at the following url: http://pubrepo.maxiv.lu.se/rpm/el7/x86_64/
+- Fedora 23 rpm packages are provided by Max IV at http://pubrepo.maxiv.lu.se/rpm/fc23/x86_64/
+- Arch Linux (AUR) packages are also available: https://aur.archlinux.org/packages/python-silx
 
 On Windows, pre-compiled binaries (aka Python wheels) are available for Python 2.7 and 3.5.
 

--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ To install silx locally, run::
  
     pip install silx --user
 
-On Linux, to install silx with pip, you must install numpy first. Unofficial packages for different distributions are available::
+On Linux, to install silx with pip, you must install numpy first. Unofficial packages for different distributions are available :
 
 - Unofficial Debian8 packages are available at http://www.silx.org/pub/debian/
 - CentOS 7 rpm packages are provided by Max IV at the following url: http://pubrepo.maxiv.lu.se/rpm/el7/x86_64/

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -72,11 +72,13 @@ On Linux, you can install *silx* in your home directory::
 To install *silx* on Debian 8, see `Installing a Debian package`_.
 This method requires **sudo** privileges, but has the benefit of installing dependencies in a simple way.
 
-A CentOS rpm package is provided by Max IV at the following url: http://pubrepo.maxiv.lu.se/rpm/el7/x86_64/
+CentOS 7 rpm packages are provided by Max IV at the following url: http://pubrepo.maxiv.lu.se/rpm/el7/x86_64/
 
-An Arch Linux (AUR) package is also available:Â https://aur.archlinux.org/packages/python-silx
+Fedora 23 rpm packages are provided by Max IV at http://pubrepo.maxiv.lu.se/rpm/fc23/x86_64/
 
-You can also choose to compile and install *silx* from it's sources:Â 
+An Arch Linux (AUR) package is also available: https://aur.archlinux.org/packages/python-silx
+
+You can also choose to compile and install *silx* from it's sources: 
 see `Installing from source`_.
 
 


### PR DESCRIPTION
Max IV is providing CentOS 7 and Fedora 23 packages.