### PR TITLE
[Plot] Fix ColorBarWidget

### DIFF
--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -539,7 +539,7 @@ class _ColorScale(qt.QWidget):
         """yPixel : pixel position into _ColorScale widget reference
         """
         # widgets are bottom-top referencial but we display in top-bottom referential
-        return 1 - float(yPixel)/float(self.height() - 2*self.margin)
+        return 1. - (yPixel - self.margin) / float(self.height() - 2 * self.margin)
 
     def getValueFromRelativePosition(self, value):
         """Return the value in the colorMap from a relative position in the

--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -92,7 +92,6 @@ class ColorBarWidget(qt.QWidget):
         self.layout().setSizeConstraint(qt.QLayout.SetMinAndMaxSize)
         self.setSizePolicy(qt.QSizePolicy.Minimum, qt.QSizePolicy.Expanding)
 
-
     def getPlot(self):
         """Returns the :class:`Plot` associated to this widget or None"""
         return self._plot
@@ -320,15 +319,16 @@ class ColorScaleBar(qt.QWidget):
 
         # create the left side group (ColorScale)
         self.colorScale = _ColorScale(colormap=colormap,
-                                     parent=self,
-                                     margin=ColorScaleBar._TEXT_MARGIN)
+                                      parent=self,
+                                      margin=ColorScaleBar._TEXT_MARGIN)
 
-        self.tickbar = _TickBar(vmin=colormap['vmin'] if colormap else 0.0,
-                               vmax=colormap['vmax'] if colormap else 1.0,
-                               norm=colormap['normalization'] if colormap else 'linear',
-                               parent=self,
-                               displayValues=displayTicksValues,
-                               margin=ColorScaleBar._TEXT_MARGIN)
+        self.tickbar = _TickBar(
+            vmin=colormap['vmin'] if colormap else 0.0,
+            vmax=colormap['vmax'] if colormap else 1.0,
+            norm=colormap['normalization'] if colormap else 'linear',
+            parent=self,
+            displayValues=displayTicksValues,
+            margin=ColorScaleBar._TEXT_MARGIN)
 
         self.layout().addWidget(self.tickbar, 1, 0)
         self.layout().addWidget(self.colorScale, 1, 1)
@@ -441,8 +441,8 @@ class _ColorScale(qt.QWidget):
     ...       'vmax':100000,
     ...       'autoscale':False
     ...       }
-    >>> colorscale = ColorScale(parent=None,
-    ...                         colormap=colormap)
+    >>> colorscale = _ColorScale(parent=None,
+    ...                          colormap=colormap)
     >>> colorscale.show()
 
     Initializer parameters :
@@ -461,6 +461,7 @@ class _ColorScale(qt.QWidget):
     def __init__(self, colormap, parent=None, margin=5):
         qt.QWidget.__init__(self, parent)
         self._colormap = None
+        self.margin = 0
         self.setColormap(colormap)
 
         self.setLayout(qt.QVBoxLayout())
@@ -583,7 +584,7 @@ class _TickBar(qt.QWidget):
 
     To run the following sample code, a QApplication must be initialized.
 
-    >>> bar = TickBar(1, 1000, norm='log', parent=None, displayValues=True)
+    >>> bar = _TickBar(1, 1000, norm='log', parent=None, displayValues=True)
     >>> bar.show()
 
     .. image:: img/tickbar.png
@@ -616,6 +617,10 @@ class _TickBar(qt.QWidget):
     def __init__(self, vmin, vmax, norm, parent=None, displayValues=True,
                  nticks=None, margin=5):
         super(_TickBar, self).__init__(parent)
+        self.margin = 0
+        self._nticks = None
+        self.ticks = ()
+        self.subTicks = ()
         self._forcedDisplayType = None
         self.ticksDensity = _TickBar.DEFAULT_TICK_DENSITY
 
@@ -669,7 +674,6 @@ class _TickBar(qt.QWidget):
             optimal number of ticks from the tick density.
         """
         self._nticks = nticks
-        self.ticks = None
         self.computeTicks()
         qt.QWidget.update(self)
 
@@ -743,13 +747,12 @@ class _TickBar(qt.QWidget):
         painter.setFont(font)
 
         # paint ticks
