### PR TITLE
Robustness on GUI unittests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,6 @@ before_script:
           sleep 3;
       fi
 
-script:
     # Install optional dependencies for running test
     - pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ pyopencl==2015.1
     # This installs PyQt and scipy if wheels are available
@@ -112,7 +111,7 @@ script:
     - "pip install --upgrade pynput"
     - "python ci/close_popup.py"
 
-    # Run the tests
+script:
     - echo "WITH_QT_TEST="$WITH_QT_TEST
     - if [ "$TRAVIS_OS_NAME" == "osx" ];
       then

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,3 +118,7 @@ script:
           export SILX_TEST_LOW_MEM=True;
       fi
     - python run_tests.py --installed -v
+
+after_failure:
+    # Display result as base64, while it is not possible to expose files
+    - "for f in ./build/test-debug/*.png; do echo $f as base64; echo $( base64 $f); done"

--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,9 @@ script:
           ldd $(python -c "import h5py;print(h5py.h5d.__file__)");
       fi
 
+    - "pip install --upgrade pynput"
+    - "python ci/close_popup.py"
+
     # Run the tests
     - echo "WITH_QT_TEST="$WITH_QT_TEST
     - if [ "$TRAVIS_OS_NAME" == "osx" ];

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -120,6 +120,13 @@ after_test:
     - "%VENV_TEST_DIR%\\Scripts\\deactivate.bat"
     - "rmdir %VENV_TEST_DIR% /s /q"
 
+on_failure:
+    # Push test-debug files as artefact
+    - ps: >-
+        if (Test-Path -LiteralPath "build\test-debug") {
+            Get-ChildItem .\build\test-debug\* | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+        }
+
 artifacts:
     # Archive the generated wheel package in the ci.appveyor.com build report.
     - path: dist\*

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -110,10 +110,7 @@ before_test:
 test_script:
     # Run tests with selected Qt binding and without OpenCL
     - echo "WITH_GL_TEST=%WITH_GL_TEST%"
-    #- "python run_tests.py --installed -v --no-opencl --qt-binding %QT_BINDING%"
-    # Do not test the GUI while there is a problem with appveyor
-    # https://github.com/appveyor/ci/issues/1715
-    - "python run_tests.py --installed -v --no-opencl --no-gui --qt-binding %QT_BINDING%"
+    - "python run_tests.py --installed -v --no-opencl --qt-binding %QT_BINDING%"
 
 after_test:
     # Leave test virtualenv

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -82,7 +82,7 @@ build_script:
     - "%VENV_BUILD_DIR%\\Scripts\\deactivate.bat"
     - "rmdir %VENV_BUILD_DIR% /s /q"
 
-test_script:
+before_test:
     # Create test virtualenv
     - "virtualenv --clear %VENV_TEST_DIR%"
     - "%VENV_TEST_DIR%\\Scripts\\activate.bat"
@@ -107,6 +107,7 @@ test_script:
     - "pip install --upgrade pynput"
     - "python ./ci/close_popup.py"
 
+test_script:
     # Run tests with selected Qt binding and without OpenCL
     - echo "WITH_GL_TEST=%WITH_GL_TEST%"
     #- "python run_tests.py --installed -v --no-opencl --qt-binding %QT_BINDING%"
@@ -114,6 +115,7 @@ test_script:
     # https://github.com/appveyor/ci/issues/1715
     - "python run_tests.py --installed -v --no-opencl --no-gui --qt-binding %QT_BINDING%"
 
+after_test:
     # Leave test virtualenv
     - "%VENV_TEST_DIR%\\Scripts\\deactivate.bat"
     - "rmdir %VENV_TEST_DIR% /s /q"

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -103,6 +103,10 @@ test_script:
     - "python ci\\info_platform.py"
     - "pip list"
 
+    # Try to close popups
+    - "pip install --upgrade pynput"
+    - "python ./ci/close_popup.py"
+
     # Run tests with selected Qt binding and without OpenCL
     - echo "WITH_GL_TEST=%WITH_GL_TEST%"
     #- "python run_tests.py --installed -v --no-opencl --qt-binding %QT_BINDING%"

