### PR TITLE
[Plot] Fix SaveAction with OpenGL backend

### DIFF
--- a/silx/gui/plot/Plot.py
+++ b/silx/gui/plot/Plot.py
@@ -2321,8 +2321,10 @@ class Plot(object):
     def saveGraph(self, filename, fileFormat=None, dpi=None, **kw):
         """Save a snapshot of the plot.
 
-        Supported file formats: "png", "svg", "pdf", "ps", "eps",
-        "tif", "tiff", "jpeg", "jpg".
+        Supported file formats depends on the backend in use.
+        The following file formats are always supported: "png", "svg".
+        The matplotlib backend supports more formats:
+        "pdf", "ps", "eps", "tiff", "jpeg", "jpg".
 
         :param filename: Destination
         :type filename: str, StringIO or BytesIO

--- a/silx/gui/plot/PlotActions.py
+++ b/silx/gui/plot/PlotActions.py
@@ -501,11 +501,10 @@ class SaveAction(PlotAction):
     """
     # TODO find a way to make the filter list selectable and extensible
 
+    SNAPSHOT_FILTER_PNG = 'Plot Snapshot as PNG (*.png)'
     SNAPSHOT_FILTER_SVG = 'Plot Snapshot as SVG (*.svg)'
 
-    SNAPSHOT_FILTERS = ('Plot Snapshot as PNG (*.png)',
-                        'Plot Snapshot as JPEG (*.jpg)',
-                        SNAPSHOT_FILTER_SVG)
+    SNAPSHOT_FILTERS = (SNAPSHOT_FILTER_PNG, SNAPSHOT_FILTER_SVG)
 
     # Dict of curve filters with CSV-like format
     # Using ordered dict to guarantee filters order
@@ -576,19 +575,16 @@ class SaveAction(PlotAction):
         :return: False if format is not supported or save failed,
                  True otherwise.
         """
-        if nameFilter == self.SNAPSHOT_FILTER_SVG:
-            self.plot.saveGraph(filename, fileFormat='svg')
+        if nameFilter == self.SNAPSHOT_FILTER_PNG:
+            fileFormat = 'png'
+        elif nameFilter == self.SNAPSHOT_FILTER_SVG:
+            fileFormat = 'svg'
+        else:  # Format not supported
+            _logger.error(
+                'Saving plot snapshot failed: format not supported')
+            return False
 
-        else:
-            if hasattr(qt.QPixmap, "grabWidget"):
-                # Qt 4
-                pixmap = qt.QPixmap.grabWidget(self.plot.getWidgetHandle())
-            else:
-                # Qt 5
-                pixmap = self.plot.getWidgetHandle().grab()
-            if not pixmap.save(filename):
-                self._errorMessage()
-                return False
+        self.plot.saveGraph(filename, fileFormat=fileFormat)
         return True
 
     def _saveCurve(self, filename, nameFilter):

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -307,6 +307,8 @@ class BackendBase(object):
     def saveGraph(self, fileName, fileFormat, dpi):
         """Save the graph to a file (or a StringIO)
 
+        At least "png", "svg" are supported.
+
         :param fileName: Destination
         :type fileName: String or StringIO or BytesIO
         :param str fileFormat: String specifying the format

--- a/silx/gui/plot/backends/glutils/PlotImageFile.py
+++ b/silx/gui/plot/backends/glutils/PlotImageFile.py
@@ -96,7 +96,11 @@ def saveImageToFile(data, fileNameOrObj, fileFormat):
         if sys.version < "3.0":
             fileObj = open(fileNameOrObj, "wb")
         else:
-            fileObj = open(fileNameOrObj, "w", newline='')
+            if fileFormat in ('png', 'ppm', 'tiff'):
+                # Open in binary mode
+                fileObj = open(fileNameOrObj, 'wb')
+            else:
+                fileObj = open(fileNameOrObj, 'w', newline='')
     else:  # Use as a file-like object
         fileObj = fileNameOrObj
 
@@ -127,9 +131,9 @@ def saveImageToFile(data, fileNameOrObj, fileFormat):
     elif fileFormat == 'ppm':
         height, width = data.shape[:2]
 
-        fileObj.write('P6\n')
-        fileObj.write('%d %d\n' % (width, height))
-        fileObj.write('255\n')
+        fileObj.write(b'P6\n')
+        fileObj.write(b'%d %d\n' % (width, height))
+        fileObj.write(b'255\n')
         fileObj.write(data.tostring())
 
     elif fileFormat == 'png':
@@ -143,7 +147,7 @@ def saveImageToFile(data, fileNameOrObj, fileFormat):
         from silx.third_party.TiffIO import TiffIO
 
         tif = TiffIO(fileNameOrObj, mode='wb+')
-        tif.writeImage(data, info={'Title': 'PyMCA GL Snapshot'})
+        tif.writeImage(data, info={'Title': 'OpenGL Plot Snapshot'})
 
     if fileObj != fileNameOrObj:
         fileObj.close()


### PR DESCRIPTION
This PR closes #850.

It removes the option to save a snapshot of the plot as JPEG (anyway, I see little interest to save a snapshot in a lossy format...).
A snapshot of the plot can be saved as either PNG or SVG.
