### PR TITLE
Bugfix in backprojection

### DIFF
--- a/silx/opencl/backprojection.py
+++ b/silx/opencl/backprojection.py
@@ -312,6 +312,7 @@ class Backprojection(OpenclProcessing):
                     self.wg,
                     *kernel_args
                 )
+            self.slice *= 0
             events.append(EventDescription("backprojection", event_bpj))
             ev = pyopencl.enqueue_copy(self.queue, self.slice, self.cl_mem["d_slice"])
             events.append(EventDescription("copy D->H result", ev))


### PR DESCRIPTION
This PR fixes a bug in the Backprojection class when using it to reconstruct multiple slices.