### PR TITLE
[plot] Split Image class

### DIFF
--- a/doc/source/modules/gui/plot/items.rst
+++ b/doc/source/modules/gui/plot/items.rst
@@ -15,10 +15,14 @@ Curve
    :members:
    :inherited-members:
 
-Image
------
+Images
+------
 
-.. autoclass:: Image
+.. autoclass:: ImageData
+   :members:
+   :inherited-members:
+
+.. autoclass:: ImageRgba
    :members:
    :inherited-members:
 

--- a/doc/source/modules/gui/plot/items.rst
+++ b/doc/source/modules/gui/plot/items.rst
@@ -26,6 +26,15 @@ Images
    :members:
    :inherited-members:
 
+
+Scatter
+-------
+
+.. autoclass:: Scatter
+   :members:
+   :inherited-members:
+
+
 Markers
 -------
 

--- a/silx/gui/plot/ImageView.py
+++ b/silx/gui/plot/ImageView.py
@@ -721,7 +721,7 @@ class ImageView(PlotWindow):
 
         # Update active image colormap
         activeImage = self.getActiveImage()
-        if isinstance(activeImage, items.ImageData):
+        if isinstance(activeImage, items.ColormapMixIn):
             activeImage.setColormap(self.getColormap())
 
     def setImage(self, image, origin=(0, 0), scale=(1., 1.),

--- a/silx/gui/plot/ImageView.py
+++ b/silx/gui/plot/ImageView.py
@@ -55,8 +55,7 @@ import numpy
 
 from .. import qt
 
-from . import PlotWindow, PlotWidget
-from . import PlotActions
+from . import items, PlotWindow, PlotWidget, PlotActions
 from .Colors import cursorColorForColormap
 from .PlotTools import LimitsToolBar
 from .Profile import ProfileToolBar
@@ -720,14 +719,10 @@ class ImageView(PlotWindow):
 
         self.setDefaultColormap(cmapDict)
 
+        # Update active image colormap
         activeImage = self.getActiveImage()
-        if activeImage is not None:  # Refresh image with new colormap
-            self.addImage(activeImage.getData(copy=False),
-                          legend=activeImage.getLegend(),
-                          info=activeImage.getInfo(),
-                          pixmap=activeImage.getPixmap(),
-                          colormap=self.getColormap(),
-                          replace=False)
+        if isinstance(activeImage, items.ImageData):
+            activeImage.setColormap(self.getColormap())
 
     def setImage(self, image, origin=(0, 0), scale=(1., 1.),
                  copy=True, reset=True):

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -44,6 +44,7 @@ import numpy
 import logging
 
 from silx.image import shapes
+from . import items
 from .Colors import cursorColorForColormap, rgba
 from .. import icons, qt
 
@@ -854,6 +855,18 @@ class MaskToolsWidget(qt.QWidget):
             self.plot.sigActiveImageChanged.connect(
                 self._activeImageChangedAfterCare)
 
+    def _setOverlayColorForImage(self, image):
+        """Set the color of overlay adapted to image
+
+        :param image: :class:`.items.ImageBase` object to set color for.
+        """
+        if isinstance(image, items.ColormapMixIn):
+            colormap = image.getColormap()
+            self._defaultOverlayColor = rgba(
+                cursorColorForColormap(colormap['name']))
+        else:
+            self._defaultOverlayColor = rgba('black')
+
     def _activeImageChangedAfterCare(self, *args):
         """Check synchro of active image and mask when mask widget is hidden.
 
@@ -866,8 +879,7 @@ class MaskToolsWidget(qt.QWidget):
             self.plot.sigActiveImageChanged.disconnect(
                 self._activeImageChangedAfterCare)
         else:
-            colormap = activeImage.getColormap()
-            self._defaultOverlayColor = rgba(cursorColorForColormap(colormap['name']))
+            self._setOverlayColorForImage(activeImage)
             self._setMaskColors(self.levelSpinBox.value(),
                                 self.transparencySlider.value() /
                                 self.transparencySlider.maximum())
@@ -901,8 +913,8 @@ class MaskToolsWidget(qt.QWidget):
         else:  # There is an active image
             self.setEnabled(True)
 
-            colormap = activeImage.getColormap()
-            self._defaultOverlayColor = rgba(cursorColorForColormap(colormap['name']))
+            self._setOverlayColorForImage(activeImage)
+
             self._setMaskColors(self.levelSpinBox.value(),
                                 self.transparencySlider.value() /
                                 self.transparencySlider.maximum())
@@ -1405,7 +1417,7 @@ class MaskToolsWidget(qt.QWidget):
     def _loadRangeFromColormapTriggered(self):
         """Set range from active image colormap range"""
         activeImage = self.plot.getActiveImage()
-        if (activeImage is not None and
+        if (isinstance(activeImage, items.ColormapMixIn) and
                 activeImage.getLegend() != self._maskName):
             # Update thresholds according to colormap
             colormap = activeImage.getColormap()

--- a/silx/gui/plot/Plot.py
+++ b/silx/gui/plot/Plot.py
@@ -797,7 +797,7 @@ class Plot(object):
             image._setSelectable(selectable)
         if draggable is not None:
             image._setDraggable(draggable)
-        if colormap is not None and isinstance(image, items.ImageData):
+        if colormap is not None and isinstance(image, items.ColormapMixIn):
             image.setColormap(colormap)
         if xlabel is not None:
             image._setXLabel(xlabel)

--- a/silx/gui/plot/Plot.py
+++ b/silx/gui/plot/Plot.py
@@ -442,7 +442,7 @@ class Plot(object):
         """
         if isinstance(item, items.Curve):
             kind = 'curve'
-        elif isinstance(item, items.Image):
+        elif isinstance(item, items.ImageBase):
             kind = 'image'
         elif isinstance(item, items.Scatter):
             kind = 'scatter'
@@ -470,7 +470,7 @@ class Plot(object):
         item._setPlot(self)
         if item.isVisible():
             self._itemRequiresUpdate(item)
-        if isinstance(item, (items.Curve, items.Image)):
+        if isinstance(item, (items.Curve, items.ImageBase)):
             self._invalidateDataRange()  # TODO handle this automatically
 
     def _remove(self, item):
@@ -764,12 +764,25 @@ class Plot(object):
         # Check if image was previously active
         wasActive = self.getActiveImage(just_legend=True) == legend
 
+        data = numpy.array(data, copy=False)
+        assert data.ndim in (2, 3)
+
         image = self.getImage(legend)
+        if image is not None and image.getData(copy=False).ndim != data.ndim:
+            # Update a data image with RGBA image or the other way around:
+            # Remove previous image
+            # In this case, we don't retrieve defaults from the previous image
+            self._remove(image)
+            image = None
+
         if image is None:
             # No previous image, create a default one and add it to the plot
-            image = items.Image()
+            if data.ndim == 2:
+                image = items.ImageData()
+                image.setColormap(self.getDefaultColormap())
+            else:
+                image = items.ImageRgba()
             image._setLegend(legend)
-            image.setColormap(self.getDefaultColormap())
             self._add(image)
 
         # Override previous/default values with provided ones
@@ -784,14 +797,20 @@ class Plot(object):
             image._setSelectable(selectable)
         if draggable is not None:
             image._setDraggable(draggable)
-        if colormap is not None:
+        if colormap is not None and isinstance(image, items.ImageData):
             image.setColormap(colormap)
         if xlabel is not None:
             image._setXLabel(xlabel)
         if ylabel is not None:
             image._setYLabel(ylabel)
 
-        image.setData(data, pixmap, copy=copy)
+        if data.ndim == 2:
+            image.setData(data, alternative=pixmap, copy=copy)
+        else:  # RGB(A) image
+            if pixmap is not None:
+                _logger.warning(
+                    'addImage: pixmap argument ignored when data is RGB(A)')
+            image.setData(data, copy=copy)
 
         if replace:
             for img in self.getAllImages():
@@ -1475,9 +1494,9 @@ class Plot(object):
         :param bool just_legend: True to get the legend of the image,
                                  False (the default) to get the image data
                                  and info.
-        :return: Active image's legend or corresponding
-                 :class:`.items.Image`
-        :rtype: str or :class:`.items.Image` or None
+        :return: Active image's legend or corresponding image object
+        :rtype: str, :class:`.items.ImageData`, :class:`.items.ImageRgba`
+                or None
         """
         return self._getActiveItem(kind='image', just_legend=just_legend)
 
@@ -1626,15 +1645,15 @@ class Plot(object):
 
         It returns an empty list in case of not having any image.
 
-        If just_legend is False, it returns a list of :class:`items.Image`
+        If just_legend is False, it returns a list of :class:`items.ImageBase`
         objects describing the images.
         If just_legend is True, it returns a list of legends.
 
         :param bool just_legend: True to get the legend of the images,
                                  False (the default) to get the images'
                                  object.
-        :return: list of images' legend or :class:`.items.Image`
-        :rtype: list of str or list of :class:`.items.Image`
+        :return: list of images' legend or :class:`.items.ImageBase`
+        :rtype: list of str or list of :class:`.items.ImageBase`
         """
         return self._getItems(kind='image',
                               just_legend=just_legend,
@@ -1650,7 +1669,7 @@ class Plot(object):
             If not provided or None (the default), the active image is returned
             or if there is no active image, the latest updated image
             is returned if there are images in the plot.
-        :return: None or :class:`.items.Image` object
+        :return: None or :class:`.items.ImageBase` object
         """
         return self._getItem(kind='image', legend=legend)
 

--- a/silx/gui/plot/PlotActions.py
+++ b/silx/gui/plot/PlotActions.py
@@ -71,7 +71,7 @@ import numpy
 from .. import icons
 from .. import qt
 from .._utils import convertArrayToQImage
-from . import Colors
+from . import Colors, items
 from .ColormapDialog import ColormapDialog
 from ._utils import applyZoomToPlot as _applyZoomToPlot
 from silx.third_party.EdfFile import EdfFile
@@ -408,16 +408,10 @@ class ColormapAction(PlotAction):
         # Update default colormap
         self.plot.setDefaultColormap(colormap)
 
-        # Update active image
-        image = self.plot.getActiveImage()
-        if image is not None:
-            # Update image: This do not preserve pixmap
-            self.plot.addImage(image.getData(copy=False),
-                               legend=image.getLegend(),
-                               info=image.getInfo(),
-                               colormap=colormap,
-                               replace=False,
-                               resetzoom=False)
+        # Update active image colormap
+        activeImage = self.plot.getActiveImage()
+        if isinstance(activeImage, items.ImageData):
+            activeImage.setColormap(colormap)
 
 
 class KeepAspectRatioAction(PlotAction):

--- a/silx/gui/plot/PlotActions.py
+++ b/silx/gui/plot/PlotActions.py
@@ -411,7 +411,7 @@ class ColormapAction(PlotAction):
 
         # Update active image colormap
         activeImage = self.plot.getActiveImage()
-        if isinstance(activeImage, items.ImageData):
+        if isinstance(activeImage, items.ColormapMixIn):
             activeImage.setColormap(colormap)
 
 

--- a/silx/gui/plot/PlotActions.py
+++ b/silx/gui/plot/PlotActions.py
@@ -366,8 +366,9 @@ class ColormapAction(PlotAction):
             self._dialog = ColormapDialog()
 
         image = self.plot.getActiveImage()
-        if image is None:
-            # No active image, set dialog from default info
+        if not isinstance(image, items.ColormapMixIn):
+            # No active image or active image is RGBA,
+            # set dialog from default info
             colormap = self.plot.getDefaultColormap()
 
             self._dialog.setHistogram()  # Reset histogram and range if any
@@ -757,10 +758,8 @@ class SaveAction(PlotAction):
 
         elif nameFilter in (self.IMAGE_FILTER_RGB_PNG,
                             self.IMAGE_FILTER_RGB_TIFF):
-            # Apply colormap to data
-            colormap = image.getColormap()
-            rgbaImage = Colors.applyColormapToData(data, **colormap)
-
+            # Get displayed image
+            rgbaImage = image.getRbgaImageData(copy=False)
             # Convert RGB QImage
             qimage = convertArrayToQImage(rgbaImage[:, :, :3])
 

--- a/silx/gui/plot/Profile.py
+++ b/silx/gui/plot/Profile.py
@@ -37,6 +37,7 @@ from silx.image.bilinear import BilinearImage
 
 from .. import icons
 from .. import qt
+from . import items
 from .Colors import cursorColorForColormap
 from .PlotActions import PlotAction
 from .PlotToolButtons import ProfileToolButton
@@ -476,9 +477,11 @@ class ProfileToolBar(qt.QToolBar):
         if legend is not None:
             # Update default profile color
             activeImage = self.plot.getActiveImage()
-            if activeImage is not None:
+            if isinstance(activeImage, items.ColormapMixIn):
                 self._defaultOverlayColor = cursorColorForColormap(
                     activeImage.getColormap()['name'])
+            else:
+                self._defaultOverlayColor = 'black'
 
             self.updateProfile()
 
@@ -588,7 +591,7 @@ class ProfileToolBar(qt.QToolBar):
         self._createProfile(currentData=image.getData(copy=False),
                             origin=image.getOrigin(),
                             scale=image.getScale(),
-                            colormap=image.getColormap(),
+                            colormap=None,  # Not used for 2D data
                             z=image.getZValue())
 
     def _createProfile(self, currentData, origin, scale, colormap, z):

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -80,8 +80,7 @@ except ImportError:
 
 from silx.gui import qt
 from .. import icons
-from . import PlotWindow
-from . import PlotActions
+from . import items, PlotWindow, PlotActions
 from .Colors import cursorColorForColormap
 from .PlotTools import LimitsToolBar
 from .Profile import Profile3DToolBar
@@ -770,18 +769,10 @@ class StackView(qt.QMainWindow):
 
         self._plot.setDefaultColormap(cmapDict)
 
-        # Refresh image with new colormap
+        # Update active image colormap
         activeImage = self._plot.getActiveImage()
-        if activeImage is not None:
-            self._plot.addImage(
-                activeImage.getData(copy=False),
-                origin=self._getImageOrigin(),
-                scale=self._getImageScale(),
-                legend=activeImage.getLegend(),
-                info=activeImage.getInfo(),
-                pixmap=activeImage.getPixmap(copy=False),
-                colormap=self.getColormap(),
-                resetzoom=False)
+        if isinstance(activeImage, items.ImageData):
+            activeImage.setColormap(self.getColormap())
 
     def isKeepDataAspectRatio(self):
         """Returns whether the plot is keeping data aspect ratio or not."""

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -486,6 +486,11 @@ class StackView(qt.QMainWindow):
         if image is None:
             return None
 
+        if isinstance(image, items.ColormapMixIn):
+            colormap = image.getColormap()
+        else:
+            colormap = None
+
         params = {
             'info': image.getInfo(),
             'origin': image.getOrigin(),
@@ -493,7 +498,7 @@ class StackView(qt.QMainWindow):
             'z': image.getZValue(),
             'selectable': image.isSelectable(),
             'draggable': image.isDraggable(),
-            'colormap': image.getColormap(),
+            'colormap': colormap,
             'xlabel': image.getXLabel(),
             'ylabel': image.getYLabel(),
         }
@@ -532,6 +537,11 @@ class StackView(qt.QMainWindow):
         if image is None:
             return None
 
+        if isinstance(image, items.ColormapMixIn):
+            colormap = image.getColormap()
+        else:
+            colormap = None
+
         params = {
             'info': image.getInfo(),
             'origin': image.getOrigin(),
@@ -539,7 +549,7 @@ class StackView(qt.QMainWindow):
             'z': image.getZValue(),
             'selectable': image.isSelectable(),
             'draggable': image.isDraggable(),
-            'colormap': image.getColormap(),
+            'colormap': colormap,
             'xlabel': image.getXLabel(),
             'ylabel': image.getYLabel(),
         }
@@ -771,7 +781,7 @@ class StackView(qt.QMainWindow):
 
         # Update active image colormap
         activeImage = self._plot.getActiveImage()
-        if isinstance(activeImage, items.ImageData):
+        if isinstance(activeImage, items.ColormapMixIn):
             activeImage.setColormap(self.getColormap())
 
     def isKeepDataAspectRatio(self):

--- a/silx/gui/plot/items/__init__.py
+++ b/silx/gui/plot/items/__init__.py
@@ -36,7 +36,7 @@ from .core import (Item, LabelsMixIn, DraggableMixIn, ColormapMixIn,  # noqa
                    SymbolMixIn, ColorMixIn, YAxisMixIn, FillMixIn,  # noqa
                    AlphaMixIn)  # noqa
 from .curve import Curve  # noqa
-from .image import Image  # noqa
+from .image import ImageBase, ImageData, ImageRgba  # noqa
 from .shape import Shape  # noqa
 from .scatter import Scatter  # noqa
 from .marker import Marker, XMarker, YMarker  # noqa

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -22,7 +22,8 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-"""This module provides the :class:`Image` item of the :class:`Plot`.
+"""This module provides the :class:`ImageData` and :class:`ImageRgba` items
+of the :class:`Plot`.
 """
 
 __authors__ = ["T. Vincent"]

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -36,54 +36,65 @@ import logging
 import numpy
 
 from .core import Item, LabelsMixIn, DraggableMixIn, ColormapMixIn, AlphaMixIn
+from ..Colors import applyColormapToData
 from ....utils.decorators import deprecated
 
 
 _logger = logging.getLogger(__name__)
 
 
-class Image(Item, LabelsMixIn, DraggableMixIn, ColormapMixIn, AlphaMixIn):
-    """Description of an image"""
+def _convertImageToRgba32(image, copy=True):
+    """Convert an RGB or RGBA image to RGBA32.
 
-    # TODO method to get image of data converted to RGBA with current colormap
+    It converts from floats in [0, 1], bool, integer and uint in [0, 255]
+
+    If the input image is already an RGBA32 image,
+    the returned image shares the same data.
+
+    :param image: Image to convert to
+    :type image: numpy.ndarray with 3 dimensions: height, width, color channels
+    :param bool copy: True (Default) to get a copy, False, avoid copy if possible
+    :return: The image converted to RGBA32 with dimension: (height, width, 4)
+    :rtype: numpy.ndarray of uint8
+    """
+    assert image.ndim == 3
+    assert image.shape[-1] in (3, 4)
+
+    # Convert type to uint8
+    if image.dtype.name != 'uin8':
+        if image.dtype.kind == 'f':  # Float in [0, 1]
+            image = (numpy.clip(image, 0., 1.) * 255).astype(numpy.uint8)
+        elif image.dtype.kind == 'b':  # boolean
+            image = image.astype(numpy.uint8) * 255
+        elif image.dtype.kind in ('i', 'u'):  # int, uint
+            image = numpy.clip(image, 0, 255).astype(numpy.uint8)
+        else:
+            raise ValueError('Unsupported image dtype: %s', image.dtype.name)
+        copy = False  # A copy as already been done, avoid next one
+
+    # Convert RGB to RGBA
+    if image.shape[-1] == 3:
+        new_image = numpy.empty((image.shape[0], image.shape[1], 4),
+                                dtype=numpy.uint8)
+        new_image[:, :, :3] = image
+        new_image[:, :, 3] = 255
+        return new_image  # This is a copy anyway
+    else:
+        return numpy.array(image, copy=copy)
+
+
+class ImageBase(Item, LabelsMixIn, DraggableMixIn, AlphaMixIn):
+    """Description of an image"""
 
     def __init__(self):
         Item.__init__(self)
         LabelsMixIn.__init__(self)
         DraggableMixIn.__init__(self)
-        ColormapMixIn.__init__(self)
         AlphaMixIn.__init__(self)
-        self._data = ()
-        self._pixmap = None
+        self._data = numpy.zeros((0, 0, 4), dtype=numpy.uint8)
 
-        # TODO use calibration instead of origin and scale?
         self._origin = (0., 0.)
         self._scale = (1., 1.)
-
-    def _addBackendRenderer(self, backend):
-        """Update backend renderer"""
-        plot = self.getPlot()
-        assert plot is not None
-        if plot.isXAxisLogarithmic() or plot.isYAxisLogarithmic():
-            return None  # Do not render with log scales
-
-        if self.getPixmap(copy=False) is not None:
-            dataToSend = self.getPixmap(copy=False)
-        else:
-            dataToSend = self.getData(copy=False)
-
-        if dataToSend.size == 0:
-            return None  # No data to display
-
-        return backend.addImage(dataToSend,
-                                legend=self.getLegend(),
-                                origin=self.getOrigin(),
-                                scale=self.getScale(),
-                                z=self.getZValue(),
-                                selectable=self.isSelectable(),
-                                draggable=self.isDraggable(),
-                                colormap=self.getColormap(),
-                                alpha=self.getAlpha())
 
     @deprecated
     def __getitem__(self, item):
@@ -98,7 +109,7 @@ class Image(Item, LabelsMixIn, DraggableMixIn, ColormapMixIn, AlphaMixIn):
             info = self.getInfo(copy=False)
             return {} if info is None else info
         elif item == 3:
-            return self.getPixmap(copy=False)
+            return None
         elif item == 4:
             params = {
                 'info': self.getInfo(),
@@ -107,7 +118,7 @@ class Image(Item, LabelsMixIn, DraggableMixIn, ColormapMixIn, AlphaMixIn):
                 'z': self.getZValue(),
                 'selectable': self.isSelectable(),
                 'draggable': self.isDraggable(),
-                'colormap': self.getColormap(),
+                'colormap': None,
                 'xlabel': self.getXLabel(),
                 'ylabel': self.getYLabel(),
             }
@@ -121,7 +132,7 @@ class Image(Item, LabelsMixIn, DraggableMixIn, ColormapMixIn, AlphaMixIn):
         :param bool visible: True to display it, False otherwise
         """
         visibleChanged = self.isVisible() != bool(visible)
-        super(Image, self).setVisible(visible)
+        super(ImageBase, self).setVisible(visible)
 
         # TODO hackish data range implementation
         if visibleChanged:
@@ -161,46 +172,12 @@ class Image(Item, LabelsMixIn, DraggableMixIn, ColormapMixIn, AlphaMixIn):
         """
         return numpy.array(self._data, copy=copy)
 
-    def getPixmap(self, copy=True):
-        """Get the optional pixmap that is displayed instead of the data
+    def getRgbaImageData(self, copy=True):
+        """Get the displayed RGB(A) image
 
-        :param copy: True (Default) to get a copy,
-                     False to use internal representation (do not modify!)
-        :return: The pixmap representing the data if any
-        :rtype: numpy.ndarray or None
+        :returns: numpy.ndarray of uint8 of shape (height, width, 4)
         """
-        if self._pixmap is None:
-            return None
-        else:
-            return numpy.array(self._pixmap, copy=copy)
-
-    def setData(self, data, pixmap=None, copy=True):
-        """Set the image data
-
-        :param data: Image data to set
-        :param pixmap: Optional RGB(A) image representing the data
-        :param bool copy: True (Default) to get a copy,
-                          False to use internal representation (do not modify!)
-        """
-        data = numpy.array(data, copy=copy)
-        assert data.ndim in (2, 3)
-        if data.ndim == 3:
-            assert data.shape[1] in (3, 4)
-        self._data = data
-
-        if pixmap is not None:
-            pixmap = numpy.array(pixmap, copy=copy)
-            assert pixmap.ndim == 3
-            assert pixmap.shape[2] in (3, 4)
-            assert pixmap.shape[:2] == data.shape[:2]
-        self._pixmap = pixmap
-        self._updated()
-
-        # TODO hackish data range implementation
-        if self.isVisible():
-            plot = self.getPlot()
-            if plot is not None:
-                plot._invalidateDataRange()
+        raise NotImplementedError('This MUST be implemented in sub-class')
 
     def getOrigin(self):
         """Returns the offset from origin at which to display the image.
@@ -249,3 +226,162 @@ class Image(Item, LabelsMixIn, DraggableMixIn, ColormapMixIn, AlphaMixIn):
         if scale != self._scale:
             self._scale = scale
             self._updated()
+
+
+class ImageData(ImageBase, ColormapMixIn):
+    """Description of a data image with a colormap"""
+
+    def __init__(self):
+        ImageBase.__init__(self)
+        ColormapMixIn.__init__(self)
+        self._data = numpy.zeros((0, 0), dtype=numpy.float32)
+        self._alternativeImage = None
+
+    def _addBackendRenderer(self, backend):
+        """Update backend renderer"""
+        plot = self.getPlot()
+        assert plot is not None
+        if plot.isXAxisLogarithmic() or plot.isYAxisLogarithmic():
+            return None  # Do not render with log scales
+
+        if self.getAlternativeImageData(copy=False) is not None:
+            dataToUse = self.getAlternativeImageData(copy=False)
+        else:
+            dataToUse = self.getData(copy=False)
+
+        if dataToUse.size == 0:
+            return None  # No data to display
+
+        return backend.addImage(dataToUse,
+                                legend=self.getLegend(),
+                                origin=self.getOrigin(),
+                                scale=self.getScale(),
+                                z=self.getZValue(),
+                                selectable=self.isSelectable(),
+                                draggable=self.isDraggable(),
+                                colormap=self.getColormap(),
+                                alpha=self.getAlpha())
+
+    @deprecated
+    def __getitem__(self, item):
+        """Compatibility with PyMca and silx <= 0.4.0"""
+        if item == 3:
+            return self.getAlternativeImageData(copy=False)
+
+        params = ImageBase.__getitem__(self, item)
+        if item == 4:
+            params['colormap'] = self.getColormap()
+
+        return params
+
+    def getRgbaImageData(self, copy=True):
+        """Get the displayed RGB(A) image
+
+        :returns: numpy.ndarray of uint8 of shape (height, width, 4)
+        """
+        if self._alternativeImage is not None:
+            return _convertImageToRgba32(
+                self.getAlternativeImageData(copy=False), copy=copy)
+        else:
+            # Apply colormap, in this case an new array is always returned
+            colormap = self.getColormap()
+            image = applyColormapToData(self.getData(copy=False),
+                                        **colormap)
+            return image
+
+    def getAlternativeImageData(self, copy=True):
+        """Get the optional RGBA image that is displayed instead of the data
+
+        :param copy: True (Default) to get a copy,
+                     False to use internal representation (do not modify!)
+        :returns: None or numpy.ndarray
+        :rtype: numpy.ndarray or None
+        """
+        if self._alternativeImage is None:
+            return None
+        else:
+            return numpy.array(self._alternativeImage, copy=copy)
+
+    def setData(self, data, alternative=None, copy=True):
+        """"Set the image data and optionally an alternative RGB(A) representation
+
+        :param numpy.ndarray data: Data array with 2 dimensions (h, w)
+        :param alternative: RGB(A) image to display instead of data,
+                            shape: (h, w, 3 or 4)
+        :type alternative: None or numpy.ndarray
+        :param bool copy: True (Default) to get a copy,
+                          False to use internal representation (do not modify!)
+        """
+        data = numpy.array(data, copy=copy)
+        assert data.ndim == 2
+        self._data = data
+
+        if alternative is not None:
+            alternative = numpy.array(alternative, copy=copy)
+            assert alternative.ndim == 3
+            assert alternative.shape[2] in (3, 4)
+            assert alternative.shape[:2] == data.shape[:2]
+        self._alternativeImage = alternative
+        self._updated()
+
+        # TODO hackish data range implementation
+        if self.isVisible():
+            plot = self.getPlot()
+            if plot is not None:
+                plot._invalidateDataRange()
+
+
+class ImageRgba(ImageBase):
+    """Description of an RGB(A) image"""
+
+    def __init__(self):
+        ImageBase.__init__(self)
+
+    def _addBackendRenderer(self, backend):
+        """Update backend renderer"""
+        plot = self.getPlot()
+        assert plot is not None
+        if plot.isXAxisLogarithmic() or plot.isYAxisLogarithmic():
+            return None  # Do not render with log scales
+
+        data = self.getData(copy=False)
+
+        if data.size == 0:
+            return None  # No data to display
+
+        return backend.addImage(data,
+                                legend=self.getLegend(),
+                                origin=self.getOrigin(),
+                                scale=self.getScale(),
+                                z=self.getZValue(),
+                                selectable=self.isSelectable(),
+                                draggable=self.isDraggable(),
+                                colormap=None,
+                                alpha=self.getAlpha())
+
+    def getRgbaImageData(self, copy=True):
+        """Get the displayed RGB(A) image
+
+        :returns: numpy.ndarray of uint8 of shape (height, width, 4)
+        """
+        return _convertImageToRgba32(self.getData(copy=False), copy=copy)
+
+    def setData(self, data, copy=True):
+        """Set the image data
+
+        :param data: RGB(A) image data to set
+        :param bool copy: True (Default) to get a copy,
+                          False to use internal representation (do not modify!)
+        """
+        data = numpy.array(data, copy=copy)
+        assert data.ndim == 3
+        assert data.shape[-1] in (3, 4)
+        self._data = data
+
+        self._updated()
+
+        # TODO hackish data range implementation
+        if self.isVisible():
+            plot = self.getPlot()
+            if plot is not None:
+                plot._invalidateDataRange()

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-"""This module provides the :class:`Image` item of the :class:`Plot`.
+"""This module provides the :class:`Scatter` item of the :class:`Plot`.
 """
 
 __authors__ = ["T. Vincent", "P. Knobel"]
@@ -41,7 +41,7 @@ _logger = logging.getLogger(__name__)
 
 
 class Scatter(Points, ColormapMixIn):
-    """Description of a scatter plot"""
+    """Description of a scatter"""
     _DEFAULT_SYMBOL = 'o'
     """Default symbol of the scatter plots"""
 


### PR DESCRIPTION
This PR splits Image class into ImageBase which is inherited by ImageData (2d data + colormap) and ImageRgba (RGB(A) image).

It follows API proposed in issue #686 except for `getGrayscaleImageData` which is not available (there are different ways to compute a grayscale image + this can be added later if needed).
So `Image.getPixmap` is no more available.

Closes #686