### PR TITLE
[fabioh5] Support UB matrix

### DIFF
--- a/silx/io/test/test_fabioh5.py
+++ b/silx/io/test/test_fabioh5.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "10/04/2017"
+__date__ = "11/04/2017"
 
 import logging
 import numpy
@@ -215,7 +215,7 @@ class TestFabioH5(unittest.TestCase):
         self.assertIn(d.dtype.char, ['d', 'f'])
         numpy.testing.assert_array_almost_equal(d[...], expected)
 
-        d = sample['orientation_matrix']
+        d = sample['ub']
         expected = numpy.array([[[1.99593e-16, 2.73682e-16, -1.54],
                                  [-1.08894, 1.08894, 1.6083e-16],
                                  [1.08894, 1.08894, 9.28619e-17]]])


### PR DESCRIPTION
Here is the first implementation.

- A `sample` group is created only if expected and contains few informations from `UB_pos/mne` and `sample_pos/mne`.
- It only reach data from the first header (i do not check hole the frames for efficiency)
- Nexus requests float for this datasets. `numpy.array` used by it-self `float64`. I think it's fine.
- I add `interpretation=scalar` for this 3 datasets. Like this we display it as raw data.
- I use `medipix.edf` to create a unittest. I think it is a very old data, then it would be nice to test the result with an up-to-date file.


![screenshot from 2017-04-10 17 49 36](https://cloud.githubusercontent.com/assets/7579321/24870642/3e5a9c7a-1e17-11e7-82e7-8687b107a2b9.png)