--- a/ci/close_popup.py
+++ b/ci/close_popup.py
@@ -1,0 +1,276 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Try to close system popup before testing our application.
+
+The application can be tested with a set of samples:
+
+>>> scp -r www.silx.org:/data/distributions/ci_popups .
+>>> python ./ci/close_popup.py ci_popups
+"""
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "01/09/2017"
+
+
+import os
+import sys
+import logging
+import time
+import pynput
+
+qt = None
+try:
+    from PyQt5 import Qt as qt
+except ImportError:
+    pass
+
+if qt is None:
+    try:
+        from PyQt4 import Qt as qt
+    except ImportError:
+        pass
+
+if qt is None:
+    try:
+        # Create a 'qt'-like module
+        mapping = {}
+        from PySide import QtCore as __mapping
+        mapping.update(__mapping.__dict__)
+        from PySide import QtGui as __mapping
+        mapping.update(__mapping.__dict__)
+
+        class Mapping(object):
+            pass
+        qt = Mapping()
+        for k, v in mapping.items():
+            if k.startswith("_"):
+                continue
+            setattr(qt, k, v)
+    except ImportError:
+        pass
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("close_popup")
+
+
+def getScreenShot(qapp):
+    """
+    Get a screenshot of the full screen.
+
+    :rtype: qt.QImage
+    """
+    if not hasattr(qapp, "primaryScreen"):
+        # Qt4
+        winId = qt.QApplication.desktop().winId()
+        pixmap = qt.QPixmap.grabWindow(winId)
+    else:
+        # Qt5
+        screen = qapp.primaryScreen()
+        pixmap = screen.grabWindow(0)
+    image = pixmap.toImage()
+    return image
+
+
+class CheckPopup(object):
+    """Generic class to detect a popup and the location of the button to
+    close it"""
+
+    def check(self, image):
+        """Return true if the popup is there
+
+        :param qt.QImage image: Image of the screen
+        """
+        raise NotImplemented()
+
+    def clickPosition(self):
+        """Return the x,y coord defined to close the popup
+
+        :rtype: tuple(int, int)
+        """
+        raise NotImplemented()
+
+    def isMostlySameColor(self, color1, color2):
+        """
+        Returns true if color1 and color2 are mostly the same.
+
+        The delta is based on the sum of the difference between each RBG
+        components.
+
+        :rtype: bool
+        """
+        delta = 0
+        delta += abs(color1.red() - color2.red())
+        delta += abs(color1.green() - color2.green())
+        delta += abs(color1.blue() - color2.blue())
+        return delta < 10
+
+    def checkColors(self, image, pixelsDescription):
+        """
+        Returns true if the pixel description match with the image.
+
+        :param qt.QImage image: Image to check
+        :param pixelsDescription: List of pixel expectation containing a
+            position, a text description, and an expected color.
+        :rtype: bool
+        """
+        for description in pixelsDescription:
+            pos, _description, expectedColor = description
+            rgb = image.pixel(pos[0], pos[1])
+            color = qt.QColor(rgb)
+            if not self.isMostlySameColor(color, expectedColor):
+                return False
+        return True
+
+
+class CheckWindowsPopup_NetworkDeviceDiscovery(CheckPopup):
+
+    platform = "win32"
+    name = "network device discovery"
+
+    def check(self, image):
+        screenSize = image.width(), image.height()
+        if screenSize != (1024, 768):
+            return False
+
+        expectedPixelColors = [
+            ((926, 88), "popup", qt.QColor("#061f5e")),
+            ((798, 372), "button", qt.QColor("#0077c6")),
+            ((726, 165), "text", qt.QColor("#ffffff")),
+        ]
+        return self.checkColors(image, expectedPixelColors)
+
+    def clickPosition(self):
+        return (798, 372)
+
+
+class CheckMacOsXPopup_NameAsBeenChanged(CheckPopup):
+
+    platform = "darwin"
+    name = "computer renamed"
+
+    def check(self, image):
+        screenSize = image.width(), image.height()
+        if screenSize != (1024, 768):
+            return False
+
+        expectedPixelColors = [
+            ((430, 150), "header", qt.QColor("#f6f6f6")),
+            ((388, 190), "popup", qt.QColor("#ececec")),
+            ((637, 324), "yes button", qt.QColor("#ffffff")),
+            ((364, 213), "logo", qt.QColor("#ecc520")),
+        ]
+        return self.checkColors(image, expectedPixelColors)
+
+    def clickPosition(self):
+        return (660, 324)
+
+
+def checkPopups(popupList, filename):
+    """Check if an image contains a popup from the provided list
+
+    :param str filename: Name of the file to check or a directory.
+    """
+    if os.path.isdir(filename):
+        base_dir = filename
+        filenames = os.listdir(base_dir)
+        filenames = [os.path.join(base_dir, filename) for filename in filenames]
+    else:
+        filenames = [filename]
+
+    for filename in filenames:
+        print(filename)
+        pixmap = qt.QPixmap(filename)
+        if pixmap.isNull():
+            logger.debug("File %s skipped.", filename)
+            continue
+        image = pixmap.toImage()
+        detected = False
+        for popup in popupList:
+            if popup.check(image):
+                print("- Popup '%s' is visible." % popup.name)
+                detected = True
+        if not detected:
+            print("- No popups detected.")
+
+
+def closePopup(qapp, popupList):
+    """Check the list of popups and close them
+
+    :param qt.QApplication qapp: Qt application
+    :param list popupList: List of popup definitions
+    """
+    popup_found_count = 0
+    for _ in range(10):
+        image = getScreenShot(qapp)
+
+        popup_found = False
+        for popup in popupList:
+            if sys.platform != popup.platform:
+                logger.debug("Popup %s skipped, wrong platform.", popup.name)
+                continue
+
+            if popup.check(image):
+                logger.info("Popup '%s' found. Try to close it.", popup.name)
+                mouse = pynput.mouse.Controller()
+                mouse.position = popup.clickPosition()
+                mouse.click(pynput.mouse.Button.left)
+                time.sleep(5)
+                popup_found = True
+                popup_found_count += 1
+
+        if not popup_found:
+            break
+
+    if popup_found_count == 0:
+        logger.info("No popup found.")
+    else:
+        logger.info("No more popup found.")
+
+
+def main():
+    if qt is None:
+        logger.info("Qt is not available.")
+        return
+
+    popupList = [
+        CheckWindowsPopup_NetworkDeviceDiscovery(),
+        CheckMacOsXPopup_NameAsBeenChanged(),
+    ]
+    logger.info("Popup database: %d.", len(popupList))
+
+    qapp = qt.QApplication([])
+
+    if len(sys.argv) == 2:
+        logger.info("Check input path.")
+        checkPopups(popupList, sys.argv[1])
+    else:
+        logger.info("Check and close popups.")
+        closePopup(qapp, popupList)
+
+
+if __name__ == "__main__":
+    main()

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -29,6 +29,7 @@ __license__ = "MIT"
 __date__ = "01/09/2017"
 
 
+import sys
 import time
 import os
 import unittest
@@ -586,6 +587,9 @@ class TestH5Node(TestCaseQt):
         self.assertEqual(h5node.local_name, "/link/soft_link_to_link")
 
     def testExternalLink(self):
+        if sys.platform == "win32":
+            # FIXME it have to be removed
+            self.skipTest("Creates issue on win32. See https://github.com/silx-kit/silx/issues/1073")
         path = ["base.h5", "link", "external_link"]
         h5node = self.getH5NodeFromPath(self.model, path)
 
@@ -598,6 +602,9 @@ class TestH5Node(TestCaseQt):
         self.assertEqual(h5node.local_name, "/link/external_link")
 
     def testExternalLinkToLink(self):
+        if sys.platform == "win32":
+            # FIXME it have to be removed
+            self.skipTest("Creates issue on win32. See https://github.com/silx-kit/silx/issues/1073")
         path = ["base.h5", "link", "external_link_to_link"]
         h5node = self.getH5NodeFromPath(self.model, path)
 

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "28/08/2017"
+__date__ = "01/09/2017"
 
 
 import time
@@ -461,9 +461,13 @@ class TestH5Node(TestCaseQt):
     @classmethod
     def setUpClass(cls):
         super(TestH5Node, cls).setUpClass()
+        if h5py is None:
+            raise unittest.SkipTest("h5py is not available")
+
         cls.tmpDirectory = tempfile.mkdtemp()
         cls.h5Filename = cls.createResource(cls.tmpDirectory)
-        cls.model = cls.createModel(cls.h5Filename)
+        cls.h5File = h5py.File(cls.h5Filename, mode="r")
+        cls.model = cls.createModel(cls.h5File)
 
     @classmethod
     def createResource(cls, directory):
@@ -492,13 +496,15 @@ class TestH5Node(TestCaseQt):
         return filename
 
     @classmethod
-    def createModel(cls, filename):
+    def createModel(cls, h5pyFile):
         model = hdf5.Hdf5TreeModel()
-        model.appendFile(filename)
+        model.insertH5pyObject(h5pyFile)
         return model
 
     @classmethod
     def tearDownClass(cls):
+        cls.model = None
+        cls.h5File.close()
         shutil.rmtree(cls.tmpDirectory)
         super(TestH5Node, cls).tearDownClass()
 

--- a/silx/gui/plot/test/testItem.py
+++ b/silx/gui/plot/test/testItem.py
@@ -26,48 +26,19 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "13/07/2017"
+__date__ = "01/09/2017"
 
 
 import unittest
 
 import numpy
 
-from silx.gui.test.utils import SignalListener, TestCaseQt
-
-from silx.gui import qt
-from silx.gui.plot import PlotWidget
+from silx.gui.test.utils import SignalListener
 from silx.gui.plot.items import ItemChangedType
+from .utils import PlotWidgetTestCase
 
 
-SIZE = 1024
-"""Size of the test image"""
-
-DATA_2D = numpy.arange(SIZE ** 2).reshape(SIZE, SIZE)
-"""Image data set"""
-
-
-class _PlotWidgetTest(TestCaseQt):
-    """Base class for tests of PlotWidget, not a TestCase in itself.
-
-    plot attribute is the PlotWidget created for the test.
-    """
-
-    def setUp(self):
-        super(_PlotWidgetTest, self).setUp()
-        self.plot = PlotWidget()
-        self.plot.show()
-        self.qWaitForWindowExposed(self.plot)
-
-    def tearDown(self):
-        self.qapp.processEvents()
-        self.plot.setAttribute(qt.Qt.WA_DeleteOnClose)
-        self.plot.close()
-        del self.plot
-        super(_PlotWidgetTest, self).tearDown()
-
-
-class TestSigItemChangedSignal(_PlotWidgetTest):
+class TestSigItemChangedSignal(PlotWidgetTestCase):
     """Test item's sigItemChanged signal"""
 
     def testCurveChanged(self):

