### PR TITLE
Improve computation time of SpecH5

### DIFF
--- a/silx/io/specfile/specfile.c
+++ b/silx/io/specfile/specfile.c
@@ -3112,10 +3112,11 @@ static PyObject *__pyx_pf_8specfile_3MCA_8__getitem__(CYTHON_UNUSED PyObject *__
   int __pyx_t_2;
   PyObject *__pyx_t_3 = NULL;
   int __pyx_t_4;
-  PyObject *__pyx_t_5 = NULL;
+  int __pyx_t_5;
   PyObject *__pyx_t_6 = NULL;
   PyObject *__pyx_t_7 = NULL;
   PyObject *__pyx_t_8 = NULL;
+  PyObject *__pyx_t_9 = NULL;
   int __pyx_lineno = 0;
   const char *__pyx_filename = NULL;
   int __pyx_clineno = 0;
@@ -3137,7 +3138,7 @@ static PyObject *__pyx_pf_8specfile_3MCA_8__getitem__(CYTHON_UNUSED PyObject *__
  *         if not len(self):
  *             raise IndexError("No MCA spectrum found in this scan")             # <<<<<<<<<<<<<<
  * 
- *         if isinstance(key, int):
+ *         if isinstance(key, (int, long)):
  */
     __pyx_t_3 = __Pyx_PyObject_Call(__pyx_builtin_IndexError, __pyx_tuple__4, NULL); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 296; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_3);
@@ -3149,17 +3150,27 @@ static PyObject *__pyx_pf_8specfile_3MCA_8__getitem__(CYTHON_UNUSED PyObject *__
   /* "specfile.pyx":298
  *             raise IndexError("No MCA spectrum found in this scan")
  * 
- *         if isinstance(key, int):             # <<<<<<<<<<<<<<
+ *         if isinstance(key, (int, long)):             # <<<<<<<<<<<<<<
  *             mca_index = key
  *             # allow negative index, like lists
  */
-  __pyx_t_2 = PyInt_Check(__pyx_v_key); 
+  __pyx_t_4 = PyInt_Check(__pyx_v_key); 
+  __pyx_t_5 = (__pyx_t_4 != 0);
+  if (!__pyx_t_5) {
+  } else {
+    __pyx_t_2 = __pyx_t_5;
+    goto __pyx_L5_bool_binop_done;
+  }
+  __pyx_t_5 = PyLong_Check(__pyx_v_key); 
+  __pyx_t_4 = (__pyx_t_5 != 0);
+  __pyx_t_2 = __pyx_t_4;
+  __pyx_L5_bool_binop_done:;
   __pyx_t_4 = (__pyx_t_2 != 0);
   if (__pyx_t_4) {
 
     /* "specfile.pyx":299
  * 
- *         if isinstance(key, int):
+ *         if isinstance(key, (int, long)):
  *             mca_index = key             # <<<<<<<<<<<<<<
  *             # allow negative index, like lists
  *             if mca_index < 0:
@@ -3189,14 +3200,14 @@ static PyObject *__pyx_pf_8specfile_3MCA_8__getitem__(CYTHON_UNUSED PyObject *__
       __pyx_t_1 = PyObject_Length(__pyx_v_self); if (unlikely(__pyx_t_1 == -1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 302; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
       __pyx_t_3 = PyInt_FromSsize_t(__pyx_t_1); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 302; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
       __Pyx_GOTREF(__pyx_t_3);
-      __pyx_t_5 = PyNumber_Add(__pyx_t_3, __pyx_v_mca_index); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 302; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
-      __Pyx_GOTREF(__pyx_t_5);
+      __pyx_t_6 = PyNumber_Add(__pyx_t_3, __pyx_v_mca_index); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 302; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+      __Pyx_GOTREF(__pyx_t_6);
       __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-      __Pyx_DECREF_SET(__pyx_v_mca_index, __pyx_t_5);
-      __pyx_t_5 = 0;
-      goto __pyx_L5;
+      __Pyx_DECREF_SET(__pyx_v_mca_index, __pyx_t_6);
+      __pyx_t_6 = 0;
+      goto __pyx_L7;
     }
-    __pyx_L5:;
+    __pyx_L7:;
     goto __pyx_L4;
   }
   /*else*/ {
@@ -3208,18 +3219,18 @@ static PyObject *__pyx_pf_8specfile_3MCA_8__getitem__(CYTHON_UNUSED PyObject *__
  *                             (type(key)))
  * 
  */
-    __pyx_t_5 = __Pyx_PyString_Format(__pyx_kp_s_MCA_index_should_be_an_integer_s, ((PyObject *)Py_TYPE(__pyx_v_key))); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 304; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
-    __Pyx_GOTREF(__pyx_t_5);
+    __pyx_t_6 = __Pyx_PyString_Format(__pyx_kp_s_MCA_index_should_be_an_integer_s, ((PyObject *)Py_TYPE(__pyx_v_key))); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 304; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __Pyx_GOTREF(__pyx_t_6);
     __pyx_t_3 = PyTuple_New(1); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 304; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_3);
-    PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_5);
-    __Pyx_GIVEREF(__pyx_t_5);
-    __pyx_t_5 = 0;
-    __pyx_t_5 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_3, NULL); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 304; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
-    __Pyx_GOTREF(__pyx_t_5);
+    PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_t_6);
+    __Pyx_GIVEREF(__pyx_t_6);
+    __pyx_t_6 = 0;
+    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_TypeError, __pyx_t_3, NULL); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 304; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __Pyx_Raise(__pyx_t_5, 0, 0, 0);
-    __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
+    __Pyx_Raise(__pyx_t_6, 0, 0, 0);
+    __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     {__pyx_filename = __pyx_f[0]; __pyx_lineno = 304; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   }
   __pyx_L4:;
