### PR TITLE
[test] Create test app

### DIFF
--- a/silx/__main__.py
+++ b/silx/__main__.py
@@ -32,7 +32,7 @@ Your environment should provide a command `silx`. You can reach help with
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "18/04/2017"
+__date__ = "29/06/2017"
 
 
 import logging
@@ -56,6 +56,9 @@ def main():
     launcher.add_command("view",
                          module_name="silx.app.view",
                          description="Browse a data file with a GUI")
+    launcher.add_command("test",
+                         module_name="silx.app.test_",
+                         description="Launch silx unittest")
     status = launcher.execute(sys.argv)
     return status
 

--- a/silx/app/test_.py
+++ b/silx/app/test_.py
@@ -62,6 +62,17 @@ _logger = logging.getLogger(__name__)
 """Module logger"""
 
 
+class TextTestResultWithSkipList(unittest.TextTestResult):
+    """Override default TextTestResult to display list of skipped tests at the
+    end
+    """
+
+    def printErrors(self):
+        unittest.TextTestResult.printErrors(self)
+        # Print skipped tests at the end
+        self.printErrorList("SKIPPED", self.skipped)
+
+
 def main(argv):
     """
     Main function to launch the unittests as an application
@@ -146,14 +157,8 @@ def main(argv):
     test_suite.addTest(silx.test.suite())
     result = runner.run(test_suite)
 
-    for test, reason in result.skipped:
-        description = test.shortDescription() or ''
-        _logger.warning('Skipped %s (%s): %s', test.id(), description, reason)
-
     if result.wasSuccessful():
-        _logger.info("Test suite succeeded")
         exit_status = 0
     else:
-        _logger.warning("Test suite failed")
         exit_status = 1
     return exit_status

--- a/silx/app/test_.py
+++ b/silx/app/test_.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "02/08/2017"
+__date__ = "04/08/2017"
 
 import sys
 import os
@@ -53,10 +53,20 @@ class StreamHandlerUnittestReady(logging.StreamHandler):
         pass
 
 
+def createBasicHandler():
+    """Create the handler using the basic configuration"""
+    hdlr = StreamHandlerUnittestReady()
+    fs = logging.BASIC_FORMAT
+    dfs = None
+    fmt = logging.Formatter(fs, dfs)
+    hdlr.setFormatter(fmt)
+    return hdlr
+
+
 # Use an handler compatible with unittests, else use_buffer is not working
 for h in logging.root.handlers:
     logging.root.removeHandler(h)
-logging.root.addHandler(StreamHandlerUnittestReady())
+logging.root.addHandler(createBasicHandler())
 logging.captureWarnings(True)
 
 _logger = logging.getLogger(__name__)

--- a/silx/app/test_.py
+++ b/silx/app/test_.py
@@ -57,6 +57,7 @@ class StreamHandlerUnittestReady(logging.StreamHandler):
 for h in logging.root.handlers:
     logging.root.removeHandler(h)
 logging.root.addHandler(StreamHandlerUnittestReady())
+logging.captureWarnings(True)
 
 _logger = logging.getLogger(__name__)
 """Module logger"""

--- a/silx/app/test_.py
+++ b/silx/app/test_.py
@@ -1,0 +1,127 @@
+# coding: utf-8
+# /*##########################################################################
+# Copyright (C) 2016 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+"""Launch unittests of the library"""
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "02/08/2017"
+
+import sys
+import os
+import argparse
+import logging
+import unittest
+
+_logger = logging.getLogger(__name__)
+"""Module logger"""
+
+
+def main(argv):
+    """
+    Main function to launch the unittests as an application
+
+    :param argv: Command line arguments
+    :returns: exit status
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-v", "--verbose", default=0,
+                        action="count", dest="verbose",
+                        help="Increase verbosity. Option -v prints additional " +
+                             "INFO messages. Use -vv for full verbosity, " +
+                             "including debug messages and test help strings.")
+    parser.add_argument("-x", "--no-gui", dest="gui", default=True,
+                        action="store_false",
+                        help="Disable the test of the graphical use interface")
+    parser.add_argument("-g", "--no-opengl", dest="opengl", default=True,
+                        action="store_false",
+                        help="Disable tests using OpenGL")
+    parser.add_argument("-o", "--no-opencl", dest="opencl", default=True,
+                        action="store_false",
+                        help="Disable the test of the OpenCL part")
+    parser.add_argument("-l", "--low-mem", dest="low_mem", default=False,
+                        action="store_true",
+                        help="Disable test with large memory consumption (>100Mbyte")
+    parser.add_argument("--qt-binding", dest="qt_binding", default=None,
+                        help="Force using a Qt binding, from 'PyQt4', 'PyQt5', or 'PySide'")
+
+    options = parser.parse_args(argv[1:])
+
+    test_verbosity = 1
+    if options.verbose == 1:
+        logging.root.setLevel(logging.INFO)
+        _logger.info("Set log level: INFO")
+        test_verbosity = 2
+    elif options.verbose > 1:
+        logging.root.setLevel(logging.DEBUG)
+        _logger.info("Set log level: DEBUG")
+        test_verbosity = 2
+
+    if not options.gui:
+        os.environ["WITH_QT_TEST"] = "False"
+
+    if not options.opencl:
+        os.environ["SILX_OPENCL"] = "False"
+
+    if not options.opengl:
+        os.environ["WITH_GL_TEST"] = "False"
+
+    if options.low_mem:
+        os.environ["SILX_TEST_LOW_MEM"] = "True"
+
+    if options.qt_binding:
+        binding = options.qt_binding.lower()
+        if binding == "pyqt4":
+            _logger.info("Force using PyQt4")
+            import PyQt4.QtCore  # noqa
+        elif binding == "pyqt5":
+            _logger.info("Force using PyQt5")
+            import PyQt5.QtCore  # noqa
+        elif binding == "pyside":
+            _logger.info("Force using PySide")
+            import PySide.QtCore  # noqa
+        else:
+            raise ValueError("Qt binding '%s' is unknown" % options.qt_binding)
+
+    # Run the tests
+    runnerArgs = {}
+    runnerArgs["verbosity"] = test_verbosity
+    runner = unittest.TextTestRunner(**runnerArgs)
+
+    test_suite = unittest.TestSuite()
+
+    import silx.test
+    test_suite.addTest(silx.test.suite())
+    result = runner.run(test_suite)
+
+    for test, reason in result.skipped:
+        description = test.shortDescription() or ''
+        _logger.warning('Skipped %s (%s): %s', test.id(), description, reason)
+
+    if result.wasSuccessful():
+        _logger.info("Test suite succeeded")
+        exit_status = 0
+    else:
+        _logger.warning("Test suite failed")
+        exit_status = 1
+    return exit_status

