### PR TITLE
[utils] Improve deprecation log

### DIFF
--- a/silx/test/__init__.py
+++ b/silx/test/__init__.py
@@ -32,7 +32,7 @@ It will skip all tests from :mod:`silx.test.gui`.
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "20/04/2017"
+__date__ = "22/06/2017"
 
 
 import logging
@@ -61,7 +61,6 @@ def suite():
     test_suite.addTest(test_utils.suite())
     test_suite.addTest(test_version.suite())
     test_suite.addTest(test_resources.suite())
-    test_suite.addTest(test_utils.suite())
     test_suite.addTest(test_io.suite())
     test_suite.addTest(test_math.suite())
     test_suite.addTest(test_image.suite())

--- a/silx/utils/deprecation.py
+++ b/silx/utils/deprecation.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import, print_function, division
 
 __authors__ = ["Jerome Kieffer"]
 __license__ = "MIT"
-__date__ = "16/06/2017"
+__date__ = "22/06/2017"
 
 import sys
 import logging
@@ -80,6 +80,10 @@ def deprecated_warning(type_, name, reason=None, replacement=None,
     :param str since_version: First *silx* version for which the function was
         deprecated (e.g. "0.5.0").
     """
+    if not depreclog.isEnabledFor(logging.WARNING):
+        # Avoid computation when it is not logged
+        return
+
     msg = "%s, %s is deprecated"
     if since_version is not None:
         msg += " since silx version %s" % since_version

--- a/silx/utils/deprecation.py
+++ b/silx/utils/deprecation.py
@@ -33,7 +33,6 @@ __date__ = "22/06/2017"
 import sys
 import logging
 import functools
-import os
 import traceback
 
 depreclog = logging.getLogger("silx.DEPRECATION")
@@ -92,5 +91,7 @@ def deprecated_warning(type_, name, reason=None, replacement=None,
         msg += " Reason: %s." % reason
     if replacement is not None:
         msg += " Use '%s' instead." % replacement
-    depreclog.warning(msg + " %s", type_, name,
-                      os.linesep.join([""] + traceback.format_stack()[:-1]))
+    msg = msg + "\n%s"
+    backtrace = "".join([""] + traceback.format_stack()[:-1])
+    backtrace = backtrace.rstrip()
+    depreclog.warning(msg, type_, name, backtrace)

--- a/silx/utils/deprecation.py
+++ b/silx/utils/deprecation.py
@@ -99,7 +99,7 @@ def deprecated_warning(type_, name, reason=None, replacement=None,
     if replacement is not None:
         msg += " Use '%s' instead." % replacement
     msg = msg + "\n%s"
-    backtrace = "".join([""] + traceback.format_stack()[-2:-1])
+    backtrace = "".join(traceback.format_stack()[-2:-1])
     backtrace = backtrace.rstrip()
     if only_once:
         data = (msg, type_, name, backtrace)

--- a/silx/utils/deprecation.py
+++ b/silx/utils/deprecation.py
@@ -92,6 +92,6 @@ def deprecated_warning(type_, name, reason=None, replacement=None,
     if replacement is not None:
         msg += " Use '%s' instead." % replacement
     msg = msg + "\n%s"
-    backtrace = "".join([""] + traceback.format_stack()[:-1])
+    backtrace = "".join([""] + traceback.format_stack()[-2:-1])
     backtrace = backtrace.rstrip()
     depreclog.warning(msg, type_, name, backtrace)

--- a/silx/utils/test/test_deprecation.py
+++ b/silx/utils/test/test_deprecation.py
@@ -45,6 +45,14 @@ class TestDeprecation(unittest.TestCase):
     def deprecatedWithParams(self):
         pass
 
+    @deprecation.deprecated(reason="r", replacement="r", since_version="v", only_once=True)
+    def deprecatedOnlyOnce(self):
+        pass
+
+    @deprecation.deprecated(reason="r", replacement="r", since_version="v", only_once=False)
+    def deprecatedEveryTime(self):
+        pass
+
     @utils.test_logging(deprecation.depreclog.name, warning=1)
     def testAnnotationWithoutParam(self):
         self.deprecatedWithoutParam()
@@ -52,6 +60,18 @@ class TestDeprecation(unittest.TestCase):
     @utils.test_logging(deprecation.depreclog.name, warning=1)
     def testAnnotationWithParams(self):
         self.deprecatedWithParams()
+
+    @utils.test_logging(deprecation.depreclog.name, warning=1)
+    def testLoggedOnlyOnce(self):
+        self.deprecatedOnlyOnce()
+        self.deprecatedOnlyOnce()
+        self.deprecatedOnlyOnce()
+
+    @utils.test_logging(deprecation.depreclog.name, warning=3)
+    def testLoggedEveryTime(self):
+        self.deprecatedEveryTime()
+        self.deprecatedEveryTime()
+        self.deprecatedEveryTime()
 
     @utils.test_logging(deprecation.depreclog.name, warning=1)
     def testWarning(self):

--- a/silx/utils/test/test_deprecation.py
+++ b/silx/utils/test/test_deprecation.py
@@ -22,24 +22,48 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-__authors__ = ["T. Vincent", "P. Knobel"]
+"""Tests for html module"""
+
+__authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "22/06/2017"
 
 
 import unittest
-from . import test_weakref
-from . import test_html
-from . import test_array_like
-from . import test_launcher
-from . import test_deprecation
+from .. import deprecation
+from silx.test import utils
+
+
+class TestDeprecation(unittest.TestCase):
+    """Tests for deprecation module."""
+
+    @deprecation.deprecated
+    def deprecatedWithoutParam(self):
+        pass
+
+    @deprecation.deprecated(reason="r", replacement="r", since_version="v")
+    def deprecatedWithParams(self):
+        pass
+
+    @utils.test_logging(deprecation.depreclog.name, warning=1)
+    def testAnnotationWithoutParam(self):
+        self.deprecatedWithoutParam()
+
+    @utils.test_logging(deprecation.depreclog.name, warning=1)
+    def testAnnotationWithParams(self):
+        self.deprecatedWithParams()
+
+    @utils.test_logging(deprecation.depreclog.name, warning=1)
+    def testWarning(self):
+        deprecation.deprecated_warning(type_="t", name="n")
 
 
 def suite():
     test_suite = unittest.TestSuite()
-    test_suite.addTest(test_weakref.suite())
-    test_suite.addTest(test_html.suite())
-    test_suite.addTest(test_array_like.suite())
-    test_suite.addTest(test_launcher.suite())
-    test_suite.addTest(test_deprecation.suite())
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(TestDeprecation))
     return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
- Add unittest for deprecation module
- Fix empty lines on the output
- Log by default deprecations only once
- Do not display the full backtrace but only the previous caller (which should/must only be outside our lib)
- Fix test suite: test_utils was executed 2 times