--- a/silx/gui/plot/test/testMaskToolsWidget.py
+++ b/silx/gui/plot/test/testMaskToolsWidget.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "15/05/2017"
+__date__ = "08/08/2017"
 
 
 import logging
@@ -37,8 +37,9 @@ import numpy
 
 from silx.gui import qt
 from silx.test.utils import temp_dir, ParametricTestCase
-from silx.gui.test.utils import TestCaseQt, getQToolButtonFromAction
+from silx.gui.test.utils import getQToolButtonFromAction
 from silx.gui.plot import PlotWindow, MaskToolsWidget
+from silx.gui.plot.test.testPlotWidget import _PlotWidgetTest
 
 try:
     import fabio
@@ -49,29 +50,21 @@ except ImportError:
 _logger = logging.getLogger(__name__)
 
 
-class TestMaskToolsWidget(TestCaseQt, ParametricTestCase):
+class TestMaskToolsWidget(_PlotWidgetTest, ParametricTestCase):
     """Basic test for MaskToolsWidget"""
+
+    def _createPlot(self):
+        return PlotWindow()
 
     def setUp(self):
         super(TestMaskToolsWidget, self).setUp()
-        self.plot = PlotWindow()
-
         self.widget = MaskToolsWidget.MaskToolsDockWidget(plot=self.plot, name='TEST')
         self.plot.addDockWidget(qt.Qt.BottomDockWidgetArea, self.widget)
-
-        self.plot.show()
-        self.qWaitForWindowExposed(self.plot)
-
         self.maskWidget = self.widget.widget()
 
     def tearDown(self):
         del self.maskWidget
         del self.widget
-
-        self.plot.setAttribute(qt.Qt.WA_DeleteOnClose)
-        self.plot.close()
-        del self.plot
-
         super(TestMaskToolsWidget, self).tearDown()
 
     def testEmptyPlot(self):
@@ -109,6 +102,7 @@ class TestMaskToolsWidget(TestCaseQt, ParametricTestCase):
                 (x + offset, y - offset),
                 (x, y + offset)]  # Close polygon
 
+        self.mouseMove(plot, pos=(0, 0))
         for pos in star:
             self.mouseMove(plot, pos=pos)
             self.mouseClick(plot, qt.Qt.LeftButton, pos=pos)
@@ -125,9 +119,10 @@ class TestMaskToolsWidget(TestCaseQt, ParametricTestCase):
                 (x - offset, y),
                 (x + offset, y - offset)]
 
+        self.mouseMove(plot, pos=(0, 0))
         self.mouseMove(plot, pos=star[0])
         self.mousePress(plot, qt.Qt.LeftButton, pos=star[0])
-        for pos in star:
+        for pos in star[1:]:
             self.mouseMove(plot, pos=pos)
         self.mouseRelease(
             plot, qt.Qt.LeftButton, pos=star[-1])

--- a/silx/gui/plot/test/testMaskToolsWidget.py
+++ b/silx/gui/plot/test/testMaskToolsWidget.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "08/08/2017"
+__date__ = "01/09/2017"
 
 
 import logging
@@ -39,7 +39,7 @@ from silx.gui import qt
 from silx.test.utils import temp_dir, ParametricTestCase
 from silx.gui.test.utils import getQToolButtonFromAction
 from silx.gui.plot import PlotWindow, MaskToolsWidget
-from silx.gui.plot.test.testPlotWidget import _PlotWidgetTest
+from .utils import PlotWidgetTestCase
 
 try:
     import fabio
@@ -50,7 +50,7 @@ except ImportError:
 _logger = logging.getLogger(__name__)
 
 
-class TestMaskToolsWidget(_PlotWidgetTest, ParametricTestCase):
+class TestMaskToolsWidget(PlotWidgetTestCase, ParametricTestCase):
     """Basic test for MaskToolsWidget"""
 
     def _createPlot(self):

--- a/silx/gui/plot/test/testPlotInteraction.py
+++ b/silx/gui/plot/test/testPlotInteraction.py
@@ -26,12 +26,12 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "13/10/2016"
+__date__ = "01/09/2017"
 
 
 import unittest
 from silx.gui import qt
-from silx.gui.plot.test.testPlotWidget import _PlotWidgetTest
+from .utils import PlotWidgetTestCase
 
 
 class _SignalDump(object):
@@ -49,7 +49,7 @@ class _SignalDump(object):
         return list(self._received)
 
 
