### PR TITLE
[TableWidget] copy single cell action

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -27,11 +27,11 @@ environment:
     matrix:
         # Python 3.6
         - PYTHON_DIR: "C:\\Python36-x64"
-          QT_BINDINGS: "PyQt5"
+          QT_BINDINGS: "PyQt5==5.8.2"
   
         # Python 3.5
         - PYTHON_DIR: "C:\\Python35-x64"
-          QT_BINDINGS: "PyQt5"
+          QT_BINDINGS: "PyQt5==5.8.2"
 
         # Python 2.7
         - PYTHON_DIR: "C:\\Python27-x64"

--- a/silx/gui/widgets/TableWidget.py
+++ b/silx/gui/widgets/TableWidget.py
@@ -448,19 +448,25 @@ class TableWidget(qt.QTableWidget):
         """
         if mode == qt.QTableView.NoSelection:
             self.copySelectedCellsAction.setVisible(False)
+            self.copySelectedCellsAction.setEnabled(False)
             if self.cutSelectedCellsAction is not None:
                 self.cutSelectedCellsAction.setVisible(False)
+                self.cutSelectedCellsAction.setEnabled(False)
             if self.copySingleCellAction is None:
                 self.copySingleCellAction = CopySingleCellAction(self)
                 self.insertAction(self.copySelectedCellsAction,  # before first action
                                   self.copySingleCellAction)
             self.copySingleCellAction.setVisible(True)
+            self.copySingleCellAction.setEnabled(True)
         else:
             self.copySelectedCellsAction.setVisible(True)
+            self.copySelectedCellsAction.setEnabled(True)
             if self.cutSelectedCellsAction is not None:
                 self.cutSelectedCellsAction.setVisible(True)
+                self.cutSelectedCellsAction.setEnabled(True)
             if self.copySingleCellAction is not None:
                 self.copySingleCellAction.setVisible(False)
+                self.copySingleCellAction.setEnabled(False)
         super(TableWidget, self).setSelectionMode(mode)
 
 
@@ -572,19 +578,25 @@ class TableView(qt.QTableView):
         """
         if mode == qt.QTableView.NoSelection:
             self.copySelectedCellsAction.setVisible(False)
+            self.copySelectedCellsAction.setEnabled(False)
             if self.cutSelectedCellsAction is not None:
                 self.cutSelectedCellsAction.setVisible(False)
+                self.cutSelectedCellsAction.setEnabled(False)
             if self.copySingleCellAction is None:
                 self.copySingleCellAction = CopySingleCellAction(self)
                 self.insertAction(self.copySelectedCellsAction,  # before first action
                                   self.copySingleCellAction)
             self.copySingleCellAction.setVisible(True)
+            self.copySingleCellAction.setEnabled(True)
         else:
             self.copySelectedCellsAction.setVisible(True)
+            self.copySelectedCellsAction.setEnabled(True)
             if self.cutSelectedCellsAction is not None:
                 self.cutSelectedCellsAction.setVisible(True)
+                self.cutSelectedCellsAction.setEnabled(True)
             if self.copySingleCellAction is not None:
                 self.copySingleCellAction.setVisible(False)
+                self.copySingleCellAction.setEnabled(False)
         super(TableView, self).setSelectionMode(mode)
 
 

--- a/silx/gui/widgets/TableWidget.py
+++ b/silx/gui/widgets/TableWidget.py
@@ -411,7 +411,8 @@ class TableWidget(qt.QTableWidget):
 
     def mousePressEvent(self, event):
         item = self.itemAt(event.pos())
-        self._text_last_cell_clicked = item.text()
+        if item is not None:
+            self._text_last_cell_clicked = item.text()
         super(TableWidget, self).mousePressEvent(event)
 
     def enablePaste(self):

--- a/silx/gui/widgets/TableWidget.py
+++ b/silx/gui/widgets/TableWidget.py
@@ -456,7 +456,8 @@ class TableWidget(qt.QTableWidget):
                 self.cutSelectedCellsAction.setVisible(False)
             if self.copySingleCellAction is None:
                 self.copySingleCellAction = CopySingleCellAction(self)
