### PR TITLE
[StackView] implement getPlot()

### DIFF
--- a/doc/source/modules/gui/plot/stackview.rst
+++ b/doc/source/modules/gui/plot/stackview.rst
@@ -13,7 +13,9 @@
 
 .. autoclass:: StackView
    :members:
-   :exclude-members: remove, setInteractiveMode, addItem
+   :exclude-members: remove, setInteractiveMode, addItem, getActiveImage,
+       resetZoom, setYAxisInverted, isYAxisInverted, getSupportedColormaps,
+       isKeepDataAspectRatio, setKeepDataAspectRatio
 
 :class:`StackViewMainWindow` class
 ----------------------------------

--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -450,8 +450,8 @@ class ArrayStackPlot(qt.QWidget):
 
         self._stack_view.setGraphTitle(title or "")
         # by default, the z axis is the image position (dimension not plotted)
-        self._stack_view.getXAxis().setLabel(self.__x_axis_name or "X")
-        self._stack_view.getYAxis().setLabel(self.__y_axis_name or "Y")
+        self._stack_view.getPlot().getXAxis().setLabel(self.__x_axis_name or "X")
+        self._stack_view.getPlot().getYAxis().setLabel(self.__y_axis_name or "Y")
 
         self._updateStack()
 

--- a/silx/gui/plot/Profile.py
+++ b/silx/gui/plot/Profile.py
@@ -678,17 +678,21 @@ class ProfileToolBar(qt.QToolBar):
 
 
 class Profile3DToolBar(ProfileToolBar):
-    def __init__(self, parent=None, plot=None, title='Profile Selection'):
+    def __init__(self, parent=None, stackview=None,
+                 title='Profile Selection'):
         """QToolBar providing profile tools for an image or a stack of images.
 
         :param parent: the parent QWidget
-        :param plot: :class:`PlotWindow` instance on which to operate.
+        :param stackview: :class:`StackView` instance on which to operate.
         :param str title: See :class:`QToolBar`.
         :param parent: See :class:`QToolBar`.
         """
         # TODO: add param profileWindow (specify the plot used for profiles)
-        super(Profile3DToolBar, self).__init__(parent=parent, plot=plot,
+        super(Profile3DToolBar, self).__init__(parent=parent,
+                                               plot=stackview.getPlot(),
                                                title=title)
+        self.stackView = stackview
+        """:class:`StackView` instance"""
 
         self.profile3dAction = ProfileToolButton(
             parent=self, plot=self.plot)
@@ -721,8 +725,8 @@ class Profile3DToolBar(ProfileToolBar):
         if self._profileType == "1D":
             super(Profile3DToolBar, self).updateProfile()
         elif self._profileType == "2D":
-            stackData = self.plot.getCurrentView(copy=False,
-                                                 returnNumpyArray=True)
+            stackData = self.stackView.getCurrentView(copy=False,
+                                                      returnNumpyArray=True)
             if stackData is None:
                 return
             self.plot.remove(self._POLYGON_LEGEND, kind='item')

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -204,7 +204,7 @@ class StackView(qt.QMainWindow):
         self._addColorBarAction()
 
         self._plot.profile = Profile3DToolBar(parent=self._plot,
-                                              plot=self)
+                                              stackview=self)
         self._plot.addToolBar(self._plot.profile)
         self._plot.getXAxis().setLabel('Columns')
         self._plot.getYAxis().setLabel('Rows')


### PR DESCRIPTION
Implement a `getPlot()` method, remove dependency on legacy `StackView` functional API in `Profile3DToolbar`.

Closes #927 