### PR TITLE
[plot] symbolsize for scatter and curve

### DIFF
--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -85,7 +85,7 @@ class BackendBase(object):
                  color, symbol, linewidth, linestyle,
                  yaxis,
                  xerror, yerror, z, selectable,
-                 fill, alpha):
+                 fill, alpha, symbolsize):
         """Add a 1D curve given by x an y to the graph.
 
         :param numpy.ndarray x: The data corresponding to the x axis
@@ -123,6 +123,8 @@ class BackendBase(object):
         :param bool selectable: indicate if the curve can be selected
         :param bool fill: True to fill the curve, False otherwise
         :param float alpha: Curve opacity, as a float in [0., 1.]
+        :param float symbolsize: Size of the symbol (if any) drawn
+                                 at each (x, y) position.
         :returns: The handle used by the backend to univocally access the curve
         """
         return legend

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -115,9 +115,9 @@ class BackendMatplotlib(BackendBase.BackendBase):
                  color, symbol, linewidth, linestyle,
                  yaxis,
                  xerror, yerror, z, selectable,
-                 fill, alpha):
+                 fill, alpha, symbolsize):
         for parameter in (x, y, legend, color, symbol, linewidth, linestyle,
-                          yaxis, z, selectable, fill):
+                          yaxis, z, selectable, fill, alpha, symbolsize):
             assert parameter is not None
         assert yaxis in ('left', 'right')
 
@@ -174,7 +174,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
                                    label=legend,
                                    color=actualColor,
                                    marker=symbol,
-                                   picker=picker)
+                                   picker=picker,
+                                   s=symbolsize)
             artists.append(scatter)
 
             if fill:
@@ -188,7 +189,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
                                   color=color,
                                   linewidth=linewidth,
                                   marker=symbol,
-                                  picker=picker)
+                                  picker=picker,
+                                  markersize=symbolsize)
             artists += list(curveList)
 
             if fill:

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -320,7 +320,7 @@ class SymbolMixIn(object):
     _DEFAULT_SYMBOL = ''
     """Default marker of the item"""
 
-    _DEFAULT_SYMBOL_SIZE = 1.0
+    _DEFAULT_SYMBOL_SIZE = 6.0
     """Default marker size of the item"""
 
     def __init__(self):

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -320,8 +320,12 @@ class SymbolMixIn(object):
     _DEFAULT_SYMBOL = ''
     """Default marker of the item"""
 
+    _DEFAULT_SYMBOL_SIZE = 1.0
+    """Default marker size of the item"""
+
     def __init__(self):
         self._symbol = self._DEFAULT_SYMBOL
+        self._symbol_size = self._DEFAULT_SYMBOL_SIZE
 
     def getSymbol(self):
         """Return the point marker type.
@@ -352,6 +356,26 @@ class SymbolMixIn(object):
             symbol = self._DEFAULT_SYMBOL
         if symbol != self._symbol:
             self._symbol = symbol
+            self._updated()
+
+    def getSymbolSize(self):
+        """Return the point marker size in points.
+
+        :rtype: float
+        """
+        return self._symbol_size
+
+    def setSymbolSize(self, size):
+        """Set the point marker size in points.
+
+        See :meth:`getSymbolSize`.
+
+        :param str symbol: Marker type
+        """
+        if size is None:
+            size = self._DEFAULT_SYMBOL_SIZE
+        if size != self._symbol_size:
+            self._symbol_size = size
             self._updated()
 
 

--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -179,7 +179,8 @@ class Curve(Points, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn):
                                 z=self.getZValue(),
                                 selectable=self.isSelectable(),
                                 fill=self.isFill(),
-                                alpha=self.getAlpha())
+                                alpha=self.getAlpha(),
+                                symbolsize=self.getSymbolSize())
 
     @deprecated
     def __getitem__(self, item):

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -79,7 +79,8 @@ class Scatter(Points, ColormapMixIn):
                                 z=self.getZValue(),
                                 selectable=self.isSelectable(),
                                 fill=False,
-                                alpha=self.getAlpha())
+                                alpha=self.getAlpha(),
+                                symbolsize=self.getSymbolSize())
 
     def _logFilterData(self, xPositive, yPositive):
         """Filter out values with x or y <= 0 on log axes

--- a/silx/gui/plot/test/testPlot.py
+++ b/silx/gui/plot/test/testPlot.py
@@ -497,7 +497,7 @@ class TestPlotAddScatter(unittest.TestCase):
         self.assertEqual(active.getLegend(), 'scatter 0')
 
         # check default values
-        self.assertAlmostEqual(active.getSymbolSize(),)
+        self.assertAlmostEqual(active.getSymbolSize(), active._DEFAULT_SYMBOL_SIZE)
         self.assertEqual(active.getSymbol(), "o")
         self.assertAlmostEqual(active.getAlpha(), 1.0)
 

--- a/silx/gui/plot/test/testPlot.py
+++ b/silx/gui/plot/test/testPlot.py
@@ -492,9 +492,25 @@ class TestPlotAddScatter(unittest.TestCase):
         plot.addScatter(x=(0, 1), y=(0, 1), value=(0, 1), legend='scatter 2')
         plot._setActiveItem('scatter', 'scatter 0')
 
-        # Active curve
+        # Active scatter
         active = plot._getActiveItem(kind='scatter')
         self.assertEqual(active.getLegend(), 'scatter 0')
+
+        # check default values
+        self.assertAlmostEqual(active.getSymbolSize(),)
+        self.assertEqual(active.getSymbol(), "o")
+        self.assertAlmostEqual(active.getAlpha(), 1.0)
+
+        # modify parameters
+        active.setSymbolSize(20.5)
+        active.setSymbol("d")
+        active.setAlpha(0.777)
+
+        s0 = plot.getScatter("scatter 0")
+
+        self.assertAlmostEqual(s0.getSymbolSize(), 20.5)
+        self.assertEqual(s0.getSymbol(), "d")
+        self.assertAlmostEqual(s0.getAlpha(), 0.777)
 
         scatter1 = plot._getItem(kind='scatter', legend='scatter 1')
         self.assertEqual(scatter1.getLegend(), 'scatter 1')


### PR DESCRIPTION
This PR adds the possibility to change the symbol size for scatter and curve items. 

i'm not sure about `_DEFAULT_SYMBOL_SIZE = 1.0`. I wasn't able to find the matplotlib default value for markersize (confusing documentation).
