### PR TITLE
API to add constraints on plot axes

### DIFF
--- a/examples/plotLimits.py
+++ b/examples/plotLimits.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This script is an example to illustrate how to use axis synchronization
+tool.
+"""
+
+from silx.gui import qt
+from silx.gui import plot
+import numpy
+import silx.test.utils
+
+
+class ConstrainedViewPlot(qt.QMainWindow):
+
+    def __init__(self):
+        qt.QMainWindow.__init__(self)
+        self.setWindowTitle("Plot with synchronized axes")
+        widget = qt.QWidget(self)
+        self.setCentralWidget(widget)
+
+        layout = qt.QGridLayout()
+        widget.setLayout(layout)
+
+        backend = "mpl"
+
+        data = numpy.arange(100 * 100)
+        data = (data % 100) / 5.0
+        data = numpy.sin(data)
+        data = silx.test.utils.add_gaussian_noise(data, mean=0.01)
+        data.shape = 100, 100
+
+        data1d = numpy.mean(data, axis=0)
+
+        self.plot2d = plot.Plot2D(parent=widget, backend=backend)
+        self.plot2d.setGraphTitle("A pixel can't be too big")
+        self.plot2d.setInteractiveMode('pan')
+        self.plot2d.addImage(data)
+        self.plot2d.setLimitConstraints(minXRange=10, minYRange=10)
+
+        self.plot2d2 = plot.Plot2D(parent=widget, backend=backend)
+        self.plot2d2.setGraphTitle("The image can't be too small")
+        self.plot2d2.setInteractiveMode('pan')
+        self.plot2d2.addImage(data)
+        self.plot2d2.setLimitConstraints(maxXRange=200, maxYRange=200)
+
+        self.plot1d = plot.Plot1D(parent=widget, backend=backend)
+        self.plot1d.setGraphTitle("The curve is clamped into the view")
+        self.plot1d.addCurve(x=numpy.arange(100), y=data1d, legend="mean")
+        self.plot1d.setLimitConstraints(xMin=0, xMax=100, yMin=data1d.min(), yMax=data1d.max())
+
+        self.plot1d2 = plot.Plot1D(parent=widget, backend=backend)
+        self.plot1d2.setGraphTitle("Only clamp y-axis")
+        self.plot1d2.setInteractiveMode('pan')
+        self.plot1d2.addCurve(x=numpy.arange(100), y=data1d, legend="mean")
+        self.plot1d2.setLimitConstraints(yMin=data1d.min(), yMax=data1d.max())
+
+        layout.addWidget(self.plot2d, 0, 0)
+        layout.addWidget(self.plot1d, 0, 1)
+        layout.addWidget(self.plot2d2, 1, 0)
+        layout.addWidget(self.plot1d2, 1, 1)
+
+
+if __name__ == "__main__":
+    app = qt.QApplication([])
+    window = ConstrainedViewPlot()
+    window.setVisible(True)
+    app.exec_()

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -175,7 +175,7 @@ from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent"]
 __license__ = "MIT"
-__date__ = "04/08/2017"
+__date__ = "08/08/2017"
 
 
 from collections import OrderedDict, namedtuple
@@ -199,7 +199,7 @@ from . import _utils
 from . import items
 
 from .. import qt
-from ._utils.panzoom import ViewConstaints
+from ._utils.panzoom import ViewConstraints
 
 
 _logger = logging.getLogger(__name__)
@@ -339,7 +339,7 @@ class PlotWidget(qt.QMainWindow):
             _logger.warning('deprecated: __init__ callback argument')
 
         self._panWithArrowKeys = True
-        self._viewContrains = None
+        self._viewConstrains = None
 
         super(PlotWidget, self).__init__(parent)
         if parent is not None:
@@ -2093,8 +2093,8 @@ class PlotWidget(qt.QMainWindow):
             axis = self.getYAxis(axis="right")
             y2min, y2max = axis._checkLimits(y2min, y2max)
 
-        if self._viewContrains:
-            view = self._viewContrains.normalize(xmin, xmax, ymin, ymax)
+        if self._viewConstrains:
+            view = self._viewConstrains.normalize(xmin, xmax, ymin, ymax)
             xmin, xmax, ymin, ymax = view
 
         self._backend.setLimits(xmin, xmax, ymin, ymax, y2min, y2max)
@@ -2111,7 +2111,7 @@ class PlotWidget(qt.QMainWindow):
         The arguments `xMin`, `xMax`, `yMin`, `yMax` define the region within
         the viewbox coordinate system that may be accessed by panning the view.
 
-        The arguments ranges arguments prevent the view being zoomed in or
+        The ranges arguments prevent the view being zoomed in or
         out too far.
 
         .. versionadded:: 0.6
@@ -2125,14 +2125,14 @@ class PlotWidget(qt.QMainWindow):
         :param float minYRange: Minimum allowed top-to-bottom span across the view.
         :param float maxYRange: Maximum allowed top-to-bottom span across the view.
         """