-        if self.ticks is not None:
-            for val in self.ticks:
-                self._paintTick(val, painter, majorTick=True)
+        for val in self.ticks:
+            self._paintTick(val, painter, majorTick=True)
 
-            # paint subticks
-            for val in self.subTicks:
-                self._paintTick(val, painter, majorTick=False)
+        # paint subticks
+        for val in self.subTicks:
+            self._paintTick(val, painter, majorTick=False)
 
         qt.QWidget.paintEvent(self, event)
 

--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -470,6 +470,8 @@ class _ColorScale(qt.QWidget):
         self.setMargin(margin)
         self.setContentsMargins(0, 0, 0, 0)
 
+        self.setMinimumSize(10, self._NB_CONTROL_POINTS // 2 + 2 * self.margin)
+
     def setColormap(self, colormap):
         """Set the new colormap to be displayed
 
@@ -519,11 +521,10 @@ class _ColorScale(qt.QWidget):
     def paintEvent(self, event):
         """"""
         qt.QWidget.paintEvent(self, event)
-        if self.getColormap() is None:
-            return
 
         painter = qt.QPainter(self)
-        painter.setBrush(self._gradient)
+        if self.getColormap() is not None:
+            painter.setBrush(self._gradient)
         painter.drawRect(qt.QRect(
             0,
             self.margin,
@@ -548,9 +549,13 @@ class _ColorScale(qt.QWidget):
         :param value: float value in [0, 1]
         :return: the value in [colormap['vmin'], colormap['vmax']]
         """
+        colormap = self.getColormap()
+        if colormap is None:
+            return
+
         value = max(0.0, value)
         value = min(value, 1.0)
-        colormap = self.getColormap()
+
         vmin = colormap['vmin']
         vmax = colormap['vmax']
         if colormap['normalization'] is 'linear':

--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -388,7 +388,7 @@ class ColorScaleBar(qt.QWidget):
     def _updateMinMax(self):
         """Update the min and max label if we are in the case of the
         configuration 'minMaxValueOnly'"""
-        if self._minLabel is None:
+        if self.minVal is None:
             text, tooltip = '', ''
         else:
             if self.minVal == 0 or 0 <= numpy.log10(abs(self.minVal)) < 7:
@@ -400,7 +400,7 @@ class ColorScaleBar(qt.QWidget):
         self._minLabel.setText(text)
         self._minLabel.setToolTip(tooltip)
 
-        if self._maxLabel is None:
+        if self.maxVal is None:
             text, tooltip = '', ''
         else:
             if self.maxVal == 0 or 0 <= numpy.log10(abs(self.maxVal)) < 7:

--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -494,7 +494,7 @@ class _ColorScale(qt.QWidget):
 
         :rtype: dict
         """
-        return self._colormap.copy()
+        return None if self._colormap is None else self._colormap.copy()
 
     def _updateColorGradient(self):
         """Compute the color gradient"""

--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -90,7 +90,6 @@ class ColorBarWidget(qt.QWidget):
         self.layout().addWidget(self.legend)
 
         self.layout().setSizeConstraint(qt.QLayout.SetMinAndMaxSize)
-        self.setSizePolicy(qt.QSizePolicy.Minimum, qt.QSizePolicy.Expanding)
 
     def getPlot(self):
         """Returns the :class:`Plot` associated to this widget or None"""
@@ -330,23 +329,23 @@ class ColorScaleBar(qt.QWidget):
             displayValues=displayTicksValues,
             margin=ColorScaleBar._TEXT_MARGIN)
 
-        self.layout().addWidget(self.tickbar, 1, 0)
-        self.layout().addWidget(self.colorScale, 1, 1)
+        self.layout().addWidget(self.tickbar, 1, 0, 1, 1, qt.Qt.AlignRight)
+        self.layout().addWidget(self.colorScale, 1, 1, qt.Qt.AlignLeft)
 
         self.layout().setContentsMargins(0, 0, 0, 0)
         self.layout().setSpacing(0)
 
         # max label
         self._maxLabel = qt.QLabel(str(1.0), parent=self)
-        self._maxLabel.setAlignment(qt.Qt.AlignHCenter)
-        self._maxLabel.setSizePolicy(qt.QSizePolicy.Minimum, qt.QSizePolicy.Minimum)
-        self.layout().addWidget(self._maxLabel, 0, 1)
+        self.layout().addWidget(self._maxLabel, 0, 0, 1, 2, qt.Qt.AlignRight)
 
         # min label
         self._minLabel = qt.QLabel(str(0.0), parent=self)
-        self._minLabel.setAlignment(qt.Qt.AlignHCenter)
-        self._minLabel.setSizePolicy(qt.QSizePolicy.Minimum, qt.QSizePolicy.Minimum)
-        self.layout().addWidget(self._minLabel, 2, 1)
+        self.layout().addWidget(self._minLabel, 2, 0, 1, 2, qt.Qt.AlignRight)
+
+        self.layout().setSizeConstraint(qt.QLayout.SetMinAndMaxSize)
+        self.layout().setColumnStretch(0, 1)
+        self.layout().setRowStretch(1, 1)
 
     def getTickBar(self):
         """
@@ -465,13 +464,14 @@ class _ColorScale(qt.QWidget):
         self.setColormap(colormap)
 
         self.setLayout(qt.QVBoxLayout())
-        self.setSizePolicy(qt.QSizePolicy.Expanding, qt.QSizePolicy.Expanding)
+        self.setSizePolicy(qt.QSizePolicy.Fixed, qt.QSizePolicy.Expanding)
         # needed to get the mouse event without waiting for button click
         self.setMouseTracking(True)
         self.setMargin(margin)
         self.setContentsMargins(0, 0, 0, 0)
 
-        self.setMinimumSize(10, self._NB_CONTROL_POINTS // 2 + 2 * self.margin)
+        self.setMinimumHeight(self._NB_CONTROL_POINTS // 2 + 2 * self.margin)
+        self.setFixedWidth(25)
 
     def setColormap(self, colormap):
         """Set the new colormap to be displayed
@@ -637,7 +637,6 @@ class _TickBar(qt.QWidget):
         self.displayValues = displayValues
         self.setTicksNumber(nticks)
 
-        self.setLayout(qt.QVBoxLayout())
         self.setMargin(margin)
         self.setContentsMargins(0, 0, 0, 0)
 
@@ -648,8 +647,8 @@ class _TickBar(qt.QWidget):
         self._resetWidth()
 
     def _resetWidth(self):
-        self.width = _TickBar._WIDTH_DISP_VAL if self.displayValues else _TickBar._WIDTH_NO_DISP_VAL
-        self.setFixedWidth(self.width)
+        width = self._WIDTH_DISP_VAL if self.displayValues else self._WIDTH_NO_DISP_VAL
+        self.setFixedWidth(width)
 
     def update(self, vmin, vmax, norm):
         self._vmin = vmin
@@ -754,8 +753,6 @@ class _TickBar(qt.QWidget):
         for val in self.subTicks:
             self._paintTick(val, painter, majorTick=False)
 
-        qt.QWidget.paintEvent(self, event)
-
     def _getRelativePosition(self, val):
         """Return the relative position of val according to min and max value
         """
@@ -781,9 +778,9 @@ class _TickBar(qt.QWidget):
         if majorTick is False:
             lineWidth /= 2
 
-        painter.drawLine(qt.QLine(self.width - lineWidth,
+        painter.drawLine(qt.QLine(self.width() - lineWidth,
                                   height,
-                                  self.width,
+                                  self.width(),
                                   height))
 
         if self.displayValues and majorTick is True:

--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -68,10 +68,11 @@ class ColorBarWidget(qt.QWidget):
     """
 
     def __init__(self, parent=None, plot=None, legend=None):
-        super(ColorBarWidget, self).__init__(parent)
         self._isConnected = False
         self._plot = None
         self._viewAction = None
+
+        super(ColorBarWidget, self).__init__(parent)
 
         self.__buildGUI()
         self.setLegend(legend)
@@ -298,14 +299,6 @@ class ColorScaleBar(qt.QWidget):
     """The tick bar need a margin to display all labels at the correct place.
     So the ColorScale should have the same margin in order for both to fit"""
 
-    _MIN_LIM_SCI_FORM = -1000
-    """Used for the min and max label to know when we should display it under
-    the scientific form"""
-
-    _MAX_LIM_SCI_FORM = 1000
-    """Used for the min and max label to know when we should display it under
-    the scientific form"""
-
     def __init__(self, parent=None, colormap=None, displayTicksValues=True):
         super(ColorScaleBar, self).__init__(parent)
 
@@ -395,20 +388,29 @@ class ColorScaleBar(qt.QWidget):
     def _updateMinMax(self):
         """Update the min and max label if we are in the case of the
         configuration 'minMaxValueOnly'"""
-        if self._minLabel is not None and self._maxLabel is not None:
-            if self.minVal is not None:
-                if ColorScaleBar._MIN_LIM_SCI_FORM <= self.minVal <= ColorScaleBar._MAX_LIM_SCI_FORM:
-                    self._minLabel.setText(str(self.minVal))
-                else:
-                    self._minLabel.setText("{0:.0e}".format(self.minVal))
-                self._minLabel.setToolTip(str(self.minVal))
+        if self._minLabel is None:
+            text, tooltip = '', ''
+        else:
+            if self.minVal == 0 or 0 <= numpy.log10(abs(self.minVal)) < 7:
+                text = '%.7g' % self.minVal
+            else:
+                text = '%.2e' % self.minVal
+            tooltip = repr(self.minVal)
 
-            if self.maxVal is not None:
-                if ColorScaleBar._MIN_LIM_SCI_FORM <= self.maxVal <= ColorScaleBar._MAX_LIM_SCI_FORM:
-                    self._maxLabel.setText(str(self.maxVal))
-                else:
-                    self._maxLabel.setText("{0:.0e}".format(self.maxVal))
-                self._maxLabel.setToolTip(str(self.maxVal))
+        self._minLabel.setText(text)
+        self._minLabel.setToolTip(tooltip)
+
+        if self._maxLabel is None:
+            text, tooltip = '', ''
+        else:
+            if self.maxVal == 0 or 0 <= numpy.log10(abs(self.maxVal)) < 7:
+                text = '%.7g' % self.maxVal
+            else:
+                text = '%.2e' % self.maxVal
+            tooltip = repr(self.maxVal)
+
+        self._maxLabel.setText(text)
+        self._maxLabel.setToolTip(tooltip)
 
     def _setMinMaxLabels(self, minVal, maxVal):
         """Change the value of the min and max labels to be displayed.

--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -277,11 +277,11 @@ class ColorScaleBar(qt.QWidget):
 
     To run the following sample code, a QApplication must be initialized.
 
-    >>> colormap={'name':'gray',
-    ...       'normalization':'log',
-    ...       'vmin':1,
-    ...       'vmax':100000,
-    ...       'autoscale':False
+    >>> colormap={'name': 'gray',
+    ...       'normalization': 'log',
+    ...       'vmin': 1,
+    ...       'vmax': 100000,
+    ...       'autoscale': False
     ...       }
     >>> colorscale = ColorScaleBar(parent=None,
     ...                            colormap=colormap )
@@ -434,11 +434,11 @@ class _ColorScale(qt.QWidget):
 
     To run the following sample code, a QApplication must be initialized.
 
-    >>> colormap={'name':'viridis',
-    ...       'normalization':'log',
-    ...       'vmin':1,
-    ...       'vmax':100000,
-    ...       'autoscale':False
+    >>> colormap={'name': 'viridis',
+    ...       'normalization': 'log',
+    ...       'vmin': 1,
+    ...       'vmax': 100000,
+    ...       'autoscale': False
     ...       }
     >>> colorscale = _ColorScale(parent=None,
     ...                          colormap=colormap)

--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -337,10 +337,12 @@ class ColorScaleBar(qt.QWidget):
 
         # max label
         self._maxLabel = qt.QLabel(str(1.0), parent=self)
+        self._maxLabel.setToolTip(str(0.0))
         self.layout().addWidget(self._maxLabel, 0, 0, 1, 2, qt.Qt.AlignRight)
 
         # min label
         self._minLabel = qt.QLabel(str(0.0), parent=self)
+        self._minLabel.setToolTip(str(0.0))
         self.layout().addWidget(self._minLabel, 2, 0, 1, 2, qt.Qt.AlignRight)
 
         self.layout().setSizeConstraint(qt.QLayout.SetMinAndMaxSize)
@@ -399,11 +401,14 @@ class ColorScaleBar(qt.QWidget):
                     self._minLabel.setText(str(self.minVal))
                 else:
                     self._minLabel.setText("{0:.0e}".format(self.minVal))
+                self._minLabel.setToolTip(str(self.minVal))
+
             if self.maxVal is not None:
                 if ColorScaleBar._MIN_LIM_SCI_FORM <= self.maxVal <= ColorScaleBar._MAX_LIM_SCI_FORM:
                     self._maxLabel.setText(str(self.maxVal))
                 else:
                     self._maxLabel.setText("{0:.0e}".format(self.maxVal))
+                self._maxLabel.setToolTip(str(self.maxVal))
 
     def _setMinMaxLabels(self, minVal, maxVal):
         """Change the value of the min and max labels to be displayed.

--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -533,8 +533,9 @@ class _ColorScale(qt.QWidget):
             self.height() - 2. * self.margin - 1.))
 
     def mouseMoveEvent(self, event):
-        """"""
-        self.setToolTip(str(self.getValueFromRelativePosition(self._getRelativePosition(event.y()))))
+        tooltip = str(self.getValueFromRelativePosition(
+            self._getRelativePosition(event.y())))
+        qt.QToolTip.showText(event.globalPos(), tooltip, self)
         super(_ColorScale, self).mouseMoveEvent(event)
 
     def _getRelativePosition(self, yPixel):

--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -481,6 +481,7 @@ class _ColorScale(qt.QWidget):
                 raise ValueError('vmin and vmax should be positives')
         self.colormap = colormap
         self._computeColorPoints()
+        self.update()
 
     def _computeColorPoints(self):
         """Compute the color points for the gradient
@@ -564,6 +565,7 @@ class _ColorScale(qt.QWidget):
         :param int margin: the margin to apply on the top and bottom.
         """
         self.margin = margin
+        self.update()
 
 
 class _TickBar(qt.QWidget):

--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -806,7 +806,6 @@ class _TickBar(qt.QWidget):
 
         :param QFont font: the font we want want to use durint the painting
         """
-        assert(type(self._vmin) == type(self._vmax))
         form = self._getStandardFormat()
 
         fm = qt.QFontMetrics(font)

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -191,6 +191,9 @@ It provides the following keys:
 
 'interactiveModeChanged' event with a 'source' key identifying the object
 setting the interactive mode.
+
+'defaultColormapChanged' event is triggered when the default colormap of
+the plot is updated.
 """
 
 from __future__ import division
@@ -2369,6 +2372,7 @@ class PlotWidget(qt.QMainWindow):
             colormap = {'name': 'gray', 'normalization': 'linear',
                         'autoscale': True, 'vmin': 0.0, 'vmax': 1.0}
         self._defaultColormap = colormap.copy()
+        self.notify('defaultColormapChanged')
 
     @staticmethod
     def getSupportedColormaps():

--- a/silx/gui/plot/_utils/__init__.py
+++ b/silx/gui/plot/_utils/__init__.py
@@ -35,17 +35,6 @@ from .panzoom import FLOAT32_SAFE_MIN, FLOAT32_MINPOS, FLOAT32_SAFE_MAX
 from .panzoom import applyZoomToPlot, applyPan
 
 
-def clipColormapLogRange(colormap):
-    """Clip colormap vmin and vmax to 1, 10 if normalization is 'log' and vmin
-    or vmax <1
-
-    :param dict colormap: the colormap for which we want to clip vmin and vmax
-    """
-    if colormap['normalization'] is 'log':
-        if colormap['vmin'] < 1. or colormap['vmax'] < 1.:
-            colormap['vmin'], colormap['vmax'] = 1., 10.
-
-
 def addMarginsToLimits(margins, isXLog, isYLog,
                        xMin, xMax, yMin, yMax, y2Min=None, y2Max=None):
     """Returns updated limits by extending them with margins.

--- a/silx/gui/plot/test/testColorBar.py
+++ b/silx/gui/plot/test/testColorBar.py
@@ -33,6 +33,7 @@ from silx.gui.test.utils import TestCaseQt
 from silx.gui.plot.ColorBar import _ColorScale
 from silx.gui.plot.ColorBar import ColorBarWidget
 from silx.gui.plot import Plot2D
+from silx.gui import qt
 import numpy
 
 
@@ -84,23 +85,31 @@ class TestColorScale(unittest.TestCase):
         self.assertTrue(val == 1.0)
 
 
-class TestNoAutoscale(unittest.TestCase):
+class TestNoAutoscale(TestCaseQt):
     """Test that ticks and color displayed are correct in the case of a colormap
     with no autoscale
     """
 
     def setUp(self):
+        super(TestNoAutoscale, self).setUp()
         self.plot = Plot2D()
-        self.colorBar = ColorBarWidget(parent=None, plot=self.plot)
+        self.colorBar = self.plot.getColorBarWidget()
+        self.colorBar.setVisible(True)  # Makes sure the colormap is visible
         self.tickBar = self.colorBar.getColorScaleBar().getTickBar()
         self.colorScale = self.colorBar.getColorScaleBar().getColorScale()
 
+        self.plot.show()
+        self.qWaitForWindowExposed(self.plot)
+
     def tearDown(self):
+        self.qapp.processEvents()
         self.tickBar = None
         self.colorScale = None
         del self.colorBar
+        self.plot.setAttribute(qt.Qt.WA_DeleteOnClose)
         self.plot.close()
         del self.plot
+        super(TestNoAutoscale, self).tearDown()
 
     def testLogNormNoAutoscale(self):
         colormapLog = { 'name': 'gray', 'normalization': 'log',
@@ -146,19 +155,25 @@ class TestNoAutoscale(unittest.TestCase):
         val = self.colorScale.getValueFromRelativePosition(0.0)
         self.assertTrue(val == -4.0)
 
+
 class TestColorbarWidget(TestCaseQt):
     """Test interaction with the ColorScaleBar"""
 
     def setUp(self):
         super(TestColorbarWidget, self).setUp()
         self.plot = Plot2D()
-        self.colorBar = ColorBarWidget(parent=None, plot=self.plot)
+        self.colorBar = self.plot.getColorBarWidget()
+        self.colorBar.setVisible(True)  # Makes sure the colormap is visible
+
+        self.plot.show()
+        self.qWaitForWindowExposed(self.plot)
 
     def tearDown(self):
+        self.qapp.processEvents()
         del self.colorBar
+        self.plot.setAttribute(qt.Qt.WA_DeleteOnClose)
         self.plot.close()
         del self.plot
-
         super(TestColorbarWidget, self).tearDown()
 
     def testEmptyColorBar(self):

--- a/silx/gui/plot/test/testColorBar.py
+++ b/silx/gui/plot/test/testColorBar.py
@@ -95,27 +95,6 @@ class TestColorScale(TestCaseQt):
         val = self.colorScaleWidget.getValueFromRelativePosition(0.0)
         self.assertTrue(val == 1.0)
 
-    def testToolTip(self):
-        """Test value displayed in tool tip"""
-        colormap = {'name': 'gray', 'normalization': 'linear',
-                    'autoscale': False, 'vmin': 1.0, 'vmax': 100.0}
-        self.colorScaleWidget.setColormap(colormap)
-
-        xCenter = self.colorScaleWidget.width() / 2.
-        height = self.colorScaleWidget.height()
-
-        self.mouseMove(self.colorScaleWidget, (xCenter, height - 1))
-        self.assertEqual(self.colorScaleWidget.toolTip(),
-                         str(colormap['vmin']))
-
-        self.mouseMove(self.colorScaleWidget, (xCenter, height // 2))
-        self.assertEqual(self.colorScaleWidget.toolTip(),
-                         str((colormap['vmax'] + colormap['vmin'])/2.))
-
-        self.mouseMove(self.colorScaleWidget, (xCenter, 0))
-        self.assertEqual(self.colorScaleWidget.toolTip(),
-                         str(colormap['vmax']))
-
 
 class TestNoAutoscale(TestCaseQt):
     """Test that ticks and color displayed are correct in the case of a colormap

--- a/silx/gui/plot/test/testColorBar.py
+++ b/silx/gui/plot/test/testColorBar.py
@@ -47,8 +47,8 @@ class TestColorScale(unittest.TestCase):
         self.colorScaleWidget = None
 
     def testRelativePositionLinear(self):
-        self.colorMapLin1 = { 'name': 'gray', 'normalization': 'linear',
-                    'autoscale': False, 'vmin': 0.0, 'vmax': 1.0 }
+        self.colorMapLin1 = {'name': 'gray', 'normalization': 'linear',
+                             'autoscale': False, 'vmin': 0.0, 'vmax': 1.0}
         self.colorScaleWidget.setColormap(self.colorMapLin1)
         
         self.assertTrue(
@@ -58,8 +58,8 @@ class TestColorScale(unittest.TestCase):
         self.assertTrue(
             self.colorScaleWidget.getValueFromRelativePosition(1.0) == 1.0)
 
-        self.colorMapLin2 = { 'name': 'viridis', 'normalization': 'linear',
-                    'autoscale': False, 'vmin': -10, 'vmax': 0 }
+        self.colorMapLin2 = {'name': 'viridis', 'normalization': 'linear',
+                             'autoscale': False, 'vmin': -10, 'vmax': 0}
         self.colorScaleWidget.setColormap(self.colorMapLin2)
         
         self.assertTrue(
@@ -70,8 +70,8 @@ class TestColorScale(unittest.TestCase):
             self.colorScaleWidget.getValueFromRelativePosition(1.0) == 0.0)
 
     def testRelativePositionLog(self):
-        self.colorMapLog1 = { 'name': 'temperature', 'normalization': 'log',
-                    'autoscale': False, 'vmin': 1.0, 'vmax': 100.0 }
+        self.colorMapLog1 = {'name': 'temperature', 'normalization': 'log',
+                             'autoscale': False, 'vmin': 1.0, 'vmax': 100.0}
 
         self.colorScaleWidget.setColormap(self.colorMapLog1)
 
@@ -112,8 +112,8 @@ class TestNoAutoscale(TestCaseQt):
         super(TestNoAutoscale, self).tearDown()
 
     def testLogNormNoAutoscale(self):
-        colormapLog = { 'name': 'gray', 'normalization': 'log',
-                    'autoscale': False, 'vmin': 1.0, 'vmax': 100.0 }
+        colormapLog = {'name': 'gray', 'normalization': 'log',
+                       'autoscale': False, 'vmin': 1.0, 'vmax': 100.0}
 
         data = numpy.linspace(10, 1e10, 9).reshape(3, 3)
         self.plot.addImage(data=data, colormap=colormapLog, legend='toto')
@@ -135,8 +135,8 @@ class TestNoAutoscale(TestCaseQt):
         self.assertTrue(val == 1.0)
 
     def testLinearNormNoAutoscale(self):
-        colormapLog = { 'name': 'gray', 'normalization': 'linear',
-                    'autoscale': False, 'vmin': -4, 'vmax': 5 }
+        colormapLog = {'name': 'gray', 'normalization': 'linear',
+                       'autoscale': False, 'vmin': -4, 'vmax': 5}
 
         data = numpy.linspace(1, 9, 9).reshape(3, 3)
         self.plot.addImage(data=data, colormap=colormapLog, legend='toto')
@@ -187,11 +187,11 @@ class TestColorbarWidget(TestCaseQt):
 
         Note : colorbar is modified by the Plot directly not ColorBarWidget
         """
-        colormapLog = { 'name': 'gray', 'normalization': 'log',
-                    'autoscale': True, 'vmin': -1.0, 'vmax': 1.0 }
+        colormapLog = {'name': 'gray', 'normalization': 'log',
+                       'autoscale': True, 'vmin': -1.0, 'vmax': 1.0}
 
-        colormapLog2 = { 'name': 'gray', 'normalization': 'log',
-                    'autoscale': False, 'vmin': -1.0, 'vmax': 1.0 }
+        colormapLog2 = {'name': 'gray', 'normalization': 'log',
+                        'autoscale': False, 'vmin': -1.0, 'vmax': 1.0}
 
         data = numpy.array([-5, -4, 0, 2, 3, 5, 10, 20, 30])
         data = data.reshape(3, 3)
@@ -199,7 +199,7 @@ class TestColorbarWidget(TestCaseQt):
         self.plot.setActiveImage('toto')
 
         # default behavior when autoscale : set to minmal positive value
-        data[data<1] = data.max()
+        data[data < 1] = data.max()
         self.assertTrue(self.colorBar.getColormap()['vmin'] == data.min())
         self.assertTrue(self.colorBar.getColormap()['vmax'] == data.max())
 
@@ -213,8 +213,8 @@ class TestColorbarWidget(TestCaseQt):
 
     def testPlotAssocation(self):
         """Make sure the ColorBarWidget is proparly connected with the plot"""
-        colormap = { 'name': 'gray', 'normalization': 'linear',
-                    'autoscale': True, 'vmin': -1.0, 'vmax': 1.0 }
+        colormap = {'name': 'gray', 'normalization': 'linear',
+                    'autoscale': True, 'vmin': -1.0, 'vmax': 1.0}
 
         # make sure that default settings are the same
         self.assertTrue(

--- a/silx/gui/plot/test/testColorBar.py
+++ b/silx/gui/plot/test/testColorBar.py
@@ -83,20 +83,7 @@ class TestColorScale(unittest.TestCase):
         val = self.colorScaleWidget.getValueFromRelativePosition(0.0)
         self.assertTrue(val == 1.0)
 
-    def testNegativeLogMin(self):
-        colormap = { 'name': 'gray', 'normalization': 'log',
-                    'autoscale': False, 'vmin': -1.0, 'vmax': 1.0 }
 
-        with self.assertRaises(ValueError):
-            self.colorScaleWidget.setColormap(colormap)
-
-    def testNegativeLogMax(self):
-        colormap = { 'name': 'gray', 'normalization': 'log',
-                    'autoscale': False, 'vmin': 1.0, 'vmax': -1.0 }
-
-        with self.assertRaises(ValueError):
-            self.colorScaleWidget.setColormap(colormap)
-        
 class TestNoAutoscale(unittest.TestCase):
     """Test that ticks and color displayed are correct in the case of a colormap
     with no autoscale
@@ -198,16 +185,16 @@ class TestColorbarWidget(TestCaseQt):
 
         # default behavior when autoscale : set to minmal positive value
         data[data<1] = data.max()
-        self.assertTrue(self.colorBar._colormap['vmin'] == data.min())
-        self.assertTrue(self.colorBar._colormap['vmax'] == data.max())
+        self.assertTrue(self.colorBar.getColormap()['vmin'] == data.min())
+        self.assertTrue(self.colorBar.getColormap()['vmax'] == data.max())
 
         data = numpy.linspace(-9, -2, 100).reshape(10, 10)
 
         self.plot.addImage(data=data, colormap=colormapLog2, legend='toto')
         self.plot.setActiveImage('toto')
         # if negative values, changing bounds for default : 1, 10
-        self.assertTrue(self.colorBar._colormap['vmin'] == 1)
-        self.assertTrue(self.colorBar._colormap['vmax'] == 10)
+        self.assertTrue(self.colorBar.getColormap()['vmin'] == 1)
+        self.assertTrue(self.colorBar.getColormap()['vmax'] == 10)
 
     def testPlotAssocation(self):
         """Make sure the ColorBarWidget is proparly connected with the plot"""


### PR DESCRIPTION
This PR fixes issues in the ColorBarWidget. It fixes most of #889 issues. 

Issues:
- [x] `ColorBarWidget` is not synchronized when `PlotWidget`'s default colormap is updated.
- [x] From the console, doing an `addImage` with a different colormap does not update the colorbar immediately. It is only updated when `PlotWindow` gets the focus when clicking on it.
- [x] ColorBar.py l809 `assert(type(self._vmin) == type(self._vmax))`: why is it needed? One can enter vmin=1, vmax=1.5 and it should work.
- [x] If setting a colorbar with vmin == vmax, the colorbar gradient is not updated and displays the previous colormap.
- [x] Missalignment of tooltip and color gradient (due to widget margins?).

Improvements:
- [x] large values of vmin or vmax enlarges the width of the colorbar. The QLabels could span over/under the ticks to minimize the width of the colorbar + we could display those values with a limited number of significant digits (and have the full value displayed in a tooltip). Anyway, I would not enlarge the colorbar gradient above a certain width.
- [x] It is probably worth listening for active image changes only when the ColorBarWidget is visible.

Refactoring:
- [x] Refactor set|getColormap to only store it once in _ColorScale (and do the checks once) and have proxy to access it in other classes.
- [x] In _ColorScale, it looks possible to create the QLinearGradient during setColormap rather than for each paintEvent.