-class TestSelectPolygon(_PlotWidgetTest):
+class TestSelectPolygon(PlotWidgetTestCase):
     """Test polygon selection interaction"""
 
     def _interactionModeChanged(self, source):

--- a/silx/gui/plot/test/testPlotTools.py
+++ b/silx/gui/plot/test/testPlotTools.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "05/12/2016"
+__date__ = "09/08/2017"
 
 
 import numpy
@@ -37,6 +37,7 @@ from silx.gui.test.utils import (
     qWaitForWindowExposedAndActivate, TestCaseQt, getQToolButtonFromAction)
 from silx.gui import qt
 from silx.gui.plot import Plot2D, PlotWindow, PlotTools
+from silx.gui.plot.test.testPlotWidget import _PlotWidgetTest
 
 
 # Makes sure a QApplication exists
@@ -67,23 +68,19 @@ def _tearDownDocTest(docTest):
 # """
 
 
-class TestPositionInfo(TestCaseQt):
+class TestPositionInfo(_PlotWidgetTest):
     """Tests for PositionInfo widget."""
+
+    def _createPlot(self):
+        return PlotWindow()
 
     def setUp(self):
         super(TestPositionInfo, self).setUp()
-        self.plot = PlotWindow()
-        self.plot.show()
-        self.qWaitForWindowExposed(self.plot)
-        self.mouseMove(self.plot, pos=(1, 1))
+        self.mouseMove(self.plot, pos=(0, 0))
         self.qapp.processEvents()
         self.qWait(100)
 
     def tearDown(self):
-        self.plot.setAttribute(qt.Qt.WA_DeleteOnClose)
-        self.plot.close()
-        del self.plot
-
         super(TestPositionInfo, self).tearDown()
 
     def _test(self, positionWidget, converterNames, **kwargs):
@@ -104,10 +101,10 @@ class TestPositionInfo(TestCaseQt):
 
         with TestLogging(PlotTools.__name__, **kwargs):
             # Move mouse to center
-            self.mouseMove(self.plot)
+            center = self.plot.size() / 2
+            self.mouseMove(self.plot, pos=(center.width(), center.height()))
+            # Move out
             self.mouseMove(self.plot, pos=(1, 1))
-            self.qapp.processEvents()
-            self.qWait(100)
 
     def testDefaultConverters(self):
         """Test PositionInfo with default converters"""

--- a/silx/gui/plot/test/testPlotTools.py
+++ b/silx/gui/plot/test/testPlotTools.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "09/08/2017"
+__date__ = "01/09/2017"
 
 
 import numpy
@@ -37,7 +37,7 @@ from silx.gui.test.utils import (
     qWaitForWindowExposedAndActivate, TestCaseQt, getQToolButtonFromAction)
 from silx.gui import qt
 from silx.gui.plot import Plot2D, PlotWindow, PlotTools
-from silx.gui.plot.test.testPlotWidget import _PlotWidgetTest
+from .utils import PlotWidgetTestCase
 
 
 # Makes sure a QApplication exists
@@ -68,7 +68,7 @@ def _tearDownDocTest(docTest):
 # """
 
 
-class TestPositionInfo(_PlotWidgetTest):
+class TestPositionInfo(PlotWidgetTestCase):
     """Tests for PositionInfo widget."""
 
     def _createPlot(self):

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -26,11 +26,12 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "16/08/2017"
+__date__ = "01/09/2017"
 
 
 import unittest
-
+import logging
+import contextlib
 import numpy
 
 from silx.test.utils import ParametricTestCase
@@ -42,6 +43,7 @@ from silx.utils import deprecation
 from silx.gui import qt
 from silx.gui.plot import PlotWidget
 from silx.gui.plot.Colormap import Colormap
+from silx.gui.plot.backends.BackendMatplotlib import BackendMatplotlibQt
 
 
 SIZE = 1024
@@ -51,11 +53,18 @@ DATA_2D = numpy.arange(SIZE ** 2).reshape(SIZE, SIZE)
 """Image data set"""
 
 
+logger = logging.getLogger(__name__)
+
+
 class _PlotWidgetTest(TestCaseQt):
     """Base class for tests of PlotWidget, not a TestCase in itself.
 
     plot attribute is the PlotWidget created for the test.
     """
+
+    def __init__(self, methodName='runTest'):
+        TestCaseQt.__init__(self, methodName=methodName)
+        self.__mousePos = None
 
     def _createPlot(self):
         return PlotWidget()
@@ -65,6 +74,7 @@ class _PlotWidgetTest(TestCaseQt):
         self.plot = self._createPlot()
         self.plot.show()
         self.qWaitForWindowExposed(self.plot)
+        TestCaseQt.mouseClick(self, self.plot, button=qt.Qt.LeftButton, pos=(0, 0))
 
     def tearDown(self):
         self.qapp.processEvents()
@@ -72,6 +82,116 @@ class _PlotWidgetTest(TestCaseQt):
         self.plot.close()
         del self.plot
         super(_PlotWidgetTest, self).tearDown()
