### PR TITLE
[spech5] all 0 values in unit cell or UB matrix

### DIFF
--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -559,6 +559,41 @@ def _column_label_in_scan(sf, scan_key, column_label):
     return ret
 
 
+def _parse_UB_matrix(header_line):
+    """Parse G3 header line and return UB matrix
+
+    :param str header_line: G3 header line
+    :return: UB matrix
+    """
+    return numpy.array(list(map(float, header_line.split()))).reshape((1, 3, 3))
+
+
+def _ub_matrix_in_scan(scan):
+    """Return True if scan header has a G3 line and all values are not 0.
+
+    :param scan: specfile.Scan instance
+    :return: True or False
+    """
+    if "G3" not in scan.scan_header_dict:
+        return False
+    return numpy.any(_parse_UB_matrix(scan.scan_header_dict["G3"]))
+
+
+def _parse_unit_cell(header_line):
+    return numpy.array(list(map(float, header_line.split()))[0:6]).reshape((1, 6))
+
+
+def _unit_cell_in_scan(scan):
+    """Return True if scan header has a G1 line and all values are not 0.
+
+    :param scan: specfile.Scan instance
+    :return: True or False
+    """
+    if "G1" not in scan.scan_header_dict:
+        return False
+    return numpy.any(_parse_unit_cell(scan.scan_header_dict["G1"]))
+
+
 def _parse_ctime(ctime_lines, analyser_index=0):
     """
     :param ctime_lines: e.g ``@CTIME %f %f %f``, first word ``@CTIME`` optional
@@ -1046,28 +1081,25 @@ def _dataset_builder(name, specfileh5, parent_group):
         array_like = scan.mca.channels[analyser_index]
 
     elif ub_matrix_pattern.match(name):
-        if not "G3" in scan.scan_header_dict:
-            raise KeyError("No UB matrix in a scan without a #G3 header line")
-        array_like = numpy.array(
-                list(map(float, scan.scan_header_dict["G3"].split()))).reshape((1, 3, 3))
+        if not _ub_matrix_in_scan(scan):
+            raise KeyError("No UB matrix in a scan without a #G3 header line"
+                           " or all zeros.")
+        array_like = _parse_UB_matrix(scan.scan_header_dict["G3"])
     elif unit_cell_pattern.match(name):
-        if not "G1" in scan.scan_header_dict:
+        if not _unit_cell_in_scan(scan):
             raise KeyError(
                     "No unit_cell matrix in a scan without a #G1 header line")
-        array_like = numpy.array(
-                list(map(float, scan.scan_header_dict["G1"].split()))[0:6]).reshape((1, 6))
+        array_like = _parse_unit_cell(scan.scan_header_dict["G1"])
     elif unit_cell_abc_pattern.match(name):
-        if not "G1" in scan.scan_header_dict:
+        if not _unit_cell_in_scan(scan):
             raise KeyError(
                     "No unit_cell matrix in a scan without a #G1 header line")
-        array_like = numpy.array(
-                list(map(float, scan.scan_header_dict["G1"].split()))[0:3]).reshape((3,))
+        array_like = _parse_unit_cell(scan.scan_header_dict["G1"])[0, 0:3]
     elif unit_cell_alphabetagamma_pattern.match(name):
-        if not "G1" in scan.scan_header_dict:
+        if not _unit_cell_in_scan(scan):
             raise KeyError(
                     "No unit_cell matrix in a scan without a #G1 header line")
-        array_like = numpy.array(
-                list(map(float, scan.scan_header_dict["G1"].split()))[3:6]).reshape((3,))
+        array_like = _parse_unit_cell(scan.scan_header_dict["G1"])[0, 3:6]
     elif "CTIME" in scan.mca_header_dict and "mca_" in name:
         m = re.compile(r"/.*/mca_([0-9]+)/.*").match(name)
         analyser_index = int(m.group(1))
@@ -1289,21 +1321,16 @@ class SpecH5Group(object):
             return "CTIME" in self.file._sf[scan_key].mca_header_dict
 
         if sample_pattern.match(key):
-            return ("G3" in self.file._sf[scan_key].scan_header_dict or
-                    "G1" in self.file._sf[scan_key].scan_header_dict)
+            return (_ub_matrix_in_scan(self.file._sf[scan_key]) or
+                    _unit_cell_in_scan(self.file._sf[scan_key]))
 
         if key.endswith("sample/ub_matrix"):
-            return "G3" in self.file._sf[scan_key].scan_header_dict
+            return _ub_matrix_in_scan(self.file._sf[scan_key])
 
-        if key.endswith("sample/unit_cell"):
-            return "G1" in self.file._sf[scan_key].scan_header_dict
-
-        if key.endswith("sample/unit_cell_abc"):
-            return "G1" in self.file._sf[scan_key].scan_header_dict
-
-
-        if key.endswith("sample/unit_cell_alphabetagamma"):
-            return "G1" in self.file._sf[scan_key].scan_header_dict
+        if (key.endswith("sample/unit_cell") or
+            key.endswith("sample/unit_cell_abc") or
+            key.endswith("sample/unit_cell_alphabetagamma")):
+            return _unit_cell_in_scan(self.file._sf[scan_key])
 
         # header, title, start_time, existing scan/mca/motor/measurement
         return True
@@ -1412,7 +1439,7 @@ class SpecH5Group(object):
 
         if scan_pattern.match(self.name):
             ret = static_items["scan"]
-            if "G1" in self._scan.scan_header_dict or "G3" in self._scan.scan_header_dict:
+            if _unit_cell_in_scan(self._scan) or _ub_matrix_in_scan(self._scan):
                 return ret + [u"sample"]
             return ret
 
@@ -1434,11 +1461,11 @@ class SpecH5Group(object):
 
         if sample_pattern.match(self.name):
             ret = []
-            if "G1" in self._scan.scan_header_dict:
+            if _unit_cell_in_scan(self._scan):
                 ret.append(u"unit_cell")
                 ret.append(u"unit_cell_abc")
                 ret.append(u"unit_cell_alphabetagamma")
-            if "G3" in self._scan.scan_header_dict:
+            if _ub_matrix_in_scan(self._scan):
                 ret.append(u"ub_matrix")
             return ret
 

--- a/silx/io/test/test_spech5.py
+++ b/silx/io/test/test_spech5.py
@@ -109,6 +109,12 @@ sftext = """#F /tmp/sf.dat
 #L a  b
 1 2
 
