### PR TITLE
Improve HDF5 property view

### DIFF
--- a/silx/app/view.py
+++ b/silx/app/view.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "15/05/2017"
+__date__ = "15/06/2017"
 
 import sys
 import os
@@ -227,7 +227,7 @@ class Viewer(qt.QMainWindow):
     def displayData(self):
         """Called to update the dataviewer with the selected data.
         """
-        selected = list(self.__treeview.selectedH5Nodes())
+        selected = list(self.__treeview.selectedH5Nodes(ignoreBrokenLinks=False))
         if len(selected) == 1:
             # Update the viewer for a single selection
             data = selected[0]
@@ -242,7 +242,7 @@ class Viewer(qt.QMainWindow):
         :param silx.gui.hdf5.Hdf5ContextMenuEvent event: Event
             containing expected information to populate the context menu
         """
-        selectedObjects = event.source().selectedH5Nodes()
+        selectedObjects = event.source().selectedH5Nodes(ignoreBrokenLinks=False)
         menu = event.menu()
 
         hasDataset = False
@@ -264,7 +264,7 @@ class Viewer(qt.QMainWindow):
         :param silx.gui.hdf5.Hdf5ContextMenuEvent event: Event
             containing expected information to populate the context menu
         """
-        selectedObjects = event.source().selectedH5Nodes()
+        selectedObjects = event.source().selectedH5Nodes(ignoreBrokenLinks=False)
         menu = event.menu()
 
         if len(menu.children()):

--- a/silx/app/view.py
+++ b/silx/app/view.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "15/06/2017"
+__date__ = "16/06/2017"
 
 import sys
 import os
@@ -103,6 +103,12 @@ class Viewer(qt.QMainWindow):
         # you have to store it first
         self.__store_lambda = lambda event: self.closeAndSyncCustomContextMenu(event)
         self.__treeview.addContextMenuCallback(self.__store_lambda)
