### PR TITLE
[ProfileToolBar] bugfix for eventfilter missing plot attribute

### DIFF
--- a/silx/gui/plot/Profile.py
+++ b/silx/gui/plot/Profile.py
@@ -346,10 +346,10 @@ class ProfileToolBar(qt.QToolBar):
 
     def __init__(self, parent=None, plot=None, profileWindow=None,
                  title='Profile Selection'):
-        super(ProfileToolBar, self).__init__(title, parent)
         assert plot is not None
         self.plot = plot
-
+        super(ProfileToolBar, self).__init__(title, parent)
+        
         self._overlayColor = None
         self._defaultOverlayColor = 'red'  # update when active image change
 

--- a/silx/gui/plot/Profile.py
+++ b/silx/gui/plot/Profile.py
@@ -358,7 +358,7 @@ class ProfileToolBar(qt.QToolBar):
         if profileWindow is None:
             # Import here to avoid cyclic import
             from .PlotWindow import Plot1D  # noqa
-            self.profileWindow = Plot1D()
+            self.profileWindow = Plot1D(self)
             self._ownProfileWindow = True
         else:
             self.profileWindow = profileWindow
@@ -440,9 +440,6 @@ class ProfileToolBar(qt.QToolBar):
 
         # will manage the close event
         self.profileWindow.installEventFilter(self)
-        
-    def __del__(self):
-        self.profileWindow.removeEventFilter(self)
 
     def eventFilter(self, qobject, event):
         """Observe when the close event is emitted to clear the profile

--- a/silx/gui/plot/Profile.py
+++ b/silx/gui/plot/Profile.py
@@ -440,6 +440,9 @@ class ProfileToolBar(qt.QToolBar):
 
         # will manage the close event
         self.profileWindow.installEventFilter(self)
+        
+    def __del__(self):
+        self.profileWindow.removeEventFilter(self)
 
     def eventFilter(self, qobject, event):
         """Observe when the close event is emitted to clear the profile

--- a/silx/gui/plot/Profile.py
+++ b/silx/gui/plot/Profile.py
@@ -743,7 +743,7 @@ class Profile3DToolBar(ProfileToolBar):
         :param event: the event received by qobject
         """
         if not hasattr(self, "plot"):
-            return
+            return False  # allow further processing of event by following filters
         if event.type() in (qt.QEvent.Close, qt.QEvent.Hide):
             # when the container widget is closed/hidden, clear the profile
             if qobject is self.ndProfileWindow:

--- a/silx/gui/plot/Profile.py
+++ b/silx/gui/plot/Profile.py
@@ -447,8 +447,9 @@ class ProfileToolBar(qt.QToolBar):
         :param qobject: the object observe
         :param event: the event received by qobject
         """
-        if event.type() in (qt.QEvent.Close, qt.QEvent.Hide):
-            self.clearProfile()
+        if hasattr(self, "plot"):
+            if event.type() in (qt.QEvent.Close, qt.QEvent.Hide):
+                self.clearProfile()
 
         return qt.QToolBar.eventFilter(self, qobject, event)
 
@@ -741,6 +742,8 @@ class Profile3DToolBar(ProfileToolBar):
         :param qobject: the observed object
         :param event: the event received by qobject
         """
+        if not hasattr(self, "plot"):
+            return
         if event.type() in (qt.QEvent.Close, qt.QEvent.Hide):
             # when the container widget is closed/hidden, clear the profile
             if qobject is self.ndProfileWindow:


### PR DESCRIPTION
Define `plot` attribute prior to calling `qt.QToolBar __init__`, in the hope it will fix the CI test failure (Python 3.5, Qt5, Qt tests enabled) related to the `eventFilter` called before plot is defined..

```
testAlignedProfile (silx.gui.plot.test.testProfile.TestProfileToolBar)
Test horizontal and vertical profile, without and with image ... Traceback (most recent call last):
  File "C:\projects\silx\venv_test\lib\site-packages\silx\gui\plot\Profile.py", line 451, in eventFilter
    self.clearProfile()
  File "C:\projects\silx\venv_test\lib\site-packages\silx\gui\plot\Profile.py", line 551, in clearProfile
    self.updateProfile()
  File "C:\projects\silx\venv_test\lib\site-packages\silx\gui\plot\Profile.py", line 558, in updateProfile
    imageData = self.plot.getActiveImage()
AttributeError: 'ProfileToolBar' object has no attribute 'plot'
```