### PR TITLE
[plot3d] Show/Hide bounding box and orientation indicator

### DIFF
--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -118,13 +118,12 @@ class Plot3DWidget(glu.OpenGLWidget):
         # Window describing on screen area to render
         self._window = scene.Window(mode='framebuffer')
         self._window.viewports = [self.viewport, self.overview]
+        self._window.addListener(self._redraw)
 
         self.eventHandler = interaction.CameraControl(
             self.viewport, orbitAroundCenter=False,
             mode='position', scaleTransform=sceneScale,
             selectCB=None)
-
-        self.viewport.addListener(self._redraw)
 
     def setProjection(self, projection):
         """Change the projection in use.
@@ -170,6 +169,25 @@ class Plot3DWidget(glu.OpenGLWidget):
         """Returns the RGBA background color (QColor)."""
         return qt.QColor.fromRgbF(*self.viewport.background)
 
+    def isOrientationIndicatorVisible(self):
+        """Returns True if the orientation indicator is displayed.
+
+        :rtype: bool
+        """
+        return self.overview in self._window.viewports
+
+    def setOrientationIndicatorVisible(self, visible):
+        """Set the orientation indicator visibility.
+
+        :param bool visible: True to show
+        """
+        visible = bool(visible)
+        if visible != self.isOrientationIndicatorVisible():
+            if visible:
+                self._window.viewports = [self.viewport, self.overview]
+            else:
+                self._window.viewports = [self.viewport]
+
     def centerScene(self):
         """Position the center of the scene at the center of rotation."""
         self.viewport.resetCamera()
@@ -186,7 +204,7 @@ class Plot3DWidget(glu.OpenGLWidget):
 
     def _redraw(self, source=None):
         """Viewport listener to require repaint"""
-        if not self._updating and self.viewport.dirty:
+        if not self._updating:
             self._updating = True  # Mark that an update is requested
             self.update()  # Queued repaint (i.e., asynchronous)
 

--- a/silx/gui/plot3d/SFViewParamTree.py
+++ b/silx/gui/plot3d/SFViewParamTree.py
@@ -344,6 +344,24 @@ class HighlightColorItem(ColorItem):
         return self.subject.getHighlightColor()
 
 
+class BoundingBoxItem(SubjectItem):
+    """Bounding box, axes labels and grid visibility item.
+
+    Item is checkable.
+    """
+    itemName = 'Bounding Box'
+
+    def _init(self):
+        visible = self.subject.isBoundingBoxVisible()
+        self.setCheckable(True)
+        self.setCheckState(qt.Qt.Checked if visible else qt.Qt.Unchecked)
+
+    def leftClicked(self):
+        checked = (self.checkState() == qt.Qt.Checked)
+        if checked != self.subject.isBoundingBoxVisible():
+            self.subject.setBoundingBoxVisible(checked)
+
+
 class ViewSettingsItem(qt.QStandardItem):
     """Viewport settings"""
 
@@ -353,7 +371,8 @@ class ViewSettingsItem(qt.QStandardItem):
 
         self.setEditable(False)
 
-        classes = BackgroundColorItem, ForegroundColorItem, HighlightColorItem
+        classes = (BackgroundColorItem, ForegroundColorItem,
+                   HighlightColorItem, BoundingBoxItem)
         for cls in classes:
             titleItem = qt.QStandardItem(cls.itemName)
             titleItem.setEditable(False)

--- a/silx/gui/plot3d/SFViewParamTree.py
+++ b/silx/gui/plot3d/SFViewParamTree.py
@@ -362,6 +362,26 @@ class BoundingBoxItem(SubjectItem):
             self.subject.setBoundingBoxVisible(checked)
 
 
+class OrientationIndicatorItem(SubjectItem):
+    """Orientation indicator visibility item.
+
+    Item is checkable.
+    """
+    itemName = 'Axes indicator'
+
+    def _init(self):
+        plot3d = self.subject.getPlot3DWidget()
+        visible = plot3d.isOrientationIndicatorVisible()
+        self.setCheckable(True)
+        self.setCheckState(qt.Qt.Checked if visible else qt.Qt.Unchecked)
+
+    def leftClicked(self):
+        plot3d = self.subject.getPlot3DWidget()
+        checked = (self.checkState() == qt.Qt.Checked)
+        if checked != plot3d.isOrientationIndicatorVisible():
+            plot3d.setOrientationIndicatorVisible(checked)
+
+
 class ViewSettingsItem(qt.QStandardItem):
     """Viewport settings"""
 
@@ -372,7 +392,8 @@ class ViewSettingsItem(qt.QStandardItem):
         self.setEditable(False)
 
         classes = (BackgroundColorItem, ForegroundColorItem,
-                   HighlightColorItem, BoundingBoxItem)
+                   HighlightColorItem,
+                   BoundingBoxItem, OrientationIndicatorItem)
         for cls in classes:
             titleItem = qt.QStandardItem(cls.itemName)
             titleItem.setEditable(False)

--- a/silx/gui/plot3d/ScalarFieldView.py
+++ b/silx/gui/plot3d/ScalarFieldView.py
@@ -1110,6 +1110,20 @@ class ScalarFieldView(Plot3DWindow):
 
     # Axes labels
 
+    def isBoundingBoxVisible(self):
+        """Returns axes labels, grid and bounding box visibility.
+
+        :rtype: bool
+        """
+        return self._bbox.boxVisible
+
+    def setBoundingBoxVisible(self, visible):
+        """Set axes labels, grid and bounding box visibility.
+
+        :param bool visible: True to show axes, False to hide
+        """
+        self._bbox.boxVisible = bool(visible)
+
     def setAxesLabels(self, xlabel=None, ylabel=None, zlabel=None):
         """Set the text labels of the axes.
 