+
+    def _logMplEvents(self, event):
+        self.__mplEvents.append(event)
+
+    @contextlib.contextmanager
+    def _waitForMplEvent(self, plot, mplEventType):
+        """Check if an event was received by the MPL backend.
+
+        :param PlotWidget plot: A plot widget or a MPL plot backend
+        :param str mplEventType: MPL event type
+        :raises RuntimeError: When the event did not happen
+        """
+        self.__mplEvents = []
+        if isinstance(plot, BackendMatplotlibQt):
+            backend = plot
+        else:
+            backend = plot._backend
+
+        callbackId = backend.mpl_connect(mplEventType, self._logMplEvents)
+        received = False
+        yield
+        for _ in range(100):
+            if len(self.__mplEvents) > 0:
+                received = True
+                break
+            self.qWait(10)
+        backend.mpl_disconnect(callbackId)
+        del self.__mplEvents
+        if not received:
+            self.logScreenShot()
+            raise RuntimeError("MPL event %s expected but nothing received" % mplEventType)
+
+    def _haveMplEvent(self, widget, pos):
+        """Check if the widget at this position is a matplotlib widget."""
+        if isinstance(pos, qt.QPoint):
+            pass
+        else:
+            pos = qt.QPoint(pos[0], pos[1])
+        pos = widget.mapTo(widget.window(), pos)
+        target = widget.window().childAt(pos)
+
+        # Check if the target is a MPL container
+        backend = target
+        if hasattr(target, "_backend"):
+            backend = target._backend
+        haveEvent = isinstance(backend, BackendMatplotlibQt)
+        return haveEvent
+
+    def _patchPos(self, widget, pos):
+        """Return a real position relative to the widget.
+
+        If pos is None, the returned value is the center of the widget,
+        as the default behaviour of functions like QTest.mouseMove.
+        Else the position is returned as it is.
+        """
+        if pos is None:
+            pos = widget.size() / 2
+            pos = pos.width(), pos.height()
+        return pos
+
+    def _checkMouseMove(self, widget, pos):
+        """Returns true if the position differe from the current position of
+        the cursor"""
+        pos = qt.QPoint(pos[0], pos[1])
+        pos = widget.mapTo(widget.window(), pos)
+        willMove = pos != self.__mousePos
+        self.__mousePos = pos
+        return willMove
+
+    def mouseMove(self, widget, pos=None, delay=-1):
+        """Override TestCaseQt to wait while MPL did not reveive the expected
+        event"""
+        pos = self._patchPos(widget, pos)
+        willMove = self._checkMouseMove(widget, pos)
+        hadMplEvents = self._haveMplEvent(widget, self.__mousePos)
+        willHaveMplEvents = self._haveMplEvent(widget, pos)
+        if (not hadMplEvents and not willHaveMplEvents) or not willMove:
+            return TestCaseQt.mouseMove(self, widget, pos=pos, delay=delay)
+        with self._waitForMplEvent(widget, "motion_notify_event"):
+            TestCaseQt.mouseMove(self, widget, pos=pos, delay=delay)
+
+    def mouseClick(self, widget, button, modifier=None, pos=None, delay=-1):
+        """Override TestCaseQt to wait while MPL did not reveive the expected
+        event"""
+        pos = self._patchPos(widget, pos)
+        self._checkMouseMove(widget, pos)
+        if not self._haveMplEvent(widget, pos):
+            return TestCaseQt.mouseClick(self, widget, button, modifier=modifier, pos=pos, delay=delay)
+        with self._waitForMplEvent(widget, "button_release_event"):
+            TestCaseQt.mouseClick(self, widget, button, modifier=modifier, pos=pos, delay=delay)
+
+    def mousePress(self, widget, button, modifier=None, pos=None, delay=-1):
+        """Override TestCaseQt to wait while MPL did not reveive the expected
+        event"""
+        pos = self._patchPos(widget, pos)
+        self._checkMouseMove(widget, pos)
+        if not self._haveMplEvent(widget, pos):
+            return TestCaseQt.mousePress(self, widget, button, modifier=modifier, pos=pos, delay=delay)
+        with self._waitForMplEvent(widget, "button_press_event"):
+            TestCaseQt.mousePress(self, widget, button, modifier=modifier, pos=pos, delay=delay)
+
+    def mouseRelease(self, widget, button, modifier=None, pos=None, delay=-1):
+        """Override TestCaseQt to wait while MPL did not reveive the expected
+        event"""
+        pos = self._patchPos(widget, pos)
+        self._checkMouseMove(widget, pos)
+        if not self._haveMplEvent(widget, pos):
+            return TestCaseQt.mouseRelease(self, widget, button, modifier=modifier, pos=pos, delay=delay)
+        with self._waitForMplEvent(widget, "button_release_event"):
+            TestCaseQt.mouseRelease(self, widget, button, modifier=modifier, pos=pos, delay=delay)
 
 
 class TestPlotWidget(_PlotWidgetTest, ParametricTestCase):

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -57,9 +57,12 @@ class _PlotWidgetTest(TestCaseQt):
     plot attribute is the PlotWidget created for the test.
     """
 
+    def _createPlot(self):
+        return PlotWidget()
+
     def setUp(self):
         super(_PlotWidgetTest, self).setUp()
-        self.plot = PlotWidget()
+        self.plot = self._createPlot()
         self.plot.show()
         self.qWaitForWindowExposed(self.plot)
 

--- a/silx/gui/plot/test/testScatterMaskToolsWidget.py
+++ b/silx/gui/plot/test/testScatterMaskToolsWidget.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "08/08/2017"
+__date__ = "01/09/2017"
 
 
 import logging
@@ -39,7 +39,7 @@ from silx.gui import qt
 from silx.test.utils import temp_dir, ParametricTestCase
 from silx.gui.test.utils import getQToolButtonFromAction
 from silx.gui.plot import PlotWindow, ScatterMaskToolsWidget
-from silx.gui.plot.test.testPlotWidget import _PlotWidgetTest
+from .utils import PlotWidgetTestCase
 
 try:
     import fabio
@@ -50,7 +50,7 @@ except ImportError:
 _logger = logging.getLogger(__name__)
 
 
-class TestScatterMaskToolsWidget(_PlotWidgetTest, ParametricTestCase):
+class TestScatterMaskToolsWidget(PlotWidgetTestCase, ParametricTestCase):
     """Basic test for MaskToolsWidget"""
 
     def _createPlot(self):

--- a/silx/gui/plot/test/testScatterMaskToolsWidget.py
+++ b/silx/gui/plot/test/testScatterMaskToolsWidget.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "10/07/2017"
+__date__ = "08/08/2017"
 
 
 import logging
@@ -37,8 +37,9 @@ import numpy
 
 from silx.gui import qt
 from silx.test.utils import temp_dir, ParametricTestCase
-from silx.gui.test.utils import TestCaseQt, getQToolButtonFromAction
+from silx.gui.test.utils import getQToolButtonFromAction
 from silx.gui.plot import PlotWindow, ScatterMaskToolsWidget
+from silx.gui.plot.test.testPlotWidget import _PlotWidgetTest
 
 try:
     import fabio
@@ -49,30 +50,23 @@ except ImportError:
 _logger = logging.getLogger(__name__)
 
 
-class TestScatterMaskToolsWidget(TestCaseQt, ParametricTestCase):
+class TestScatterMaskToolsWidget(_PlotWidgetTest, ParametricTestCase):
     """Basic test for MaskToolsWidget"""
+
+    def _createPlot(self):
+        return PlotWindow()
 
     def setUp(self):
         super(TestScatterMaskToolsWidget, self).setUp()
-        self.plot = PlotWindow()
-
         self.widget = ScatterMaskToolsWidget.ScatterMaskToolsDockWidget(
                 plot=self.plot, name='TEST')
         self.plot.addDockWidget(qt.Qt.BottomDockWidgetArea, self.widget)
-
-        self.plot.show()
-        self.qWaitForWindowExposed(self.plot)
 
         self.maskWidget = self.widget.widget()
 
     def tearDown(self):
         del self.maskWidget
         del self.widget
-
-        self.plot.setAttribute(qt.Qt.WA_DeleteOnClose)
-        self.plot.close()
-        del self.plot
-
         super(TestScatterMaskToolsWidget, self).tearDown()
 
     def testEmptyPlot(self):
@@ -110,6 +104,7 @@ class TestScatterMaskToolsWidget(TestCaseQt, ParametricTestCase):
                 (x + offset, y - offset),
                 (x, y + offset)]  # Close polygon
 
+        self.mouseMove(plot, pos=[0, 0])
         for pos in star:
             self.mouseMove(plot, pos=pos)
             self.mouseClick(plot, qt.Qt.LeftButton, pos=pos)
@@ -126,9 +121,10 @@ class TestScatterMaskToolsWidget(TestCaseQt, ParametricTestCase):
                 (x - offset, y),
                 (x + offset, y - offset)]
 
+        self.mouseMove(plot, pos=[0, 0])
         self.mouseMove(plot, pos=star[0])
         self.mousePress(plot, qt.Qt.LeftButton, pos=star[0])
-        for pos in star:
+        for pos in star[1:]:
             self.mouseMove(plot, pos=pos)
         self.mouseRelease(
             plot, qt.Qt.LeftButton, pos=star[-1])

--- a/silx/gui/plot/test/utils.py
+++ b/silx/gui/plot/test/utils.py
@@ -114,46 +114,6 @@ class PlotWidgetTestCase(TestCaseQt):
             self.logScreenShot()
             raise RuntimeError("MPL event %s expected but nothing received" % mplEventType)
 
-    def __plotHandleEvent(self, event, *args, **kwargs):
-        self.__plotEvents.add(event)
-        self.__patchedPlot._eventHandler._old_handleEvent(event, *args, **kwargs)
-
-    @contextlib.contextmanager
-    def _waitForPlotEvent(self, plot, plotEventType):
-        """Check if an event was received by the Silx Plot.
-
-        :param PlotWidget plot: A plot widget or a MPL plot backend
-        :param str plotEventType: Silx plot event type
-        :raises RuntimeError: When the event did not happen
-        """
-        if isinstance(plot, BackendMatplotlibQt):
-            backend = plot
-        else:
-            backend = plot._backend
-        plot = backend._plot
-
-        self.__plotEvents = set([])
-        plot._eventHandler._old_handleEvent = plot._eventHandler.handleEvent
-        plot._eventHandler.handleEvent = self.__plotHandleEvent
-        self.__patchedPlot = plot
-
-        received = False
-        yield
-        for _ in range(100):
-            if plotEventType in self.__plotEvents:
-                received = True
-                break
-            self.qWait(10)
-
-        plot._eventHandler.handleEvent = plot._eventHandler._old_handleEvent
-        del plot._eventHandler._old_handleEvent
-        del self.__patchedPlot
-
-        if not received:
-            self.logScreenShot()
-            raise RuntimeError("Backend function _%s expected but nothing received" % plotEventType)
-        del self.__plotEvents
-
     def _haveMplEvent(self, widget, pos):
         """Check if the widget at this position is a matplotlib widget."""
         if isinstance(pos, qt.QPoint):
@@ -200,9 +160,8 @@ class PlotWidgetTestCase(TestCaseQt):
         willHaveMplEvents = self._haveMplEvent(widget, pos)
         if (not hadMplEvents and not willHaveMplEvents) or not willMove:
             return TestCaseQt.mouseMove(self, widget, pos=pos, delay=delay)
-        with self._waitForPlotEvent(widget, "move"):
-            with self._waitForMplEvent(widget, "motion_notify_event"):
-                TestCaseQt.mouseMove(self, widget, pos=pos, delay=delay)
+        with self._waitForMplEvent(widget, "motion_notify_event"):
+            TestCaseQt.mouseMove(self, widget, pos=pos, delay=delay)
 
     def mouseClick(self, widget, button, modifier=None, pos=None, delay=-1):
         """Override TestCaseQt to wait while MPL did not reveive the expected