-                self.addAction(self.copySingleCellAction)
+                self.insertAction(self.copySelectedCellsAction,  # before first action
+                                  self.copySingleCellAction)
             self.copySingleCellAction.setVisible(True)
         else:
             self.copySelectedCellsAction.setVisible(True)
@@ -577,7 +578,8 @@ class TableView(qt.QTableView):
                 self.cutSelectedCellsAction.setVisible(False)
             if self.copySingleCellAction is None:
                 self.copySingleCellAction = CopySingleCellAction(self)
-                self.addAction(self.copySingleCellAction)
+                self.insertAction(self.copySelectedCellsAction,  # before first action
+                                  self.copySingleCellAction)
             self.copySingleCellAction.setVisible(True)
         else:
             self.copySelectedCellsAction.setVisible(True)

--- a/silx/gui/widgets/TableWidget.py
+++ b/silx/gui/widgets/TableWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2016 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -50,7 +50,7 @@ creating the widgets, or later by calling their :meth:`enableCut` and
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "26/01/2017"
+__date__ = "03/07/2017"
 
 
 import sys
@@ -356,8 +356,13 @@ class TableWidget(qt.QTableWidget):
     """
     def __init__(self, parent=None, cut=False, paste=False):
         super(TableWidget, self).__init__(parent)
-        self.addAction(CopySelectedCellsAction(self))
-        self.addAction(CopyAllCellsAction(self))
+        self.copySelectedCellsAction = CopySelectedCellsAction(self)
+        self.copyAllCellsAction = CopyAllCellsAction(self)
+        self.pasteCellsAction = None
+        self.cutSelectedCellsAction = None
+        self.cutAllCellsAction = None
+        self.addAction(self.copySelectedCellsAction)
+        self.addAction(self.copyAllCellsAction)
         if cut:
             self.enableCut()
         if paste:
@@ -374,7 +379,8 @@ class TableWidget(qt.QTableWidget):
             This action can cause data to be overwritten.
             There is currently no *Undo* action to retrieve lost data.
         """
-        self.addAction(PasteCellsAction(self))
+        self.pasteCellsAction = PasteCellsAction(self)
+        self.addAction(self.pasteCellsAction)
 
     def enableCut(self):
         """Enable cut action.
@@ -383,8 +389,27 @@ class TableWidget(qt.QTableWidget):
 
             This action can cause data to be deleted.
             There is currently no *Undo* action to retrieve lost data."""
-        self.addAction(CutSelectedCellsAction(self))
-        self.addAction(CutAllCellsAction(self))
+        self.cutSelectedCellsAction = CutSelectedCellsAction(self)
+        self.cutAllCellsAction = CutAllCellsAction(self)
+        self.addAction(self.cutSelectedCellsAction)
+        self.addAction(self.cutAllCellsAction)
+
+    def setSelectionMode(self, mode):
+        """Overloaded from QTableWidget to disable cut/copy selection
+        actions in case mode is NoSelection
+
+        :param mode:
+        :return:
+        """
+        if mode == qt.QTableView.NoSelection:
+            self.copySelectedCellsAction.setEnabled(False)
+            if self.cutSelectedCellsAction is not None:
+                self.cutSelectedCellsAction.setEnabled(False)
+        else:
+            self.copySelectedCellsAction.setEnabled(True)
+            if self.cutSelectedCellsAction is not None:
+                self.cutSelectedCellsAction.setEnabled(True)
+        super(TableWidget, self).setSelectionMode(mode)
 
 
 class TableView(qt.QTableView):
@@ -417,6 +442,12 @@ class TableView(qt.QTableView):
         self.cut = cut
         self.paste = paste
 
+        self.copySelectedCellsAction = None
+        self.copyAllCellsAction = None
+        self.pasteCellsAction = None
+        self.cutSelectedCellsAction = None
+        self.cutAllCellsAction = None
+
     def setModel(self, model):
         """Set the data model for the table view, activate the actions
         and the context menu.
@@ -425,8 +456,10 @@ class TableView(qt.QTableView):
         """
         super(TableView, self).setModel(model)
 
