### PR TITLE
[CI] Add OpenGL to test environments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ addons:
             - libegl1-mesa  # Required by Qt xcb platform plugin
             - libboost-python-dev # for PyOpenCL
             - opencl-headers
+            - libgl1-mesa-glx  # For OpenGL
+            - xserver-xorg-video-dummy  # For OpenGL
 
 before_install:
     # On Linux: install OpenCL

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -27,11 +27,13 @@ environment:
     matrix:
         # Python 3.6
         - PYTHON_DIR: "C:\\Python36-x64"
-          QT_BINDING: "PyQt5==5.8.2"
+          QT_BINDING: "PyQt5"
+          QT_PINNED_VERSION: "==5.8.2"
   
         # Python 3.5
         - PYTHON_DIR: "C:\\Python35-x64"
-          QT_BINDING: "PyQt5==5.8.2"
+          QT_BINDING: "PyQt5"
+          QT_PINNED_VERSION: "==5.8.2"
 
         # Python 2.7
         - PYTHON_DIR: "C:\\Python27-x64"
@@ -85,7 +87,7 @@ test_script:
     - pip install --pre -r requirements.txt
 
     # Install selected Qt binding
-    - "pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ %QT_BINDING%"
+    - "pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ %QT_BINDING%%QT_PINNED_VERSION%"
 
     # Install the generated wheel package to test it
     # Make sure silx does not come from cache or pypi

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -27,18 +27,18 @@ environment:
     matrix:
         # Python 3.6
         - PYTHON_DIR: "C:\\Python36-x64"
-          QT_BINDINGS: "PyQt5==5.8.2"
+          QT_BINDING: "PyQt5==5.8.2"
   
         # Python 3.5
         - PYTHON_DIR: "C:\\Python35-x64"
-          QT_BINDINGS: "PyQt5==5.8.2"
+          QT_BINDING: "PyQt5==5.8.2"
 
         # Python 2.7
         - PYTHON_DIR: "C:\\Python27-x64"
-          QT_BINDINGS: "PyQt4"
+          QT_BINDING: "PyQt4"
 
         - PYTHON_DIR: "C:\\Python27-x64"
-          QT_BINDINGS: "PySide"
+          QT_BINDING: "PySide"
 
 install:
     # Add Python to PATH
@@ -81,26 +81,11 @@ test_script:
     - "virtualenv --clear %VENV_TEST_DIR%"
     - "%VENV_TEST_DIR%\\Scripts\\activate.bat"
 
-    # Install numpy
-    - "pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ --upgrade numpy"
+    # Install dependencies
+    - pip install --pre -r requirements.txt
 
-    # Install Qt binding and matplotlib
-    # Install PyQt4 from www.silx.org and PyQt5/PySide from pypi
-    - "pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ %QT_BINDINGS%"
-    - "pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ matplotlib"
-
-    # Install h5py for silx.io tests
-    - "pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ h5py"
-
-    # Install fabio
-    - "pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ fabio"
-
-    # Install scipy for silx.image.sift tests
-    - "pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ scipy"
-
-    # Install IPython and qtconsole for silx.gui.console tests
-    - "pip install ipython"
-    - "pip install qtconsole"
+    # Install selected Qt binding
+    - "pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ %QT_BINDING%"
 
     # Install the generated wheel package to test it
     # Make sure silx does not come from cache or pypi
@@ -112,7 +97,8 @@ test_script:
     - "python ci\\info_platform.py"
     - "pip list"
 
-    - "python run_tests.py --installed -v"
+    # Run tests with selected Qt binding and without OpenCL
+    - "python run_tests.py --installed -v --no-opencl --qt-binding %QT_BINDING%"
 
     # Leave test virtualenv
     - "%VENV_TEST_DIR%\\Scripts\\deactivate.bat"

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -52,6 +52,9 @@ install:
     - "pip install --upgrade virtualenv"
     - "virtualenv --version"
 
+    # Download Mesa OpenGL in current directory
+    - curl -fsS -o opengl32.dll http://www.silx.org/pub/silx/continuous_integration/opengl32_mingw-mesa-x86_64.dll
+
 build_script:
     # Create build virtualenv
     - "virtualenv --clear %VENV_BUILD_DIR%"

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -54,8 +54,8 @@ install:
     - "pip install --upgrade virtualenv"
     - "virtualenv --version"
 
-    # Download Mesa OpenGL in current directory
-    - curl -fsS -o opengl32.dll http://www.silx.org/pub/silx/continuous_integration/opengl32_mingw-mesa-x86_64.dll
+    # Download Mesa OpenGL in Python directory
+    - curl -fsS -o %PYTHON_DIR%\\opengl32.dll http://www.silx.org/pub/silx/continuous_integration/opengl32_mingw-mesa-x86_64.dll
 
 build_script:
     # Create build virtualenv

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -29,18 +29,22 @@ environment:
         - PYTHON_DIR: "C:\\Python36-x64"
           QT_BINDING: "PyQt5"
           QT_PINNED_VERSION: "==5.8.2"
