### PR TITLE
Add support of Qt5.4's QOpenGLWidget to OpenGL plot backend and plot3d

### DIFF
--- a/silx/gui/_glutils/OpenGLWidget.py
+++ b/silx/gui/_glutils/OpenGLWidget.py
@@ -107,8 +107,13 @@ class OpenGLWidget(_BaseOpenGLWidget):
     BASE_WIDGET = _BASE_WIDGET
     """Name of the underlying OpenGL widget"""
 
-    # Only display no OpenGL pop-up once for all widgets.
-    _noOpenGLErrorMessageDisplayed = False
+    DISPLAY_NO_OPENGL_POP_UP = True
+    """Control the display of a pop-up when OpenGL is not available.
+
+    True (default) to display a pop-up once if a problem occurs.
+    Once the pop-up is displayed, this is set to False.
+    Set to False to disable OpenGL availability pop-up.
+    """
 
     def __init__(self, parent=None,
                  alphaBufferSize=0,
@@ -211,8 +216,8 @@ class OpenGLWidget(_BaseOpenGLWidget):
     def showEvent(self, event):
         """Handle show events for the no OpenGL fallback to display an error
         """
-        if not self.BASE_WIDGET and not self._noOpenGLErrorMessageDisplayed:
-            self.__class__._noOpenGLErrorMessageDisplayed = True
+        if not self.BASE_WIDGET and self.DISPLAY_NO_OPENGL_POP_UP:
+            self.__class__.DISPLAY_NO_OPENGL_POP_UP = False
             messageBox = qt.QMessageBox(parent=self)
             messageBox.setIcon(qt.QMessageBox.Critical)
             messageBox.setWindowTitle('Error')
@@ -244,8 +249,8 @@ class OpenGLWidget(_BaseOpenGLWidget):
                 'OpenGL widget disabled: OpenGL %d.%d not available' %
                 self.getRequestedOpenGLVersion())
 
-            if not self._noOpenGLErrorMessageDisplayed:
-                self.__class__._noOpenGLErrorMessageDisplayed = True
+            if self.DISPLAY_NO_OPENGL_POP_UP:
+                self.__class__.DISPLAY_NO_OPENGL_POP_UP = False
                 messageBox = qt.QMessageBox(parent=self)
                 messageBox.setIcon(qt.QMessageBox.Critical)
                 messageBox.setWindowTitle('Error')

--- a/silx/gui/_glutils/OpenGLWidget.py
+++ b/silx/gui/_glutils/OpenGLWidget.py
@@ -249,8 +249,8 @@ class OpenGLWidget(_BaseOpenGLWidget):
             # Requested OpenGL version not available, just clear the color buffer.
             gl.glViewport(0,
                           0,
-                          self.width() * self.getDevicePixelRatio(),
-                          self.height() * self.getDevicePixelRatio())
+                          int(self.width() * self.getDevicePixelRatio()),
+                          int(self.height() * self.getDevicePixelRatio()))
 
             gl.glClearColor(0., 0., 0., 1.)
             gl.glClear(gl.GL_COLOR_BUFFER_BIT)

