### PR TITLE
[tests] Improve run tests

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -64,6 +64,7 @@ class StreamHandlerUnittestReady(logging.StreamHandler):
 
 # Use an handler compatible with unittests, else use_buffer is not working
 logging.root.addHandler(StreamHandlerUnittestReady())
+logging.captureWarnings(True)
 
 logger = logging.getLogger("run_tests")
 logger.setLevel(logging.WARNING)

--- a/run_tests.py
+++ b/run_tests.py
@@ -62,8 +62,18 @@ class StreamHandlerUnittestReady(logging.StreamHandler):
         pass
 
 
+def createBasicHandler():
+    """Create the handler using the basic configuration"""
+    hdlr = StreamHandlerUnittestReady()
+    fs = logging.BASIC_FORMAT
+    dfs = None
+    fmt = logging.Formatter(fs, dfs)
+    hdlr.setFormatter(fmt)
+    return hdlr
+
+
 # Use an handler compatible with unittests, else use_buffer is not working
-logging.root.addHandler(StreamHandlerUnittestReady())
+logging.root.addHandler(createBasicHandler())
 logging.captureWarnings(True)
 
 logger = logging.getLogger("run_tests")

--- a/run_tests.py
+++ b/run_tests.py
@@ -100,6 +100,17 @@ PROJECT_NAME = get_project_name(PROJECT_DIR)
 logger.info("Project name: %s", PROJECT_NAME)
 
 
+class TextTestResultWithSkipList(unittest.TextTestResult):
+    """Override default TextTestResult to display list of skipped tests at the
+    end
+    """
+
+    def printErrors(self):
+        unittest.TextTestResult.printErrors(self)
+        # Print skipped tests at the end
+        self.printErrorList("SKIPPED", self.skipped)
+
+
 class ProfileTextTestResult(unittest.TextTestRunner.resultclass):
 
     def __init__(self, *arg, **kwarg):
@@ -355,6 +366,8 @@ runnerArgs = {}
 runnerArgs["verbosity"] = test_verbosity
 if options.memprofile:
     runnerArgs["resultclass"] = ProfileTextTestResult
+else:
+    runnerArgs["resultclass"] = TextTestResultWithSkipList
 runner = unittest.TextTestRunner(**runnerArgs)
 
 logger.warning("Test %s %s from %s",
@@ -379,15 +392,10 @@ else:
 unittest.installHandler()
 
 result = runner.run(test_suite)
-for test, reason in result.skipped:
-    logger.warning('Skipped %s (%s): %s',
-                   test.id(), test.shortDescription() or '', reason)
 
 if result.wasSuccessful():
-    logger.info("Test suite succeeded")
     exit_status = 0
 else:
-    logger.warning("Test suite failed")
     exit_status = 1
 
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -32,7 +32,7 @@ Test coverage dependencies: coverage, lxml.
 """
 
 __authors__ = ["Jérôme Kieffer", "Thomas Vincent"]
-__date__ = "19/04/2017"
+__date__ = "03/08/2017"
 __license__ = "MIT"
 
 import distutils.util
@@ -375,6 +375,8 @@ else:
     test_suite.addTest(
         unittest.defaultTestLoader.loadTestsFromNames(options.test_name))
 
+# Display the result when using CTRL-C
+unittest.installHandler()
 
 result = runner.run(test_suite)
 for test, reason in result.skipped:


### PR DESCRIPTION
Implement:
- Bufferization to avoid verbosity in tests (it is disabled when using -v or -vv)
- Display test results when using CTRL-C


Relative to #1012 
Closes #1013