-        self.addAction(CopySelectedCellsAction(self))
-        self.addAction(CopyAllCellsAction(self))
+        self.copySelectedCellsAction = CopySelectedCellsAction(self)
+        self.copyAllCellsAction = CopyAllCellsAction(self)
+        self.addAction(self.copySelectedCellsAction)
+        self.addAction(self.copyAllCellsAction)
         if self.cut:
             self.enableCut()
         if self.paste:
@@ -443,7 +476,8 @@ class TableView(qt.QTableView):
             This action can cause data to be overwritten.
             There is currently no *Undo* action to retrieve lost data.
         """
-        self.addAction(PasteCellsAction(self))
+        self.pasteCellsAction = PasteCellsAction(self)
+        self.addAction(self.pasteCellsAction)
 
     def enableCut(self):
         """Enable cut action.
@@ -453,8 +487,10 @@ class TableView(qt.QTableView):
             This action can cause data to be deleted.
             There is currently no *Undo* action to retrieve lost data.
         """
-        self.addAction(CutSelectedCellsAction(self))
-        self.addAction(CutAllCellsAction(self))
+        self.cutSelectedCellsAction = CutSelectedCellsAction(self)
+        self.cutAllCellsAction = CutAllCellsAction(self)
+        self.addAction(self.cutSelectedCellsAction)
+        self.addAction(self.cutAllCellsAction)
 
     def addAction(self, action):
         # ensure the actions are not added multiple times:
@@ -465,6 +501,24 @@ class TableView(qt.QTableView):
                         action.table is existing_action.table:
                     return None
         super(TableView, self).addAction(action)
+
+    def setSelectionMode(self, mode):
+        """Overloaded from QTableView to disable cut/copy selection
+        actions in case mode is NoSelection
+
+        :param mode:
+        :return:
+        """
+        if mode == qt.QTableView.NoSelection:
+            self.copySelectedCellsAction.setEnabled(False)
+            if self.cutSelectedCellsAction is not None:
+                self.cutSelectedCellsAction.setEnabled(False)
+        else:
+            self.copySelectedCellsAction.setEnabled(True)
+            if self.cutSelectedCellsAction is not None:
+                self.cutSelectedCellsAction.setEnabled(True)
+        super(TableView, self).setSelectionMode(mode)
+
 
 if __name__ == "__main__":
     app = qt.QApplication([])

--- a/silx/gui/widgets/TableWidget.py
+++ b/silx/gui/widgets/TableWidget.py
@@ -456,6 +456,7 @@ class TableWidget(qt.QTableWidget):
                 self.cutSelectedCellsAction.setEnabled(False)
             if self.copySingleCellAction is None:
                 self.copySingleCellAction = CopySingleCellAction(self)
+                self.addAction(self.copySingleCellAction)
             self.copySingleCellAction.setEnabled(True)
         else:
             self.copySelectedCellsAction.setEnabled(True)
@@ -576,6 +577,7 @@ class TableView(qt.QTableView):
                 self.cutSelectedCellsAction.setEnabled(False)
             if self.copySingleCellAction is None:
                 self.copySingleCellAction = CopySingleCellAction(self)
+                self.addAction(self.copySingleCellAction)
             self.copySingleCellAction.setEnabled(True)
         else:
             self.copySelectedCellsAction.setEnabled(True)

--- a/silx/gui/widgets/TableWidget.py
+++ b/silx/gui/widgets/TableWidget.py
@@ -104,6 +104,8 @@ class CopySelectedCellsAction(qt.QAction):
         Put this text into the clipboard.
         """
         selected_idx = self.table.selectedIndexes()
+        if not selected_idx:
+            return
         selected_idx_tuples = [(idx.row(), idx.column()) for idx in selected_idx]
 
         selected_rows = [idx[0] for idx in selected_idx_tuples]