--- a/silx/gui/_glutils/OpenGLWidget.py
+++ b/silx/gui/_glutils/OpenGLWidget.py
@@ -1,0 +1,211 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This package provides a compatibility layer for OpenGL widget.
+
+It provides a compatibility layer for Qt OpenGL widget used in silx
+across Qt<=5.3 QtOpenGL.QGLWidget and QOpenGLWidget.
+
+"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "09/05/2017"
+
+
+import logging
+
+from .. import qt
+from .._glutils import gl
+
+
+_logger = logging.getLogger(__name__)
+
+
+# TODO setFormat
+# TODO convert openGLVersionFlags to version
+# TODO split _OpenGLWidgetBase and OpenGL2.1 specific stuff
+# TODO different modes for message box, set color of clear...
+class _OpenGLWidgetBase(object):
+    """Base class for OpenGL widget wrapper over QGLWidget and QOpenGLWidget
+
+    This wrapper API follows QOpenGLWidget API as much as possible.
+    Methods to override to implement rendering are named differently:
+
+    - :meth:`initializeOpenGL` instead of :meth:`initializeGL`,
+    - :meth:`paintOpenGL` instead of :meth:`paintGL` and
+    - :meth:`resizeOpenGL` instead of :meth:`resizeGL`.
+    """
+
+    def __init__(self):
+        self._devicePixelRatio = 1.0
+        self._isOpenGL21 = False
+
+    def getDevicePixelRatio(self):
+        """Returns the ratio device-independent / device pixel size
+
+        It should be either 1.0 or 2.0.
+
+        :return: Scale factor between screen and Qt units
+        :rtype: float
+        """
+        return self._devicePixelRatio
+
+    def _updateDevicePixelRatio(self):
+        """Run in :meth:`paintGL` to update devicePixelRatio value.
+        """
+        pass
+
+    def isOpenGL2_1(self):
+        """Returns whether OpenGL 2.1 is available or not.
+
+        This is only valid after the OpenGL context has been initialised.
+
+        :return: True if OpenGL2.1 is supported, False otherwise
+        :rtype: bool
+        """
+        return self._isOpenGL21
+
+    def _checkOpenGL2_1(self):
+        """Override to implement the check of OpenGL version.
+
+         This is run in :meth:`initializeGL`.
+
+        :return: True if OpenGL 2.1 is available, False otherwise
+        :rtype: bool
+        """
+        return False
+
+    # Implementation of *GL methods
+
+    def initializeGL(self):
+        # Check if OpenGL2.1 is available
+        self._isOpenGL21 = self._checkOpenGL2_1()
+
+        if not self.isOpenGL2_1():
+            _logger.error(
+                'OpenGL widget disabled: OpenGL 2.1 not available')
+
+            messageBox = qt.QMessageBox(parent=self)
+            messageBox.setIcon(qt.QMessageBox.Critical)
+            messageBox.setWindowTitle('Error')
+            messageBox.setText('OpenGL widget disabled.\n\n'
+                               'Reason: OpenGL 2.1 is not available.')
+            messageBox.addButton(qt.QMessageBox.Ok)
+            messageBox.setWindowModality(qt.Qt.WindowModal)
+            messageBox.setAttribute(qt.Qt.WA_DeleteOnClose)
+            messageBox.show()
+
+        self.initializeOpenGL()
+
+    def paintGL(self):
+        self._updateDevicePixelRatio()
+
+        if not self.isOpenGL2_1():
+            # Cannot render scene, just clear the color buffer.
+            gl.glViewport(0,
+                          0,
+                          self.width() * self.getDevicePixelRatio(),
+                          self.height() * self.getDevicePixelRatio())
+
+            gl.glClearColor(0., 0., 0., 1.)
+            gl.glClear(gl.GL_COLOR_BUFFER_BIT)
+
+        else:
+            self.paintOpenGL()
+
+    def resizeGL(self, width, height):
+        # Call resizeOpenGL with device-independent pixel unit
+        # This works over both QGLWidget and QOpenGLWidget
+        self.resizeOpenGL(self.width(), self.height())
+
+    # API to override, replacing *GL methods
+
+    def initializeOpenGL(self):
+        """Override to implement equivalent of initializeGL."""
+        pass
+
+    def paintOpenGL(self):
+        """Override to implement equivalent of paintGL."""
+        pass
+
+    def resizeOpenGL(self, width, height):
+        """Override to implement equivalent of resizeGL.
+
+        :param int width: Width in device-independent pixels
+        :param int height: Height in device-independent pixels
+        """
+        pass
+
+
+class _OpenGLWidgetQt5(_OpenGLWidgetBase):
+    """Base class for OpenGL widget wrapper for PyQt5"""
+
+    def _updateDevicePixelRatio(self):
+        devicePixelRatio = self.context().screen().devicePixelRatio()
+        if devicePixelRatio != self.getDevicePixelRatio():
+            # Update devicePixelRatio and call resizeOpenGL
+            # as resizeGL is not always called.
+            self._devicePixelRatio = devicePixelRatio
+            self.makeCurrent()
+            self.resizeOpenGL(self.width(), self.height())
+
+
+if qt.BINDING == 'PyQt5' and hasattr(qt, 'QOpenGLWidget'):  # PyQt>=5.4
+    class OpenGLWidget(qt.QOpenGLWidget, _OpenGLWidgetQt5):
+
+        def __init__(self, parent=None, f=qt.Qt.WindowFlags()):
+            _OpenGLWidgetQt5.__init__(self)
+            qt.QOpenGLWidget.__init__(self, parent, f)
+
+        def _checkOpenGL2_1(self):
+            return self.format().version() >= (2, 1)
+
+elif qt.HAS_OPENGL:  # Using QtOpenGL.QGLwidget
+
+    class _QGLWidget(qt.QGLWidget):
+        """Class with QGLWidget method shared for Qt4 and Qt5"""
+        def _checkOpenGL2_1(self):
+            versionFlags = self.format().openGLVersionFlags()
+            return bool(versionFlags & qt.QGLFormat.OpenGL_Version_2_1)
+
+    if qt.BINDING == 'PyQt5':
+        class OpenGLWidget(_QGLWidget, _OpenGLWidgetQt5):
+            def __init__(self, parent=None, f=qt.Qt.WindowFlags()):
+                _OpenGLWidgetQt5.__init__(self)
+                _QGLWidget.__init__(self, parent, None, f)
+
+    else:  # Qt4
+        class OpenGLWidget(_QGLWidget, _OpenGLWidgetBase):
+            def __init__(self, parent=None, f=qt.Qt.WindowFlags()):
+                _OpenGLWidgetBase.__init__(self)
+                _QGLWidget.__init__(self, parent, None, f)
+
+else:
+    _logger.error('QtOpenGL is not available!')
+    OpenGLWidget = None
+
+
+# Set docstring
+OpenGLWidget.__doc__ = _OpenGLWidgetBase.__doc__