@@ -211,9 +170,8 @@ class PlotWidgetTestCase(TestCaseQt):
         self._checkMouseMove(widget, pos)
         if not self._haveMplEvent(widget, pos):
             return TestCaseQt.mouseClick(self, widget, button, modifier=modifier, pos=pos, delay=delay)
-        with self._waitForPlotEvent(widget, "release"):
-            with self._waitForMplEvent(widget, "button_release_event"):
-                TestCaseQt.mouseClick(self, widget, button, modifier=modifier, pos=pos, delay=delay)
+        with self._waitForMplEvent(widget, "button_release_event"):
+            TestCaseQt.mouseClick(self, widget, button, modifier=modifier, pos=pos, delay=delay)
 
     def mousePress(self, widget, button, modifier=None, pos=None, delay=-1):
         """Override TestCaseQt to wait while MPL did not reveive the expected
@@ -222,9 +180,8 @@ class PlotWidgetTestCase(TestCaseQt):
         self._checkMouseMove(widget, pos)
         if not self._haveMplEvent(widget, pos):
             return TestCaseQt.mousePress(self, widget, button, modifier=modifier, pos=pos, delay=delay)
-        with self._waitForPlotEvent(widget, "press"):
-            with self._waitForMplEvent(widget, "button_press_event"):
-                TestCaseQt.mousePress(self, widget, button, modifier=modifier, pos=pos, delay=delay)
+        with self._waitForMplEvent(widget, "button_press_event"):
+            TestCaseQt.mousePress(self, widget, button, modifier=modifier, pos=pos, delay=delay)
 
     def mouseRelease(self, widget, button, modifier=None, pos=None, delay=-1):
         """Override TestCaseQt to wait while MPL did not reveive the expected
@@ -233,6 +190,5 @@ class PlotWidgetTestCase(TestCaseQt):
         self._checkMouseMove(widget, pos)
         if not self._haveMplEvent(widget, pos):
             return TestCaseQt.mouseRelease(self, widget, button, modifier=modifier, pos=pos, delay=delay)