-        if self._viewContrains is None:
-            self._viewContrains = ViewConstaints()
-        updated = self._viewContrains.update(xMin=xMin, xMax=xMax,
-                                             yMin=yMin, yMax=yMax,
-                                             minXRange=minXRange,
-                                             maxXRange=maxXRange,
-                                             minYRange=minYRange,
-                                             maxYRange=maxYRange)
+        if self._viewConstrains is None:
+            self._viewConstrains = ViewConstraints()
+        updated = self._viewConstrains.update(xMin=xMin, xMax=xMax,
+                                              yMin=yMin, yMax=yMax,
+                                              minXRange=minXRange,
+                                              maxXRange=maxXRange,
+                                              minYRange=minYRange,
+                                              maxYRange=maxYRange)
         if updated:
             xMin, xMax = self.getXAxis().getLimits()
             yMin, yMax = self.getYAxis().getLimits()

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -175,7 +175,7 @@ from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent"]
 __license__ = "MIT"
-__date__ = "28/06/2017"
+__date__ = "04/08/2017"
 
 
 from collections import OrderedDict, namedtuple
@@ -199,6 +199,7 @@ from . import _utils
 from . import items
 
 from .. import qt
+from ._utils.panzoom import ViewConstaints
 
 
 _logger = logging.getLogger(__name__)
@@ -338,6 +339,7 @@ class PlotWidget(qt.QMainWindow):
             _logger.warning('deprecated: __init__ callback argument')
 
         self._panWithArrowKeys = True
+        self._viewContrains = None
 
         super(PlotWidget, self).__init__(parent)
         if parent is not None:
@@ -2091,9 +2093,51 @@ class PlotWidget(qt.QMainWindow):
             axis = self.getYAxis(axis="right")
             y2min, y2max = axis._checkLimits(y2min, y2max)
 
+        if self._viewContrains:
+            view = self._viewContrains.normalize(xmin, xmax, ymin, ymax)
+            xmin, xmax, ymin, ymax = view
+
         self._backend.setLimits(xmin, xmax, ymin, ymax, y2min, y2max)
         self._setDirtyPlot()
         self._notifyLimitsChanged()
+
+    def setLimitConstraints(self, xMin=None, xMax=None,
+                            yMin=None, yMax=None,
+                            minXRange=None, maxXRange=None,
+                            minYRange=None, maxYRange=None):
+        """
+        Set limits that constrain the possible view ranges.
+
+        The arguments `xMin`, `xMax`, `yMin`, `yMax` define the region within
+        the viewbox coordinate system that may be accessed by panning the view.
+
+        The arguments ranges arguments prevent the view being zoomed in or
+        out too far.
+
+        .. versionadded:: 0.6
+
+        :param float xMin: Minimum allowed x-axis value
+        :param float xMax: Maximum allowed x-axis value
+        :param float yMin: Minimum allowed y-axis value
+        :param float yMax: Maximum allowed y-axis value
+        :param float minXRange: Minimum allowed left-to-right span across the view.
+        :param float maxXRange: Maximum allowed left-to-right span across the view.
+        :param float minYRange: Minimum allowed top-to-bottom span across the view.
+        :param float maxYRange: Maximum allowed top-to-bottom span across the view.
+        """
+        if self._viewContrains is None:
+            self._viewContrains = ViewConstaints()
+        updated = self._viewContrains.update(xMin=xMin, xMax=xMax,
+                                             yMin=yMin, yMax=yMax,
+                                             minXRange=minXRange,
+                                             maxXRange=maxXRange,
+                                             minYRange=minYRange,
+                                             maxYRange=maxYRange)
+        if updated:
+            xMin, xMax = self.getXAxis().getLimits()
+            yMin, yMax = self.getYAxis().getLimits()
+            y2Min, y2Max = self.getYAxis('right').getLimits()
+            self.setLimits(xMin, xMax, yMin, yMax, y2Min, y2Max)
 
     # Title and labels
 