--- a/silx/gui/_glutils/OpenGLWidget.py
+++ b/silx/gui/_glutils/OpenGLWidget.py
@@ -194,15 +194,6 @@ class OpenGLWidget(_BaseOpenGLWidget):
         else:
             return 0, 0
 
-    def makeCurrent(self):
-        """Make this widget's OpenGL context current.
-
-        See :meth:`QopenGLWidget.makeCurrent`
-        """
-        # Here to provide a fallback in case OpenGL widget is not available
-        if self.BASE_WIDGET:
-            return super(OpenGLWidget, self).makeCurrent()
-
     def defaultFramebufferObject(self):
         """Returns the framebuffer object handle.
 
@@ -214,6 +205,32 @@ class OpenGLWidget(_BaseOpenGLWidget):
             return 0
         else:
             return 0
+
+    # Method useful for no QtOpenGL widgets
+
+    def showEvent(self, event):
+        """Handle show events for the no OpenGL fallback to display an error
+        """
+        if not self.BASE_WIDGET and not self._noOpenGLErrorMessageDisplayed:
+            self.__class__._noOpenGLErrorMessageDisplayed = True
+            messageBox = qt.QMessageBox(parent=self)
+            messageBox.setIcon(qt.QMessageBox.Critical)
+            messageBox.setWindowTitle('Error')
+            messageBox.setText('OpenGL widgets disabled.\n\n'
+                               'Reason: QtOpenGL widgets not available.')
+            messageBox.addButton(qt.QMessageBox.Ok)
+            messageBox.setWindowModality(qt.Qt.WindowModal)
+            messageBox.setAttribute(qt.Qt.WA_DeleteOnClose)
+            messageBox.show()
+
+    def makeCurrent(self):
+        """Make this widget's OpenGL context current.
+
+        See :meth:`QopenGLWidget.makeCurrent`
+        """
+        # Here to provide a fallback in case OpenGL widget is not available
+        if self.BASE_WIDGET:
+            return super(OpenGLWidget, self).makeCurrent()
 
     # Implementation of *GL methods
 

--- a/silx/gui/_glutils/OpenGLWidget.py
+++ b/silx/gui/_glutils/OpenGLWidget.py
@@ -51,6 +51,7 @@ if qt.BINDING == 'PyQt5' and hasattr(qt, 'QOpenGLWidget'):
     _logger.info('Using QOpenGLWidget')
     _BaseOpenGLWidget = qt.QOpenGLWidget
     _BASE_WIDGET = 'QOpenGLWidget'
+    _ERROR_MSG = ''
 
 elif qt.HAS_OPENGL and (
         not qt.QApplication.instance() or qt.QGLFormat.hasOpenGL()):
@@ -60,19 +61,18 @@ elif qt.HAS_OPENGL and (
     _logger.info('Using QGLWidget')
     _BaseOpenGLWidget = qt.QGLWidget
     _BASE_WIDGET = 'QGLWidget'
+    _ERROR_MSG = ''
 
 else: # No OpenGL widget available, fallback to a dummy widget
+    _ERROR_MSG = 'OpenGL-based widget disabled'
     if not qt.HAS_OPENGL:
-         _logger.error(
-            'QtOpenGL is not available: OpenGL-based widget disabled')
+        _ERROR_MSG += ':\n%s.QtOpenGL not available' % qt.BINDING
     elif qt.QApplication.instance() and not qt.QGLFormat.hasOpenGL():
         # qt.QGLFormat.hasOpenGL MUST be called with a QApplication created
         # so this is only checked if the QApplication is already created
-        _logger.error(
-            'OpenGL is not available: OpenGL-based widget disabled')
-    else:
-        _logger.error('OpenGL-based widget disabled')
+        _ERROR_MSG += ':\nOpenGL not available'
 
+    _logger.error(_ERROR_MSG)
     _logger.info('Using QWidget')
     _BaseOpenGLWidget = qt.QWidget
     _BASE_WIDGET = ''
@@ -150,6 +150,11 @@ class OpenGLWidget(_BaseOpenGLWidget):
             super(OpenGLWidget, self).__init__(format_, parent, None, f)
         else:  # Fallback
             super(OpenGLWidget, self).__init__(parent, f)
+            layout = qt.QHBoxLayout()
+            label = qt.QLabel(_ERROR_MSG)
+            label.setAlignment(qt.Qt.AlignCenter)
+            layout.addWidget(label)
+            self.setLayout(layout)
 
     def getDevicePixelRatio(self):
         """Returns the ratio device-independent / device pixel size