+
+        treeModel = self.__treeview.findHdf5TreeModel()
+        columns = list(treeModel.COLUMN_IDS)
+        columns.remove(treeModel.DESCRIPTION_COLUMN)
+        columns.remove(treeModel.NODE_COLUMN)
+        self.__treeview.header().setSections(columns)
 
         self.createActions()
         self.createMenus()

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -38,7 +38,7 @@ from silx.io.nxdata import NXdata
 
 __authors__ = ["V. Valls", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "07/04/2017"
+__date__ = "15/06/2017"
 
 _logger = logging.getLogger(__name__)
 
@@ -62,6 +62,8 @@ def _normalizeData(data):
     If the data embed a numpy data or a dataset it is returned.
     Else returns the input data."""
     if isinstance(data, H5Node):
+        if data.is_broken:
+            return None
         return data.h5py_object
     return data
 

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -287,7 +287,6 @@ class CompositeDataView(DataView):
 
     def getBestView(self, data, info):
         """Returns the best view according to priorities."""
-        info = DataInfo(data)
         views = [(v.getDataPriority(data, info), v) for v in self.__views.keys()]
         views = filter(lambda t: t[0] > DataView.UNSUPPORTED, views)
         views = sorted(views, reverse=True)

--- a/silx/gui/data/Hdf5TableView.py
+++ b/silx/gui/data/Hdf5TableView.py
@@ -270,18 +270,35 @@ class Hdf5TableModel(HierarchicalTableView.HierarchicalTableModel):
         else:
             objectType = obj.__class__.__name__
         self.__data.addHeaderRow(headerLabel="HDF5 %s" % objectType)
+
         self.__data.addHeaderRow(headerLabel="Path info")
-
-        self.__data.addHeaderValueRow("basename", lambda x: os.path.basename(x.name))
-        self.__data.addHeaderValueRow("name", lambda x: x.name)
-        if silx.io.is_file(obj):
-            self.__data.addHeaderValueRow("filename", lambda x: x.filename)
-
         if isinstance(obj, silx.gui.hdf5.H5Node):
             # helpful informations if the object come from an HDF5 tree
-            self.__data.addHeaderValueRow("local_basename", lambda x: x.local_basename)
-            self.__data.addHeaderValueRow("local_name", lambda x: x.local_name)
-            self.__data.addHeaderValueRow("local_filename", lambda x: x.local_file.filename)
+            self.__data.addHeaderValueRow("Basename", lambda x: x.local_basename)
+            self.__data.addHeaderValueRow("Path", lambda x: x.local_name)
+            local = lambda x: x.local_filename + " :: " + x.local_name
+            self.__data.addHeaderValueRow("Local", local)
+            physical = lambda x: x.physical_filename + " :: " + x.physical_name
+            self.__data.addHeaderValueRow("Physical", physical)
+        else:
+            # it's a real H5py object
+            self.__data.addHeaderValueRow("Basename", lambda x: os.path.basename(x.name))
+            self.__data.addHeaderValueRow("Name", lambda x: x.name)
+            self.__data.addHeaderValueRow("File", lambda x: x.file.filename)
+
+            if hasattr(obj, "path"):
+                # That's a link
+                if hasattr(obj, "filename"):
+                    link = lambda x: x.filename + " :: " + x.path
+                else:
+                    link = lambda x: x.path
+                self.__data.addHeaderValueRow("Link", link)
+            else:
+                if silx.io.is_file(obj):
+                    physical = lambda x: x.filename + " :: " + x.name
+                else:
+                    physical = lambda x: x.file.filename + " :: " + x.name
+                self.__data.addHeaderValueRow("Physical", physical)
 
         if hasattr(obj, "dtype"):
             self.__data.addHeaderRow(headerLabel="Data info")

--- a/silx/gui/data/Hdf5TableView.py
+++ b/silx/gui/data/Hdf5TableView.py
@@ -271,14 +271,16 @@ class Hdf5TableModel(HierarchicalTableView.HierarchicalTableModel):
             objectType = obj.__class__.__name__
         self.__data.addHeaderRow(headerLabel="HDF5 %s" % objectType)
 
+        SEPARATOR = "::"
+
         self.__data.addHeaderRow(headerLabel="Path info")
         if isinstance(obj, silx.gui.hdf5.H5Node):
             # helpful informations if the object come from an HDF5 tree
             self.__data.addHeaderValueRow("Basename", lambda x: x.local_basename)
-            self.__data.addHeaderValueRow("Path", lambda x: x.local_name)
-            local = lambda x: x.local_filename + " :: " + x.local_name
+            self.__data.addHeaderValueRow("Name", lambda x: x.local_name)
+            local = lambda x: x.local_filename + SEPARATOR + x.local_name
             self.__data.addHeaderValueRow("Local", local)
-            physical = lambda x: x.physical_filename + " :: " + x.physical_name
+            physical = lambda x: x.physical_filename + SEPARATOR + x.physical_name
             self.__data.addHeaderValueRow("Physical", physical)
         else:
             # it's a real H5py object
@@ -289,15 +291,15 @@ class Hdf5TableModel(HierarchicalTableView.HierarchicalTableModel):
             if hasattr(obj, "path"):
                 # That's a link
                 if hasattr(obj, "filename"):
-                    link = lambda x: x.filename + " :: " + x.path
+                    link = lambda x: x.filename + SEPARATOR + x.path
                 else:
                     link = lambda x: x.path
                 self.__data.addHeaderValueRow("Link", link)
             else:
                 if silx.io.is_file(obj):
-                    physical = lambda x: x.filename + " :: " + x.name
+                    physical = lambda x: x.filename + SEPARATOR + x.name
                 else:
-                    physical = lambda x: x.file.filename + " :: " + x.name
+                    physical = lambda x: x.file.filename + SEPARATOR + x.name
                 self.__data.addHeaderValueRow("Physical", physical)
 
         if hasattr(obj, "dtype"):

--- a/silx/gui/hdf5/Hdf5HeaderView.py
+++ b/silx/gui/hdf5/Hdf5HeaderView.py
@@ -90,6 +90,7 @@ class Hdf5HeaderView(qt.QHeaderView):
             setResizeMode(Hdf5TreeModel.VALUE_COLUMN, qt.QHeaderView.Interactive)
             setResizeMode(Hdf5TreeModel.DESCRIPTION_COLUMN, qt.QHeaderView.Interactive)
             setResizeMode(Hdf5TreeModel.NODE_COLUMN, qt.QHeaderView.ResizeToContents)
+            setResizeMode(Hdf5TreeModel.LINK_COLUMN, qt.QHeaderView.ResizeToContents)
         else:
             setResizeMode(Hdf5TreeModel.NAME_COLUMN, qt.QHeaderView.Interactive)
             setResizeMode(Hdf5TreeModel.TYPE_COLUMN, qt.QHeaderView.Interactive)
@@ -97,6 +98,7 @@ class Hdf5HeaderView(qt.QHeaderView):
             setResizeMode(Hdf5TreeModel.VALUE_COLUMN, qt.QHeaderView.Interactive)
             setResizeMode(Hdf5TreeModel.DESCRIPTION_COLUMN, qt.QHeaderView.Interactive)
             setResizeMode(Hdf5TreeModel.NODE_COLUMN, qt.QHeaderView.Interactive)
+            setResizeMode(Hdf5TreeModel.LINK_COLUMN, qt.QHeaderView.Interactive)
 
     def setAutoResizeColumns(self, autoResize):
         """Enable/disable auto-resize. When auto-resized, the header take care

--- a/silx/gui/hdf5/Hdf5HeaderView.py
+++ b/silx/gui/hdf5/Hdf5HeaderView.py
@@ -25,10 +25,11 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "08/11/2016"
+__date__ = "16/06/2017"
 
 
 from .. import qt
+from .Hdf5TreeModel import Hdf5TreeModel
 
 QTVERSION = qt.qVersion()
 
@@ -83,19 +84,19 @@ class Hdf5HeaderView(qt.QHeaderView):
             setResizeMode = self.setSectionResizeMode
 
         if self.__auto_resize:
-            setResizeMode(0, qt.QHeaderView.ResizeToContents)
-            setResizeMode(1, qt.QHeaderView.ResizeToContents)
-            setResizeMode(2, qt.QHeaderView.ResizeToContents)
-            setResizeMode(3, qt.QHeaderView.Interactive)
-            setResizeMode(4, qt.QHeaderView.Interactive)
-            setResizeMode(5, qt.QHeaderView.ResizeToContents)
+            setResizeMode(Hdf5TreeModel.NAME_COLUMN, qt.QHeaderView.ResizeToContents)
+            setResizeMode(Hdf5TreeModel.TYPE_COLUMN, qt.QHeaderView.ResizeToContents)
+            setResizeMode(Hdf5TreeModel.SHAPE_COLUMN, qt.QHeaderView.ResizeToContents)
+            setResizeMode(Hdf5TreeModel.VALUE_COLUMN, qt.QHeaderView.Interactive)
+            setResizeMode(Hdf5TreeModel.DESCRIPTION_COLUMN, qt.QHeaderView.Interactive)
+            setResizeMode(Hdf5TreeModel.NODE_COLUMN, qt.QHeaderView.ResizeToContents)
         else:
-            setResizeMode(0, qt.QHeaderView.Interactive)
-            setResizeMode(1, qt.QHeaderView.Interactive)
-            setResizeMode(2, qt.QHeaderView.Interactive)
-            setResizeMode(3, qt.QHeaderView.Interactive)
-            setResizeMode(4, qt.QHeaderView.Interactive)
-            setResizeMode(5, qt.QHeaderView.Interactive)
+            setResizeMode(Hdf5TreeModel.NAME_COLUMN, qt.QHeaderView.Interactive)
+            setResizeMode(Hdf5TreeModel.TYPE_COLUMN, qt.QHeaderView.Interactive)
+            setResizeMode(Hdf5TreeModel.SHAPE_COLUMN, qt.QHeaderView.Interactive)
+            setResizeMode(Hdf5TreeModel.VALUE_COLUMN, qt.QHeaderView.Interactive)
+            setResizeMode(Hdf5TreeModel.DESCRIPTION_COLUMN, qt.QHeaderView.Interactive)
+            setResizeMode(Hdf5TreeModel.NODE_COLUMN, qt.QHeaderView.Interactive)
 
     def setAutoResizeColumns(self, autoResize):
         """Enable/disable auto-resize. When auto-resized, the header take care

--- a/silx/gui/hdf5/Hdf5Item.py
+++ b/silx/gui/hdf5/Hdf5Item.py
@@ -434,3 +434,30 @@ class Hdf5Item(Hdf5Node):
                 return ""
             return "Class name: %s" % self.__class__
         return None
+
+    def dataLink(self, role):
+        """Data for the link column
+
+        Overwrite it to implement the content of the 'link' column.
+
+        :rtype: qt.QVariant
+        """
+        if role == qt.Qt.DecorationRole:
+            return None
+        if role == qt.Qt.TextAlignmentRole:
+            return qt.Qt.AlignTop | qt.Qt.AlignLeft
+        if role == qt.Qt.DisplayRole:
+            link = self.linkClass
+            if link is None:
+                return ""
+            elif link is h5py.ExternalLink:
+                return "External"
+            elif link is h5py.SoftLink:
+                return "Soft"
+            elif link is h5py.HardLink:
+                return ""
+            else:
+                return link.__name__
+        if role == qt.Qt.ToolTipRole:
+            return None
+        return None

--- a/silx/gui/hdf5/Hdf5Item.py
+++ b/silx/gui/hdf5/Hdf5Item.py
@@ -423,9 +423,9 @@ class Hdf5Item(Hdf5Node):
         if role == qt.Qt.TextAlignmentRole:
             return qt.Qt.AlignTop | qt.Qt.AlignLeft
         if role == qt.Qt.DisplayRole:
-            class_ = self.h5pyClass
-            if class_ is None:
+            if self.isBrokenObj():
                 return ""
+            class_ = self.h5pyClass
             text = class_.__name__.split(".")[-1]
             return text
         if role == qt.Qt.ToolTipRole:

--- a/silx/gui/hdf5/Hdf5Item.py
+++ b/silx/gui/hdf5/Hdf5Item.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "20/01/2017"
+__date__ = "16/06/2017"
 
 
 import numpy
@@ -55,7 +55,7 @@ class Hdf5Item(Hdf5Node):
     tree structure.
     """
 
-    def __init__(self, text, obj, parent, key=None, h5pyClass=None, isBroken=False, populateAll=False):
+    def __init__(self, text, obj, parent, key=None, h5pyClass=None, linkClass=None, populateAll=False):
         """
         :param str text: text displayed
         :param object obj: Pointer to h5py data. See the `obj` attribute.
@@ -63,9 +63,10 @@ class Hdf5Item(Hdf5Node):
         self.__obj = obj
         self.__key = key
         self.__h5pyClass = h5pyClass
-        self.__isBroken = isBroken
+        self.__isBroken = obj is None and h5pyClass is None
         self.__error = None
         self.__text = text
+        self.__linkClass = linkClass
         Hdf5Node.__init__(self, parent, populateAll=populateAll)
 
     @property
@@ -88,9 +89,17 @@ class Hdf5Item(Hdf5Node):
 
         :rtype: h5py.File or h5py.Dataset or h5py.Group
         """
-        if self.__h5pyClass is None:
+        if self.__h5pyClass is None and self.obj is not None:
             self.__h5pyClass = silx.io.utils.get_h5py_class(self.obj)
         return self.__h5pyClass
+
+    @property
+    def linkClass(self):
+        """Returns the link class object of this node
+
+        :type: h5py.SoftLink or h5py.HardLink or h5py.ExternalLink or None
+        """
+        return self.__linkClass
 
     def isGroupObj(self):
         """Returns true if the stored HDF5 object is a group (contains sub
@@ -98,6 +107,8 @@ class Hdf5Item(Hdf5Node):
 
         :rtype: bool
         """
+        if self.h5pyClass is None:
+            return False
         return issubclass(self.h5pyClass, h5py.Group)
 
     def isBrokenObj(self):
@@ -166,15 +177,15 @@ class Hdf5Item(Hdf5Node):
             for name in self.obj:
                 try:
                     class_ = self.obj.get(name, getclass=True)
-                    has_error = False
+                    link = self.obj.get(name, getclass=True, getlink=True)
                 except Exception as e:
-                    _logger.error("Internal h5py error", exc_info=True)
+                    _logger.warn("Internal h5py error", exc_info=True)
+                    class_ = None
                     try:
-                        class_ = self.obj.get(name, getclass=True, getlink=True)
+                        link = self.obj.get(name, getclass=True, getlink=True)
                     except Exception as e:
-                        class_ = h5py.HardLink
-                    has_error = True
-                item = Hdf5Item(text=name, obj=None, parent=self, key=name, h5pyClass=class_, isBroken=has_error)
+                        link = h5py.HardLink
+                item = Hdf5Item(text=name, obj=None, parent=self, key=name, h5pyClass=class_, linkClass=link)
                 self.appendChild(item)
 
     def hasChildren(self):
@@ -413,9 +424,13 @@ class Hdf5Item(Hdf5Node):
             return qt.Qt.AlignTop | qt.Qt.AlignLeft
         if role == qt.Qt.DisplayRole:
             class_ = self.h5pyClass
+            if class_ is None:
+                return ""
             text = class_.__name__.split(".")[-1]
             return text
         if role == qt.Qt.ToolTipRole:
             class_ = self.h5pyClass
+            if class_ is None:
+                return ""
             return "Class name: %s" % self.__class__
         return None

--- a/silx/gui/hdf5/Hdf5Node.py
+++ b/silx/gui/hdf5/Hdf5Node.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "23/09/2016"
+__date__ = "16/06/2017"
 
 
 class Hdf5Node(object):
@@ -204,6 +204,15 @@ class Hdf5Node(object):
         """Data for the node column
 
         Overwrite it to implement the content of the 'node' column.
+
+        :rtype: qt.QVariant
+        """
+        return None
+
+    def dataLink(self, role):
+        """Data for the link column
+
+        Overwrite it to implement the content of the 'link' column.
 
         :rtype: qt.QVariant
         """

--- a/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/silx/gui/hdf5/Hdf5TreeModel.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "19/12/2016"
+__date__ = "16/06/2017"
 
 
 import os
@@ -188,7 +188,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         super(Hdf5TreeModel, self).__init__(parent)
 
         self.treeView = parent
-        self.header_labels = [None] * 6
+        self.header_labels = [None] * len(self.COLUMN_IDS)
         self.header_labels[self.NAME_COLUMN] = 'Name'
         self.header_labels[self.TYPE_COLUMN] = 'Type'
         self.header_labels[self.SHAPE_COLUMN] = 'Shape'
@@ -427,7 +427,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
             return None
 
     def columnCount(self, parent=qt.QModelIndex()):
-        return len(self.header_labels)
+        return len(self.COLUMN_IDS)
 
     def hasChildren(self, parent=qt.QModelIndex()):
         node = self.nodeFromIndex(parent)

--- a/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/silx/gui/hdf5/Hdf5TreeModel.py
@@ -174,6 +174,9 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
     NODE_COLUMN = 5
     """Column id containing HDF5 node type"""
 
+    LINK_COLUMN = 6
+    """Column id containing HDF5 link type"""
+
     COLUMN_IDS = [
         NAME_COLUMN,
         TYPE_COLUMN,
@@ -181,6 +184,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         VALUE_COLUMN,
         DESCRIPTION_COLUMN,
         NODE_COLUMN,
+        LINK_COLUMN,
     ]
     """List of logical columns available"""
 
@@ -195,6 +199,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         self.header_labels[self.VALUE_COLUMN] = 'Value'
         self.header_labels[self.DESCRIPTION_COLUMN] = 'Description'
         self.header_labels[self.NODE_COLUMN] = 'Node'
+        self.header_labels[self.LINK_COLUMN] = 'Link'
 
         # Create items
         self.__root = Hdf5Node()
@@ -423,6 +428,8 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
             return node.dataDescription(role)
         elif index.column() == self.NODE_COLUMN:
             return node.dataNode(role)
+        elif index.column() == self.LINK_COLUMN:
+            return node.dataLink(role)
         else:
             return None
 

--- a/silx/gui/hdf5/NexusSortFilterProxyModel.py
+++ b/silx/gui/hdf5/NexusSortFilterProxyModel.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "12/04/2017"
+__date__ = "16/06/2017"
 
 
 import logging
@@ -86,7 +86,8 @@ class NexusSortFilterProxyModel(qt.QSortFilterProxyModel):
 
     def __isNXentry(self, node):
         """Returns true if the node is an NXentry"""
-        if not issubclass(node.h5pyClass, h5py.Group):
+        class_ = node.h5pyClass
+        if class_ is None or not issubclass(node.h5pyClass, h5py.Group):
             return False
         nxClass = node.obj.attrs.get("NX_class", None)
         return nxClass == "NXentry"

--- a/silx/gui/hdf5/_utils.py
+++ b/silx/gui/hdf5/_utils.py
@@ -28,11 +28,10 @@ package `silx.gui.hdf5` package.
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "15/06/2017"
+__date__ = "16/06/2017"
 
 
 import logging
-import numpy
 from .. import qt
 import silx.io.utils
 from silx.utils.html import escape

--- a/silx/gui/hdf5/_utils.py
+++ b/silx/gui/hdf5/_utils.py
@@ -192,7 +192,8 @@ class H5Node(object):
         result = []
         item = self.__h5py_item
         while item is not None:
-            if issubclass(item.h5pyClass, h5py.File):
+            # stop before the root item (item without parent)
+            if item.parent.parent is None:
                 break
             result.append(item.basename)
             item = item.parent
@@ -212,7 +213,8 @@ class H5Node(object):
         """
         item = self.__h5py_item
         while item is not None:
-            if issubclass(item.h5pyClass, h5py.File):
+            class_ = item.h5pyClass
+            if class_ is not None and issubclass(class_, h5py.File):
                 return item
             item = item.parent
         raise RuntimeError("The item does not have parent holding h5py.File")
@@ -251,7 +253,8 @@ class H5Node(object):
 
         :rtype: str
         """
-        if issubclass(self.__h5py_item.h5pyClass, h5py.File):
+        class_ = self.__h5py_item.h5pyClass
+        if class_ is not None and issubclass(class_, h5py.File):
             return ""
         return self.__h5py_item.basename
 

--- a/silx/gui/hdf5/_utils.py
+++ b/silx/gui/hdf5/_utils.py
@@ -28,7 +28,7 @@ package `silx.gui.hdf5` package.
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "26/04/2017"
+__date__ = "15/06/2017"
 
 
 import logging
@@ -179,8 +179,9 @@ class H5Node(object):
             raise RuntimeError("h5py_item is not defined")
         return self.__h5py_item.isBrokenObj()
 
+    @property
     def local_name(self):
-        """Returns the local path of this h5py node.
+        """Returns the path from the master file root to this node.
 
         For links, this path is not equal to the h5py one.
 
@@ -219,7 +220,7 @@ class H5Node(object):
 
     @property
     def local_file(self):
-        """Returns the local :class:`h5py.File` object.
+        """Returns the master file in which is this node.
 
         For path containing external links, this file is not equal to the h5py
         one.
@@ -232,7 +233,7 @@ class H5Node(object):
 
     @property
     def local_filename(self):
-        """Returns the local filename of the h5py node.
+        """Returns the filename from the master file of this node.
 
         For path containing external links, this path is not equal to the
         filename provided by h5py.
@@ -244,7 +245,7 @@ class H5Node(object):
 
     @property
     def local_basename(self):
-        """Returns the local filename of the h5py node.
+        """Returns the basename from the master file root to this node.
 
         For path containing links, this basename can be different than the
         basename provided by h5py.
@@ -254,3 +255,46 @@ class H5Node(object):
         if issubclass(self.__h5py_item.h5pyClass, h5py.File):
             return ""
         return self.__h5py_item.basename
+
+    @property
+    def physical_name(self):
+        """Returns the path from the location this h5py node is physically
+        stored.
+
+        For broken links, this filename can be different from the
+        filename provided by h5py.
+
+        :rtype: str
+        """
+        if isinstance(self.__h5py_object, h5py.ExternalLink):
+            return self.__h5py_object.path
+        if isinstance(self.__h5py_object, h5py.SoftLink):
+            return self.__h5py_object.path
+        return self.__h5py_object.name
+
+    @property
+    def physical_filename(self):
+        """Returns the filename from the location this h5py node is physically
+        stored.
+
+        For broken links, this filename can be different from the
+        filename provided by h5py.
+
+        :rtype: str
+        """
+        if isinstance(self.__h5py_object, h5py.ExternalLink):
+            return self.__h5py_object.filename
+        else:
+            return self.__h5py_object.file.filename
+
+    @property
+    def physical_basename(self):
+        """Returns the basename from the location this h5py node is physically
+        stored.
+
+        For broken links, this basename can be different from the
+        basename provided by h5py.
+
+        :rtype: str
+        """
+        return self.physical_name.split("/")[-1]

--- a/silx/gui/hdf5/_utils.py
+++ b/silx/gui/hdf5/_utils.py
@@ -170,6 +170,15 @@ class H5Node(object):
         return self.__h5py_object.name.split("/")[-1]
 
     @property
+    def is_broken(self):
+        """Returns true if the node is a broken link.
+
+        :rtype: bool
+        """
+        if self.__h5py_item is None:
+            raise RuntimeError("h5py_item is not defined")
+        return self.__h5py_item.isBrokenObj()
+
     def local_name(self):
         """Returns the local path of this h5py node.
 


### PR DESCRIPTION
- Broken nodes are now selectable
- HDF5 property view displays a little more information
- There is a new column for the kind of links
- I remove the `description` and the `node` columns from `silx view`

![screenshot from 2017-06-16 18 15 01](https://user-images.githubusercontent.com/7579321/27235541-75aed3ba-52c1-11e7-8b49-28ee32a5fef2.png)


Closes #888 
Closes #886 
Closes #885 