--- a/silx/gui/widgets/TableWidget.py
+++ b/silx/gui/widgets/TableWidget.py
@@ -451,19 +451,19 @@ class TableWidget(qt.QTableWidget):
         :return:
         """
         if mode == qt.QTableView.NoSelection:
-            self.copySelectedCellsAction.setEnabled(False)
+            self.copySelectedCellsAction.setVisible(False)
             if self.cutSelectedCellsAction is not None:
-                self.cutSelectedCellsAction.setEnabled(False)
+                self.cutSelectedCellsAction.setVisible(False)
             if self.copySingleCellAction is None:
                 self.copySingleCellAction = CopySingleCellAction(self)
                 self.addAction(self.copySingleCellAction)
-            self.copySingleCellAction.setEnabled(True)
+            self.copySingleCellAction.setVisible(True)
         else:
-            self.copySelectedCellsAction.setEnabled(True)
+            self.copySelectedCellsAction.setVisible(True)
             if self.cutSelectedCellsAction is not None:
-                self.cutSelectedCellsAction.setEnabled(True)
+                self.cutSelectedCellsAction.setVisible(True)
             if self.copySingleCellAction is not None:
-                self.copySingleCellAction.setEnabled(False)
+                self.copySingleCellAction.setVisible(False)
         super(TableWidget, self).setSelectionMode(mode)
 
 
@@ -572,19 +572,19 @@ class TableView(qt.QTableView):
         :return:
         """
         if mode == qt.QTableView.NoSelection:
-            self.copySelectedCellsAction.setEnabled(False)
+            self.copySelectedCellsAction.setVisible(False)
             if self.cutSelectedCellsAction is not None:
-                self.cutSelectedCellsAction.setEnabled(False)
+                self.cutSelectedCellsAction.setVisible(False)
             if self.copySingleCellAction is None:
                 self.copySingleCellAction = CopySingleCellAction(self)
                 self.addAction(self.copySingleCellAction)
-            self.copySingleCellAction.setEnabled(True)
+            self.copySingleCellAction.setVisible(True)
         else:
-            self.copySelectedCellsAction.setEnabled(True)
+            self.copySelectedCellsAction.setVisible(True)
             if self.cutSelectedCellsAction is not None:
-                self.cutSelectedCellsAction.setEnabled(True)
+                self.cutSelectedCellsAction.setVisible(True)
             if self.copySingleCellAction is not None:
-                self.copySingleCellAction.setEnabled(False)
+                self.copySingleCellAction.setVisible(False)
         super(TableView, self).setSelectionMode(mode)
 
 

--- a/silx/io/test/test_spech5.py
+++ b/silx/io/test/test_spech5.py
@@ -314,6 +314,7 @@ class TestSpecH5(unittest.TestCase):
         # spech5 does not define external link, so there is no way
         # a group can *get* a SpecH5 class
 
+    @unittest.skipIf(h5py is None, "test requires h5py (not installed)")
     def testGetApi(self):
         result = self.sfh5.get("1.1", getclass=True, getlink=True)
         self.assertIs(result, h5py.HardLink)

--- a/silx/io/test/test_utils.py
+++ b/silx/io/test/test_utils.py
@@ -35,11 +35,9 @@ from .. import utils
 
 try:
     import h5py
-except ImportError:
-    h5py_missing = True
-else:
-    h5py_missing = False
     from ..utils import h5ls
+except ImportError:
+    h5py = None
 
 try:
     import fabio
@@ -208,7 +206,7 @@ def assert_match_any_string_in_list(test, pattern, list_of_strings):
     return False
 
 