--- a/silx/gui/_glutils/OpenGLWidget.py
+++ b/silx/gui/_glutils/OpenGLWidget.py
@@ -200,7 +200,7 @@ class OpenGLWidget(_BaseOpenGLWidget):
     def initializeGL(self):
         # Check OpenGL version
         self.__requestedOpenGLVersionAvailable = \
-            self.getRequestedOpenGLVersion() >= self.getOpenGLVersion()
+            self.getOpenGLVersion() >= self.getRequestedOpenGLVersion()
 
         if not self.isRequestedOpenGLVersionAvailable():
             _logger.error(

--- a/silx/gui/_glutils/OpenGLWidget.py
+++ b/silx/gui/_glutils/OpenGLWidget.py
@@ -45,9 +45,6 @@ from . import gl
 _logger = logging.getLogger(__name__)
 
 
-# TODO different modes for message box, set color of clear...
-# TODO pop-up once when using fallback QWidget
-
 
 if qt.BINDING == 'PyQt5' and hasattr(qt, 'QOpenGLWidget'):
     # PyQt>=5.4
@@ -276,7 +273,7 @@ class OpenGLWidget(_BaseOpenGLWidget):
 
                     painter = qt.QPainter()
                     painter.begin(image)
-                    painter.setBrush(self.palette().windowText())
+                    painter.setPen(self.palette().color(qt.QPalette.WindowText))
                     painter.setFont(self.font())
                     painter.drawText(0, 0, self.width(), self.height(),
                                      qt.Qt.AlignCenter | qt.Qt.TextWordWrap,

--- a/silx/gui/_glutils/OpenGLWidget.py
+++ b/silx/gui/_glutils/OpenGLWidget.py
@@ -269,7 +269,7 @@ class OpenGLWidget(_BaseOpenGLWidget):
                     image = qt.QImage(
                         self.width() * devicePixelRatio,
                         self.height() * devicePixelRatio,
-                        qt.QImage.Format_RGB888)
+                        qt.QImage.Format_RGB32)
                     image.fill(self.palette().color(qt.QPalette.Window))
                     if hasattr(image, 'setDevicePixelRatio'):  # Qt5
                         image.setDevicePixelRatio(devicePixelRatio)

--- a/silx/gui/_glutils/OpenGLWidget.py
+++ b/silx/gui/_glutils/OpenGLWidget.py
@@ -194,6 +194,15 @@ class OpenGLWidget(_BaseOpenGLWidget):
         else:
             return 0, 0
 
+    def makeCurrent(self):
+        """Make this widget's OpenGL context current.
+
+        See :meth:`QopenGLWidget.makeCurrent`
+        """
+        # Here to provide a fallback in case OpenGL widget is not available
+        if self.BASE_WIDGET:
+            return super(OpenGLWidget, self).makeCurrent()
+
     def defaultFramebufferObject(self):
         """Returns the framebuffer object handle.
 

--- a/silx/gui/_glutils/OpenGLWidget.py
+++ b/silx/gui/_glutils/OpenGLWidget.py
@@ -36,7 +36,7 @@ __date__ = "09/05/2017"
 import logging
 
 from .. import qt
-from .._glutils import gl
+from . import gl
 
 
 _logger = logging.getLogger(__name__)
@@ -45,11 +45,19 @@ _logger = logging.getLogger(__name__)
 # TODO different modes for message box, set color of clear...
 # TODO pop-up once when using fallback QWidget
 
-if qt.BINDING == 'PyQt5' and hasattr(qt, 'QOpenGLWidget'):  # PyQt>=5.4
+
+if qt.BINDING == 'PyQt5' and hasattr(qt, 'QOpenGLWidget'):
+    # PyQt>=5.4
+    _logger.info('Using QOpenGLWidget')
     _BaseOpenGLWidget = qt.QOpenGLWidget
     _BASE_WIDGET = 'QOpenGLWidget'
 
-elif qt.HAS_OPENGL and qt.QGLFormat.hasOpenGL():  # Using QtOpenGL.QGLwidget
+elif qt.HAS_OPENGL and (
+        not qt.QApplication.instance() or qt.QGLFormat.hasOpenGL()):
+    # Using QtOpenGL.QGLwidget
+    # qt.QGLFormat.hasOpenGL MUST be called with a QApplication created
+    # so this is only checked if the QApplication is already created
+    _logger.info('Using QGLWidget')
     _BaseOpenGLWidget = qt.QGLWidget
     _BASE_WIDGET = 'QGLWidget'
 
@@ -57,12 +65,15 @@ else: # No OpenGL widget available, fallback to a dummy widget
     if not qt.HAS_OPENGL:
          _logger.error(
             'QtOpenGL is not available: OpenGL-based widget disabled')
-    elif not qt.QGLFormat.hasOpenGL():
+    elif qt.QApplication.instance() and not qt.QGLFormat.hasOpenGL():
+        # qt.QGLFormat.hasOpenGL MUST be called with a QApplication created
+        # so this is only checked if the QApplication is already created
         _logger.error(
             'OpenGL is not available: OpenGL-based widget disabled')
     else:
         _logger.error('OpenGL-based widget disabled')
 
+    _logger.info('Using QWidget')
     _BaseOpenGLWidget = qt.QWidget
     _BASE_WIDGET = ''
 

--- a/silx/gui/_glutils/OpenGLWidget.py
+++ b/silx/gui/_glutils/OpenGLWidget.py
@@ -225,7 +225,8 @@ class OpenGLWidget(_BaseOpenGLWidget):
 
     def paintGL(self):
         if qt.BINDING == 'PyQt5':
-            devicePixelRatio = self.context().screen().devicePixelRatio()
+            devicePixelRatio = self.window().windowHandle().devicePixelRatio()
+
             if devicePixelRatio != self.getDevicePixelRatio():
                 # Update devicePixelRatio and call resizeOpenGL
                 # as resizeGL is not always called.

--- a/silx/gui/_glutils/OpenGLWidget.py
+++ b/silx/gui/_glutils/OpenGLWidget.py
@@ -218,21 +218,6 @@ class OpenGLWidget(_BaseOpenGLWidget):
 
     # Method useful for no QtOpenGL widgets
 
-    def showEvent(self, event):
-        """Handle show events for the no OpenGL fallback to display an error
-        """
-        if not self.BASE_WIDGET and self.DISPLAY_NO_OPENGL_POP_UP:
-            self.__class__.DISPLAY_NO_OPENGL_POP_UP = False
-            messageBox = qt.QMessageBox(parent=self)
-            messageBox.setIcon(qt.QMessageBox.Critical)
-            messageBox.setWindowTitle('Error')
-            messageBox.setText('OpenGL widgets disabled.\n\n'
-                               'Reason: QtOpenGL widgets not available.')
-            messageBox.addButton(qt.QMessageBox.Ok)
-            messageBox.setWindowModality(qt.Qt.WindowModal)
-            messageBox.setAttribute(qt.Qt.WA_DeleteOnClose)
-            messageBox.show()
-
     def makeCurrent(self):
         """Make this widget's OpenGL context current.
 

--- a/silx/gui/_glutils/VertexBuffer.py
+++ b/silx/gui/_glutils/VertexBuffer.py
@@ -180,7 +180,7 @@ class VertexBufferAttrib(object):
                  dimension=1,
                  offset=0,
                  stride=0,
-                 normalisation=False):
+                 normalization=False):
         self.vbo = vbo
         assert type_ in self._GL_TYPES
         self.type_ = type_
