### PR TITLE
[StackView] update perspective selector when calling setStack()

### DIFF
--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -1419,7 +1419,7 @@ class MaskToolsWidget(qt.QWidget):
 
 
 class MaskToolsDockWidget(qt.QDockWidget):
-    """:class:`MaskToolsDockWidget` embedded in a QDockWidget.
+    """:class:`MaskToolsWidget` embedded in a QDockWidget.
 
     For integration in a :class:`PlotWindow`.
 

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -255,7 +255,9 @@ class StackView(qt.QMainWindow):
                                            None)
 
     def __setPerspective(self, perspective):
-        """Function called when the browsed/orthogonal dimension changes
+        """Function called when the browsed/orthogonal dimension changes.
+        Updates :attr:`_perspective`, transposes data, updates the plot,
+        emits :attr:`sigPlaneSelectionChanged` and :attr:`sigStackChanged`.
 
         :param perspective: the new browsed dimension
         """
@@ -389,9 +391,12 @@ class StackView(qt.QMainWindow):
         self._browser.setEnabled(True)
 
         if perspective != self._perspective:
-            self.__setPerspective(perspective)
+            self.__planeSelection.setPerspective(perspective)
+            # this causes self.__setPerspective to be called, which emits
+            # sigStackChanged and sigPlaneSelectionChanged
 
-        self.sigStackChanged.emit(stack.size)
+        else:
+            self.sigStackChanged.emit(stack.size)
 
     def getStack(self, copy=True, returnNumpyArray=False):
         """Get the original stack, as a 3D array or dataset.
@@ -796,6 +801,17 @@ class PlanesWidget(qt.QWidget):
           - slice plane Dim0-Dim1: perspective 2
         """
         self.sigPlaneSelectionChanged.emit(idx)
+
+    def setPerspective(self, perspective):
+        """Update the combobox selection.
+
+          - slice plane Dim1-Dim2: perspective 0
+          - slice plane Dim0-Dim2: perspective 1
+          - slice plane Dim0-Dim1: perspective 2
+
+        :param perspective: Orthogonal dimension number (0, 1, or 2)
+        """
+        self.qcbAxisSelection.setCurrentIndex(perspective)
 
 
 class StackViewMainWindow(StackView):

--- a/silx/gui/plot/test/testStackView.py
+++ b/silx/gui/plot/test/testStackView.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "19/12/2016"
+__date__ = "20/03/2017"
 
 
 import unittest
@@ -55,7 +55,7 @@ class TestStackView(TestCaseQt):
         self.qWaitForWindowExposed(self.stackview)
         self.mystack = numpy.fromfunction(
             lambda i, j, k: numpy.sin(i/15.) + numpy.cos(j/4.) + 2 * numpy.sin(k/6.),
-            (100, 200, 300)
+            (10, 20, 30)
         )
 
     def tearDown(self):
@@ -113,6 +113,23 @@ class TestStackView(TestCaseQt):
                               ListOfImages)  # returnNumpyArray=False by default in getStack
         self.assertIs(my_trans_stack.images, loi)
 
+    def testPerspective(self):
+        self.stackview.setStack(numpy.arange(24).reshape((2, 3, 4)))
+        self.assertEqual(self.stackview._perspective, 0,
+                         "Default perspective is not 0 (dim1-dim2).")
+
+        self.stackview._StackView__planeSelection.setPerspective(1)
+        self.assertEqual(self.stackview._perspective, 1,
+                         "Plane selection combobox not updating perspective")
+
+        self.stackview.setStack(numpy.arange(6).reshape((1, 2, 3)))
+        self.assertEqual(self.stackview._perspective, 0,
+                         "Default perspective not restored in setStack.")
+
+        self.stackview.setStack(numpy.arange(24).reshape((2, 3, 4)), perspective=2)
+        self.assertEqual(self.stackview._perspective, 2,
+                         "Perspective not set in setStack(..., perspective=2).")
+
 
 class TestStackViewMainWindow(TestCaseQt):
     """Base class for tests of StackView."""
@@ -124,7 +141,7 @@ class TestStackViewMainWindow(TestCaseQt):
         self.qWaitForWindowExposed(self.stackview)
         self.mystack = numpy.fromfunction(
             lambda i, j, k: numpy.sin(i/15.) + numpy.cos(j/4.) + 2 * numpy.sin(k/6.),
-            (100, 200, 300)
+            (10, 20, 30)
         )
 
     def tearDown(self):


### PR DESCRIPTION
Combo-box was not updated when the perspective was changed through `setStack`. 

Closes #676