### PR TITLE
[FitAction] keep a constant color for fitted curve

### DIFF
--- a/silx/gui/plot/PlotActions.py
+++ b/silx/gui/plot/PlotActions.py
@@ -51,7 +51,7 @@ from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "16/02/2017"
+__date__ = "20/04/2017"
 
 
 from collections import OrderedDict
@@ -1147,24 +1147,23 @@ class FitAction(PlotAction):
     def handle_signal(self, ddict):
         x_fit = self.x[self.xmin <= self.x]
         x_fit = x_fit[x_fit <= self.xmax]
-        if ddict["event"] == "EstimateFinished":
-            self.plot.removeCurve("Fit <%s>" % self.legend)
-            y_fit = self.fit_widget.fitmanager.gendata(estimated=True)
-            self.plot.addCurve(x_fit, y_fit,
-                               "Estimated <%s>" % self.legend,
-                               xlabel=self.xlabel, ylabel=self.ylabel,
-                               resetzoom=False)
+        fit_legend = "Fit <%s>" % self.legend
+        fit_curve = self.plot.getCurve(fit_legend)
+
         if ddict["event"] == "FitFinished":
-            self.plot.removeCurve("Estimated <%s>" % self.legend)
             y_fit = self.fit_widget.fitmanager.gendata()
-            self.plot.addCurve(x_fit, y_fit,
-                               "Fit <%s>" % self.legend,
-                               xlabel=self.xlabel, ylabel=self.ylabel,
-                               resetzoom=False)
-        if ddict["event"] in ["EstimateStarted", "EstimateFailed"]:
-            self.plot.removeCurve("Estimated <%s>" % self.legend)
+            if fit_curve is None:
+                self.plot.addCurve(x_fit, y_fit,
+                                   fit_legend,
+                                   xlabel=self.xlabel, ylabel=self.ylabel,
+                                   resetzoom=False)
+            else:
+                fit_curve.setData(x_fit, y_fit)
+                fit_curve.setVisible(True)
+
         if ddict["event"] in ["FitStarted", "FitFailed"]:
-            self.plot.removeCurve("Fit <%s>" % self.legend)
+            if fit_curve is not None:
+                fit_curve.setVisible(False)
 
 
 class PixelIntensitiesHistoAction(PlotAction):


### PR DESCRIPTION
Ensure the fit curve keeps the same color by reusing a curve object

Also, remove the display of the estimation curve. To do it properly, one would need to update the plot also when the estimated parameters are manually modified.

Closes #742 