@@ -189,7 +189,7 @@ class VertexBufferAttrib(object):
         self.dimension = dimension
         self.offset = offset
         self.stride = stride
-        self.normalisation = bool(normalisation)
+        self.normalization = bool(normalization)
 
     @property
     def itemsize(self):
@@ -200,12 +200,12 @@ class VertexBufferAttrib(object):
 
     def setVertexAttrib(self, attribute):
         """Call glVertexAttribPointer with objects information"""
-        normalisation = gl.GL_TRUE if self.normalisation else gl.GL_FALSE
+        normalization = gl.GL_TRUE if self.normalization else gl.GL_FALSE
         with self.vbo:
             gl.glVertexAttribPointer(attribute,
                                      self.dimension,
                                      self.type_,
-                                     normalisation,
+                                     normalization,
                                      self.stride,
                                      c_void_p(self.offset))
 
@@ -216,7 +216,7 @@ class VertexBufferAttrib(object):
                                   self.dimension,
                                   self.offset,
                                   self.stride,
-                                  self.normalisation)
+                                  self.normalization)
 
 
 def vertexBuffer(arrays, prefix=None, suffix=None, usage=None):

--- a/silx/gui/_glutils/__init__.py
+++ b/silx/gui/_glutils/__init__.py
@@ -33,6 +33,7 @@ __date__ = "25/07/2016"
 
 
 # OpenGL convenient functions
