### PR TITLE
[CI] Update travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,6 @@ cache:
 addons:
     apt:
         packages:
-            - libhdf5-serial-1.8.4
-            - libhdf5-serial-dev
             - libegl1-mesa  # Required by Qt xcb platform plugin
             - libboost-python-dev # for PyOpenCL
             - opencl-headers

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
+sudo: required
+
 language: python
 
 git:


### PR DESCRIPTION
This PR updates travis config to use Ubuntu 14.04 image and should solve PyQt5.9 link issue.