### PR TITLE
[Mask] Make setSelectionMask update mask origin, scale...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -460,7 +460,7 @@ class BuildExt(build_ext):
 
     COMPILE_ARGS_CONVERTER = {'-fopenmp': '/openmp'}
 
-    LINK_ARGS_CONVERTER = {'-fopenmp': ' '}
+    LINK_ARGS_CONVERTER = {'-fopenmp': ''}
 
     description = 'Build silx extensions'
 

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -239,6 +239,19 @@ class MaskToolsWidget(BaseMaskToolsWidget):
             _logger.error('Not an image, shape: %d', len(mask.shape))
             return None
 
+        # ensure all mask attributes are synchronized with the active image
+        activeImage = self.plot.getActiveImage()
+        if activeImage is not None and activeImage.getLegend() != self._maskName:
+            self._setOverlayColorForImage(activeImage)
+            self._setMaskColors(self.levelSpinBox.value(),
+                                self.transparencySlider.value() /
+                                self.transparencySlider.maximum())
+            self._origin = activeImage.getOrigin()
+            self._scale = activeImage.getScale()
+            self._z = activeImage.getZValue() + 1
+            self._data = activeImage.getData(copy=False)
+            self._mask.setDataItem(activeImage)
+
         if self._data.shape[0:2] == (0, 0) or mask.shape == self._data.shape[0:2]:
             self._mask.setMask(mask, copy=copy)
             self._mask.commit()

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -240,17 +240,11 @@ class MaskToolsWidget(BaseMaskToolsWidget):
             return None
 
         # ensure all mask attributes are synchronized with the active image
+        # and connect listener
         activeImage = self.plot.getActiveImage()
         if activeImage is not None and activeImage.getLegend() != self._maskName:
-            self._setOverlayColorForImage(activeImage)
-            self._setMaskColors(self.levelSpinBox.value(),
-                                self.transparencySlider.value() /
-                                self.transparencySlider.maximum())
-            self._origin = activeImage.getOrigin()
-            self._scale = activeImage.getScale()
-            self._z = activeImage.getZValue() + 1
-            self._data = activeImage.getData(copy=False)
-            self._mask.setDataItem(activeImage)
+            self._activeImageChanged()
+            self.plot.sigActiveImageChanged.connect(self._activeImageChanged)
 
         if self._data.shape[0:2] == (0, 0) or mask.shape == self._data.shape[0:2]:
             self._mask.setMask(mask, copy=copy)


### PR DESCRIPTION
If the plot has an active image when `setSelectionMask` is called, it is reasonable to use its origin, scale, Z...

This enables programmatic mask setting even if mask widget is not connected to active image signals.