+from .OpenGLWidget import OpenGLWidget  # noqa
 from .Context import getGLContext, setGLContextGetter  # noqa
 from .FramebufferTexture import FramebufferTexture  # noqa
 from .Program import Program  # noqa

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1330,7 +1330,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             (self._plotFrame.size[1], self._plotFrame.size[0], 3),
             dtype=numpy.uint8, order='C')
 
-        gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, 0)
+        gl.glBindFramebuffer(gl.GL_FRAMEBUFFER,
+                             self.defaultFramebufferObject())
         gl.glPixelStorei(gl.GL_PACK_ALIGNMENT, 1)
         gl.glReadPixels(0, 0, self._plotFrame.size[0], self._plotFrame.size[1],
                         gl.GL_RGB, gl.GL_UNSIGNED_BYTE, data)

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -328,8 +328,13 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
     _sigPostRedisplay = qt.Signal()
     """Signal handling automatic asynchronous replot"""
 
-    def __init__(self, plot, parent=None):
-        glu.OpenGLWidget.__init__(self, parent)
+    def __init__(self, plot, parent=None, f=qt.Qt.WindowFlags()):
+        glu.OpenGLWidget.__init__(self, parent,
+                                  alphaBufferSize=8,
+                                  depthBufferSize=0,
+                                  stencilBufferSize=0,
+                                  version=(2, 1),
+                                  f=f)
         BackendBase.BackendBase.__init__(self, plot, parent)
 
         self.matScreenProj = mat4Identity()
@@ -1324,7 +1329,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         if fileFormat not in ['png', 'ppm', 'svg', 'tiff']:
             raise NotImplementedError('Unsupported format: %s' % fileFormat)
 
-        if not self.isOpenGL2_1():
+        if not self.isRequestedOpenGLVersionAvailable():
             _logger.error('OpenGL 2.1 not available, cannot save OpenGL image')
             width, height = self._plotFrame.size
             data = numpy.zeros((height, width, 3), dtype=numpy.uint8)

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1324,21 +1324,26 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         if fileFormat not in ['png', 'ppm', 'svg', 'tiff']:
             raise NotImplementedError('Unsupported format: %s' % fileFormat)
 
-        self.makeCurrent()
+        if not self.isOpenGL2_1():
+            _logger.error('OpenGL 2.1 not available, cannot save OpenGL image')
+            width, height = self._plotFrame.size
+            data = numpy.zeros((height, width, 3), dtype=numpy.uint8)
+        else:
+            self.makeCurrent()
 
-        data = numpy.empty(
-            (self._plotFrame.size[1], self._plotFrame.size[0], 3),
-            dtype=numpy.uint8, order='C')
+            data = numpy.empty(
+                (self._plotFrame.size[1], self._plotFrame.size[0], 3),
+                dtype=numpy.uint8, order='C')
 
-        gl.glBindFramebuffer(gl.GL_FRAMEBUFFER,
-                             self.defaultFramebufferObject())
-        gl.glPixelStorei(gl.GL_PACK_ALIGNMENT, 1)
-        gl.glReadPixels(0, 0, self._plotFrame.size[0], self._plotFrame.size[1],
-                        gl.GL_RGB, gl.GL_UNSIGNED_BYTE, data)
+            gl.glBindFramebuffer(gl.GL_FRAMEBUFFER,
+                                 self.defaultFramebufferObject())
+            gl.glPixelStorei(gl.GL_PACK_ALIGNMENT, 1)
+            gl.glReadPixels(0, 0, self._plotFrame.size[0], self._plotFrame.size[1],
+                            gl.GL_RGB, gl.GL_UNSIGNED_BYTE, data)
 
-        # glReadPixels gives bottom to top,
-        # while images are stored as top to bottom
-        data = numpy.flipud(data)
+            # glReadPixels gives bottom to top,
+            # while images are stored as top to bottom
+            data = numpy.flipud(data)
 
         # fileName is either a file-like object or a str
         saveImageToFile(data, fileName, fileFormat)

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -427,7 +427,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
     def leaveEvent(self, _):
         self._plot.onMouseLeaveWidget()
 
-    # QGLWidget API
+    # OpenGLWidget API
 
     @staticmethod
     def _setBlendFuncGL():

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -313,7 +313,7 @@ def _getContext():
     return _current_context
 
 
