### PR TITLE
Fix dependency from silx package to python3-pkg-resources

### DIFF
--- a/package/debian8/control
+++ b/package/debian8/control
@@ -73,7 +73,7 @@ Architecture: all
 Depends: ${misc:Depends},
          ${python:Depends},
          ${shlibs:Depends},
-         python3-setuptools,
+         python3-pkg-resources,
          python3-silx (>= ${source:Version})
 Description: Toolbox for X-Ray data analysis - Executables
  .

--- a/package/debian9/control
+++ b/package/debian9/control
@@ -53,7 +53,7 @@ Architecture: all
 Depends: ${misc:Depends},
          ${python:Depends},
          ${shlibs:Depends},
-         python3-setuptools,
+         python3-pkg-resources,
          python3-silx (>= ${source:Version})
 Description: Toolbox for X-Ray data analysis - Executables
  .


### PR DESCRIPTION
The dependency was previously on `setuptools`. But debian packages `pkg-resources` into a specific package.

It closes #809