+          WITH_GL_TEST: True
   
         # Python 3.5
         - PYTHON_DIR: "C:\\Python35-x64"
           QT_BINDING: "PyQt5"
           QT_PINNED_VERSION: "==5.8.2"
+          WITH_GL_TEST: True
 
         # Python 2.7
         - PYTHON_DIR: "C:\\Python27-x64"
           QT_BINDING: "PyQt4"
+          WITH_GL_TEST: False
 
         - PYTHON_DIR: "C:\\Python27-x64"
           QT_BINDING: "PySide"
+          WITH_GL_TEST: False
 
 install:
     # Add Python to PATH
@@ -54,8 +58,8 @@ install:
     - "pip install --upgrade virtualenv"
     - "virtualenv --version"
 
-    # Download Mesa OpenGL in Python directory
-    - curl -fsS -o %PYTHON_DIR%\\opengl32.dll http://www.silx.org/pub/silx/continuous_integration/opengl32_mingw-mesa-x86_64.dll
+    # Download Mesa OpenGL in Python directory when testing OpenGL
+    - IF %WITH_GL_TEST%==True curl -fsS -o %PYTHON_DIR%\\opengl32.dll http://www.silx.org/pub/silx/continuous_integration/opengl32_mingw-mesa-x86_64.dll
 
 build_script:
     # Create build virtualenv
@@ -100,6 +104,7 @@ test_script:
     - "pip list"
 
     # Run tests with selected Qt binding and without OpenCL
+    - echo "WITH_GL_TEST=%WITH_GL_TEST%"
     - "python run_tests.py --installed -v --no-opencl --qt-binding %QT_BINDING%"
 
     # Leave test virtualenv

--- a/run_tests.py
+++ b/run_tests.py
@@ -305,6 +305,14 @@ if options.qt_binding:
     binding = options.qt_binding.lower()
     if binding == "pyqt4":
         logger.info("Force using PyQt4")
+        if sys.version < "3.0.0":
+            try:
+                import sip
+
+                sip.setapi("QString", 2)
+                sip.setapi("QVariant", 2)
+            except:
+                logger.warning("Cannot set sip API")
         import PyQt4.QtCore  # noqa
     elif binding == "pyqt5":
         logger.info("Force using PyQt5")

--- a/silx/gui/plot3d/test/__init__.py
+++ b/silx/gui/plot3d/test/__init__.py
@@ -56,7 +56,9 @@ def suite():
     # Import here to avoid loading modules if tests are disabled
 
     from ..scene import test as test_scene
+    from .testScalarFieldView import suite as testScalarFieldViewSuite
 
     test_suite = unittest.TestSuite()
     test_suite.addTest(test_scene.suite())
+    test_suite.addTest(testScalarFieldViewSuite())
     return test_suite

--- a/silx/gui/plot3d/test/__init__.py
+++ b/silx/gui/plot3d/test/__init__.py
@@ -56,9 +56,11 @@ def suite():
     # Import here to avoid loading modules if tests are disabled
 
     from ..scene import test as test_scene
+    from .testGL import suite as testGLSuite
     from .testScalarFieldView import suite as testScalarFieldViewSuite
 
     test_suite = unittest.TestSuite()
+    test_suite.addTest(testGLSuite())
     test_suite.addTest(test_scene.suite())
     test_suite.addTest(testScalarFieldViewSuite())
     return test_suite