--- a/silx/app/test_.py
+++ b/silx/app/test_.py
@@ -136,6 +136,10 @@ def main(argv):
     runnerArgs["verbosity"] = test_verbosity
     runnerArgs["buffer"] = use_buffer
     runner = unittest.TextTestRunner(**runnerArgs)
+    runner.resultclass = TextTestResultWithSkipList
+
+    # Display the result when using CTRL-C
+    unittest.installHandler()
 
     import silx.test
     test_suite = unittest.TestSuite()


### PR DESCRIPTION
- Create `silx test` app
    - Reuse only few command lines from run_tests
    - CTRL-C cancel tests but display the current result
    - Skipped tests are displayed like other output ERROR/FAILED
    - Reduce logs by using unittest buffer
        - By default nothing is displayed (but `.EFs`) all informations of fails and errors will be displayed at the end (with associated log and stdout)
       - `-v` displays for each tests the name then log and stdout
       - `-vv` displays for each tests the name then log (with debug level) and stdout


```
> silx test --help
usage: silx test [-h] [-v] [-x] [-g] [-o] [-l] [--qt-binding QT_BINDING]
                 [test_name [test_name ...]]

Launch unittests of the library

optional arguments:
  -h, --help            show this help message and exit
  -v, --verbose         Increase verbosity. Option -v prints additional INFO
                        messages. Use -vv for full verbosity, including debug
                        messages and test help strings.
  -x, --no-gui          Disable the test of the graphical use interface
  -g, --no-opengl       Disable tests using OpenGL
  -o, --no-opencl       Disable the test of the OpenCL part
  -l, --low-mem         Disable test with large memory consumption (>100Mbyte
  --qt-binding QT_BINDING
                        Force using a Qt binding, from 'PyQt4', 'PyQt5', or
                        'PySide'
```

