### PR TITLE
[plot.items] Remove deprecation warnings

### DIFF
--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -37,7 +37,6 @@ import numpy
 from .. import Colors
 from .core import (Points, LabelsMixIn, SymbolMixIn,
                    ColorMixIn, YAxisMixIn, FillMixIn, LineMixIn)
-from ....utils.decorators import deprecated
 
 
 _logger = logging.getLogger(__name__)
@@ -95,7 +94,6 @@ class Curve(Points, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixIn):
                                 alpha=self.getAlpha(),
                                 symbolsize=self.getSymbolSize())
 
-    @deprecated
     def __getitem__(self, item):
         """Compatibility with PyMca and silx <= 0.4.0"""
         if isinstance(item, slice):

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -38,7 +38,6 @@ import numpy
 
 from .core import Item, LabelsMixIn, DraggableMixIn, ColormapMixIn, AlphaMixIn
 from ..Colors import applyColormapToData
-from ....utils.decorators import deprecated
 
 
 _logger = logging.getLogger(__name__)
@@ -97,7 +96,6 @@ class ImageBase(Item, LabelsMixIn, DraggableMixIn, AlphaMixIn):
         self._origin = (0., 0.)
         self._scale = (1., 1.)
 
-    @deprecated
     def __getitem__(self, item):
         """Compatibility with PyMca and silx <= 0.4.0"""
         if isinstance(item, slice):
@@ -263,7 +261,6 @@ class ImageData(ImageBase, ColormapMixIn):
                                 colormap=self.getColormap(),
                                 alpha=self.getAlpha())
 
-    @deprecated
     def __getitem__(self, item):
         """Compatibility with PyMca and silx <= 0.4.0"""
         if item == 3:


### PR DESCRIPTION
These warnings were added for detecting usages of the old plot API between releases 0.4 and 0.5 