### PR TITLE
[ProfileToolBar] refactoring

### DIFF
--- a/examples/stackView.py
+++ b/examples/stackView.py
@@ -32,9 +32,7 @@ from silx.gui import qt
 # from silx.gui.plot import StackView
 from silx.gui.plot.StackView import StackViewMainWindow
 
-
 app = qt.QApplication(sys.argv[1:])
-sys.excepthook = qt.exceptionHandler
     
 # synthetic data, stack of 100 images of size 200x300
 mystack = numpy.fromfunction(
@@ -51,4 +49,3 @@ sv.setLabels(["1st dim (0-99)", "2nd dim (0-199)",
 sv.show()
 
 app.exec_()
-sys.excepthook = sys.__excepthook__

--- a/silx/gui/plot/PlotToolButtons.py
+++ b/silx/gui/plot/PlotToolButtons.py
@@ -235,15 +235,15 @@ class ProfileToolButton(PlotToolButton):
 
     def __init__(self, parent=None, plot=None):
         if self.STATE is None:
-            self.STATE = {}
+            self.STATE = {
+                (1, "icon"): icons.getQIcon('profile1D'),
+                (1, "state"): "1D profile is computed on visible image",
+                (1, "action"): "1D profile on visible image",
+                (2, "icon"): icons.getQIcon('profile2D'),
+                (2, "state"): "2D profile is computed, one 1D profile for each image in the stack",
+                (2, "action"): "2D profile on image stack"}
             # Compute 1D profile
-            self.STATE[1, "icon"] = icons.getQIcon('profile1D')
-            self.STATE[1, "state"] = "1D profile is computed on visible image"
-            self.STATE[1, "action"] = "1D profile on visible image"
             # Compute 2D profile
-            self.STATE[2, "icon"] = icons.getQIcon('profile2D')
-            self.STATE[2, "state"] = "2D profile is computed, one 1D profile for each image in the stack"
-            self.STATE[2, "action"] = "2D profile on image stack"
 
         super(ProfileToolButton, self).__init__(parent=parent, plot=plot)
 

--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -710,9 +710,13 @@ class Plot2D(PlotWindow):
         """
         return self.profile
 
+    @deprecated   # since silx 0.5
     def getProfileWindow(self):
-        """Plot window used to display profile curve.
+        return self.getProfilePlot()
+
+    def getProfilePlot(self):
+        """Return plot window used to display profile curve.
 
         :return: :class:`Plot1D`
         """
-        return self.profile.getProfileWindow()
+        return self.profile.getProfilePlot()

--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -715,4 +715,4 @@ class Plot2D(PlotWindow):
 
         :return: :class:`Plot1D`
         """
-        return self.profile.profileWindow
+        return self.profile.getProfileWindow()

--- a/silx/gui/plot/Profile.py
+++ b/silx/gui/plot/Profile.py
@@ -748,8 +748,8 @@ class Profile3DToolBar(ProfileToolBar):
         if self._profileDimensions == 1:
             super(Profile3DToolBar, self).updateProfile()
         elif self._profileDimensions == 2:
-            stackData = self.plot.getStack(copy=False,
-                                           returnNumpyArray=True)
+            stackData = self.plot.getCurrentView(copy=False,
+                                                 returnNumpyArray=True)
             if stackData is None:
                 return
             self.plot.remove(self._POLYGON_LEGEND, kind='item')

--- a/silx/gui/plot/ProfileMainWindow.py
+++ b/silx/gui/plot/ProfileMainWindow.py
@@ -1,0 +1,89 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This module contains a QMainWindow class used to display profile plots.
+"""
+from silx.gui import qt
+
+
+__authors__ = ["P. Knobel"]
+__license__ = "MIT"
+__date__ = "21/02/2017"
+
+
+class ProfileMainWindow(qt.QMainWindow):
+    """QMainWindow providing 2 plot widgets specialized in
+    1D and 2D plotting. Only one of the plots is visible at any given time.
+    """
+    sigProfileDimensionsChanged = qt.Signal(int)
+    """This signal is emitted when :meth:`setProfileDimensions` is called.
+    It carries the number of dimensions for the profile data (1 or 2)"""
+
+    def __init__(self, parent=None):
+        qt.QMainWindow.__init__(self, parent=parent)
+
+        self.setWindowTitle('Profile window')
+        # plots are created on demand, in self.setProfileDimensions()
+        self._plot1D = None
+        self._plot2D = None
+        # by default, profile is assumed to be a 1D curve
+        self._profileDimensions = 1
+        self.setProfileDimensions(1)
+
+    def setProfileDimensions(self, dimensions):
+        """Set which profile plot widget (1D or 2D) is to be used
+
+        :param int dimensions: Number of dimensions for profile data
+            (1 dimension for a curve, 2  dimensions for an image)
+        """
+        # import here to avoid circular import
+        from .PlotWindow import Plot1D, Plot2D      # noqa
+        self._profileDimensions = dimensions
+
+        if self._profileDimensions == 1:
+            if self._plot2D is not None:
+                self._plot2D.setParent(None)   # necessary to avoid widget destruction
+            if self._plot1D is None:
+                self._plot1D = Plot1D()
+            self.setCentralWidget(self._plot1D)
+        elif self._profileDimensions == 2:
+            if self._plot1D is not None:
+                self._plot1D.setParent(None)   # necessary to avoid widget destruction
+            if self._plot2D is None:
+                self._plot2D = Plot2D()
+            self.setCentralWidget(self._plot2D)
+        else:
+            raise ValueError("Profile dimensions must be 1 or 2")
+
+        self.sigProfileDimensionsChanged.emit(dimensions)
+
+    def getPlot(self):
+        """Return the profile plot widget which is currently in use.
+        This can be the 2D profile plot or the 1D profile plot.
+        """
+        assert self._profileDimensions in [1, 2]
+        if self._profileDimensions == 2:
+            return self._plot2D
+        else:
+            return self._plot1D

--- a/silx/gui/plot/ProfileMainWindow.py
+++ b/silx/gui/plot/ProfileMainWindow.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -34,11 +34,18 @@ __date__ = "21/02/2017"
 
 class ProfileMainWindow(qt.QMainWindow):
     """QMainWindow providing 2 plot widgets specialized in
-    1D and 2D plotting. Only one of the plots is visible at any given time.
+    1D and 2D plotting, with different toolbars.
+    Only one of the plots is visible at any given time.
     """
     sigProfileDimensionsChanged = qt.Signal(int)
     """This signal is emitted when :meth:`setProfileDimensions` is called.
-    It carries the number of dimensions for the profile data (1 or 2)"""
+    It carries the number of dimensions for the profile data (1 or 2).
+    It can be used to be notified that the profile plot widget has changed.
+    """
+
+    sigClose = qt.Signal()
+    """Emitted by :meth:`closeEvent` (e.g. when the window is closed
+    through the window manager's close icon)."""
 
     def __init__(self, parent=None):
         qt.QMainWindow.__init__(self, parent=parent)
@@ -87,3 +94,7 @@ class ProfileMainWindow(qt.QMainWindow):
             return self._plot2D
         else:
             return self._plot1D
+
+    def closeEvent(self, qCloseEvent):
+        self.sigClose.emit()
+        qCloseEvent.accept()

--- a/silx/gui/plot/ProfileMainWindow.py
+++ b/silx/gui/plot/ProfileMainWindow.py
@@ -55,42 +55,41 @@ class ProfileMainWindow(qt.QMainWindow):
         self._plot1D = None
         self._plot2D = None
         # by default, profile is assumed to be a 1D curve
-        self._profileDimensions = 1
-        self.setProfileDimensions(1)
+        self._profileType = None
+        self.setProfileType("1D")
 
-    def setProfileDimensions(self, dimensions):
+    def setProfileType(self, profileType):
         """Set which profile plot widget (1D or 2D) is to be used
 
-        :param int dimensions: Number of dimensions for profile data
-            (1 dimension for a curve, 2  dimensions for an image)
+        :param str profileType: Type of profile data,
+            "1D" for a curve or "2D" for an image
         """
         # import here to avoid circular import
         from .PlotWindow import Plot1D, Plot2D      # noqa
-        self._profileDimensions = dimensions
+        self._profileType = profileType
 
-        if self._profileDimensions == 1:
+        if self._profileType == "1D":
             if self._plot2D is not None:
                 self._plot2D.setParent(None)   # necessary to avoid widget destruction
             if self._plot1D is None:
                 self._plot1D = Plot1D()
             self.setCentralWidget(self._plot1D)
-        elif self._profileDimensions == 2:
+        elif self._profileType == "2D":
             if self._plot1D is not None:
                 self._plot1D.setParent(None)   # necessary to avoid widget destruction
             if self._plot2D is None:
                 self._plot2D = Plot2D()
             self.setCentralWidget(self._plot2D)
         else:
-            raise ValueError("Profile dimensions must be 1 or 2")
+            raise ValueError("Profile type must be '1D' or '2D'")
 
-        self.sigProfileDimensionsChanged.emit(dimensions)
+        self.sigProfileDimensionsChanged.emit(profileType)
 
     def getPlot(self):
         """Return the profile plot widget which is currently in use.
         This can be the 2D profile plot or the 1D profile plot.
         """
-        assert self._profileDimensions in [1, 2]
-        if self._profileDimensions == 2:
+        if self._profileType == "2D":
             return self._plot2D
         else:
             return self._plot1D

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -218,6 +218,8 @@ class StackView(qt.QMainWindow):
         # clear profile lines when the profile changes (plane browsed changed)
         self.__planeSelection.sigPlaneSelectionChanged.connect(
             self._plot.profile.hideProfileWindow)
+        self.__planeSelection.sigPlaneSelectionChanged.connect(
+            self._plot.profile.clearProfile)
 
     def setOptionVisible(self, isVisible):
         """

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -215,9 +215,9 @@ class StackView(qt.QMainWindow):
         central_widget.setLayout(layout)
         self.setCentralWidget(central_widget)
 
-        # clear profile lines when the profile changes (plane browsed changed)
+        # clear profile lines when the perspective changes (plane browsed changed)
         self.__planeSelection.sigPlaneSelectionChanged.connect(
-            self._plot.profile.hideProfileWindow)
+            self._plot.profile.getProfilePlot().clear)
         self.__planeSelection.sigPlaneSelectionChanged.connect(
             self._plot.profile.clearProfile)
 

--- a/silx/gui/plot/test/testProfile.py
+++ b/silx/gui/plot/test/testProfile.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,10 +24,9 @@
 # ###########################################################################*/
 """Basic tests for Profile"""
 
-__authors__ = ["T. Vincent"]
+__authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "05/12/2016"
-
+__date__ = "23/02/2017"
 
 import numpy
 import unittest
@@ -36,7 +35,8 @@ from silx.test.utils import ParametricTestCase
 from silx.gui.test.utils import (
     TestCaseQt, getQToolButtonFromAction)
 from silx.gui import qt
-from silx.gui.plot import PlotWindow, Profile
+from silx.gui.plot import PlotWindow, Plot1D, Plot2D, Profile
+from silx.gui.plot.StackView import StackView
 
 
 # Makes sure a QApplication exists
@@ -129,10 +129,51 @@ class TestProfileToolBar(TestCaseQt, ParametricTestCase):
                 self.plot.clear()
 
 
+class TestGetProfilePlot(TestCaseQt):
+
+    def testProfile1D(self):
+        plot = Plot2D()
+        plot.show()
+        self.qWaitForWindowExposed(plot)
+        plot.addImage([[0, 1], [2, 3]])
+        self.assertIsInstance(plot.getProfileToolbar().getProfileMainWindow(),
+                              qt.QMainWindow)
+        self.assertIsInstance(plot.getProfilePlot(),
+                              Plot1D)
+        plot.setAttribute(qt.Qt.WA_DeleteOnClose)
+        plot.close()
+        del plot
+
+    def testProfile2D(self):
+        """Test that the profile plot associated to a stack view is either a
+        Plot1D or a plot 2D instance."""
+        plot = StackView()
+        plot.show()
+        self.qWaitForWindowExposed(plot)
+
+        plot.setStack(numpy.array([[[0, 1], [2, 3]],
+                                   [[4, 5], [6, 7]]]))
+
+        self.assertIsInstance(plot.getProfileToolbar().getProfileMainWindow(),
+                              qt.QMainWindow)
+
+        # plot.getProfileToolbar().profile3dAction.computeProfileIn2D()  # default
+
+        self.assertIsInstance(plot.getProfileToolbar().getProfilePlot(),
+                              Plot2D)
+        plot.getProfileToolbar().profile3dAction.computeProfileIn1D()
+        self.assertIsInstance(plot.getProfileToolbar().getProfilePlot(),
+                              Plot1D)
+
+        plot.setAttribute(qt.Qt.WA_DeleteOnClose)
+        plot.close()
+        del plot
+
+
 def suite():
     test_suite = unittest.TestSuite()
     # test_suite.addTest(positionInfoTestSuite)
-    for testClass in (TestProfileToolBar,):
+    for testClass in (TestProfileToolBar, TestGetProfilePlot):
         test_suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(
             testClass))
     return test_suite


### PR DESCRIPTION
Addresses #628, and more refactoring.

 - New class `ProfileMainWindow`, for a better handling of switching between Plot1D and Plot2D.
 - New getters: `getProfilePlot()` and `getProfileMainWindow()` (provides a uniform API for both `ProfileToolBar` and `Profile3DToolBar`, and reduces the number of methods to be overloaded).
 - Deprecate `profileWindow` attribute in favor of `getProfilePlot()` method
 - Remove `getProfileWindow1D()`, `getProfileWindow2D()` and `_ndProfileWindow`

I still need to work on getting rid of event filters, if possible.