```
> silx test
Start Xvfb
feature module is not available to compare results with C++ implementation. Matching cannot be tested.
OpenGL-based widget disabled:
OpenGL not available
...................................................................................................................
...................................................................................................................
..............s...................................................................................................
.....................................s............................................................................
...................................................................................................................
...................................................................................................................
...................................................................................................................
...................................................................................................................
......................................................
----------------------------------------------------------------------
Ran 972 tests in 90.097s

OK (skipped=2)
Skipped silx.gui.data.test.test_dataviewer.TestDataView.testCubeWithComplex (): OpenGL widget not yet tested
Skipped silx.io.test.test_specfile.TestSFLocale.test_locale_de_DE (): de_DE.utf8 locale not installed
Test suite succeeded
python: Fatal IO error 11 (Resource temporarily unavailable) on X server :1974.
```
As you can see Xvfb crashes at the end. `$? == 1`. But i think it is not a big problem here.

```
> silx test -v
QTest.qWaitForWindowExposed not available,using QTest.qWaitForWindowShown instead.
feature module is not available to compare results with C++ implementation. Matching cannot be tested.
Xlib:  extension "RANDR" missing on display ":2066".
No OpenGL_accelerate module loaded: No module named OpenGL_accelerate
Unable to load registered array format handler numeric:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/OpenGL/arrays/formathandler.py", line 35, in loadPlugin
    plugin_class = entrypoint.load()
  File "/usr/lib/python2.7/dist-packages/OpenGL/plugins.py", line 14, in load
    return importByName( self.import_path )
  File "/usr/lib/python2.7/dist-packages/OpenGL/plugins.py", line 28, in importByName
    module = __import__( ".".join(moduleName), {}, {}, moduleName)
  File "/usr/lib/python2.7/dist-packages/OpenGL/arrays/numeric.py", line 15, in <module>
    raise ImportError( """No Numeric module present: %s"""%(err))
ImportError: No Numeric module present: No module named Numeric

Unable to load registered array format handler vbo:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/OpenGL/arrays/formathandler.py", line 35, in loadPlugin
    plugin_class = entrypoint.load()
  File "/usr/lib/python2.7/dist-packages/OpenGL/plugins.py", line 14, in load
    return importByName( self.import_path )
  File "/usr/lib/python2.7/dist-packages/OpenGL/plugins.py", line 28, in importByName
    module = __import__( ".".join(moduleName), {}, {}, moduleName)
  File "/usr/lib/python2.7/dist-packages/OpenGL/arrays/vbo.py", line 33, in <module>
    from OpenGL import GL
ImportError: cannot import name GL

Unable to load registered array format handler vbooffset:
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/OpenGL/arrays/formathandler.py", line 35, in loadPlugin
    plugin_class = entrypoint.load()
  File "/usr/lib/python2.7/dist-packages/OpenGL/plugins.py", line 14, in load
    return importByName( self.import_path )
  File "/usr/lib/python2.7/dist-packages/OpenGL/plugins.py", line 28, in importByName
    module = __import__( ".".join(moduleName), {}, {}, moduleName)
  File "/usr/lib/python2.7/dist-packages/OpenGL/arrays/vbo.py", line 33, in <module>
    from OpenGL import GL
ImportError: cannot import name GL

Xlib:  extension "GLX" missing on display ":2066".
Xlib:  extension "GLX" missing on display ":2066".
OpenGL-based widget disabled:
OpenGL not available
Using QLabel
test_imshow (silx.test.test_sx.SXTest)
Test imshow function ... Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 0: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
ok
test_plot (silx.test.test_sx.SXTest)
Test plot function ... Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
ok
testQObject (silx.gui.test.test_qt.TestQtWrapper)
Test that QObject is there. ... ok
testLoadUi (silx.gui.test.test_qt.TestLoadUi)
Create a QMainWindow from an ui file ... ok
testNiceNumbers (silx.gui.plot._utils.test.test_ticklayout.TestTickLayout)
Minimalistic tests of :func:`niceNumbers` ... ok
testNiceNumbersLog (silx.gui.plot._utils.test.test_ticklayout.TestTickLayout)
Minimalistic tests of :func:`niceNumbersForLog10` ... ok
testNoColormap (silx.gui.plot.test.testColorBar.TestColorScale)
Test _ColorScale without a colormap ... ok
testRelativePositionLinear (silx.gui.plot.test.testColorBar.TestColorScale) ... ok
testRelativePositionLog (silx.gui.plot.test.testColorBar.TestColorScale) ... ok
testLinearNormNoAutoscale (silx.gui.plot.test.testColorBar.TestNoAutoscale) ... Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
ok
testLogNormNoAutoscale (silx.gui.plot.test.testColorBar.TestNoAutoscale) ... Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
ok
testColormapWithoutRange (silx.gui.plot.test.testColorBar.TestColorBarWidget)
Test with a colormap with vmin==vmax ... Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
ok
testEmptyColorBar (silx.gui.plot.test.testColorBar.TestColorBarWidget) ... Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
ok
testNegativeColormaps (silx.gui.plot.test.testColorBar.TestColorBarWidget)
test the behavior of the ColorBarWidget in the case of negative ... Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 0: changing bounds.
Log colormap with bound <= 0: changing bounds.
Log colormap with negative bounds, changing bounds to positive ones.
ok
testPlotAssocation (silx.gui.plot.test.testColorBar.TestColorBarWidget)
Make sure the ColorBarWidget is properly connected to the plot ... Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
ok
testRGBA (silx.gui.plot.test.testColors.TestRGBA)
"Test rgba function with accepted values ... ok
testApplyColormapToData (silx.gui.plot.test.testColors.TestApplyColormapToData)
Simple test of applyColormapToData function ... ok
ColormapDialog (silx.gui.plot)
Doctest: silx.gui.plot.ColormapDialog ... /usr/lib/python2.7/dist-packages/matplotlib/collections.py:571: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
  if self._edgecolors == str('face'):
ok
testCalculation (silx.gui.plot.test.testCurvesROIWidget.TestCurvesROIWidget) ... Log colormap with bound <= 1: changing bounds.
ok
testEmptyPlot (silx.gui.plot.test.testCurvesROIWidget.TestCurvesROIWidget)
Empty plot, display ROI widget ... Log colormap with bound <= 1: changing bounds.
ok
testWithCurves (silx.gui.plot.test.testCurvesROIWidget.TestCurvesROIWidget)
Plot with curves: test all ROI widget buttons ... Log colormap with bound <= 1: changing bounds.
ok
testGetAlpha (silx.gui.plot.test.testAlphaSlider.TestActiveImageAlphaSlider) ... ok
testGetImage (silx.gui.plot.test.testAlphaSlider.TestActiveImageAlphaSlider) ... ok
testWidgetEnabled (silx.gui.plot.test.testAlphaSlider.TestActiveImageAlphaSlider) ... ok
testGetAlpha (silx.gui.plot.test.testAlphaSlider.TestNamedImageAlphaSlider) ... ok
testGetImage (silx.gui.plot.test.testAlphaSlider.TestNamedImageAlphaSlider) ... ok
testWidgetEnabled (silx.gui.plot.test.testAlphaSlider.TestNamedImageAlphaSlider) ... ok
testGetAlpha (silx.gui.plot.test.testAlphaSlider.TestNamedScatterAlphaSlider) ... /usr/lib/python2.7/dist-packages/matplotlib/collections.py:631: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
  if self._edgecolors_original != str('face'):
ok
testGetScatter (silx.gui.plot.test.testAlphaSlider.TestNamedScatterAlphaSlider) ... ok
testWidgetEnabled (silx.gui.plot.test.testAlphaSlider.TestNamedScatterAlphaSlider) ... ok
testClickOrDrag (silx.gui.plot.test.testInteraction.TestInteraction)
Minimalistic test for click or drag state machine. ... ok
testLegendSelector (silx.gui.plot.test.testLegendSelector.TestLegendSelector)
Test copied from __main__ of LegendSelector in PyMca ... ok
testDialog (silx.gui.plot.test.testLegendSelector.TestRenameCurveDialog)
Create dialog, change name and press OK ... ok
testEmptyPlot (silx.gui.plot.test.testMaskToolsWidget.TestMaskToolsWidget)
Empty plot, display MaskToolsDockWidget, toggle multiple masks ... Log colormap with bound <= 1: changing bounds.
ok
testLoadSaveFit2D (silx.gui.plot.test.testMaskToolsWidget.TestMaskToolsWidget) ... Log colormap with bound <= 1: changing bounds.
ok
testLoadSaveNpy (silx.gui.plot.test.testMaskToolsWidget.TestMaskToolsWidget) ... Log colormap with bound <= 1: changing bounds.
ok
testSigMaskChangedEmitted (silx.gui.plot.test.testMaskToolsWidget.TestMaskToolsWidget) ... Log colormap with bound <= 1: changing bounds.
ok
testWithAnImage (silx.gui.plot.test.testMaskToolsWidget.TestMaskToolsWidget)
Plot with an image: test MaskToolsWidget interactions ... Log colormap with bound <= 1: changing bounds.
ok
testEmptyPlot (silx.gui.plot.test.testScatterMaskToolsWidget.TestScatterMaskToolsWidget)
Empty plot, display MaskToolsDockWidget, toggle multiple masks ... Log colormap with bound <= 1: changing bounds.
ok
testLoadSaveCsv (silx.gui.plot.test.testScatterMaskToolsWidget.TestScatterMaskToolsWidget) ... Log colormap with bound <= 1: changing bounds.
ok
testLoadSaveNpy (silx.gui.plot.test.testScatterMaskToolsWidget.TestScatterMaskToolsWidget) ... Log colormap with bound <= 1: changing bounds.
ok
testSigMaskChangedEmitted (silx.gui.plot.test.testScatterMaskToolsWidget.TestScatterMaskToolsWidget) ... Log colormap with bound <= 1: changing bounds.
ok
testWithAScatter (silx.gui.plot.test.testScatterMaskToolsWidget.TestScatterMaskToolsWidget)
Plot with a Scatter: test MaskToolsWidget interactions ... Log colormap with bound <= 1: changing bounds.
ok
test (silx.gui.plot.test.testPlotInteraction.TestSelectPolygon)
Test draw polygons + events ... ok
testAddNoRemove (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlot)
add objects to the Plot ... PlotWidget backend does not support widget
ok
testPlotTitleLabels (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlot)
Create a Plot and set the labels ... PlotWidget backend does not support widget
ok
testDataRangeCurveImage (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotRanges)
right+left+image axis range ... PlotWidget backend does not support widget
ok
testDataRangeHiddenCurve (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotRanges)
curves with a hidden curve ... PlotWidget backend does not support widget
ok
testDataRangeImage (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotRanges)
image data range ... PlotWidget backend does not support widget
ok
testDataRangeImageNegativeScaleX (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotRanges)
image data range, negative scale ... PlotWidget backend does not support widget
ok
testDataRangeImageNegativeScaleY (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotRanges)
image data range, negative scale ... PlotWidget backend does not support widget
ok
testDataRangeLeft (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotRanges)
left axis range ... PlotWidget backend does not support widget
ok
testDataRangeLeftRight (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotRanges)
right+left axis range ... PlotWidget backend does not support widget
ok
testDataRangeNoPlot (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotRanges)
empty plot data range ... PlotWidget backend does not support widget
ok
testDataRangeRight (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotRanges)
right axis range ... PlotWidget backend does not support widget
ok
testGetAllImages (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotGetCurveImage)
PlotWidget.getAllImages test ... PlotWidget backend does not support widget
ok
testGetCurve (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotGetCurveImage)
PlotWidget.getCurve and Plot.getActiveCurve tests ... PlotWidget backend does not support widget
ok
testGetCurveOldApi (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotGetCurveImage)
old API PlotWidget.getCurve and Plot.getActiveCurve tests ... PlotWidget backend does not support widget
ok
testGetImage (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotGetCurveImage)
PlotWidget.getImage and PlotWidget.getActiveImage tests ... PlotWidget backend does not support widget
ok
testGetImageOldApi (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotGetCurveImage)
PlotWidget.getImage and PlotWidget.getActiveImage old API tests ... PlotWidget backend does not support widget
ok
testEdges (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotHistogram) ... ok
testHistogramCurve (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotHistogram) ... ok
testAddGetScatter (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotAddScatter) ... PlotWidget backend does not support widget
ok
testGetAllScatters (silx.gui.plot.test.testPlotWidgetNoBackend.TestPlotAddScatter)
PlotWidget.getAllImages test ... PlotWidget backend does not support widget
ok
testCustomConverters (silx.gui.plot.test.testPlotTools.TestPositionInfo)
Test PositionInfo with custom converters ... Log colormap with bound <= 1: changing bounds.
ok
testDefaultConverters (silx.gui.plot.test.testPlotTools.TestPositionInfo)
Test PositionInfo with default converters ... Log colormap with bound <= 1: changing bounds.
ok
testFailingConverters (silx.gui.plot.test.testPlotTools.TestPositionInfo)
Test PositionInfo with failing custom converters ... Log colormap with bound <= 1: changing bounds.
ok
testImageFormatInput (silx.gui.plot.test.testPlotTools.TestPixelIntensitiesHisto)
Test multiple type as image input ... Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
ok
testShowAndHide (silx.gui.plot.test.testPlotTools.TestPixelIntensitiesHisto)
Simple test that the plot is showing and hiding when activating the ... Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
Log colormap with bound <= 1: changing bounds.
ok
testChangeLimitsWithAspectRatio (silx.gui.plot.test.testPlotWidget.TestPlotWidget) ... ok
testSetTitleLabels (silx.gui.plot.test.testPlotWidget.TestPlotWidget)
Set title and axes labels ... ok
testShow (silx.gui.plot.test.testPlotWidget.TestPlotWidget)
Most basic test ... ok
testImageOriginScale (silx.gui.plot.test.testPlotWidget.TestPlotImage)
Test of image with different origin and scale ... ok
testPlotColormapCustom (silx.gui.plot.test.testPlotWidget.TestPlotImage) ... ok
testPlotColormapGray (silx.gui.plot.test.testPlotWidget.TestPlotImage) ... ok
testPlotColormapTemperature (silx.gui.plot.test.testPlotWidget.TestPlotImage) ... ok
testPlotColormapTemperatureLog (silx.gui.plot.test.testPlotWidget.TestPlotImage) ... ok
testPlotRgbRgba (silx.gui.plot.test.testPlotWidget.TestPlotImage) ... ok
testPlotCurveColorByte (silx.gui.plot.test.testPlotWidget.TestPlotCurve) ... ok
testPlotCurveColorFloat (silx.gui.plot.test.testPlotWidget.TestPlotCurve) ... ok
testPlotCurveColors (silx.gui.plot.test.testPlotWidget.TestPlotCurve) ... ok
testPlotMarkerPt (silx.gui.plot.test.testPlotWidget.TestPlotMarker) ... ok
testPlotMarkerWithoutLegend (silx.gui.plot.test.testPlotWidget.TestPlotMarker) ... ok
testPlotMarkerX (silx.gui.plot.test.testPlotWidget.TestPlotMarker) ... ok
testPlotMarkerY (silx.gui.plot.test.testPlotWidget.TestPlotMarker) ... ok
testPlotItemPolygonFill (silx.gui.plot.test.testPlotWidget.TestPlotItem) ... ok
testPlotItemPolygonNoFill (silx.gui.plot.test.testPlotWidget.TestPlotItem) ... ok
testPlotItemRectangleFill (silx.gui.plot.test.testPlotWidget.TestPlotItem) ... ok
testPlotItemRectangleNoFill (silx.gui.plot.test.testPlotWidget.TestPlotItem) ... ok
testEmptyPlotTitleLabelsLog (silx.gui.plot.test.testPlotWidget.TestPlotEmptyLog) ... ok
testPlotCurveErrorLogXY (silx.gui.plot.test.testPlotWidget.TestPlotCurveLog) ... ok
testPlotCurveLogX (silx.gui.plot.test.testPlotWidget.TestPlotCurveLog) ... ok
testPlotCurveLogXY (silx.gui.plot.test.testPlotWidget.TestPlotCurveLog) ... ok
testPlotCurveLogY (silx.gui.plot.test.testPlotWidget.TestPlotCurveLog) ... ok
testPlotCurveToggleLog (silx.gui.plot.test.testPlotWidget.TestPlotCurveLog)
Add a curve with negative data and toggle log axis ... /usr/lib/python2.7/dist-packages/matplotlib/scale.py:100: RuntimeWarning: invalid value encountered in less_equal
  a[a <= 0.0] = 1e-300
/workspace/valls/silx.git/build/lib.linux-x86_64-2.7/silx/gui/plot/items/core.py:714: RuntimeWarning: All-NaN axis encountered
  numpy.nanmin(x),
/workspace/valls/silx.git/build/lib.linux-x86_64-2.7/silx/gui/plot/items/core.py:715: RuntimeWarning: All-NaN slice encountered
  numpy.nanmax(x),
/workspace/valls/silx.git/build/lib.linux-x86_64-2.7/silx/gui/plot/items/core.py:716: RuntimeWarning: All-NaN axis encountered
  numpy.nanmin(y),
/workspace/valls/silx.git/build/lib.linux-x86_64-2.7/silx/gui/plot/items/core.py:717: RuntimeWarning: All-NaN slice encountered
  numpy.nanmax(y)
/workspace/valls/silx.git/build/lib.linux-x86_64-2.7/silx/gui/plot/PlotWidget.py:520: RuntimeWarning: All-NaN axis encountered
  xMin = numpy.nanmin([xMin, bounds[0]])
/workspace/valls/silx.git/build/lib.linux-x86_64-2.7/silx/gui/plot/PlotWidget.py:521: RuntimeWarning: All-NaN axis encountered
  xMax = numpy.nanmax([xMax, bounds[1]])
/workspace/valls/silx.git/build/lib.linux-x86_64-2.7/silx/gui/plot/PlotWidget.py:528: RuntimeWarning: All-NaN axis encountered
  yMinLeft = numpy.nanmin([yMinLeft, bounds[2]])
/workspace/valls/silx.git/build/lib.linux-x86_64-2.7/silx/gui/plot/PlotWidget.py:529: RuntimeWarning: All-NaN axis encountered
  yMaxLeft = numpy.nanmax([yMaxLeft, bounds[3]])
ok
testPlotColormapGrayLogX (silx.gui.plot.test.testPlotWidget.TestPlotImageLog) ... ok
testPlotColormapGrayLogXY (silx.gui.plot.test.testPlotWidget.TestPlotImageLog) ... ok
testPlotColormapGrayLogY (silx.gui.plot.test.testPlotWidget.TestPlotImageLog) ... ok
testPlotRgbRgbaLogXY (silx.gui.plot.test.testPlotWidget.TestPlotImageLog) ... ok
testPlotMarkerPtLog (silx.gui.plot.test.testPlotWidget.TestPlotMarkerLog) ... ok
testPlotMarkerXLog (silx.gui.plot.test.testPlotWidget.TestPlotMarkerLog) ... ok
testPlotMarkerYLog (silx.gui.plot.test.testPlotWidget.TestPlotMarkerLog) ... ok
testPlotItemPolygonLogFill (silx.gui.plot.test.testPlotWidget.TestPlotItemLog) ... ok
testPlotItemPolygonLogNoFill (silx.gui.plot.test.testPlotWidget.TestPlotItemLog) ... ok
testPlotItemRectangleLogFill (silx.gui.plot.test.testPlotWidget.TestPlotItemLog) ... ok
testPlotItemRectangleLogNoFill (silx.gui.plot.test.testPlotWidget.TestPlotItemLog) ... ok

... i removed some logs...

Calculating octave 7
Octave 7 scale 0 blur with sigma 1.22627349847
Octave 7 scale 1 blur with sigma 1.54500779364
Octave 7 scale 2 blur with sigma 1.94658784146
Octave 7 scale 3 blur with sigma 2.45254699693
Octave 7 scale 4 blur with sigma 3.09001558729
Compact 0 -> 0 / 900000
Compact 0 -> 0 / 900000
Compact 0 -> 0 / 900000
in octave 7 found 0 kp
Execution time: 197.247ms
[[  5.09644653e-01]
 [  6.93721695e-01]
 [ -4.04438903e+02]
 [ -7.40845963e-01]
 [  9.96513237e-01]
 [  1.17361511e+03]]
Max error: 255.000000 at (1446, 1315)
minimal MSE according to least squares : 19.647030
Global execution time: CPU 358.482ms, GPU: 17.806ms.
Transformation took 5.208ms
ok

----------------------------------------------------------------------
Ran 972 tests in 91.654s

OK (skipped=2)
Skipped silx.gui.data.test.test_dataviewer.TestDataView.testCubeWithComplex (): OpenGL widget not yet tested
Skipped silx.io.test.test_specfile.TestSFLocale.test_locale_de_DE (): de_DE.utf8 locale not installed
Test suite succeeded
python: Fatal IO error 11 (Resource temporarily unavailable) on X server :2066.
```

```
> silx test -vv # this one will also display debug logs
```