### PR TITLE
Fix build-deb7

### DIFF
--- a/build-deb7.sh
+++ b/build-deb7.sh
@@ -112,7 +112,7 @@ then
 else
   echo Using Python 2
   # bdist_deb feed /usr/bin using setup.py entry-points
-  PATH=$CCPATH python setup.py --command-packages=stdeb.command bdist_deb --no-cython
+  PATH=$CCPATH python setup.py --command-packages=stdeb.command build --no-cython bdist_deb
   rc=$?
 fi
 


### PR DESCRIPTION
The `setup.py` was cleaned-up. `--no-cython` is an argument of the build target