### PR TITLE
Add resetZoom on right click to zoom interation mode

### DIFF
--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -296,13 +296,21 @@ class Zoom(_ZoomOnWheel):
             try:
                 xMin, xMax, yMin, yMax, y2Min, y2Max = self.zoomStack.pop()
             except IndexError:
-                # Signal mouse clicked event
-                dataPos = self.plot.pixelToData(x, y)
-                assert dataPos is not None
-                eventDict = prepareMouseSignal('mouseClicked', 'right',
-                                               dataPos[0], dataPos[1],
-                                               x, y)
-                self.plot.notify(**eventDict)
+                previousLimits = (self.plot.getGraphXLimits(),
+                                  self.plot.getGraphYLimits(),
+                                  self.plot.getGraphYLimits(axis='right'))
+                self.plot.resetZoom()
+                newLimits = (self.plot.getGraphXLimits(),
+                             self.plot.getGraphYLimits(),
+                             self.plot.getGraphYLimits(axis='right'))
+                if previousLimits == newLimits:
+                    # Signal mouse clicked event
+                    dataPos = self.plot.pixelToData(x, y)
+                    assert dataPos is not None
+                    eventDict = prepareMouseSignal('mouseClicked', 'right',
+                                                   dataPos[0], dataPos[1],
+                                                   x, y)
+                    self.plot.notify(**eventDict)
             else:
                 self.plot.setLimits(xMin, xMax, yMin, yMax, y2Min, y2Max)
 


### PR DESCRIPTION
This PR implements the _At least_ option of #865 by calling `resetZoom` when the history of zoom levels is empty.
To be compatible with previous event behaviour, when zoom history is empty, it only sends `mouseClicked` event when `resetZoom` didn't changed the limits.