### PR TITLE
Update a Travis test to use silx compiled with asserts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
           env:
               - BUILD_COMMAND=sdist
               - WITH_QT_TEST=False
+              - PIP_INSTALL_EXTRA_ARGS="--global-option build --global-option --debug"
 
         - python: 3.5
           os: linux
@@ -95,7 +96,7 @@ script:
     # Make sure silx does not come from cache or pypi
     # At this point all install_requires dependencies MUST be installed
     # as this is installing only from dist
-    - pip install --pre --find-links dist/ --no-cache-dir --no-index silx
+    - pip install --pre --find-links dist/ --no-cache-dir --no-index silx $PIP_INSTALL_EXTRA_ARGS
 
     # Print Python info
     - python ci/info_platform.py

--- a/setup.py
+++ b/setup.py
@@ -539,6 +539,15 @@ class BuildExt(build_ext):
         flags. This function tries to clean up default debug options.
         """
         build_obj = self.distribution.get_command_obj("build")
+        if build_obj.debug:
+            debug_mode = build_obj.debug
+        else:
+            # Also in debug_mode if we compile with python-dbg
+            # It is needed for debian packaging
+            if sys.version_info >= (3, 0):
+                debug_mode = "d" in sys.abiflags
+            else:
+                debug_mode = sys.pydebug
 
         if self.compiler.compiler_type == "unix":
             args = list(self.compiler.compiler_so)
@@ -550,7 +559,7 @@ class BuildExt(build_ext):
             # always insert symbols
             args.append("-g")
             # only strip asserts in release mode
-            if not build_obj.debug:
+            if not debug_mode:
                 args.append('-DNDEBUG')
             # patch options
             self.compiler.compiler_so = list(args)

--- a/setup.py
+++ b/setup.py
@@ -441,7 +441,6 @@ class Build(_build):
                 logger.warning(msg)
                 use_cython = "no"
 
-
         # Remove attribute used by distutils parsing
         # use 'use_cython' and 'force_cython' instead
         del self.no_cython


### PR DESCRIPTION
- Fix flag compiler to have expected behaviour with `--debug`
- Fix flag compiler according to the use of `python-dbg`
- Configure Travis Linux Python 3.4 to be compiled and tested with asserts

It closes #796
It closes #810