### PR TITLE
Improve setup.py to be able to use pip install while numpy is not here

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ import io
 import sys
 import os
 import platform
+import shutil
 import logging
 
 logging.basicConfig(level=logging.INFO)
@@ -416,6 +417,15 @@ def fake_cythonize(extensions):
 class CleanCommand(Clean):
     description = "Remove build artifacts from the source tree"
 
+    def run(self):
+        Clean.run(self)
+        # really remove the build directory
+        if not self.dry_run:
+            try:
+                shutil.rmtree(self.build_base)
+                logger.info("removing '%s'", self.build_base)
+            except OSError:
+                pass
 
 ################################################################################
 # Debian source tree

--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,9 @@ except ImportError:
 
 PROJECT = "silx"
 
-if "LANG" not in os.environ and sys.platform == "darwin" and sys.version_info[0]>2:
-    print("""WARNING: the LANG environment variable is not defined, 
-an utf-8 LANG is mandatory to use setup.py, you may face unexpected UnicodeError. 
+if "LANG" not in os.environ and sys.platform == "darwin" and sys.version_info[0] > 2:
+    print("""WARNING: the LANG environment variable is not defined,
+an utf-8 LANG is mandatory to use setup.py, you may face unexpected UnicodeError.
 export LANG=en_US.utf-8
 export LC_ALL=en_US.utf-8
 """)
@@ -79,7 +79,8 @@ def get_version():
 def get_readme():
     """Returns content of README.rst file"""
     dirname = os.path.dirname(os.path.abspath(__file__))
-    with io.open(os.path.join(dirname, "README.rst"), "r", encoding="utf-8") as fp:
+    filename = os.path.join(dirname, "README.rst")
+    with io.open(filename, "r", encoding="utf-8") as fp:
         long_description = fp.read()
     return long_description
 
@@ -172,7 +173,7 @@ except ImportError:
 if sphinx is not None:
     class BuildDocCommand(BuildDoc):
         """Command to build documentation using sphinx.
-        
+
         Project should have already be built.
         """
 
@@ -479,7 +480,7 @@ class sdist_debian(sdist):
 
 def setup_package():
     """Run setup(**kwargs)
-    
+
     Depending on the command, it either runs the complete setup which depends on numpy,
     or a *dry run* setup with no dependency on numpy.
     """

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,11 @@ except ImportError:
     sphinx = None
 
 
+USE_OPENMP = None
+"""Refere if the compilation will use OpenMP or not.
+It have to be initialized before the setup."""
+
+
 PROJECT = "silx"
 
 if "LANG" not in os.environ and sys.platform == "darwin" and sys.version_info[0] > 2:
@@ -360,15 +365,13 @@ class BuildExtFlags(build_ext):
     If building with MSVC, compiler flags are converted from gcc flags.
     """
 
-    USE_OPENMP = False
-
     COMPILE_ARGS_CONVERTER = {'-fopenmp': '/openmp'}
 
     LINK_ARGS_CONVERTER = {'-fopenmp': ' '}
 
     def build_extensions(self):
         # Remove OpenMP flags if OpenMP is disabled
-        if not self.USE_OPENMP:
+        if not USE_OPENMP:
             for ext in self.extensions:
                 ext.extra_compile_args = [
                     f for f in ext.extra_compile_args if f != '-fopenmp']
@@ -537,7 +540,7 @@ def setup_package():
         use_cython = check_cython(min_version='0.21.1')
 
         use_openmp = check_openmp()
-        BuildExtFlags.USE_OPENMP = use_openmp
+        USE_OPENMP = use_openmp
 
         try:
             from setuptools import setup

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,15 @@ except ImportError:
     from distutils.command.build_ext import build_ext
     from distutils.command.sdist import sdist
 
+try:
+    import sphinx
+    import sphinx.util.console
+    sphinx.util.console.color_terminal = lambda: False
+    from sphinx.setup_command import BuildDoc
+except ImportError:
+    sphinx = None
+
+
 PROJECT = "silx"
 
 if "LANG" not in os.environ and sys.platform == "darwin" and sys.version_info[0] > 2:
@@ -148,13 +157,7 @@ class PyTest(Command):
 # build_doc command   #
 # ################### #
 
-try:
-    import sphinx
-    import sphinx.util.console
-    sphinx.util.console.color_terminal = lambda: False
-    from sphinx.setup_command import BuildDoc
-except ImportError:
-    sphinx = None
+if sphinx is None:
     class SphinxExpectedCommand(Command):
         """Command to inform that sphinx is missing"""
         user_options = []

--- a/setup.py
+++ b/setup.py
@@ -275,15 +275,13 @@ def check_openmp():
 # Cython support #
 # ############## #
 
-CYTHON_MIN_VERSION = '0.21.1'
-
-
-def check_cython():
+def check_cython(min_version=None):
     """
     Check if cython must be activated fron te command line or the environment.
 
     Store the result in WITH_CYTHON environment variable.
 
+    :param string min_version: Minimum version of Cython requested
     :return: True if available and not disabled.
     """
 
@@ -304,7 +302,7 @@ def check_cython():
         os.environ["WITH_CYTHON"] = "False"
         return False
     else:
-        if Cython.Compiler.Version.version < CYTHON_MIN_VERSION:
+        if min_version and Cython.Compiler.Version.version < min_version:
             os.environ["WITH_CYTHON"] = "False"
             return False
 
@@ -516,7 +514,7 @@ def setup_package():
             from distutils.core import setup
         setup_kwargs = {}
     else:
-        use_cython = check_cython()
+        use_cython = check_cython(min_version='0.21.1')
 
         use_openmp = check_openmp()
         BuildExtFlags.USE_OPENMP = use_openmp

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ import sys
 import os
 import platform
 
+from distutils.command.clean import clean as Clean
 try:
     from setuptools import Command
     from setuptools.command.build_py import build_py as _build_py
@@ -411,6 +412,17 @@ def fake_cythonize(extensions):
                     raise RuntimeError("Source file not found: %s" % source)
             new_sources.append(source)
         ext_module.sources = new_sources
+
+################################################################################
+# Clean command
+################################################################################
+
+
+class CleanCommand(Clean):
+    description = "Remove build artifacts from the source tree"
+
+
+cmdclass['clean'] = CleanCommand
 
 ################################################################################
 # Debian source tree

--- a/setup.py
+++ b/setup.py
@@ -73,11 +73,13 @@ DRY_RUN = len(sys.argv) == 1 or (len(sys.argv) >= 2 and (
 
 
 def get_version():
+    """Returns current version number from version.py file"""
     import version
     return version.strictversion
 
 
 def get_readme():
+    """Returns content of README.rst file"""
     dirname = os.path.dirname(os.path.abspath(__file__))
     with io.open(os.path.join(dirname, "README.rst"), "r", encoding="utf-8") as fp:
         long_description = fp.read()
@@ -130,6 +132,7 @@ cmdclass['build_py'] = build_py
 ########
 
 class PyTest(Command):
+    """Command to start tests running the script: run_tests.py -i"""
     user_options = []
 
     def initialize_options(self):
@@ -159,6 +162,7 @@ try:
 except ImportError:
     sphinx = None
     class SphinxExpectedCommand(Command):
+        """Command to inform that sphinx is missing"""
         user_options = []
 
         def initialize_options(self):
@@ -174,6 +178,10 @@ except ImportError:
 
 if sphinx is not None:
     class BuildDocCommand(BuildDoc):
+        """Command to build documentation using sphinx.
+        
+        Project should have already be built.
+        """
 
         def run(self):
             # make sure the python path is pointing to the newly built
@@ -213,7 +221,7 @@ cmdclass['build_doc'] = BuildDocCommand
 
 if sphinx is not None:
     class TestDocCommand(BuildDoc):
-        """Target to test the documentation using sphynx doctest.
+        """Command to test the documentation using sphynx doctest.
 
         http://www.sphinx-doc.org/en/1.4.8/ext/doctest.html
         """
@@ -486,6 +494,11 @@ cmdclass['debian_src'] = sdist_debian
 # ##### #
 
 def setup_package():
+    """Run setup(**kwargs)
+    
+    Depending on the command, it either runs the complete setup which depends on numpy,
+    or a *dry run* setup with no dependency on numpy.
+    """
 
     install_requires = ["numpy"]
     setup_requires = ["numpy"]

--- a/setup.py
+++ b/setup.py
@@ -72,13 +72,6 @@ export LC_ALL=en_US.utf-8
 """)
 
 
-# Check if action requires build/install
-DRY_RUN = len(sys.argv) == 1 or (len(sys.argv) >= 2 and (
-    '--help' in sys.argv[1:] or
-    sys.argv[1] in ('--help-commands', 'egg_info', '--version',
-                    'clean', '--name')))
-
-
 def get_version():
     """Returns current version number from version.py file"""
     import version
@@ -327,9 +320,6 @@ def check_cython():
     return True
 
 
-USE_CYTHON = check_cython()
-
-
 # ############################# #
 # numpy.distutils Configuration #
 # ############################# #
@@ -510,7 +500,13 @@ def setup_package():
         clean=CleanCommand,
         debian_src=sdist_debian)
 
-    if DRY_RUN:
+    # Check if action requires build/install
+    dry_run = len(sys.argv) == 1 or (len(sys.argv) >= 2 and (
+        '--help' in sys.argv[1:] or
+        sys.argv[1] in ('--help-commands', 'egg_info', '--version',
+                        'clean', '--name')))
+
+    if dry_run:
         # DRY_RUN implies actions which do not require NumPy
         #
         # And they are required to succeed without Numpy for example when
@@ -522,6 +518,7 @@ def setup_package():
             from distutils.core import setup
         setup_kwargs = {}
     else:
+        use_cython = check_cython()
         try:
             from setuptools import setup
         except ImportError:
@@ -529,7 +526,7 @@ def setup_package():
 
         config = configuration()
 
-        if USE_CYTHON:
+        if use_cython:
             # Cythonize extensions
             from Cython.Build import cythonize
 

--- a/setup.py
+++ b/setup.py
@@ -257,6 +257,9 @@ def check_openmp():
 
     Store the result in WITH_OPENMP environment variable
 
+    TODO: It would be much better to take care of command line arguments in the
+          initialize_options and finalize_options.
+
     :return: True if available and not disabled.
     """
     if "WITH_OPENMP" in os.environ:
@@ -294,6 +297,9 @@ def check_cython(min_version=None):
     Check if cython must be activated fron te command line or the environment.
 
     Store the result in WITH_CYTHON environment variable.
+
+    TODO: It would be much better to take care of command line arguments in the
+          initialize_options and finalize_options.
 
     :param string min_version: Minimum version of Cython requested
     :return: True if available and not disabled.

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@
 # ###########################################################################*/
 
 __authors__ = ["Jérôme Kieffer", "Thomas Vincent"]
-__date__ = "20/03/2017"
+__date__ = "27/03/2017"
 __license__ = "MIT"
 
 
@@ -37,6 +37,12 @@ import io
 import sys
 import os
 import platform
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+logger = logging.getLogger("silx.setup")
+
 
 from distutils.command.clean import clean as Clean
 try:
@@ -44,6 +50,7 @@ try:
     from setuptools.command.build_py import build_py as _build_py
     from setuptools.command.build_ext import build_ext
     from setuptools.command.sdist import sdist
+    logger.info("Use setuptools")
 except ImportError:
     try:
         from numpy.distutils.core import Command
@@ -52,6 +59,7 @@ except ImportError:
     from distutils.command.build_py import build_py as _build_py
     from distutils.command.build_ext import build_ext
     from distutils.command.sdist import sdist
+    logger.info("Use distutils")
 
 try:
     import sphinx
@@ -510,8 +518,10 @@ def setup_package():
         # the system.
         try:
             from setuptools import setup
+            logger.info("Use setuptools.setup")
         except ImportError:
             from distutils.core import setup
+            logger.info("Use distutils.core.setup")
         setup_kwargs = {}
     else:
         use_cython = check_cython(min_version='0.21.1')
@@ -521,8 +531,10 @@ def setup_package():
 
         try:
             from setuptools import setup
+            logger.info("Use setuptools.setup")
         except ImportError:
             from numpy.distutils.core import setup
+            logger.info("Use numpydistutils.setup")
 
         config = configuration()
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@
 # ###########################################################################*/
 
 __authors__ = ["Jérôme Kieffer", "Thomas Vincent"]
-__date__ = "17/03/2017"
+__date__ = "20/03/2017"
 __license__ = "MIT"
 
 
@@ -54,8 +54,6 @@ except ImportError:
     from distutils.command.sdist import sdist
 
 PROJECT = "silx"
-cmdclass = {}
-
 
 if "LANG" not in os.environ and sys.platform == "darwin" and sys.version_info[0]>2:
     print("""WARNING: the LANG environment variable is not defined, 
@@ -124,9 +122,6 @@ class build_py(_build_py):
         return modules
 
 
-cmdclass['build_py'] = build_py
-
-
 ########
 # Test #
 ########
@@ -146,8 +141,6 @@ class PyTest(Command):
         errno = subprocess.call([sys.executable, 'run_tests.py', '-i'])
         if errno != 0:
             raise SystemExit(errno)
-
-cmdclass['test'] = PyTest
 
 
 # ################### #
@@ -213,7 +206,6 @@ if sphinx is not None:
 else:
     BuildDocCommand = SphinxExpectedCommand
 
-cmdclass['build_doc'] = BuildDocCommand
 
 # ################### #
 # test_doc command    #
@@ -244,7 +236,6 @@ if sphinx is not None:
 else:
     TestDocCommand = SphinxExpectedCommand
 
-cmdclass['test_doc'] = TestDocCommand
 
 # ############## #
 # OpenMP support #
@@ -395,9 +386,6 @@ class BuildExtFlags(build_ext):
         build_ext.build_extensions(self)
 
 
-cmdclass['build_ext'] = BuildExtFlags
-
-
 def fake_cythonize(extensions):
     """Replace cython files by .c or .cpp files in extension's sources.
 
@@ -429,8 +417,6 @@ def fake_cythonize(extensions):
 class CleanCommand(Clean):
     description = "Remove build artifacts from the source tree"
 
-
-cmdclass['clean'] = CleanCommand
 
 ################################################################################
 # Debian source tree
@@ -486,8 +472,6 @@ class sdist_debian(sdist):
         self.archive_files = [debian_arch]
         print("Building debian .orig.tar.gz in %s" % self.archive_files[0])
 
-cmdclass['debian_src'] = sdist_debian
-
 
 # ##### #
 # setup #
@@ -512,6 +496,15 @@ def setup_package():
             'gui/icons/*.gif',
             'opencl/sift/*.cl']
     }
+
+    cmdclass = dict(
+        build_py=build_py,
+        test=PyTest,
+        build_doc=BuildDocCommand,
+        test_doc=TestDocCommand,
+        build_ext=BuildExtFlags,
+        clean=CleanCommand,
+        debian_src=sdist_debian)
 
     if DRY_RUN:
         # DRY_RUN implies actions which do not require NumPy

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@
 # ###########################################################################*/
 
 __authors__ = ["Jérôme Kieffer", "Thomas Vincent"]
-__date__ = "16/11/2016"
+__date__ = "16/03/2017"
 __license__ = "MIT"
 
 
@@ -348,13 +348,10 @@ def configuration(parent_package='', top_path=None):
     config.add_subpackage(PROJECT)
     return config
 
-
-config = configuration()
-
-
 # ############## #
 # Compiler flags #
 # ############## #
+
 
 class BuildExtFlags(build_ext):
     """Handle compiler and linker flags.
@@ -413,23 +410,6 @@ def fake_cythonize(extensions):
             new_sources.append(source)
         ext_module.sources = new_sources
 
-
-if not DRY_RUN:
-    if USE_CYTHON:
-        # Cythonize extensions
-        from Cython.Build import cythonize
-
-        config.ext_modules = cythonize(
-            config.ext_modules,
-            compiler_directives={'embedsignature': True},
-            force=(os.environ.get("FORCE_CYTHON") is "True"),
-            compile_time_env={"HAVE_OPENMP": bool(USE_OPENMP)}
-        )
-    else:
-        # Do not use Cython but convert source names from .pyx to .c or .cpp
-        fake_cythonize(config.ext_modules)
-
-
 ################################################################################
 # Debian source tree
 ################################################################################
@@ -476,9 +456,9 @@ class sdist_debian(sdist):
             dest = "".join((base, ext))
         else:
             dest = base
-#         sp = dest.split("-")
-#         base = sp[:-1]
-#         nr = sp[-1]
+        # sp = dest.split("-")
+        # base = sp[:-1]
+        # nr = sp[-1]
         debian_arch = os.path.join(dirname, self.get_debian_name() + ".orig.tar.gz")
         os.rename(self.archive_files[0], debian_arch)
         self.archive_files = [debian_arch]
@@ -491,31 +471,56 @@ cmdclass['debian_src'] = sdist_debian
 # setup #
 # ##### #
 
-setup_kwargs = config.todict()
+def setup_package():
 
-install_requires = ["numpy"]
-setup_requires = ["numpy"]
+    install_requires = ["numpy"]
+    setup_requires = ["numpy"]
 
-setup_kwargs.update(name=PROJECT,
-                    version=get_version(),
-                    url="https://github.com/silx-kit/silx",
-                    author="data analysis unit",
-                    author_email="silx@esrf.fr",
-                    classifiers=classifiers,
-                    description="Software library for X-Ray data analysis",
-                    long_description=get_readme(),
-                    install_requires=install_requires,
-                    setup_requires=setup_requires,
-                    cmdclass=cmdclass,
-                    package_data={'silx.resources': [
-                        # Add here all resources files
-                        'gui/icons/*.png',
-                        'gui/icons/*.svg',
-                        'gui/icons/*.mng',
-                        'gui/icons/*.gif',
-                        'opencl/sift/*.cl',
-                        ]},
-                    zip_safe=False,
-                    )
+    package_data = {
+        'silx.resources': [
+            # Add here all resources files
+            'gui/icons/*.png',
+            'gui/icons/*.svg',
+            'gui/icons/*.mng',
+            'gui/icons/*.gif',
+            'opencl/sift/*.cl']
+    }
 
-setup(**setup_kwargs)
+    config = configuration()
+
+    if not DRY_RUN:
+        if USE_CYTHON:
+            # Cythonize extensions
+            from Cython.Build import cythonize
+
+            config.ext_modules = cythonize(
+                config.ext_modules,
+                compiler_directives={'embedsignature': True},
+                force=(os.environ.get("FORCE_CYTHON") is "True"),
+                compile_time_env={"HAVE_OPENMP": bool(USE_OPENMP)}
+            )
+        else:
+            # Do not use Cython but convert source names from .pyx to .c or .cpp
+            fake_cythonize(config.ext_modules)
+
+    setup_kwargs = config.todict()
+
+    setup_kwargs.update(name=PROJECT,
+                        version=get_version(),
+                        url="https://github.com/silx-kit/silx",
+                        author="data analysis unit",
+                        author_email="silx@esrf.fr",
+                        classifiers=classifiers,
+                        description="Software library for X-Ray data analysis",
+                        long_description=get_readme(),
+                        install_requires=install_requires,
+                        setup_requires=setup_requires,
+                        cmdclass=cmdclass,
+                        package_data=package_data,
+                        zip_safe=False,
+                        )
+
+    setup(**setup_kwargs)
+
+if __name__ == "__main__":
+    setup_package()

--- a/setup.py
+++ b/setup.py
@@ -189,17 +189,17 @@ if sphinx is not None:
             build = self.get_finalized_command('build')
             sys.path.insert(0, os.path.abspath(build.build_lib))
 
-#             # Copy .ui files to the path:
-#             dst = os.path.join(
-#                 os.path.abspath(build.build_lib), "silx", "gui")
-#             if not os.path.isdir(dst):
-#                 os.makedirs(dst)
-#             for i in os.listdir("gui"):
-#                 if i.endswith(".ui"):
-#                     src = os.path.join("gui", i)
-#                     idst = os.path.join(dst, i)
-#                     if not os.path.exists(idst):
-#                         shutil.copy(src, idst)
+            # # Copy .ui files to the path:
+            # dst = os.path.join(
+            #     os.path.abspath(build.build_lib), "silx", "gui")
+            # if not os.path.isdir(dst):
+            #     os.makedirs(dst)
+            # for i in os.listdir("gui"):
+            #     if i.endswith(".ui"):
+            #         src = os.path.join("gui", i)
+            #         idst = os.path.join(dst, i)
+            #         if not os.path.exists(idst):
+            #             shutil.copy(src, idst)
 
             # Build the Users Guide in HTML and TeX format
             for builder in ['html', 'latex']:


### PR DESCRIPTION
I also would like to:
- Move cmdclass declaration to the bottom
- And remove all those "###########" separator,  cause now the file is much more declarative and executive, then it looks already very readable.