-class BackendOpenGL(BackendBase.BackendBase, qt.QGLWidget):
+class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
     """OpenGL-based Plot backend.
 
     WARNINGS:
@@ -329,7 +329,7 @@ class BackendOpenGL(BackendBase.BackendBase, qt.QGLWidget):
     """Signal handling automatic asynchronous replot"""
 
     def __init__(self, plot, parent=None):
-        qt.QGLWidget.__init__(self, parent)
+        glu.OpenGLWidget.__init__(self, parent)
         BackendBase.BackendBase.__init__(self, plot, parent)
 
         self.matScreenProj = mat4Identity()
@@ -341,8 +341,6 @@ class BackendOpenGL(BackendBase.BackendBase, qt.QGLWidget):
         self._plotFBOs = {}
 
         self._keepDataAspectRatio = False
-
-        self._devicePixelRatio = 1.0
 
         self._crosshairCursor = None
         self._mousePosInPixels = None
@@ -377,15 +375,15 @@ class BackendOpenGL(BackendBase.BackendBase, qt.QGLWidget):
         return qt.QSize(8 * 80, 6 * 80)  # Mimic MatplotlibBackend
 
     def mousePressEvent(self, event):
-        xPixel = event.x() * self._devicePixelRatio
-        yPixel = event.y() * self._devicePixelRatio
+        xPixel = event.x() * self.getDevicePixelRatio()
+        yPixel = event.y() * self.getDevicePixelRatio()
         btn = self._MOUSE_BTNS[event.button()]
         self._plot.onMousePress(xPixel, yPixel, btn)
         event.accept()
 
     def mouseMoveEvent(self, event):
-        xPixel = event.x() * self._devicePixelRatio
-        yPixel = event.y() * self._devicePixelRatio
+        xPixel = event.x() * self.getDevicePixelRatio()
+        yPixel = event.y() * self.getDevicePixelRatio()
 
         # Handle crosshair
         inXPixel, inYPixel = self._mouseInPlotArea(xPixel, yPixel)
@@ -402,16 +400,16 @@ class BackendOpenGL(BackendBase.BackendBase, qt.QGLWidget):
         event.accept()
 
     def mouseReleaseEvent(self, event):
-        xPixel = event.x() * self._devicePixelRatio
-        yPixel = event.y() * self._devicePixelRatio
+        xPixel = event.x() * self.getDevicePixelRatio()
+        yPixel = event.y() * self.getDevicePixelRatio()
 
         btn = self._MOUSE_BTNS[event.button()]
         self._plot.onMouseRelease(xPixel, yPixel, btn)
         event.accept()
 
     def wheelEvent(self, event):
-        xPixel = event.x() * self._devicePixelRatio
-        yPixel = event.y() * self._devicePixelRatio
+        xPixel = event.x() * self.getDevicePixelRatio()
+        yPixel = event.y() * self.getDevicePixelRatio()
 
         if hasattr(event, 'angleDelta'):  # Qt 5
             delta = event.angleDelta().y()
@@ -434,7 +432,7 @@ class BackendOpenGL(BackendBase.BackendBase, qt.QGLWidget):
                                gl.GL_ONE,
                                gl.GL_ONE)
 
-    def initializeGL(self):
+    def initializeOpenGL(self):
         gl.testGL()
 
         gl.glClearColor(1., 1., 1., 1.)
@@ -520,18 +518,11 @@ class BackendOpenGL(BackendBase.BackendBase, qt.QGLWidget):
         self._renderMarkersGL()
         self._renderOverlayGL()
 
-    def paintGL(self):
+    def paintOpenGL(self):
         global _current_context
         _current_context = self.context()
 
         glu.setGLContextGetter(_getContext)
-
-        if hasattr(self, 'windowHandle'):  # Qt 5
-            devicePixelRatio = self.windowHandle().devicePixelRatio()
-            if devicePixelRatio != self._devicePixelRatio:
-                self._devicePixelRatio = devicePixelRatio
-                self.resizeGL(int(self.width() * devicePixelRatio),
-                              int(self.height() * devicePixelRatio))
 
         # Release OpenGL resources
         for item in self._glGarbageCollector:
@@ -913,10 +904,13 @@ class BackendOpenGL(BackendBase.BackendBase, qt.QGLWidget):
 
         gl.glDisable(gl.GL_SCISSOR_TEST)
 
-    def resizeGL(self, width, height):
+    def resizeOpenGL(self, width, height):
         if width == 0 or height == 0:  # Do not resize
             return
-        self._plotFrame.size = width, height
+
+        self._plotFrame.size = (
+            int(self.getDevicePixelRatio() * width),
+            int(self.getDevicePixelRatio() * height))
 
         self.matScreenProj = mat4Ortho(0, self._plotFrame.size[0],
                                        self._plotFrame.size[1], 0,

--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -116,8 +116,8 @@ class Plot3DWidget(glu.OpenGLWidget):
         self.setBackgroundColor((0.2, 0.2, 0.2, 1.))
 
         # Window describing on screen area to render
-        self.window = scene.Window(mode='framebuffer')
-        self.window.viewports = [self.viewport, self.overview]
+        self._window = scene.Window(mode='framebuffer')
+        self._window.viewports = [self.viewport, self.overview]
 
         self.eventHandler = interaction.CameraControl(
             self.viewport, orbitAroundCenter=False,
@@ -205,7 +205,7 @@ class Plot3DWidget(glu.OpenGLWidget):
         if self.viewport.dirty:
             self.viewport.adjustCameraDepthExtent()
 
-        self.window.render(self.context(), self.getDevicePixelRatio())
+        self._window.render(self.context(), self.getDevicePixelRatio())
 
         if self._firstRender:  # TODO remove this ugly hack
             self._firstRender = False
@@ -215,8 +215,8 @@ class Plot3DWidget(glu.OpenGLWidget):
     def resizeOpenGL(self, width, height):
         width *= self.getDevicePixelRatio()
         height *= self.getDevicePixelRatio()
-        self.window.size = width, height
-        self.viewport.size = self.window.size
+        self._window.size = width, height
+        self.viewport.size = self._window.size
         overviewWidth, overviewHeight = self.overview.size
         self.overview.origin = width - overviewWidth, height - overviewHeight
 
@@ -228,12 +228,12 @@ class Plot3DWidget(glu.OpenGLWidget):
         """
         if not self.isRequestedOpenGLVersionAvailable():
             _logger.error('OpenGL 2.1 not available, cannot save OpenGL image')
