### PR TITLE
[plot gl] Fix bad scatter plot color display

### DIFF
--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -1185,7 +1185,7 @@ class GLPlotCurve2D(object):
             self.yVboData.offset += yAttrib.itemsize
 
             if cAttrib is not None and colorData.dtype.kind == 'u':
-                cAttrib.normalisation = True  # Normalise uint to [0, 1]
+                cAttrib.normalization = True  # Normalize uint to [0, 1]
             self.colorVboData = cAttrib
             self.useColorVboData = cAttrib is not None
             self.distVboData = dAttrib


### PR DESCRIPTION
Scatter plot colors were not properly displayed due to a code typo introduced when renaming normalisation to normalization.

To reproduce:
```
from silx import sx
w = sx.Plot1D(backend='gl')
w.show()
x = numpy.arange(256)
w.addScatter(x, x, x)
w.resetZoom()
```