--- a/silx/gui/plot/_utils/panzoom.py
+++ b/silx/gui/plot/_utils/panzoom.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent", "V. Valls"]
 __license__ = "MIT"
-__date__ = "04/08/2017"
+__date__ = "08/08/2017"
 
 
 import math
@@ -160,7 +160,10 @@ class _Unset(object):
     pass
 
 
-class ViewConstaints(object):
+class ViewConstraints(object):
+    """
+    Store constraints applied on the view box and compute the resulting view box.
+    """
 
     def __init__(self):
         self._min = [None, None]
@@ -173,9 +176,9 @@ class ViewConstaints(object):
                minXRange=_Unset, maxXRange=_Unset,
                minYRange=_Unset, maxYRange=_Unset):
         """
-        Update the contraints managed by the object
+        Update the constraints managed by the object
 
-        The contraints are the same as the ones provided by PyQtGraph.
+        The constraints are the same as the ones provided by PyQtGraph.
 
         :param float xMin: Minimum allowed x-axis value.
             (default do not change the stat, None remove the constraint)
@@ -193,7 +196,7 @@ class ViewConstaints(object):
             view (default do not change the stat, None remove the constraint)
         :param float maxYRange: Maximum allowed top-to-bottom span across the
             view (default do not change the stat, None remove the constraint)
-        :return: True if the constaints was changed
+        :return: True if the constraints was changed
         """
         updated = False
 

--- a/silx/gui/plot/test/__init__.py
+++ b/silx/gui/plot/test/__init__.py
@@ -49,6 +49,7 @@ from . import testProfile
 from . import testStackView
 from . import testItem
 from . import testUtilsAxis
+from . import testLimitConstraints
 
 
 def suite():
@@ -73,5 +74,6 @@ def suite():
          testStackView.suite(),
          testColormap.suite(),
          testItem.suite(),
-         testUtilsAxis.suite()])
+         testUtilsAxis.suite(),
+         testLimitConstraints.suite()])
     return test_suite