-        with self._waitForPlotEvent(widget, "release"):
-            with self._waitForMplEvent(widget, "button_release_event"):
-                TestCaseQt.mouseRelease(self, widget, button, modifier=modifier, pos=pos, delay=delay)
+        with self._waitForMplEvent(widget, "button_release_event"):
+            TestCaseQt.mouseRelease(self, widget, button, modifier=modifier, pos=pos, delay=delay)

--- a/silx/gui/plot/test/utils.py
+++ b/silx/gui/plot/test/utils.py
@@ -1,0 +1,238 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Basic tests for PlotWidget"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "01/09/2017"
+
+
+import logging
+import contextlib
+
+from silx.gui.test.utils import TestCaseQt
+
+from silx.gui import qt
+from silx.gui.plot import PlotWidget
+from silx.gui.plot.backends.BackendMatplotlib import BackendMatplotlibQt
+
+
+logger = logging.getLogger(__name__)
+
+
+class PlotWidgetTestCase(TestCaseQt):
+    """Base class for tests of PlotWidget, not a TestCase in itself.
+
+    plot attribute is the PlotWidget created for the test.
+    """
+
+    def __init__(self, methodName='runTest'):
+        TestCaseQt.__init__(self, methodName=methodName)
+        self.__mousePos = None
+
+    def _createPlot(self):
+        return PlotWidget()
+
+    def setUp(self):
+        super(PlotWidgetTestCase, self).setUp()
+        self.plot = self._createPlot()
+        self.plot.show()
+        self.plotAlive = True
+        self.qWaitForWindowExposed(self.plot)
+        TestCaseQt.mouseClick(self, self.plot, button=qt.Qt.LeftButton, pos=(0, 0))
+
+    def __onPlotDestroyed(self):
+        self.plotAlive = False
+
+    def _waitForPlotClosed(self):
+        self.plot.setAttribute(qt.Qt.WA_DeleteOnClose)
+        self.plot.destroyed.connect(self.__onPlotDestroyed)
+        self.plot.close()
+        del self.plot
+        for _ in range(100):
+            if not self.plotAlive:
+                break
+            self.qWait(10)
+        else:
+            logger.error("Plot is still alive")
+
+    def tearDown(self):
+        self.qapp.processEvents()
+        self._waitForPlotClosed()
+        super(PlotWidgetTestCase, self).tearDown()
+
+    def _logMplEvents(self, event):
+        self.__mplEvents.append(event)
+
+    @contextlib.contextmanager
+    def _waitForMplEvent(self, plot, mplEventType):
+        """Check if an event was received by the MPL backend.
+
+        :param PlotWidget plot: A plot widget or a MPL plot backend
+        :param str mplEventType: MPL event type
+        :raises RuntimeError: When the event did not happen
+        """
+        self.__mplEvents = []
+        if isinstance(plot, BackendMatplotlibQt):
+            backend = plot
+        else:
+            backend = plot._backend
+
+        callbackId = backend.mpl_connect(mplEventType, self._logMplEvents)
+        received = False
+        yield
+        for _ in range(100):
+            if len(self.__mplEvents) > 0:
+                received = True
+                break
+            self.qWait(10)
+        backend.mpl_disconnect(callbackId)
+        del self.__mplEvents
+        if not received:
+            self.logScreenShot()
+            raise RuntimeError("MPL event %s expected but nothing received" % mplEventType)
+
+    def __plotHandleEvent(self, event, *args, **kwargs):
+        self.__plotEvents.add(event)
+        self.__patchedPlot._eventHandler._old_handleEvent(event, *args, **kwargs)
+
+    @contextlib.contextmanager
+    def _waitForPlotEvent(self, plot, plotEventType):
+        """Check if an event was received by the Silx Plot.
+
+        :param PlotWidget plot: A plot widget or a MPL plot backend
+        :param str plotEventType: Silx plot event type
+        :raises RuntimeError: When the event did not happen
+        """
+        if isinstance(plot, BackendMatplotlibQt):
+            backend = plot
+        else:
+            backend = plot._backend
+        plot = backend._plot
+
+        self.__plotEvents = set([])
+        plot._eventHandler._old_handleEvent = plot._eventHandler.handleEvent
+        plot._eventHandler.handleEvent = self.__plotHandleEvent
+        self.__patchedPlot = plot
+
+        received = False
+        yield
+        for _ in range(100):
+            if plotEventType in self.__plotEvents:
+                received = True
+                break
+            self.qWait(10)
+
+        plot._eventHandler.handleEvent = plot._eventHandler._old_handleEvent
+        del plot._eventHandler._old_handleEvent
+        del self.__patchedPlot
+
+        if not received:
+            self.logScreenShot()
+            raise RuntimeError("Backend function _%s expected but nothing received" % plotEventType)
+        del self.__plotEvents
+
+    def _haveMplEvent(self, widget, pos):
+        """Check if the widget at this position is a matplotlib widget."""
+        if isinstance(pos, qt.QPoint):
+            pass
+        else:
+            pos = qt.QPoint(pos[0], pos[1])
+        pos = widget.mapTo(widget.window(), pos)
+        target = widget.window().childAt(pos)
+
+        # Check if the target is a MPL container
+        backend = target
+        if hasattr(target, "_backend"):
+            backend = target._backend
+        haveEvent = isinstance(backend, BackendMatplotlibQt)
+        return haveEvent
+
+    def _patchPos(self, widget, pos):
+        """Return a real position relative to the widget.
+
+        If pos is None, the returned value is the center of the widget,
+        as the default behaviour of functions like QTest.mouseMove.
+        Else the position is returned as it is.
+        """
+        if pos is None:
+            pos = widget.size() / 2
+            pos = pos.width(), pos.height()
+        return pos
+
+    def _checkMouseMove(self, widget, pos):
+        """Returns true if the position differe from the current position of
+        the cursor"""
+        pos = qt.QPoint(pos[0], pos[1])
+        pos = widget.mapTo(widget.window(), pos)
+        willMove = pos != self.__mousePos
+        self.__mousePos = pos
+        return willMove
+
+    def mouseMove(self, widget, pos=None, delay=-1):
+        """Override TestCaseQt to wait while MPL did not reveive the expected
+        event"""
+        pos = self._patchPos(widget, pos)
+        willMove = self._checkMouseMove(widget, pos)
+        hadMplEvents = self._haveMplEvent(widget, self.__mousePos)
+        willHaveMplEvents = self._haveMplEvent(widget, pos)
+        if (not hadMplEvents and not willHaveMplEvents) or not willMove:
+            return TestCaseQt.mouseMove(self, widget, pos=pos, delay=delay)
+        with self._waitForPlotEvent(widget, "move"):
+            with self._waitForMplEvent(widget, "motion_notify_event"):
+                TestCaseQt.mouseMove(self, widget, pos=pos, delay=delay)
+
+    def mouseClick(self, widget, button, modifier=None, pos=None, delay=-1):
+        """Override TestCaseQt to wait while MPL did not reveive the expected
+        event"""
+        pos = self._patchPos(widget, pos)
+        self._checkMouseMove(widget, pos)
+        if not self._haveMplEvent(widget, pos):
+            return TestCaseQt.mouseClick(self, widget, button, modifier=modifier, pos=pos, delay=delay)
+        with self._waitForPlotEvent(widget, "release"):
+            with self._waitForMplEvent(widget, "button_release_event"):
+                TestCaseQt.mouseClick(self, widget, button, modifier=modifier, pos=pos, delay=delay)
+
+    def mousePress(self, widget, button, modifier=None, pos=None, delay=-1):
+        """Override TestCaseQt to wait while MPL did not reveive the expected
+        event"""
+        pos = self._patchPos(widget, pos)
+        self._checkMouseMove(widget, pos)
+        if not self._haveMplEvent(widget, pos):
+            return TestCaseQt.mousePress(self, widget, button, modifier=modifier, pos=pos, delay=delay)
+        with self._waitForPlotEvent(widget, "press"):
+            with self._waitForMplEvent(widget, "button_press_event"):
+                TestCaseQt.mousePress(self, widget, button, modifier=modifier, pos=pos, delay=delay)
+
+    def mouseRelease(self, widget, button, modifier=None, pos=None, delay=-1):
+        """Override TestCaseQt to wait while MPL did not reveive the expected
+        event"""
+        pos = self._patchPos(widget, pos)
+        self._checkMouseMove(widget, pos)
+        if not self._haveMplEvent(widget, pos):
+            return TestCaseQt.mouseRelease(self, widget, button, modifier=modifier, pos=pos, delay=delay)
+        with self._waitForPlotEvent(widget, "release"):
+            with self._waitForMplEvent(widget, "button_release_event"):
+                TestCaseQt.mouseRelease(self, widget, button, modifier=modifier, pos=pos, delay=delay)

