### PR TITLE
Load mask extensions

### DIFF
--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -35,7 +35,7 @@ from __future__ import division
 
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "20/04/2017"
+__date__ = "14/06/2017"
 
 
 import os
@@ -393,6 +393,14 @@ class MaskToolsWidget(BaseMaskToolsWidget):
                 _logger.error("Can't load filename '%s'", filename)
                 _logger.debug("Backtrace", exc_info=True)
                 raise RuntimeError('File "%s" is not a numpy file.', filename)
+        elif extension in ["tif", "tiff"]:
+            try:
+                image = TiffIO(filename, mode="r")
+                mask = image.getImage(0)
+            except Exception as e:
+                _logger.error("Can't load filename %s", filename)
+                _logger.debug("Backtrace", exc_info=True)
+                raise e
         elif extension == "edf":
             try:
                 mask = EdfFile(filename, access='r').GetData(0)

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -42,6 +42,7 @@ import os
 import sys
 import numpy
 import logging
+import collections
 
 from silx.image import shapes
 
@@ -434,14 +435,21 @@ class MaskToolsWidget(BaseMaskToolsWidget):
         dialog = qt.QFileDialog(self)
         dialog.setWindowTitle("Load Mask")
         dialog.setModal(1)
-        filters = [
-            'EDF (*.edf)',
-            'TIFF (*.tif)',
-            'NumPy binary file (*.npy)',
-            # Fit2D mask is displayed anyway fabio is here or not
-            # to show to the user that the option exists
-            'Fit2D mask (*.msk)',
-        ]
+
+        extensions = collections.OrderedDict()
+        extensions["EDF files"] = "*.edf"
+        extensions["TIFF files"] = "*.tif *.tiff"
+        extensions["NumPy binary files"] = "*.npy"
+        # Fit2D mask is displayed anyway fabio is here or not
+        # to show to the user that the option exists
+        extensions["Fit2D mask files"] = "*.msk"
+
+        filters = []
+        filters.append("All supported files (%s)" % " ".join(extensions.values()))
+        for name, extension in extensions.items():
+            filters.append("%s (%s)" % (name, extension))
+        filters.append("All files (*)")
+
         dialog.setNameFilters(filters)
         dialog.setFileMode(qt.QFileDialog.ExistingFile)
         dialog.setDirectory(self.maskFileDir)


### PR DESCRIPTION
- Support TIFF images. It was not the case before, but the tiff extension was provided (maybe a regression)
- Display all available extensions by default

#872 