--- a/silx/gui/plot/test/testLimitConstraints.py
+++ b/silx/gui/plot/test/testLimitConstraints.py
@@ -1,0 +1,130 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Test setLimitConstaints on the PlotWidget"""
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "04/08/2017"
+
+
+import unittest
+from silx.gui.plot import PlotWidget
+
+
+class TestLimitConstaints(unittest.TestCase):
+    """Tests setLimitConstaints class"""
+
+    def setUp(self):
+        self.plot = PlotWidget()
+
+    def tearDown(self):
+        self.plot = None
+
+    def testApi(self):
+        """Test availability of the API"""
+        self.plot.setLimitConstraints(
+            xMin=1,
+            xMax=1,
+            yMin=1,
+            yMax=1,
+            minXRange=1,
+            maxXRange=1,
+            minYRange=1,
+            maxYRange=1)
+
+    def testXMinMax(self):
+        """Test limit constains on x-axis"""
+        self.plot.setLimitConstraints(xMin=0, xMax=100)
+        self.plot.setLimits(xmin=-1, xmax=101, ymin=-1, ymax=101)
+        self.assertEqual(self.plot.getXAxis().getLimits(), (0, 100))
+        self.assertEqual(self.plot.getYAxis().getLimits(), (-1, 101))
+
+    def testYMinMax(self):
+        """Test limit constains on y-axis"""
+        self.plot.setLimitConstraints(yMin=0, yMax=100)
+        self.plot.setLimits(xmin=-1, xmax=101, ymin=-1, ymax=101)
+        self.assertEqual(self.plot.getXAxis().getLimits(), (-1, 101))
+        self.assertEqual(self.plot.getYAxis().getLimits(), (0, 100))
+
+    def testMinXRange(self):
+        """Test min range constains on x-axis"""
+        self.plot.setLimitConstraints(minXRange=100)
+        self.plot.setLimits(xmin=1, xmax=99, ymin=1, ymax=99)
+        limits = self.plot.getXAxis().getLimits()
+        self.assertEqual(limits[1] - limits[0], 100)
+        limits = self.plot.getYAxis().getLimits()
+        self.assertNotEqual(limits[1] - limits[0], 100)
+
+    def testMaxXRange(self):
+        """Test max range constains on x-axis"""
+        self.plot.setLimitConstraints(maxXRange=100)
+        self.plot.setLimits(xmin=-1, xmax=101, ymin=-1, ymax=101)
+        limits = self.plot.getXAxis().getLimits()
+        self.assertEqual(limits[1] - limits[0], 100)
+        limits = self.plot.getYAxis().getLimits()
+        self.assertNotEqual(limits[1] - limits[0], 100)
+
+    def testMinYRange(self):
+        """Test min range constains on y-axis"""
+        self.plot.setLimitConstraints(minYRange=100)
+        self.plot.setLimits(xmin=1, xmax=99, ymin=1, ymax=99)
+        limits = self.plot.getXAxis().getLimits()
+        self.assertNotEqual(limits[1] - limits[0], 100)
+        limits = self.plot.getYAxis().getLimits()
+        self.assertEqual(limits[1] - limits[0], 100)
+
+    def testMaxYRange(self):
+        """Test max range constains on y-axis"""
+        self.plot.setLimitConstraints(maxYRange=100)
+        self.plot.setLimits(xmin=-1, xmax=101, ymin=-1, ymax=101)
+        limits = self.plot.getXAxis().getLimits()
+        self.assertNotEqual(limits[1] - limits[0], 100)
+        limits = self.plot.getYAxis().getLimits()
+        self.assertEqual(limits[1] - limits[0], 100)
+
+    def testChangeOfConstraints(self):
+        """Test changing of the contraints"""
+        self.plot.setLimitConstraints(minXRange=10, maxXRange=10)
+        # There is no more containts on the range
+        self.plot.setLimitConstraints(xMin=0, xMax=100)
+        self.plot.setLimits(xmin=-1, xmax=101, ymin=-1, ymax=101)
+        self.assertEqual(self.plot.getXAxis().getLimits(), (0, 100))
+
+    def testSettingConstraints(self):
+        """Test setting a constaint (setLimits first then the constaint)"""
+        self.plot.setLimits(xmin=-1, xmax=101, ymin=-1, ymax=101)
+        self.plot.setLimitConstraints(xMin=0, xMax=100)
+        self.assertEqual(self.plot.getXAxis().getLimits(), (0, 100))
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(TestLimitConstaints))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/silx/gui/plot/test/testLimitConstraints.py
+++ b/silx/gui/plot/test/testLimitConstraints.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "04/08/2017"
+__date__ = "08/08/2017"
 
 
 import unittest
@@ -105,7 +105,7 @@ class TestLimitConstaints(unittest.TestCase):
         self.assertEqual(limits[1] - limits[0], 100)
 
     def testChangeOfConstraints(self):
-        """Test changing of the contraints"""
+        """Test changing of the constraints"""
         self.plot.setLimitConstraints(minXRange=10, maxXRange=10)
         # There is no more containts on the range
         self.plot.setLimitConstraints(xMin=0, xMax=100)


### PR DESCRIPTION
`setLimitConstaints` allow to add constaints a-la PyQtGraph, to avoid to move the view outside of an expected zoom or box.

The provided example shows 4 use cases.

Closes #632