### PR TITLE
Improve dataviewer

### DIFF
--- a/silx/gui/data/DataViewer.py
+++ b/silx/gui/data/DataViewer.py
@@ -293,10 +293,41 @@ class DataViewer(qt.QFrame):
         """
         return self.__currentView
 
-    def __updateView(self):
-        """Display the data using the widget which fit the best"""
-        data = self.__data
+    def addView(self, view):
+        """Allow to add a view to the dataview.
 
+        If the current data support this view, it will be displayed.
+
+        :param DataView view: A dataview
+        """
+        self.__views.append(view)
+        # TODO It can be skipped if the view do not support the data
+        self.__updateAvailableViews()
+
+    def removeView(self, view):
+        """Allow to remove a view which was available from the dataview.
+
+        If the view was displayed, the widget will be updated.
+
+        :param DataView view: A dataview
+        """
+        self.__views.remove(view)
+        self.__stack.removeWidget(view.getWidget())
+        # invalidate the full index. It will be updated as expected
+        self.__index = {}
+
+        if view is self.__currentView:
+            self.__updateView()
+        else:
+            # TODO It can be skipped if the view is not part of the
+            # available views
+            self.__updateAvailableViews()
+
+    def __updateAvailableViews(self):
+        """
+        Update available views from the current data.
+        """
+        data = self.__data
         # sort available views according to priority
         info = DataViews.DataInfo(data)
         priorities = [v.getDataPriority(data, info) for v in self.__views]
@@ -311,6 +342,14 @@ class DataViewer(qt.QFrame):
         else:
             available = [v[1] for v in views]
             self.__setCurrentAvailableViews(available)
+
+    def __updateView(self):
+        """Display the data using the widget which fit the best"""
+        data = self.__data
+
+        # update available views for this data
+        self.__updateAvailableViews()
+        available = self.__currentAvailableViews
 
         # display the view with the most priority (the default view)
         view = self.getDefaultViewFromAvailableViews(data, available)

--- a/silx/gui/data/DataViewer.py
+++ b/silx/gui/data/DataViewer.py
@@ -40,7 +40,7 @@ except ImportError:
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "07/04/2017"
+__date__ = "10/04/2017"
 
 
 _logger = logging.getLogger(__name__)
@@ -123,19 +123,26 @@ class DataViewer(qt.QFrame):
         self.__data = None
         self.__useAxisSelection = False
 
-        views = self.createDefaultViews()
-        self.__views = list(views)
-
-        # store stack index for each views
+        self.__views = []
         self.__index = {}
+        """store stack index for each views"""
 
+        self._initializeViews()
+
+    def _initializeViews(self):
+        """Inisialize the available views"""
+        views = self.createDefaultViews(self.__stack)
+        self.__views = list(views)
         self.setDisplayMode(self.EMPTY_MODE)
 
-    def createDefaultViews(self):
+    def createDefaultViews(self, parent=None):
         """Create and returns available views which can be displayed by default
-        by the data viewer.
+        by the data viewer. It is called internally by the widget. It can be
+        overwriten to provide a different set of viewers.
 