-            height, width = self.window.shape
+            height, width = self._window.shape
             image = numpy.zeros((height, width, 3), dtype=numpy.uint8)
 
         else:
             self.makeCurrent()
-            image = self.window.grab(qt.QGLContext.currentContext())
+            image = self._window.grab(qt.QGLContext.currentContext())
 
         return convertArrayToQImage(image)
 

--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -80,7 +80,7 @@ class _OverviewViewport(scene.Viewport):
 
 
 class Plot3DWidget(glu.OpenGLWidget):
-    """QGLWidget with a 3D viewport and an overview."""
+    """OpenGL widget with a 3D viewport and an overview."""
 
     def __init__(self, parent=None, f=qt.Qt.WindowFlags()):
         self._firstRender = True
@@ -233,7 +233,7 @@ class Plot3DWidget(glu.OpenGLWidget):
 
         else:
             self.makeCurrent()
-            image = self._window.grab(qt.QGLContext.currentContext())
+            image = self._window.grab(self.context())
 
         return convertArrayToQImage(image)
 

--- a/silx/gui/plot3d/Plot3DWindow.py
+++ b/silx/gui/plot3d/Plot3DWindow.py
@@ -40,7 +40,7 @@ from .ViewpointToolBar import ViewpointToolBar
 
 
 class Plot3DWindow(qt.QMainWindow):
-    """QGLWidget with a 3D viewport and an overview."""
+    """OpenGL widget with a 3D viewport and an overview."""
 
     def __init__(self, parent=None):
         super(Plot3DWindow, self).__init__(parent)

--- a/silx/gui/plot3d/__init__.py
+++ b/silx/gui/plot3d/__init__.py
@@ -25,7 +25,7 @@
 """
 This package provides widgets displaying 3D content based on OpenGL.
 
-It depends on PyOpenGL and QtOpenGL.
+It depends on PyOpenGL and PyQtx.QtOpenGL or PyQt>=5.4.
 """
 from __future__ import absolute_import
 
@@ -33,11 +33,6 @@ __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "18/01/2017"
 
-
-from .. import qt as _qt
-
-if not _qt.HAS_OPENGL:
-    raise ImportError('Qt.QtOpenGL is not available')
 
 try:
     import OpenGL as _OpenGL

--- a/silx/gui/plot3d/scene/window.py
+++ b/silx/gui/plot3d/scene/window.py
@@ -323,11 +323,12 @@ class Window(event.Notifier):
         height, width = self.shape
         image = numpy.empty((height, width, 3), dtype=numpy.uint8)
 
+        previousFramebuffer = gl.glGetInteger(gl.GL_FRAMEBUFFER_BINDING)
         gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, self.framebufferid)
         gl.glPixelStorei(gl.GL_PACK_ALIGNMENT, 1)
         gl.glReadPixels(
             0, 0, width, height, gl.GL_RGB, gl.GL_UNSIGNED_BYTE, image)
-        gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, 0)
+        gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, previousFramebuffer)
 
         # glReadPixels gives bottom to top,
         # while images are stored as top to bottom


### PR DESCRIPTION
This PR adds support of Qt>=5.4 QOpenGLWidget (which deprecates QGLWidget), closes #793.
It does so by providing a common OpenGLWigdet used by OpenGL plot backend and plot3d which inherits either from QGLWidget or QOpenGLWidget and support High-DPI with Qt5.

It also improves the support of cases where OpenGL is not available (PyQt4.QtOpenGL not installed, OpenGL2.1 not available,...).
In those cases, it displays an error pop-up once and displays an empty widget instead of the OpenGL rendering.