--- a/silx/gui/plot3d/test/testGL.py
+++ b/silx/gui/plot3d/test/testGL.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "17/07/2017"
+__date__ = "10/08/2017"
 
 
 import logging
@@ -54,9 +54,9 @@ class TestOpenGL(TestCaseQt):
             if not self._dump:
                 self._dump = True
                 _logger.info('OpenGL info:')
-                _logger.info('\tQt OpenGL context version: %d.%d', self.getOpenGLVersion())
+                _logger.info('\tQt OpenGL context version: %d.%d', *self.getOpenGLVersion())
                 _logger.info('\tGL_VERSION: %s' % gl.glGetString(gl.GL_VERSION))
-                _logger.info('\tGL_SHADING_LANGUAGE_VERSION: %s' % \
+                _logger.info('\tGL_SHADING_LANGUAGE_VERSION: %s' %
                              gl.glGetString(gl.GL_SHADING_LANGUAGE_VERSION))
                 _logger.debug('\tGL_EXTENSIONS: %s' % gl.glGetString(gl.GL_EXTENSIONS))
 

--- a/silx/gui/test/utils.py
+++ b/silx/gui/test/utils.py
@@ -360,11 +360,10 @@ class TestCaseQt(unittest.TestCase):
         """
         if not _logger.isEnabledFor(level):
             return
-        import uuid
         basedir = os.path.abspath(os.path.join("build", "test-debug"))
         if not os.path.exists(basedir):
             os.makedirs(basedir)
-        filename = str(uuid.uuid4()) + ".png"
+        filename = "Screenshot_%s.png" % self.id()
         filename = os.path.join(basedir, filename)
 
         if not hasattr(self.qapp, "primaryScreen"):

--- a/silx/gui/test/utils.py
+++ b/silx/gui/test/utils.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "15/05/2017"
+__date__ = "01/09/2017"
 
 
 import gc
@@ -35,6 +35,7 @@ import unittest
 import time
 import functools
 import sys
+import os
 
 _logger = logging.getLogger(__name__)
 
@@ -347,6 +348,35 @@ class TestCaseQt(unittest.TestCase):
             QTest.qWait(self.TIMEOUT_WAIT)
 
         return result
+
+    def logScreenShot(self, level=logging.ERROR):
+        """Take a screenshot and log it into the logging system if the
+        logger is enabled for the expected level.
+
+        The screenshot is stored in the directory "./build/test-debug", and
+        the logging system only log the path to this file.
+
+        :param level: Logging level
+        """
+        if not _logger.isEnabledFor(level):
+            return
+        import uuid
+        basedir = os.path.abspath(os.path.join("build", "test-debug"))
+        if not os.path.exists(basedir):
+            os.makedirs(basedir)
+        filename = str(uuid.uuid4()) + ".png"
+        filename = os.path.join(basedir, filename)
+
+        if not hasattr(self.qapp, "primaryScreen"):
+            # Qt4
+            winId = qt.QApplication.desktop().winId()
+            pixmap = qt.QPixmap.grabWindow(winId)
+        else:
+            # Qt5
+            screen = self.qapp.primaryScreen()
+            pixmap = screen.grabWindow(0)
+        pixmap.save(filename)
+        _logger.log(level, "Screenshot saved at %s", filename)
 
 
 class SignalListener(object):


### PR DESCRIPTION
Tests on GUI using mouse click often fail on Windows and Mac OS plus changes on Appveyor/Travis makes the things more difficult for GUI tests.

This PR try to improve the state of GUI testing by:
- Providing an application to close system popup before executing our tests
- Check reception of MPL events when using mouse interaction over the silx Plot
- [removed] Check reception of Plot events  when using mouse interaction over the silx Plot
- If the event is not received a screenshot is taken in case of further problem with another popup
- Appveyor will expose screenshot as artifact, Travis will display then in the log in base64


Here is output from CI before testing:
```
$ python ci/close_popup.py
INFO:close_popup:Popup database: 2.
INFO:close_popup:Check and close popups.
INFO:close_popup:No popup found.
```

```
$ python ./ci/close_popup.py
INFO:close_popup:Popup database: 2.
INFO:close_popup:Check and close popups.
INFO:close_popup:Popup 'network device discovery' found. Try to close it.
INFO:close_popup:No more popup found.
```

Closes #1039