-        :rtype: list[silx.gui.data.DataViews.DataView]"""
+        :param QWidget parent: QWidget parent of the views
+        :rtype: list[silx.gui.data.DataViews.DataView]
+        """
         viewClasses = [
             DataViews._EmptyView,
             DataViews._Hdf5View,
@@ -149,7 +156,7 @@ class DataViewer(qt.QFrame):
         views = []
         for viewClass in viewClasses:
             try:
-                view = viewClass(self.__stack)
+                view = viewClass(parent)
                 views.append(view)
             except Exception:
                 _logger.warning("%s instantiation failed. View is ignored" % viewClass.__name__)

--- a/silx/gui/data/DataViewerFrame.py
+++ b/silx/gui/data/DataViewerFrame.py
@@ -105,6 +105,13 @@ class DataViewerFrame(qt.QWidget):
         """Called when the displayed view changes"""
         self.displayedViewChanged.emit(view)
 
+    def availableViews(self):
+        """Returns the list of registered views
+
+        :rtype: List[DataView]
+        """
+        return self.__dataViewer.availableViews()
+
     def currentAvailableViews(self):
         """Returns the list of available views for the current data
 
@@ -121,6 +128,24 @@ class DataViewerFrame(qt.QWidget):
         :rtype: list[silx.gui.data.DataViews.DataView]
         """
         return self.__dataViewer.createDefaultViews(parent)
+
+    def addView(self, view):
+        """Allow to add a view to the dataview.
+
+        If the current data support this view, it will be displayed.
+
+        :param DataView view: A dataview
+        """
+        return self.__dataViewer.addView(view)
+
+    def removeView(self, view):
+        """Allow to remove a view which was available from the dataview.
+
+        If the view was displayed, the widget will be updated.
+
+        :param DataView view: A dataview
+        """
+        return self.__dataViewer.removeView(view)
 
     def setData(self, data):
         """Set the data to view.

--- a/silx/gui/data/DataViewerFrame.py
+++ b/silx/gui/data/DataViewerFrame.py
@@ -27,7 +27,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "25/01/2017"
+__date__ = "10/04/2017"
 
 from silx.gui import qt
 from .DataViewer import DataViewer
@@ -68,7 +68,20 @@ class DataViewerFrame(qt.QWidget):
         """
         super(DataViewerFrame, self).__init__(parent)
 
-        self.__dataViewer = DataViewer(self)
+        class _DataViewer(DataViewer):
+            """Overwrite methods to avoid to create views while the instance
+            is not created. `initializeViews` have to be called manually."""
+
+            def _initializeViews(self):
+                pass
+
+            def initializeViews(self):
+                """Avoid to create views while the instance is not created."""
+                super(_DataViewer, self)._initializeViews()
+
+        self.__dataViewer = _DataViewer(self)
+        # initialize views when `self.__dataViewer` is set
+        self.__dataViewer.initializeViews()
         self.__dataViewer.setFrameShape(qt.QFrame.StyledPanel)
         self.__dataViewer.setFrameShadow(qt.QFrame.Sunken)
         self.__dataViewerSelector = DataViewerSelector(self, self.__dataViewer)
@@ -98,6 +111,16 @@ class DataViewerFrame(qt.QWidget):
         :rtype: List[DataView]
         """
         return self.__dataViewer.currentAvailableViews()
+
+    def createDefaultViews(self, parent=None):
+        """Create and returns available views which can be displayed by default
+        by the data viewer. It is called internally by the widget. It can be
+        overwriten to provide a different set of viewers.
+
+        :param QWidget parent: QWidget parent of the views
+        :rtype: list[silx.gui.data.DataViews.DataView]
+        """
+        return self.__dataViewer.createDefaultViews(parent)
 
     def setData(self, data):
         """Set the data to view.

--- a/silx/gui/data/test/test_dataviewer.py
+++ b/silx/gui/data/test/test_dataviewer.py
@@ -24,7 +24,7 @@
 # ###########################################################################*/
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "26/01/2017"
+__date__ = "10/04/2017"
 
 import os
 import tempfile
@@ -165,6 +165,11 @@ class AbstractDataViewerTests(TestCaseQt):
         self.assertEquals(widget.displayedView().modeId(), DataViewer.RAW_MODE)
         widget.setDisplayMode(DataViewer.EMPTY_MODE)
         self.assertEquals(widget.displayedView().modeId(), DataViewer.EMPTY_MODE)
+
+    def test_create_default_views(self):
+        widget = self.create_widget()
+        views = widget.createDefaultViews()
+        self.assertTrue(len(views) > 0)
 
 
 class TestDataViewer(AbstractDataViewerTests):

--- a/silx/gui/data/test/test_dataviewer.py
+++ b/silx/gui/data/test/test_dataviewer.py
@@ -33,6 +33,9 @@ from contextlib import contextmanager
 
 import numpy
 from ..DataViewer import DataViewer
+from ..DataViews import DataView
+
+from silx.gui import qt
 
 from silx.gui.data.DataViewerFrame import DataViewerFrame
 from silx.gui.test.utils import SignalListener
@@ -42,6 +45,22 @@ try:
     import h5py
 except ImportError:
     h5py = None
+
+
+class _DataViewMock(DataView):
+    """Dummy view to display nothing"""
+
+    def __init__(self, parent):
+        DataView.__init__(self, parent)
+
+    def axesNames(self, data, info):
+        return []
+
+    def createWidget(self, parent):
+        return qt.QLabel(parent)
+
+    def getDataPriority(self, data, info):
+        return 0
 
 
 class AbstractDataViewerTests(TestCaseQt):
@@ -170,6 +189,21 @@ class AbstractDataViewerTests(TestCaseQt):
         widget = self.create_widget()
         views = widget.createDefaultViews()
         self.assertTrue(len(views) > 0)
+
+    def test_add_view(self):
+        widget = self.create_widget()
+        view = _DataViewMock(widget)
+        widget.addView(view)
+        self.assertTrue(view in widget.availableViews())
+        self.assertTrue(view in widget.currentAvailableViews())
+
+    def test_remove_view(self):
+        widget = self.create_widget()
+        widget.setData("foobar")
+        view = widget.currentAvailableViews()[0]
+        widget.removeView(view)
+        self.assertTrue(view not in widget.availableViews())
+        self.assertTrue(view not in widget.currentAvailableViews())
 
 
 class TestDataViewer(AbstractDataViewerTests):


### PR DESCRIPTION
- Allow to inherite `createDefaultViews` from `DataViewerFrame`
- Provide an API to `addView` and `removeView` on runtime
- Improve the way the default view is selected by reusing user choices when it is possible