### PR TITLE
[silx.io.open] change logging behavior when library is missing

### DIFF
--- a/silx/io/fabioh5.py
+++ b/silx/io/fabioh5.py
@@ -36,21 +36,12 @@ import collections
 import numpy
 import numbers
 import logging
+import fabio
+import h5py
 from silx.third_party import six
 
+
 _logger = logging.getLogger(__name__)
-
-try:
-    import fabio
-except ImportError as e:
-    _logger.error("Module %s requires fabio", __name__)
-    raise e
-
-try:
-    import h5py
-except ImportError as e:
-    _logger.error("Module %s requires h5py", __name__)
-    raise e
 
 
 class Node(object):

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -399,22 +399,28 @@ def open(filename):  # pylint:disable=redefined-builtin
         if h5py.is_hdf5(filename):
             return h5py.File(filename, "r")
 
+    debugging_info = []
     try:
         from . import fabioh5
         return fabioh5.File(filename)
     except ImportError:
-        logger.debug("fabioh5 can't be loaded.", exc_info=True)
+        debugging_info.append((sys.exc_info(), "fabioh5 can't be loaded."))
     except Exception:
-        logger.debug("File '%s' can't be read as fabio file.", filename, exc_info=True)
+        debugging_info.append((sys.exc_info(),
+                               "File '%s' can't be read as fabio file." % filename))
 
     try:
         from . import spech5
         return spech5.SpecH5(filename)
     except ImportError:
-        logger.debug("spech5 can't be loaded.", exc_info=True)
+        debugging_info.append((sys.exc_info(),
+                               "spech5 can't be loaded."))
     except IOError:
-        logger.debug("File '%s' can't be read as spec file.", filename, exc_info=True)
+        debugging_info.append((sys.exc_info(),
+                               "File '%s' can't be read as spec file." % filename))
 
+    for exc_info, message in debugging_info:
+        logger.debug(message, exc_info=exc_info)
     raise IOError("File '%s' can't be read as HDF5" % filename)
 
 


### PR DESCRIPTION
Closes #1000 

Importing `fabioh5` without `fabio` being installed now only raises an `ImportError`, without first logging an error message.

`silx.io.open` now only logs warning messages if both `fabioh5` and `spech5` have failed opening the file.