### PR TITLE
[StackView] Image index calibration in plot title

### DIFF
--- a/examples/stackView.py
+++ b/examples/stackView.py
@@ -29,25 +29,30 @@ widget.
 import numpy
 import sys
 from silx.gui import qt
-# from silx.gui.plot import StackView
 from silx.gui.plot.StackView import StackViewMainWindow
 
 app = qt.QApplication(sys.argv[1:])
     
-x, y, z = numpy.meshgrid(numpy.linspace(-10, 10, 200),
+a, b, c = numpy.meshgrid(numpy.linspace(-10, 10, 200),
                          numpy.linspace(-10, 5, 150),
                          numpy.linspace(-5, 10, 120),
                          indexing="ij")
-mystack = numpy.asarray(numpy.sin(x * y * z) / (x * y * z),
+mystack = numpy.asarray(numpy.sin(a * b * c) / (a * b * c),
                         dtype='float32')
+
+# linear calibrations (a, b), x -> a + bx
+dim0_calib = (-10., 20. / 200.)
+dim1_calib = (-10., 15. / 150.)
+dim2_calib = (-5., 15. / 120.)
 
 # sv = StackView()
 sv = StackViewMainWindow()
 sv.setColormap("jet", autoscale=True)
-sv.setStack(mystack)
-sv.setLabels(["x: -10 to 10 (200 samples)",
-              "y: -10 to 5 (150 samples)",
-              "z: -5 to 10 (120 samples)"])
+sv.setStack(mystack,
+            calibrations=[dim0_calib, dim1_calib, dim2_calib])
+sv.setLabels(["dim0: -10 to 10 (200 samples)",
+              "dim1: -10 to 5 (150 samples)",
+              "dim2: -5 to 10 (120 samples)"])
 sv.show()
 
 app.exec_()

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -339,6 +339,7 @@ class StackView(qt.QMainWindow):
                             scale=self._getImageScale(),
                             legend=self.__imageLegend,
                             resetzoom=False, replace=False)
+        self._plot.setGraphTitle("Image z=%g" % self._getImageZ(index))
 
     def _set3DScaleAndOrigin(self, calibrations):
         """Set scale and origin for all 3 axes, to be used when plotting
@@ -347,11 +348,11 @@ class StackView(qt.QMainWindow):
         See setStack for parameter documentation
         """
         if calibrations is None:
-            self.origin3D = (0., 0., 0.)
-            self.scale3D = (1., 1., 1.)
+            self.calibrations3D = (calibration.NoCalibration(),
+                                   calibration.NoCalibration(),
+                                   calibration.NoCalibration())
         else:
-            self.origin3D = []
-            self.scale3D = []
+            self.calibrations3D = []
             for calib in calibrations:
                 if hasattr(calib, "__len__") and len(calib) == 2:
                     calib = calibration.LinearCalibration(calib[0], calib[1])
@@ -361,31 +362,39 @@ class StackView(qt.QMainWindow):
                     raise TypeError("calibration must be a 2-tuple, None or" +
                                     " an instance of an AbstractCalibration " +
                                     "subclass")
-                self.origin3D.append(calib(0))
-                self.scale3D.append(calib.get_slope())
+                self.calibrations3D.append(calib)
+
+    def _getXYZCalibs(self):
+        xy_dims = [0, 1, 2]
+        xy_dims.remove(self._perspective)
+
+        xcalib = self.calibrations3D[max(xy_dims)]
+        ycalib = self.calibrations3D[min(xy_dims)]
+        zcalib = self.calibrations3D[self._perspective]
+
+        return xcalib, ycalib, zcalib
 
     def _getImageScale(self):
         """
         :return: 2-tuple (XScale, YScale) for current image view
         """
-        if self._perspective == 0:
-            return self.scale3D[2], self.scale3D[1]
-        if self._perspective == 1:
-            return self.scale3D[2], self.scale3D[0]
-        if self._perspective == 2:
-            return self.scale3D[1], self.scale3D[0]
+        xcalib, ycalib, _zcalib = self._getXYZCalibs()
+        return xcalib.get_slope(), ycalib.get_slope()
 
     def _getImageOrigin(self):
         """
         :return: 2-tuple (XOrigin, YOrigin) for current image view
         """
-        if self._perspective == 0:
-            return self.origin3D[2], self.origin3D[1]
-        if self._perspective == 1:
-            return self.origin3D[2], self.origin3D[0]
-        if self._perspective == 2:
-            return self.origin3D[1], self.origin3D[0]
+        xcalib, ycalib, _zcalib = self._getXYZCalibs()
+        return xcalib(0), ycalib(0)
 
+    def _getImageZ(self, index):
+        """
+        :param idx: 0-based image index in the stack
+        :return: calibrated Z value corresponding to the image idx
+        """
+        _xcalib, _ycalib, zcalib = self._getXYZCalibs()
+        return zcalib(index)
 
     # public API
     def setStack(self, stack, perspective=0, reset=True, calibrations=None):
@@ -450,6 +459,7 @@ class StackView(qt.QMainWindow):
                             scale=self._getImageScale(),
                             resetzoom=False)
         self._plot.setActiveImage(self.__imageLegend)
+        self._plot.setGraphTitle("Image z=%g" % self._getImageZ(0))
         self.__updatePlotLabels()
 
         if reset:

--- a/silx/gui/plot/test/testStackView.py
+++ b/silx/gui/plot/test/testStackView.py
@@ -130,6 +130,32 @@ class TestStackView(TestCaseQt):
         self.assertEqual(self.stackview._perspective, 2,
                          "Perspective not set in setStack(..., perspective=2).")
 
+    def testTitle(self):
+        """Test that the plot title contains the proper Z information"""
+        self.stackview.setStack(numpy.arange(24).reshape((4, 3, 2)),
+                                calibrations=[(0, 1), (-10, 10), (3.14, 3.14)])
+        self.assertEqual(self.stackview._plot.getGraphTitle(),
+                         "Image z=0")
+        self.stackview.setFrameNumber(2)
+        self.assertEqual(self.stackview._plot.getGraphTitle(),
+                         "Image z=2")
+
+        self.stackview._StackView__planeSelection.setPerspective(1)
+        self.stackview.setFrameNumber(0)
+        self.assertEqual(self.stackview._plot.getGraphTitle(),
+                         "Image z=-10")
+        self.stackview.setFrameNumber(2)
+        self.assertEqual(self.stackview._plot.getGraphTitle(),
+                         "Image z=10")
+
+        self.stackview._StackView__planeSelection.setPerspective(2)
+        self.stackview.setFrameNumber(0)
+        self.assertEqual(self.stackview._plot.getGraphTitle(),
+                         "Image z=3.14")
+        self.stackview.setFrameNumber(1)
+        self.assertEqual(self.stackview._plot.getGraphTitle(),
+                         "Image z=6.28")
+
 
 class TestStackViewMainWindow(TestCaseQt):
     """Base class for tests of StackView."""


### PR DESCRIPTION
closes #567 by displaying the image coordinate as the plot title. This is the image index by default, but can be a calibrated value if a calibration is provided for the image index dimension.