### PR TITLE
[plot gl][plot3d] Check GLX forwarding disabled

### DIFF
--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -443,7 +443,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                                gl.GL_ONE,
                                gl.GL_ONE)
 
-    def initializeOpenGL(self):
+    def initializeGL(self):
         gl.testGL()
 
         gl.glClearColor(1., 1., 1., 1.)
@@ -529,7 +529,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         self._renderMarkersGL()
         self._renderOverlayGL()
 
-    def paintOpenGL(self):
+    def paintGL(self):
         global _current_context
         _current_context = self.context()
 
@@ -915,7 +915,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
         gl.glDisable(gl.GL_SCISSOR_TEST)
 
-    def resizeOpenGL(self, width, height):
+    def resizeGL(self, width, height):
         if width == 0 or height == 0:  # Do not resize
             return
 
@@ -1330,7 +1330,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         if fileFormat not in ['png', 'ppm', 'svg', 'tiff']:
             raise NotImplementedError('Unsupported format: %s' % fileFormat)
 
-        if not self.isRequestedOpenGLVersionAvailable():
+        if not self.isValid():
             _logger.error('OpenGL 2.1 not available, cannot save OpenGL image')
             width, height = self._plotFrame.size
             data = numpy.zeros((height, width, 3), dtype=numpy.uint8)

--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -211,10 +211,10 @@ class Plot3DWidget(glu.OpenGLWidget):
     def sizeHint(self):
         return qt.QSize(400, 300)
 
-    def initializeOpenGL(self):
+    def initializeGL(self):
         pass
 
-    def paintOpenGL(self):
+    def paintGL(self):
         # In case paintGL is called by the system and not through _redraw,
         # Mark as updating.
         self._updating = True
@@ -230,7 +230,7 @@ class Plot3DWidget(glu.OpenGLWidget):
             self.centerScene()
         self._updating = False
 
-    def resizeOpenGL(self, width, height):
+    def resizeGL(self, width, height):
         width *= self.getDevicePixelRatio()
         height *= self.getDevicePixelRatio()
         self._window.size = width, height
@@ -244,7 +244,7 @@ class Plot3DWidget(glu.OpenGLWidget):
         :returns: OpenGL scene RGB rasterization
         :rtype: QImage
         """
-        if not self.isRequestedOpenGLVersionAvailable():
+        if not self.isValid():
             _logger.error('OpenGL 2.1 not available, cannot save OpenGL image')
             height, width = self._window.shape
             image = numpy.zeros((height, width, 3), dtype=numpy.uint8)
@@ -264,7 +264,7 @@ class Plot3DWidget(glu.OpenGLWidget):
             angle = event.angleDelta().y() / 8.
         event.accept()
 
-        if angle != 0:
+        if angle != 0 and self.isValid():
             self.makeCurrent()
             self.eventHandler.handleEvent('wheel', xpixel, ypixel, angle)
 
@@ -300,16 +300,18 @@ class Plot3DWidget(glu.OpenGLWidget):
         btn = self._MOUSE_BTNS[event.button()]
         event.accept()
 
-        self.makeCurrent()
-        self.eventHandler.handleEvent('press', xpixel, ypixel, btn)
+        if self.isValid():
+            self.makeCurrent()
+            self.eventHandler.handleEvent('press', xpixel, ypixel, btn)
 
     def mouseMoveEvent(self, event):
         xpixel = event.x() * self.getDevicePixelRatio()
         ypixel = event.y() * self.getDevicePixelRatio()
         event.accept()
 
-        self.makeCurrent()
-        self.eventHandler.handleEvent('move', xpixel, ypixel)
+        if self.isValid():
+            self.makeCurrent()
+            self.eventHandler.handleEvent('move', xpixel, ypixel)
 
     def mouseReleaseEvent(self, event):
         xpixel = event.x() * self.getDevicePixelRatio()
@@ -317,5 +319,6 @@ class Plot3DWidget(glu.OpenGLWidget):
         btn = self._MOUSE_BTNS[event.button()]
         event.accept()
 
-        self.makeCurrent()
-        self.eventHandler.handleEvent('release', xpixel, ypixel, btn)
+        if self.isValid():
+            self.makeCurrent()
+            self.eventHandler.handleEvent('release', xpixel, ypixel, btn)


### PR DESCRIPTION
This PR refactors `OpenGLWidget`, the Qt OpenGL wrapper widget used by both plot OpenGL backend and plot3d widgets.
It adds handling of GLX forwarding disabled when connected through ssh with PyQt4 and PySide.
The probing of this situation with PyQt5 seems "beyond repair" as Qt OpenGL widget `__init__` never returns...

The `_OpenGLWidget` inherits either from `QGLWidget` (Qt<5.4) or `QOpenGLWidget` (Qt>=5.4) and provides a wrapper API.
The `OpenGLWidget` is a `QWidget` have either `_OpenGLWidet` (when it works) or a `QLabel` (displaying an error message) as child. It provides a subset of `QOpenGLWidget` API.