-@unittest.skipIf(h5py_missing, "Could not import h5py")
+@unittest.skipIf(h5py is None, "Could not import h5py")
 class TestH5Ls(unittest.TestCase):
     """Test displaying the following HDF5 file structure:
 
@@ -292,7 +290,7 @@ class TestOpen(unittest.TestCase):
     """Test `silx.io.utils.open` function."""
 
     def testH5(self):
-        if h5py_missing:
+        if h5py is None:
             self.skipTest("H5py is missing")
 
         # create a file
@@ -310,7 +308,7 @@ class TestOpen(unittest.TestCase):
         f.close()
 
     def testH5With(self):
-        if h5py_missing:
+        if h5py is None:
             self.skipTest("H5py is missing")
 
         # create a file
@@ -336,7 +334,7 @@ class TestOpen(unittest.TestCase):
         # load it
         f = utils.open(tmp.name)
         self.assertIsNotNone(f)
-        if not h5py_missing:
+        if h5py is not None:
             self.assertEquals(f.h5py_class, h5py.File)
         f.close()
 
@@ -350,11 +348,11 @@ class TestOpen(unittest.TestCase):
         # load it
         with utils.open(tmp.name) as f:
             self.assertIsNotNone(f)
-            if not h5py_missing:
+            if h5py is not None:
                 self.assertEquals(f.h5py_class, h5py.File)
 
     def testEdf(self):
-        if h5py_missing:
+        if h5py is None:
             self.skipTest("H5py is missing")
         if fabio is None:
             self.skipTest("Fabio is missing")
@@ -375,7 +373,7 @@ class TestOpen(unittest.TestCase):
         f.close()
 
     def testEdfWith(self):
-        if h5py_missing:
+        if h5py is None:
             self.skipTest("H5py is missing")
         if fabio is None:
             self.skipTest("Fabio is missing")
@@ -411,7 +409,7 @@ class TestOpen(unittest.TestCase):
 class TestNodes(unittest.TestCase):
     """Test `silx.io.utils.is_` functions."""
     def test_real_h5py_objects(self):
-        if h5py_missing:
+        if h5py is None:
             self.skipTest("H5py is missing")
 
         name = tempfile.mktemp(suffix=".h5")
@@ -435,7 +433,7 @@ class TestNodes(unittest.TestCase):
             os.unlink(name)
 
     def test_h5py_like_file(self):
-        if h5py_missing:
+        if h5py is None:
             self.skipTest("H5py is missing")
 
         class Foo(object):
@@ -447,7 +445,7 @@ class TestNodes(unittest.TestCase):
         self.assertFalse(utils.is_dataset(obj))
 
     def test_h5py_like_group(self):
-        if h5py_missing:
+        if h5py is None:
             self.skipTest("H5py is missing")
 
         class Foo(object):
@@ -459,7 +457,7 @@ class TestNodes(unittest.TestCase):
         self.assertFalse(utils.is_dataset(obj))
 
     def test_h5py_like_dataset(self):
-        if h5py_missing:
+        if h5py is None:
             self.skipTest("H5py is missing")
 
         class Foo(object):
@@ -471,7 +469,7 @@ class TestNodes(unittest.TestCase):
         self.assertTrue(utils.is_dataset(obj))
 
     def test_bad(self):
-        if h5py_missing:
+        if h5py is None:
             self.skipTest("H5py is missing")
 
         class Foo(object):
@@ -483,7 +481,7 @@ class TestNodes(unittest.TestCase):
         self.assertFalse(utils.is_dataset(obj))
 
     def test_bad_api(self):
-        if h5py_missing:
+        if h5py is None:
             self.skipTest("H5py is missing")
 
         class Foo(object):

--- a/silx/io/test/test_utils.py
+++ b/silx/io/test/test_utils.py
@@ -336,7 +336,8 @@ class TestOpen(unittest.TestCase):
         # load it
         f = utils.open(tmp.name)
         self.assertIsNotNone(f)
-        self.assertEquals(f.h5py_class, h5py.File)
+        if not h5py_missing:
+            self.assertEquals(f.h5py_class, h5py.File)
         f.close()
 
     def testSpecWith(self):
@@ -349,7 +350,8 @@ class TestOpen(unittest.TestCase):
         # load it
         with utils.open(tmp.name) as f:
             self.assertIsNotNone(f)
-            self.assertEquals(f.h5py_class, h5py.File)
+            if not h5py_missing:
+                self.assertEquals(f.h5py_class, h5py.File)
 
     def testEdf(self):
         if h5py_missing:


### PR DESCRIPTION
If mode is set to `NoSelection`, the "Copy selected cells" action does not work and raises an error. 
This PR addresses this situation by providing a "copy single cell" action instead, when mode is NoSelection.