### PR TITLE
QDoubleValidator() cannot be used without passing parent object

### DIFF
--- a/doc/source/Tutorials/fitconfig.rst
+++ b/doc/source/Tutorials/fitconfig.rst
@@ -122,7 +122,7 @@ used by our fit function to scale the *y* values.
             self.scalingFactorEdit.setToolTip(
                 "Enter the scaling factor"
             )
-            self.scalingFactorEdit.setValidator(qt.QDoubleValidator())
+            self.scalingFactorEdit.setValidator(qt.QDoubleValidator(self))
 
             self.ok = qt.QPushButton("ok", self)
             self.ok.clicked.connect(self.accept)

--- a/silx/gui/fit/FitConfig.py
+++ b/silx/gui/fit/FitConfig.py
@@ -307,7 +307,7 @@ class SearchPage(qt.QWidget):
         self.yScalingEntry.setToolTip(
                 "Data values will be multiplied by this value prior to peak" +
                 " search")
-        self.yScalingEntry.setValidator(qt.QDoubleValidator())
+        self.yScalingEntry.setValidator(qt.QDoubleValidator(self))
         layout3.addWidget(self.yScalingEntry)
         # ----------------------------------------------------
 
@@ -324,7 +324,7 @@ class SearchPage(qt.QWidget):
             "Peak search sensitivity threshold, expressed as a multiple " +
             "of the standard deviation of the noise.\nMinimum value is 1 " +
             "(to be detected, peak must be higher than the estimated noise)")
-        sensivalidator = qt.QDoubleValidator()
+        sensivalidator = qt.QDoubleValidator(self)
         sensivalidator.setBottom(1.0)
         self.sensitivityEntry.setValidator(sensivalidator)
         layout4.addWidget(self.sensitivityEntry)
@@ -418,7 +418,7 @@ class BackgroundPage(qt.QGroupBox):
             "Factor used by the strip algorithm to decide whether a sample" +
             "value should be stripped.\nThe value must be higher than the " +
             "average of the 2 samples at +- w times this factor.\n")
-        self.thresholdFactorEntry.setValidator(qt.QDoubleValidator())
+        self.thresholdFactorEntry.setValidator(qt.QDoubleValidator(self))
         layout.addWidget(self.thresholdFactorEntry, 2, 1)
 
         self.smoothStripGB = qt.QGroupBox("Apply smoothing prior to strip", self)

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -83,7 +83,7 @@ class _FloatEdit(qt.QLineEdit):
     """
     def __init__(self, parent=None, value=None):
         qt.QLineEdit.__init__(self, parent)
-        self.setValidator(qt.QDoubleValidator())
+        self.setValidator(qt.QDoubleValidator(self))
         self.setAlignment(qt.Qt.AlignRight)
         if value is not None:
             self.setValue(value)

--- a/silx/gui/plot/PlotTools.py
+++ b/silx/gui/plot/PlotTools.py
@@ -229,7 +229,7 @@ class LimitsToolBar(qt.QToolBar):
         """Field to edit a float value."""
         def __init__(self, value=None, *args, **kwargs):
             qt.QLineEdit.__init__(self, *args, **kwargs)
-            self.setValidator(qt.QDoubleValidator())
+            self.setValidator(qt.QDoubleValidator(self))
             self.setFixedWidth(100)
             self.setAlignment(qt.Qt.AlignLeft)
             if value is not None:

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -754,13 +754,13 @@ class BaseMaskToolsWidget(qt.QWidget):
 
         self.minLineEdit = qt.QLineEdit()
         self.minLineEdit.setText('0')
-        self.minLineEdit.setValidator(qt.QDoubleValidator())
+        self.minLineEdit.setValidator(qt.QDoubleValidator(self))
         self.minLineEdit.setEnabled(False)
         form.addRow('Min:', self.minLineEdit)
 
         self.maxLineEdit = qt.QLineEdit()
         self.maxLineEdit.setText('0')
-        self.maxLineEdit.setValidator(qt.QDoubleValidator())
+        self.maxLineEdit.setValidator(qt.QDoubleValidator(self))
         self.maxLineEdit.setEnabled(False)
         form.addRow('Max:', self.maxLineEdit)
 

--- a/silx/gui/plot3d/SFViewParamTree.py
+++ b/silx/gui/plot3d/SFViewParamTree.py
@@ -882,7 +882,7 @@ class PlaneMinRangeItem(ColormapBase):
 
     def getEditor(self, parent, option, index):
         editor = qt.QLineEdit(parent)
-        editor.setValidator(qt.QDoubleValidator())
+        editor.setValidator(qt.QDoubleValidator(editor))
         return editor
 
     def setEditorData(self, editor):
@@ -924,7 +924,7 @@ class PlaneMaxRangeItem(ColormapBase):
 
     def getEditor(self, parent, option, index):
         editor = qt.QLineEdit(parent)
-        editor.setValidator(qt.QDoubleValidator())
+        editor.setValidator(qt.QDoubleValidator(editor))
         return editor
 
     def setEditorData(self, editor):


### PR DESCRIPTION
Hey guys,

I tried to use latest silx and got an error message about `QDoubleValidator()` signature ; it seems it is
invalid to call `QDoubleValidator()` constructor without at least a parent object or `None`, look:

```
   Python 2.6.6 (r266:84292, Dec 26 2010, 22:31:48)
   [GCC 4.4.5] on linux2
   Type "help", "copyright", "credits" or "license" for more information.
   >>> from PyQt4.QtCore import QT_VERSION_STR
   >>> from PyQt4.Qt import PYQT_VERSION_STR
   >>> from sip import SIP_VERSION_STR
   >>>
   >>> print("Qt version:", QT_VERSION_STR)
   ('Qt version:', '4.6.3')
   >>> print("SIP version:", SIP_VERSION_STR)
   ('SIP version:', '4.10.2')
   >>> print("PyQt version:", PYQT_VERSION_STR)
   ('PyQt version:', '4.7.3')
   >>> from PyQt4.QtGui import QDoubleValidator
   >>> v=QDoubleValidator()
   Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      TypeError: arguments did not match any overloaded call:
      QDoubleValidator(QObject): not enough arguments
      QDoubleValidator(float, float, int, QObject): not enough arguments
    >>>
``` 
This PR fixes the problem I had.