--- a/silx/gui/plot3d/test/testGL.py
+++ b/silx/gui/plot3d/test/testGL.py
@@ -1,0 +1,83 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# ###########################################################################*/
+"""Test OpenGL"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "17/07/2017"
+
+
+import logging
+import unittest
+
+from silx.gui._glutils import gl, OpenGLWidget
+from silx.gui.test.utils import TestCaseQt
+from silx.gui import qt
+
+
+_logger = logging.getLogger(__name__)
+
+
+class TestOpenGL(TestCaseQt):
+    """Tests of OpenGL widget."""
+
+    class OpenGLWidgetLogger(OpenGLWidget):
+        """Widget logging information of available OpenGL version"""
+
+        def __init__(self):
+            self._dump = False
+            super(TestOpenGL.OpenGLWidgetLogger, self).__init__(version=(1, 0))
+
+        def paintOpenGL(self):
+            """Perform the rendering and logging"""
+            if not self._dump:
+                self._dump = True
+                _logger.info('OpenGL info:')
+                _logger.info('\tGL_VERSION: %s' % gl.glGetString(gl.GL_VERSION))
+                _logger.info('\tGL_SHADING_LANGUAGE_VERSION: %s' % \
+                             gl.glGetString(gl.GL_SHADING_LANGUAGE_VERSION))
+                _logger.debug('\tGL_EXTENSIONS: %s' % gl.glGetString(gl.GL_EXTENSIONS))
+
+            gl.glClearColor(1., 1., 1., 1.)
+            gl.glClear(gl.GL_COLOR_BUFFER_BIT)
+
+    def testOpenGL(self):
+        """Log OpenGL version using an OpenGLWidget"""
+        super(TestOpenGL, self).setUp()
+        widget = self.OpenGLWidgetLogger()
+        widget.show()
+        widget.setAttribute(qt.Qt.WA_DeleteOnClose)
+        self.qWaitForWindowExposed(widget)
+        widget.close()
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(TestOpenGL))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/silx/gui/plot3d/test/testGL.py
+++ b/silx/gui/plot3d/test/testGL.py
@@ -54,6 +54,7 @@ class TestOpenGL(TestCaseQt):
             if not self._dump:
                 self._dump = True
                 _logger.info('OpenGL info:')
+                _logger.info('\tQt OpenGL context version: %d.%d', self.getOpenGLVersion())
                 _logger.info('\tGL_VERSION: %s' % gl.glGetString(gl.GL_VERSION))
                 _logger.info('\tGL_SHADING_LANGUAGE_VERSION: %s' % \
                              gl.glGetString(gl.GL_SHADING_LANGUAGE_VERSION))

--- a/silx/gui/plot3d/test/testScalarFieldView.py
+++ b/silx/gui/plot3d/test/testScalarFieldView.py
@@ -1,0 +1,84 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# ###########################################################################*/
+"""Test ScalarFieldView widget"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "11/07/2017"
+
+
+import logging
+import unittest
+
+import numpy
+
+from silx.gui.test.utils import TestCaseQt
+from silx.gui import qt
+
+from silx.gui.plot3d.ScalarFieldView import ScalarFieldView
+
+
+_logger = logging.getLogger(__name__)
+
+
+class TestScalarFieldView(TestCaseQt):
+    """Tests of ScalarFieldView widget."""
+
+    def setUp(self):
+        super(TestScalarFieldView, self).setUp()
+        self.widget = ScalarFieldView()
+        self.widget.show()
+        # Commented as it slows down the tests
+        # self.qWaitForWindowExposed(self.widget)
+
+    def tearDown(self):
+        self.qapp.processEvents()
+        self.widget.setAttribute(qt.Qt.WA_DeleteOnClose)
+        self.widget.close()
+        del self.widget
+        super(TestScalarFieldView, self).tearDown()
+
+    def testSimple(self):
+        """Set the data and an isosurface"""
+        coords = numpy.linspace(-10, 10, 32)
+        z = coords.reshape(-1, 1, 1)
+        y = coords.reshape(1, -1, 1)
+        x = coords.reshape(1, 1, -1)
+        data = numpy.sin(x * y * z) / (x * y * z)
+
+        self.widget.setData(data)
+        self.widget.addIsosurface(0.5, (1., 0., 0., 0.5))
+        self.widget.addIsosurface(0.7, qt.QColor('green'))
+        self.qapp.processEvents()
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(TestScalarFieldView))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/silx/opencl/common.py
+++ b/silx/opencl/common.py
@@ -59,13 +59,16 @@ else:
     except ImportError:
         logger.warning("Unable to import pyOpenCl. Please install it from: http://pypi.python.org/pypi/pyopencl")
         pyopencl = None
-        class mf(object):
-            WRITE_ONLY = 1
-            READ_ONLY = 1
-            READ_WRITE = 1
     else:
         import pyopencl.array as array
         mf = pyopencl.mem_flags
+
+if pyopencl is None:
+    # Define default mem flags
+    class mf(object):
+        WRITE_ONLY = 1
+        READ_ONLY = 1
+        READ_WRITE = 1
 
 
 FLOP_PER_CORE = {"GPU": 64,  # GPU, Fermi at least perform 64 flops per cycle/multicore, G80 were at 24 or 48 ...


### PR DESCRIPTION
This PR sets-up Travis and Appveyor to have OpenGL > 2.1 available:
- Out-of-the bos for Travis/MacOS
- By installing packages on Travis/Linux
- By downloading a pre-compiled Mesa DLL for Appveyor

It adds a test logging OpenGL version and a test for plot3d.ScalarFieldView.
It fixes a minor issue with OpenCL tests (when disabled).
It uses requirements.txt in appveyor configuration.

Close #959 