### PR TITLE
Silent warnings

### DIFF
--- a/silx/io/test/test_specfile.py
+++ b/silx/io/test/test_specfile.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["P. Knobel", "V.A. Sole"]
 __license__ = "MIT"
-__date__ = "15/05/2017"
+__date__ = "03/08/2017"
 
 import gc
 import locale
@@ -36,10 +36,13 @@ import sys
 import tempfile
 import unittest
 
-logger1 = logging.getLogger(__name__)
+from silx.test import utils
 
 from ..specfile import SpecFile, Scan
 from .. import specfile
+
+
+logger1 = logging.getLogger(__name__)
 
 sftext = """#F /tmp/sf.dat
 #E 1455180875
@@ -373,6 +376,7 @@ class TestSpecFile(unittest.TestCase):
         self.assertEqual(self.scan25.mca.channels,
                          [])
 
+    @utils.test_logging(specfile._logger.name, warning=1)
     def test_empty_scan(self):
         """Test reading a scan with no data points"""
         self.assertEqual(len(self.empty_scan.labels),

--- a/silx/io/test/test_spech5.py
+++ b/silx/io/test/test_spech5.py
@@ -32,6 +32,8 @@ import unittest
 import datetime
 from functools import partial
 
+from silx.test import utils
+
 from .. import spech5
 from ..spech5 import (SpecH5, SpecH5Group,
                       SpecH5Dataset, spec_date_to_iso8601)
@@ -504,6 +506,7 @@ class TestSpecH5(unittest.TestCase):
                       self.sfh5["/25.1"].values())
 
     # visit and visititems ignore links
+    @utils.test_logging(spech5.logger1.name, warning=2)
     def testVisit(self):
         name_list = []
         self.sfh5.visit(name_list.append)
@@ -531,6 +534,7 @@ class TestSpecH5(unittest.TestCase):
         self.assertIn("positioners/Pslit HGap", name_list_no_slash)
         self.assertIn("positioners", name_list_no_slash)
 
+    @utils.test_logging(spech5.logger1.name, warning=2)
     def testVisitItems(self):
         dataset_name_list = []
 
@@ -585,6 +589,7 @@ class TestSpecH5(unittest.TestCase):
         with self.assertRaises(KeyError):
             uc = self.sfh5["/1001.1/sample/unit_cell"]
 
+    @utils.test_logging(spech5.logger1.name, warning=2)
     def testOpenFileDescriptor(self):
         """Open a SpecH5 file from a file descriptor"""
         with io.open(self.sfh5.filename) as f:

--- a/silx/math/fit/test/test_fit.py
+++ b/silx/math/fit/test/test_fit.py
@@ -30,6 +30,9 @@ import unittest
 import numpy
 import sys
 
+from silx.test import utils
+from silx.math.fit.leastsq import _logger as fitlogger
+
 
 class Test_leastsq(unittest.TestCase):
     """
@@ -238,6 +241,7 @@ class Test_leastsq(unittest.TestCase):
                                                       fittedpar[i])
             self.assertTrue(test_condition, msg)
 
+    @utils.test_logging(fitlogger.name, warning=2)
     def testBadlyShapedData(self):
         parameters_actual = [10.5, 2, 1000.0, 20., 15]
         x = numpy.arange(10000.).reshape(1000, 10)
@@ -259,6 +263,7 @@ class Test_leastsq(unittest.TestCase):
                                                           fittedpar[i])
                 self.assertTrue(test_condition, msg)
 
+    @utils.test_logging(fitlogger.name, warning=3)
     def testDataWithNaN(self):
         parameters_actual = [10.5, 2, 1000.0, 20., 15]
         x = numpy.arange(10000.).reshape(1000, 10)

--- a/silx/test/utils.py
+++ b/silx/test/utils.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "20/04/2017"
+__date__ = "03/08/2017"
 
 
 import os
@@ -48,7 +48,7 @@ import tempfile
 import unittest
 from ..resources import ExternalResources
 
-logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 utilstest = ExternalResources(project="silx",
                               url_base="http://www.silx.org/pub/silx/",
@@ -157,6 +157,13 @@ class TestLogging(logging.Handler):
 
         for level, expected_count in self.count_by_level.items():
             if expected_count is None:
+                continue
+
+            # if tests are not run in verbose mode, the root logger level is
+            # WARNING, causing INFO and DEBUG messages to be not be emitted
+            if not self.logger.isEnabledFor(level):
+                _logger.debug("logger %s disabled for level %d. Cannot count messages.",
+                              self.logger.name, level)
                 continue
 
             # Number of records for the specified level_str

--- a/silx/test/utils.py
+++ b/silx/test/utils.py
@@ -149,21 +149,18 @@ class TestLogging(logging.Handler):
         self.records = []  # Reset recorded LogRecords
         self.logger.addHandler(self)
         self.logger.propagate = False
+        # ensure no log message is ignored
+        self.entry_level = self.logger.level * 1
+        self.logger.setLevel(logging.DEBUG)
 
     def __exit__(self, exc_type, exc_value, traceback):
         """Context (i.e., with) support"""
         self.logger.removeHandler(self)
         self.logger.propagate = True
+        self.logger.setLevel(self.entry_level)
 
         for level, expected_count in self.count_by_level.items():
             if expected_count is None:
-                continue
-
-            # if tests are not run in verbose mode, the root logger level is
-            # WARNING, causing INFO and DEBUG messages to be not be emitted
-            if not self.logger.isEnabledFor(level):
-                _logger.debug("logger %s disabled for level %d. Cannot count messages.",
-                              self.logger.name, level)
                 continue
 
             # Number of records for the specified level_str


### PR DESCRIPTION
Addresses #1012 : reduce number of warnings printed during tests.

This PR should be discussed in a meeting, because when running tests in verbose mode it would make sense to display warnings.

Commit https://github.com/PiRK/silx/commit/bf264c67d4cdf1edb967161039aba77c211ec07e is probably controversial too. If one tries to add `@utils.test_logging(logger.name, info=1)` to a test, the success depends on running the test in verbose mode (because in standard mode, the INFO messages are never emitted so the count is wrong. But maybe this is a feature, because test succes should be designed to not depend on the logging level? In that case, `@utils.test_logging(logger.name, warning=...)` should also be considered wrong.

Alternatively, we could possibly change the logging level to emit all logs after entering the `TestLogging` context and set it back to it's original level on exit.