--- a/silx/gui/plot3d/scene/axes.py
+++ b/silx/gui/plot3d/scene/axes.py
@@ -52,6 +52,8 @@ class LabelledAxes(primitives.GroupBBox):
 
         self._font = text.Font()
 
+        self._boxVisibility = True
+
         # TODO offset labels from anchor in pixels
 
         self._xlabel = text.Text2D(font=self._font)
@@ -145,6 +147,21 @@ class LabelledAxes(primitives.GroupBBox):
     def zlabel(self, text):
         self._zlabel.text = text
 
+    @property
+    def boxVisible(self):
+        """Returns bounding box, axes labels and grid visibility."""
+        return self._boxVisibility
+
+    @boxVisible.setter
+    def boxVisible(self, visible):
+        self._boxVisibility = bool(visible)
+        for child in self._children:
+            if child == self._tickLines:
+                if self._ticksForBounds is not None:
+                    child.visible = self._boxVisibility
+            elif child != self._group:
+                child.visible = self._boxVisibility
+
     def _updateTicks(self):
         """Check if ticks need update and update them if needed."""
         bounds = self._group.bounds(transformed=False, dataBounds=True)
@@ -187,7 +204,7 @@ class LabelledAxes(primitives.GroupBBox):
             zcoords[:, 3, 1] += ticklength[1]  # Z ticks on YZ plane
 
             self._tickLines.setPositions(coords.reshape(-1, 3))
-            self._tickLines.visible = True
+            self._tickLines.visible = self._boxVisibility
 
             # Update labels
             color = self.tickColor

--- a/silx/gui/plot3d/scene/window.py
+++ b/silx/gui/plot3d/scene/window.py
@@ -304,12 +304,11 @@ class Window(event.Notifier):
         self._viewports.removeListener(self._updated)
         self._viewports = event.NotifierList(iterable)
         self._viewports.addListener(self._updated)
-        self._dirty = True
+        self._updated(self)
 
     def _updated(self, source, *args, **kwargs):
-        if source is not self:
-            self._dirty = True
-            self.notify(*args, **kwargs)
+        self._dirty = True
+        self.notify(*args, **kwargs)
 
     framebufferid = property(lambda self: self._framebufferid,
                              doc="Framebuffer ID used to perform rendering")


### PR DESCRIPTION
This PR adds API to ScalarFieldView and Plot3dWidget and checkbox in the ParamTree -> Style to:
- Show/Hide the bounding box, its axes and grid
- Show/Hide the top-right orientation indicator 