@@ -3231,17 +3242,17 @@ static PyObject *__pyx_pf_8specfile_3MCA_8__getitem__(CYTHON_UNUSED PyObject *__
  *             msg = "MCA index must be in range 0-%d" % (len(self) - 1)
  *             raise IndexError(msg)
  */
-  __pyx_t_5 = PyObject_RichCompare(__pyx_int_0, __pyx_v_mca_index, Py_LE); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 307; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
-  if (__Pyx_PyObject_IsTrue(__pyx_t_5)) {
-    __Pyx_DECREF(__pyx_t_5);
+  __pyx_t_6 = PyObject_RichCompare(__pyx_int_0, __pyx_v_mca_index, Py_LE); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 307; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  if (__Pyx_PyObject_IsTrue(__pyx_t_6)) {
+    __Pyx_DECREF(__pyx_t_6);
     __pyx_t_1 = PyObject_Length(__pyx_v_self); if (unlikely(__pyx_t_1 == -1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 307; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __pyx_t_3 = PyInt_FromSsize_t(__pyx_t_1); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 307; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_3);
-    __pyx_t_5 = PyObject_RichCompare(__pyx_v_mca_index, __pyx_t_3, Py_LT); __Pyx_XGOTREF(__pyx_t_5); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 307; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_6 = PyObject_RichCompare(__pyx_v_mca_index, __pyx_t_3, Py_LT); __Pyx_XGOTREF(__pyx_t_6); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 307; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
   }
-  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_5); if (unlikely(__pyx_t_4 < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 307; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
-  __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
+  __pyx_t_4 = __Pyx_PyObject_IsTrue(__pyx_t_6); if (unlikely(__pyx_t_4 < 0)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 307; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
   __pyx_t_2 = ((!__pyx_t_4) != 0);
   if (__pyx_t_2) {
 
@@ -3253,11 +3264,11 @@ static PyObject *__pyx_pf_8specfile_3MCA_8__getitem__(CYTHON_UNUSED PyObject *__
  * 
  */
     __pyx_t_1 = PyObject_Length(__pyx_v_self); if (unlikely(__pyx_t_1 == -1)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 308; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
-    __pyx_t_5 = PyInt_FromSsize_t((__pyx_t_1 - 1)); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 308; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
-    __Pyx_GOTREF(__pyx_t_5);
-    __pyx_t_3 = __Pyx_PyString_Format(__pyx_kp_s_MCA_index_must_be_in_range_0_d, __pyx_t_5); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 308; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __pyx_t_6 = PyInt_FromSsize_t((__pyx_t_1 - 1)); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 308; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __Pyx_GOTREF(__pyx_t_6);
+    __pyx_t_3 = __Pyx_PyString_Format(__pyx_kp_s_MCA_index_must_be_in_range_0_d, __pyx_t_6); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 308; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
     __Pyx_GOTREF(__pyx_t_3);
-    __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
+    __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     __pyx_v_msg = __pyx_t_3;
     __pyx_t_3 = 0;
 
@@ -3273,11 +3284,11 @@ static PyObject *__pyx_pf_8specfile_3MCA_8__getitem__(CYTHON_UNUSED PyObject *__
     __Pyx_INCREF(__pyx_v_msg);
     PyTuple_SET_ITEM(__pyx_t_3, 0, __pyx_v_msg);
     __Pyx_GIVEREF(__pyx_v_msg);
-    __pyx_t_5 = __Pyx_PyObject_Call(__pyx_builtin_IndexError, __pyx_t_3, NULL); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 309; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
-    __Pyx_GOTREF(__pyx_t_5);
+    __pyx_t_6 = __Pyx_PyObject_Call(__pyx_builtin_IndexError, __pyx_t_3, NULL); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 309; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+    __Pyx_GOTREF(__pyx_t_6);
     __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-    __Pyx_Raise(__pyx_t_5, 0, 0, 0);
-    __Pyx_DECREF(__pyx_t_5); __pyx_t_5 = 0;
+    __Pyx_Raise(__pyx_t_6, 0, 0, 0);
+    __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
     {__pyx_filename = __pyx_f[0]; __pyx_lineno = 309; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   }
 
@@ -3291,17 +3302,17 @@ static PyObject *__pyx_pf_8specfile_3MCA_8__getitem__(CYTHON_UNUSED PyObject *__
   __Pyx_XDECREF(__pyx_r);
   __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_scan_2); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 311; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_3);
-  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_specfile); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 311; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
-  __Pyx_GOTREF(__pyx_t_6);
-  __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_get_mca); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 311; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
-  __Pyx_GOTREF(__pyx_t_3);
-  __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
-  __pyx_t_6 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_scan_2); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 311; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
-  __Pyx_GOTREF(__pyx_t_6);
-  __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_t_6, __pyx_n_s_index); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 311; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_t_3, __pyx_n_s_specfile); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 311; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_t_7);
-  __Pyx_DECREF(__pyx_t_6); __pyx_t_6 = 0;
+  __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
+  __pyx_t_3 = __Pyx_PyObject_GetAttrStr(__pyx_t_7, __pyx_n_s_get_mca); if (unlikely(!__pyx_t_3)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 311; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __Pyx_GOTREF(__pyx_t_3);
+  __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
+  __pyx_t_7 = __Pyx_PyObject_GetAttrStr(__pyx_v_self, __pyx_n_s_scan_2); if (unlikely(!__pyx_t_7)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 311; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __Pyx_GOTREF(__pyx_t_7);
+  __pyx_t_8 = __Pyx_PyObject_GetAttrStr(__pyx_t_7, __pyx_n_s_index); if (unlikely(!__pyx_t_8)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 311; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __Pyx_GOTREF(__pyx_t_8);
+  __Pyx_DECREF(__pyx_t_7); __pyx_t_7 = 0;
 
   /* "specfile.pyx":312
  * 
@@ -3310,35 +3321,35 @@ static PyObject *__pyx_pf_8specfile_3MCA_8__getitem__(CYTHON_UNUSED PyObject *__
  * 
  *     def __iter__(self):
  */
-  __pyx_t_6 = NULL;
+  __pyx_t_7 = NULL;
   __pyx_t_1 = 0;
   if (CYTHON_COMPILING_IN_CPYTHON && likely(PyMethod_Check(__pyx_t_3))) {
-    __pyx_t_6 = PyMethod_GET_SELF(__pyx_t_3);
-    if (likely(__pyx_t_6)) {
+    __pyx_t_7 = PyMethod_GET_SELF(__pyx_t_3);
+    if (likely(__pyx_t_7)) {
       PyObject* function = PyMethod_GET_FUNCTION(__pyx_t_3);
-      __Pyx_INCREF(__pyx_t_6);
+      __Pyx_INCREF(__pyx_t_7);
       __Pyx_INCREF(function);
       __Pyx_DECREF_SET(__pyx_t_3, function);
       __pyx_t_1 = 1;
     }
   }
-  __pyx_t_8 = PyTuple_New(2+__pyx_t_1); if (unlikely(!__pyx_t_8)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 311; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
-  __Pyx_GOTREF(__pyx_t_8);
-  if (__pyx_t_6) {
-    PyTuple_SET_ITEM(__pyx_t_8, 0, __pyx_t_6); __Pyx_GIVEREF(__pyx_t_6); __pyx_t_6 = NULL;
+  __pyx_t_9 = PyTuple_New(2+__pyx_t_1); if (unlikely(!__pyx_t_9)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 311; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __Pyx_GOTREF(__pyx_t_9);
+  if (__pyx_t_7) {
+    PyTuple_SET_ITEM(__pyx_t_9, 0, __pyx_t_7); __Pyx_GIVEREF(__pyx_t_7); __pyx_t_7 = NULL;
   }
-  PyTuple_SET_ITEM(__pyx_t_8, 0+__pyx_t_1, __pyx_t_7);
-  __Pyx_GIVEREF(__pyx_t_7);
+  PyTuple_SET_ITEM(__pyx_t_9, 0+__pyx_t_1, __pyx_t_8);
+  __Pyx_GIVEREF(__pyx_t_8);
   __Pyx_INCREF(__pyx_v_mca_index);
-  PyTuple_SET_ITEM(__pyx_t_8, 1+__pyx_t_1, __pyx_v_mca_index);
+  PyTuple_SET_ITEM(__pyx_t_9, 1+__pyx_t_1, __pyx_v_mca_index);
   __Pyx_GIVEREF(__pyx_v_mca_index);
-  __pyx_t_7 = 0;
-  __pyx_t_5 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_8, NULL); if (unlikely(!__pyx_t_5)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 311; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
-  __Pyx_GOTREF(__pyx_t_5);
-  __Pyx_DECREF(__pyx_t_8); __pyx_t_8 = 0;
+  __pyx_t_8 = 0;
+  __pyx_t_6 = __Pyx_PyObject_Call(__pyx_t_3, __pyx_t_9, NULL); if (unlikely(!__pyx_t_6)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 311; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
+  __Pyx_GOTREF(__pyx_t_6);
+  __Pyx_DECREF(__pyx_t_9); __pyx_t_9 = 0;
   __Pyx_DECREF(__pyx_t_3); __pyx_t_3 = 0;
-  __pyx_r = __pyx_t_5;
-  __pyx_t_5 = 0;
+  __pyx_r = __pyx_t_6;
+  __pyx_t_6 = 0;
   goto __pyx_L0;
 
   /* "specfile.pyx":286
@@ -3352,10 +3363,10 @@ static PyObject *__pyx_pf_8specfile_3MCA_8__getitem__(CYTHON_UNUSED PyObject *__
   /* function exit code */
   __pyx_L1_error:;
   __Pyx_XDECREF(__pyx_t_3);
-  __Pyx_XDECREF(__pyx_t_5);
   __Pyx_XDECREF(__pyx_t_6);
   __Pyx_XDECREF(__pyx_t_7);
   __Pyx_XDECREF(__pyx_t_8);
+  __Pyx_XDECREF(__pyx_t_9);
   __Pyx_AddTraceback("specfile.MCA.__getitem__", __pyx_clineno, __pyx_lineno, __pyx_filename);
   __pyx_r = NULL;
   __pyx_L0:;
@@ -16315,7 +16326,7 @@ static int __Pyx_InitCachedConstants(void) {
  *         if not len(self):
  *             raise IndexError("No MCA spectrum found in this scan")             # <<<<<<<<<<<<<<
  * 
- *         if isinstance(key, int):
+ *         if isinstance(key, (int, long)):
  */
   __pyx_tuple__4 = PyTuple_Pack(1, __pyx_kp_s_No_MCA_spectrum_found_in_this_sc); if (unlikely(!__pyx_tuple__4)) {__pyx_filename = __pyx_f[0]; __pyx_lineno = 296; __pyx_clineno = __LINE__; goto __pyx_L1_error;}
   __Pyx_GOTREF(__pyx_tuple__4);

--- a/silx/io/specfile/specfile.pyx
+++ b/silx/io/specfile/specfile.pyx
@@ -295,7 +295,7 @@ class MCA(object):
         if not len(self):
             raise IndexError("No MCA spectrum found in this scan")
 
-        if isinstance(key, int):
+        if isinstance(key, (int, long)):
             mca_index = key
             # allow negative index, like lists
             if mca_index < 0:

--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -323,6 +323,14 @@ def is_dataset(name):
     return _bulk_match(name, data_patterns)
 
 
+def is_mca_data(name):
+    """Return True if name matches a path to MCA data."""
+    mca_data_patterns = (instrument_mca_data_pattern,
+                         measurement_mca_data_pattern,
+                         measurement_mca_info_data_pattern)
+    return _bulk_match(name, mca_data_patterns)
+
+
 def is_link_to_group(name):
     """Check if ``name`` is a valid link to a group in a :class:`SpecH5`.
     Return ``True`` or ``False``
@@ -1442,7 +1450,35 @@ class SpecH5Group(object):
         else:
             raise KeyError("unrecognized group or dataset: " + full_key)
 
-        self.file.cache(full_key, obj)
+        if is_mca_data(full_key):
+            # optimization: cache all 3 datasets containing the MCA data
+            #               to avoid regenerating the data
+            scan_key = _get_scan_key_in_name(full_key)
+            mca_index = _get_mca_index_in_name(full_key)
+
+            instr_mca_name = "/%s/instrument/mca_%d/data" % (scan_key, mca_index)
+            self.file.cache(instr_mca_name,
+                            SpecH5Dataset(value=obj.value,
+                                          name=instr_mca_name,
+                                          file_=obj.file,
+                                          parent=SpecH5Group(instr_mca_name[:-5],
+                                                             obj.file)))
+
+            name_patterns = ["/%s/measurement/mca_%d/data",
+                             "/%s/measurement/mca_%d/info/data"]
+            for p in name_patterns:
+                link_name = p % (scan_key, mca_index)
+                parent_name = link_name[:-5]
+                new_obj = SpecH5LinkToDataset(value=obj.value,
+                                              name=link_name,
+                                              file_=obj.file,
+                                              parent=SpecH5Group(parent_name,
+                                                                 obj.file),
+                                              target=instr_mca_name)
+                self.file.cache(link_name,
+                                new_obj)
+        else:
+            self.file.cache(full_key, obj)
 
         return obj
 

--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -1207,16 +1207,16 @@ def _demultiplex_mca(scan, analyser_index):
     :return: 2D numpy array containing all spectra for one analyser
     """
     number_of_analysers = _get_number_of_mca_analysers(scan)
+    number_of_spectra = len(scan.mca)
+    number_of_spectra_per_analyser = number_of_spectra // number_of_analysers
+    len_spectrum = len(scan.mca[analyser_index])
 
-    number_of_MCA_spectra = len(scan.mca)
+    mca_array = numpy.empty((number_of_spectra_per_analyser, len_spectrum))
 
-    list_of_1D_arrays = []
-    for i in range(analyser_index,
-                   number_of_MCA_spectra,
-                   number_of_analysers):
-        list_of_1D_arrays.append(scan.mca[i])
-    # convert list to 2D array
-    return numpy.array(list_of_1D_arrays)
+    for i in range(number_of_spectra_per_analyser):
+        mca_array[i, :] = scan.mca[analyser_index + i * number_of_analysers]
+
+    return mca_array
 
 
 class SpecH5Group(object):
@@ -1427,17 +1427,22 @@ class SpecH5Group(object):
         :raise: KeyError if ``key`` is not a known member of this group.
         """
         full_key = self._get_full_key(key)
+        if full_key in self.file._cached_items:
+            return self.file._cached_items[full_key]
+
         if is_group(full_key):
-            return SpecH5Group(full_key, self.file)
+            self.file.cache(full_key, SpecH5Group(full_key, self.file))
         elif is_dataset(full_key):
-            return _dataset_builder(full_key, self.file, self)
+            self.file.cache(full_key, _dataset_builder(full_key, self.file, self))
         elif is_link_to_group(full_key):
             link_target = full_key.replace("measurement", "instrument").rstrip("/")[:-4]
-            return SpecH5LinkToGroup(full_key, self.file, link_target)
+            self.file.cache(full_key, SpecH5LinkToGroup(full_key, self.file, link_target))
         elif is_link_to_dataset(full_key):
-            return _link_to_dataset_builder(full_key, self.file, self)
+            self.file.cache(full_key, _link_to_dataset_builder(full_key, self.file, self))
         else:
             raise KeyError("unrecognized group or dataset: " + full_key)
+
+        return self.file._cached_items[full_key]
 
     def __iter__(self):
         for key in self.keys():
@@ -1702,11 +1707,23 @@ class SpecH5(SpecH5Group):
                             "file handle.")
         self.attrs = _get_attrs_dict("/")
         self._sf = SpecFile(self.filename)
+        self._cached_items = {}
+        """Keeps a reference to created items, to avoid regenerating
+        them again."""
 
         SpecH5Group.__init__(self, name="/", specfileh5=self)
         if len(self) == 0:
             # SpecFile library do not raise exception for non specfiles
             raise IOError("Empty specfile. Not a valid spec format.")
+
+    def cache(self, name, item):
+        self._cached_items[name] = item
+
+    def uncache(self, name):
+        if name in self._cached_items:
+            del self._cached_items[name]
+        else:
+            raise KeyError("Key %s not in cache" % name)
 
     def keys(self):
         """


### PR DESCRIPTION
This PR will improve the computation time of SpecH5 in the context of the Hdf5Tree.

- SpecH5 have enough information to return request using `getlink` and `getclass` without loading the data at this level. This patch takes care of it.
- SpecH5 will also cache datasets per files
- Links to the same dataset will only be computed one time