+#S 1001 ccccc
+#G1 0. 0. 0. 0 0 0 2.232368448 2.232368448 1.206680489 90 90 60 1 1 2 -1 2 2 26.132 7.41 -88.96 1.11 1.000012861 15.19 26.06 67.355 -88.96 1.11 1.000012861 15.11 0.723353 0.723353
+#G3 0. 0. 0. 0. 0.0 0. 0. 0. 0.
+#L a  b
+1 2
+
 """
 
 
@@ -402,7 +408,7 @@ class TestSpecH5(unittest.TestCase):
 
     def testListScanIndices(self):
         self.assertEqual(self.sfh5.keys(),
-                         ["1.1", "25.1", "1.2", "1000.1"])
+                         ["1.1", "25.1", "1.2", "1000.1", "1001.1"])
         self.assertEqual(self.sfh5["1.2"].attrs,
                          {"NX_class": "NXentry", })
 
@@ -495,7 +501,7 @@ class TestSpecH5(unittest.TestCase):
         self.sfh5.visit(name_list.append)
         self.assertIn('1.2/instrument/positioners/Pslit HGap', name_list)
         self.assertIn("1.2/instrument/specfile/scan_header", name_list)
-        self.assertEqual(len(name_list), 100)  #, "actual name list: %s" % "\n".join(name_list))
+        self.assertEqual(len(name_list), 117)
 
         # test also visit of a subgroup, with various group name formats
         name_list_leading_and_trailing_slash = []
@@ -529,7 +535,7 @@ class TestSpecH5(unittest.TestCase):
 
         self.sfh5.visititems(func_generator(dataset_name_list))
         self.assertIn('1.2/instrument/positioners/Pslit HGap', dataset_name_list)
-        self.assertEqual(len(dataset_name_list), 73)
+        self.assertEqual(len(dataset_name_list), 85)
 
         # test also visit of a subgroup, with various group name formats
         name_list_leading_and_trailing_slash = []
@@ -565,6 +571,11 @@ class TestSpecH5(unittest.TestCase):
         self.assertIn("unit_cell_abc", self.sfh5["/1000.1/sample"])
         self.assertIn("unit_cell_alphabetagamma", self.sfh5["/1000.1/sample"])
 
+        # All 0 values
+        self.assertNotIn("sample", self.sfh5["/1001.1"])
+        with self.assertRaises(KeyError):
+            uc = self.sfh5["/1001.1/sample/unit_cell"]
+
     def testOpenFileDescriptor(self):
         """Open a SpecH5 file from a file descriptor"""
         with io.open(self.sfh5.filename) as f:
@@ -573,6 +584,7 @@ class TestSpecH5(unittest.TestCase):
             name_list = []
             # check if the object is working
             self.sfh5.visit(name_list.append)
+
 
 sftext_multi_mca_headers = """
 #S 1 aaaaaa


### PR DESCRIPTION
Don't create  `sample/unit_cell*` datasets if all values are 0 in G1 header line.

Don't create  `sample/ub_matrix` dataset  if all values are 0 in G3 header line.

Don't create `sample` group if both  UB matrix and unit cell are all zeros.

Closes #899 .