### PR TITLE
Fix external download

### DIFF
--- a/silx/resources/__init__.py
+++ b/silx/resources/__init__.py
@@ -56,7 +56,7 @@ of this modules to ensure access across different distribution schemes:
 
 __authors__ = ["V.A. Sole", "Thomas Vincent", "J. Kieffer"]
 __license__ = "MIT"
-__date__ = "22/05/2017"
+__date__ = "03/08/2017"
 
 
 import os
@@ -158,6 +158,7 @@ class ExternalResources(object):
         self.url_base = url_base
         self.all_data = set()
         self.timeout = timeout
+        self.data_home = None
 
     def _initialize_tmpdir(self):
         """Initialize the temporary directory"""

--- a/silx/test/test_resources.py
+++ b/silx/test/test_resources.py
@@ -63,13 +63,13 @@ def isSilxWebsiteAvailable():
 
 
 class TestExternalResources(unittest.TestCase):
+    """This is a test for the ExternalResources"""
 
     @classmethod
     def setUpClass(cls):
         if not isSilxWebsiteAvailable():
             raise unittest.SkipTest("Network or silx website not available")
 
-    "This is a test for the TestResources"
     def test_tempdir(self):
         "test the temporary directory creation"
         myutilstest = silx.resources.ExternalResources("toto", "http://www.silx.org")

--- a/silx/test/test_resources.py
+++ b/silx/test/test_resources.py
@@ -26,12 +26,13 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "22/05/2017"
+__date__ = "03/08/2017"
 
 
 import os
 import unittest
 
+import urllib2
 import silx.resources
 from .utils import utilstest
 
@@ -53,7 +54,21 @@ class TestResources(unittest.TestCase):
         self.assertFalse(os.path.exists(filename))
 
 
+def isSilxWebsiteAvailable():
+    try:
+        urllib2.urlopen('http://www.silx.org', timeout=1)
+        return True
+    except urllib2.URLError:
+        return False
+
+
 class TestExternalResources(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        if not isSilxWebsiteAvailable():
+            raise unittest.SkipTest("Network or silx website not available")
+
     "This is a test for the TestResources"
     def test_tempdir(self):
         "test the temporary directory creation"

--- a/silx/test/test_resources.py
+++ b/silx/test/test_resources.py
@@ -32,7 +32,7 @@ __date__ = "03/08/2017"
 import os
 import unittest
 
-import urllib2
+from silx.third_party import six
 import silx.resources
 from .utils import utilstest
 
@@ -56,9 +56,9 @@ class TestResources(unittest.TestCase):
 
 def isSilxWebsiteAvailable():
     try:
-        urllib2.urlopen('http://www.silx.org', timeout=1)
+        six.moves.urllib.request.urlopen('http://www.silx.org', timeout=1)
         return True
-    except urllib2.URLError:
+    except six.moves.urllib.error.URLError:
         return False
 
 

--- a/silx/test/test_resources.py
+++ b/silx/test/test_resources.py
@@ -116,12 +116,10 @@ class TestExternalResources(unittest.TestCase):
 
 
 def suite():
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
     test_suite = unittest.TestSuite()
-    test_suite.addTest(
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestResources))
-    test_suite.addTest(TestExternalResources("test_tempdir"))
-    test_suite.addTest(TestExternalResources("test_download"))  # order matters !
-    test_suite.addTest(TestExternalResources("test_dowload_all"))
+    test_suite.addTest(loadTests(TestResources))
+    test_suite.addTest(loadTests(TestExternalResources))
     return test_suite
 
 


### PR DESCRIPTION
- Skip tests if silx.org is not available
    - while it is an external system it better to skip tests here
    - It should allow Debian to package the lib
- Clean up to have independent tests

Relative to #1009