### PR TITLE
Improve sorting by filtering NX_class types

### DIFF
--- a/silx/gui/hdf5/NexusSortFilterProxyModel.py
+++ b/silx/gui/hdf5/NexusSortFilterProxyModel.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "20/12/2016"
+__date__ = "12/04/2017"
 
 
 import logging
@@ -72,7 +72,7 @@ class NexusSortFilterProxyModel(qt.QSortFilterProxyModel):
         left = self.sourceModel().data(sourceLeft, Hdf5TreeModel.H5PY_ITEM_ROLE)
         right = self.sourceModel().data(sourceRight, Hdf5TreeModel.H5PY_ITEM_ROLE)
 
-        if issubclass(left.h5pyClass, h5py.Group) and issubclass(right.h5pyClass, h5py.Group):
+        if self.__isNXentry(left) and self.__isNXentry(right):
             less = self.childDatasetLessThan(left, right, "start_time")
             if less is not None:
                 return less
@@ -83,6 +83,13 @@ class NexusSortFilterProxyModel(qt.QSortFilterProxyModel):
         left = self.sourceModel().data(sourceLeft, qt.Qt.DisplayRole)
         right = self.sourceModel().data(sourceRight, qt.Qt.DisplayRole)
         return self.nameLessThan(left, right)
+
+    def __isNXentry(self, node):
+        """Returns try if the node is an NXentry"""
+        if not issubclass(node.h5pyClass, h5py.Group):
+            return False
+        nxClass = node.obj.attrs.get("NX_class", None)
+        return nxClass == "NXentry"
 
     def getWordsAndNumbers(self, name):
         """

--- a/silx/gui/hdf5/test/_mock.py
+++ b/silx/gui/hdf5/test/_mock.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "20/12/2016"
+__date__ = "12/04/2017"
 
 
 import numpy
@@ -92,6 +92,11 @@ class Group(Node):
 
     def create_group(self, name):
         return Group(name, self)
+
+    def create_NXentry(self, name):
+        group = Group(name, self)
+        group.attrs["NX_class"] = "NXentry"
+        return group
 
 
 class File(Group):

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "05/12/2016"
+__date__ = "12/04/2017"
 
 
 import time
@@ -315,7 +315,68 @@ class TestNexusSortFilterProxyModel(TestCaseQt):
             result.append(name)
         return result
 
+    def testNXentryStartTime(self):
+        """Test NXentry with start_time"""
+        model = hdf5.Hdf5TreeModel()
+        h5 = _mock.File("/foo/bar/1.mock")
+        h5.create_NXentry("a").create_dataset("start_time", numpy.string_("2015"))
+        h5.create_NXentry("b").create_dataset("start_time", numpy.string_("2013"))
+        h5.create_NXentry("c").create_dataset("start_time", numpy.string_("2014"))
+        model.insertH5pyObject(h5)
+
+        proxy = hdf5.NexusSortFilterProxyModel()
+        proxy.setSourceModel(model)
+        proxy.sort(0, qt.Qt.DescendingOrder)
+        names = self.getChildNames(proxy, proxy.index(0, 0, qt.QModelIndex()))
+        self.assertListEqual(names, ["a", "c", "b"])
+
+    def testNXentryStartTimeInArray(self):
+        """Test NXentry with start_time"""
+        model = hdf5.Hdf5TreeModel()
+        h5 = _mock.File("/foo/bar/1.mock")
+        h5.create_NXentry("a").create_dataset("start_time", numpy.array([numpy.string_("2015")]))
+        h5.create_NXentry("b").create_dataset("start_time", numpy.array([numpy.string_("2013")]))
+        h5.create_NXentry("c").create_dataset("start_time", numpy.array([numpy.string_("2014")]))
+        model.insertH5pyObject(h5)
+
+        proxy = hdf5.NexusSortFilterProxyModel()
+        proxy.setSourceModel(model)
+        proxy.sort(0, qt.Qt.DescendingOrder)
+        names = self.getChildNames(proxy, proxy.index(0, 0, qt.QModelIndex()))
+        self.assertListEqual(names, ["a", "c", "b"])
+
+    def testNXentryEndTimeInArray(self):
+        """Test NXentry with end_time"""
+        model = hdf5.Hdf5TreeModel()
+        h5 = _mock.File("/foo/bar/1.mock")
+        h5.create_NXentry("a").create_dataset("end_time", numpy.array([numpy.string_("2015")]))
+        h5.create_NXentry("b").create_dataset("end_time", numpy.array([numpy.string_("2013")]))
+        h5.create_NXentry("c").create_dataset("end_time", numpy.array([numpy.string_("2014")]))
+        model.insertH5pyObject(h5)
+
+        proxy = hdf5.NexusSortFilterProxyModel()
+        proxy.setSourceModel(model)
+        proxy.sort(0, qt.Qt.DescendingOrder)
+        names = self.getChildNames(proxy, proxy.index(0, 0, qt.QModelIndex()))
+        self.assertListEqual(names, ["a", "c", "b"])
+
+    def testNXentryName(self):
+        """Test NXentry without start_time  or end_time"""
+        model = hdf5.Hdf5TreeModel()
+        h5 = _mock.File("/foo/bar/1.mock")
+        h5.create_NXentry("a")
+        h5.create_NXentry("c")
+        h5.create_NXentry("b")
+        model.insertH5pyObject(h5)
+
+        proxy = hdf5.NexusSortFilterProxyModel()
+        proxy.setSourceModel(model)
+        proxy.sort(0, qt.Qt.AscendingOrder)
+        names = self.getChildNames(proxy, proxy.index(0, 0, qt.QModelIndex()))
+        self.assertListEqual(names, ["a", "b", "c"])
+
     def testStartTime(self):
+        """If it is not NXentry, start_time is not used"""
         model = hdf5.Hdf5TreeModel()
         h5 = _mock.File("/foo/bar/1.mock")
         h5.create_group("a").create_dataset("start_time", numpy.string_("2015"))
@@ -325,37 +386,9 @@ class TestNexusSortFilterProxyModel(TestCaseQt):
 
         proxy = hdf5.NexusSortFilterProxyModel()
         proxy.setSourceModel(model)
-        proxy.sort(0, qt.Qt.DescendingOrder)
+        proxy.sort(0, qt.Qt.AscendingOrder)
         names = self.getChildNames(proxy, proxy.index(0, 0, qt.QModelIndex()))
-        self.assertListEqual(names, ["a", "c", "b"])
-
-    def testStartTimeInArray(self):
-        model = hdf5.Hdf5TreeModel()
-        h5 = _mock.File("/foo/bar/1.mock")
-        h5.create_group("a").create_dataset("start_time", numpy.array([numpy.string_("2015")]))
-        h5.create_group("b").create_dataset("start_time", numpy.array([numpy.string_("2013")]))
-        h5.create_group("c").create_dataset("start_time", numpy.array([numpy.string_("2014")]))
-        model.insertH5pyObject(h5)
-
-        proxy = hdf5.NexusSortFilterProxyModel()
-        proxy.setSourceModel(model)
-        proxy.sort(0, qt.Qt.DescendingOrder)
-        names = self.getChildNames(proxy, proxy.index(0, 0, qt.QModelIndex()))
-        self.assertListEqual(names, ["a", "c", "b"])
-
-    def testEndTimeInArray(self):
-        model = hdf5.Hdf5TreeModel()
-        h5 = _mock.File("/foo/bar/1.mock")
-        h5.create_group("a").create_dataset("end_time", numpy.array([numpy.string_("2015")]))
-        h5.create_group("b").create_dataset("end_time", numpy.array([numpy.string_("2013")]))
-        h5.create_group("c").create_dataset("end_time", numpy.array([numpy.string_("2014")]))
-        model.insertH5pyObject(h5)
-
-        proxy = hdf5.NexusSortFilterProxyModel()
-        proxy.setSourceModel(model)
-        proxy.sort(0, qt.Qt.DescendingOrder)
-        names = self.getChildNames(proxy, proxy.index(0, 0, qt.QModelIndex()))
-        self.assertListEqual(names, ["a", "c", "b"])
+        self.assertListEqual(names, ["a", "b", "c"])
 
     def testName(self):
         model = hdf5.Hdf5TreeModel()


### PR DESCRIPTION
This PR sorting items by `start_time` amd `end_time` only for `NXentry` classes. It is efficient and more generic (we can custom other classes if expected) than the proposal on #336.

Closes #336