### PR TITLE
[spech5] Lazy mca loading

### DIFF
--- a/doc/source/modules/io/spech5.rst
+++ b/doc/source/modules/io/spech5.rst
@@ -35,6 +35,9 @@ Classes
     :exclude-members: add_node
 
 .. autoclass:: SpecH5Dataset
+    :show-inheritance:
+
+.. autoclass:: SpecH5NodeDataset
     :members:
     :show-inheritance:
     :undoc-members:

--- a/silx/io/commonh5.py
+++ b/silx/io/commonh5.py
@@ -392,7 +392,7 @@ class LazyLoadableDataset(Dataset):
         """
         Factory to create the data exposed by the dataset when it is needed.
 
-        It have to be implemented to work.
+        It has to be implemented for the class to work.
 
         :rtype: numpy.ndarray
         """

--- a/silx/io/commonh5.py
+++ b/silx/io/commonh5.py
@@ -339,12 +339,6 @@ class Dataset(Node):
         # python 2
         return self.__bool__()
 
-    def __eq__(self, other):
-        if is_dataset(other):
-            return self[()] == other[()]
-        else:
-            return self[()] == other
-
     def __ne__(self, other):
         if is_dataset(other):
             return self[()] != other[()]
@@ -386,7 +380,7 @@ class LazyLoadableDataset(Dataset):
 
     def __init__(self, name, parent=None, attrs=None):
         super(LazyLoadableDataset, self).__init__(name, None, parent, attrs=attrs)
-        self.__is_initialized = False
+        self._is_initialized = False
 
     def _create_data(self):
         """
@@ -406,10 +400,10 @@ class LazyLoadableDataset(Dataset):
 
         :rtype: numpy.ndarray
         """
-        if not self.__is_initialized:
+        if not self._is_initialized:
             data = self._create_data()
             self._set_data(data)
-            self.__is_initialized = True
+            self._is_initialized = True
         return super(LazyLoadableDataset, self)._get_data()
 
 

--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -431,16 +431,25 @@ def _demultiplex_mca(scan, analyser_index):
 
 
 # Node classes
-class SpecH5Dataset(commonh5.Dataset):
+class SpecH5Dataset(object):
+    """This convenience class is to be inherited by all datasets, for
+    compatibility purpose with code that tests for
+    ``isinstance(obj, SpecH5Dataset)``.
+
+    This legacy behavior is deprecated. The correct way to test
+    if an object is a dataset is to use :meth:`silx.io.utils.is_dataset`.
+
+    Datasets must also inherit :class:`SpecH5NodeDataset` or
+    :class:`SpecH5LazyNodeDataset` which actually implement all the
+    API."""
+    pass
+
+
+class SpecH5NodeDataset(commonh5.Dataset, SpecH5Dataset):
     """This class inherits :class:`commonh5.Dataset`, to which it adds
     little extra functionality. The main additional functionality is the
     proxy behavior that allows to mimic the numpy array stored in this
     class.
-
-    The correct way to test if an object is a dataset is to use
-    :meth:`silx.io.utils.is_dataset`.
-
-    Testing ``isinstance(obj, SpecH5Dataset)`` is deprecated.
     """
     def __init__(self, name, data, parent=None, attrs=None):
         # get proper value types, to inherit from numpy
@@ -467,16 +476,6 @@ class SpecH5Dataset(commonh5.Dataset):
                 value = array
         commonh5.Dataset.__init__(self, name, value, parent, attrs)
 
-    # legacy
-    # def __repr__(self):
-    #     return '<SpecH5Dataset "%s": shape %s, type "%s">' % \
-    #            (self.name, self.shape, self.dtype.str)
-    #
-    # def __str__(self):
-    #     basename = self.name.split("/")[-1]
-    #     return '<SPEC dataset "%s": shape %s, type "%s">' % \
-    #            (basename, self.shape, self.dtype.str)
-    #
     def __getattr__(self, item):
         """Proxy to underlying numpy array methods.
         """
@@ -484,6 +483,34 @@ class SpecH5Dataset(commonh5.Dataset):
             return getattr(self[()], item)
 
         raise AttributeError("SpecH5Dataset has no attribute %s" % item)
+
+
+class SpecH5LazyNodeDataset(commonh5.LazyLoadableDataset, SpecH5Dataset):
+    """This class inherits :class:`commonh5.LazyLoadableDataset`,
+    to which it adds a proxy behavior that allows to mimic the numpy
+    array stored in this class.
+
+    The class has to be inherited and the :meth:`_create_data` method has to be
+    implemented to return the numpy data exposed by the dataset. This factory
+    method is only called once, when the data is needed.
+    """
+    def __getattr__(self, item):
+        """Proxy to underlying numpy array methods.
+        """
+        if hasattr(self[()], item):
+            return getattr(self[()], item)
+
+        raise AttributeError("SpecH5Dataset has no attribute %s" % item)
+
+    def _create_data(self):
+        """
+        Factory to create the data exposed by the dataset when it is needed.
+
+        It has to be implemented for the class to work.
+
+        :rtype: numpy.ndarray
+        """
+        raise NotImplementedError()
 
 
 class SpecH5Group(object):
@@ -541,9 +568,9 @@ class ScanGroup(commonh5.Group, SpecH5Group):
         commonh5.Group.__init__(self, scan_key, parent=parent,
                                 attrs={"NX_class": "NXentry"})
 
-        self.add_node(SpecH5Dataset(name="title",
-                                    data=scan.scan_header_dict["S"],
-                                    parent=self))
+        self.add_node(SpecH5NodeDataset(name="title",
+                                        data=scan.scan_header_dict["S"],
+                                        parent=self))
 
         if "D" in scan.scan_header_dict:
             try:
@@ -568,9 +595,9 @@ class ScanGroup(commonh5.Group, SpecH5Group):
             logger1.warn("No #D line in %s header. Setting date to empty string.",
                          scan_key)
             start_time_str = ""
-        self.add_node(SpecH5Dataset(name="start_time",
-                                    data=start_time_str,
-                                    parent=self))
+        self.add_node(SpecH5NodeDataset(name="start_time",
+                                        data=start_time_str,
+                                        parent=self))
 
         self.add_node(InstrumentGroup(parent=self, scan=scan))
         self.add_node(MeasurementGroup(parent=self, scan=scan))
@@ -602,14 +629,14 @@ class InstrumentSpecfileGroup(commonh5.Group, SpecH5Group):
     def __init__(self, parent, scan):
         commonh5.Group.__init__(self, name="specfile", parent=parent,
                                 attrs={"NX_class": "NXcollection"})
-        self.add_node(SpecH5Dataset(name="file_header",
-                                    data="\n".join(scan.file_header),
-                                    parent=self,
-                                    attrs={}))
-        self.add_node(SpecH5Dataset(name="scan_header",
-                                    data="\n".join(scan.scan_header),
-                                    parent=self,
-                                    attrs={}))
+        self.add_node(SpecH5NodeDataset(name="file_header",
+                                        data="\n".join(scan.file_header),
+                                        parent=self,
+                                        attrs={}))
+        self.add_node(SpecH5NodeDataset(name="scan_header",
+                                        data="\n".join(scan.scan_header),
+                                        parent=self,
+                                        attrs={}))
 
 
 class PositionersGroup(commonh5.Group, SpecH5Group):
@@ -625,9 +652,9 @@ class PositionersGroup(commonh5.Group, SpecH5Group):
                 # Take value from #P scan header.
                 # (may return float("inf") if #P line is missing from scan hdr)
                 motor_value = scan.motor_position_by_name(motor_name)
-            self.add_node(SpecH5Dataset(name=safe_motor_name,
-                                        data=motor_value,
-                                        parent=self))
+            self.add_node(SpecH5NodeDataset(name=safe_motor_name,
+                                            data=motor_value,
+                                            parent=self))
 
 
 class InstrumentMcaGroup(commonh5.Group, SpecH5Group):
@@ -636,10 +663,9 @@ class InstrumentMcaGroup(commonh5.Group, SpecH5Group):
         commonh5.Group.__init__(self, name=name, parent=parent,
                                 attrs={"NX_class": "NXdetector"})
 
-        self.add_node(SpecH5Dataset(name="data",
-                                    data=_demultiplex_mca(scan, analyser_index),
-                                    parent=self,
-                                    attrs={"interpretation": "spectrum", }))
+        self.add_node(McaDataDataset(parent=self,
+                                     analyser_index=analyser_index,
+                                     scan=scan))
 
         if len(scan.mca.channels) == 1:
             # single @CALIB line applying to multiple devices
@@ -648,25 +674,38 @@ class InstrumentMcaGroup(commonh5.Group, SpecH5Group):
         else:
             calibration_dataset = scan.mca.calibration[analyser_index]
             channels_dataset = scan.mca.channels[analyser_index]
-        self.add_node(SpecH5Dataset(name="calibration",
-                                    data=calibration_dataset,
-                                    parent=self))
-        self.add_node(SpecH5Dataset(name="channels",
-                                    data=channels_dataset,
-                                    parent=self))
+        self.add_node(SpecH5NodeDataset(name="calibration",
+                                        data=calibration_dataset,
+                                        parent=self))
+        self.add_node(SpecH5NodeDataset(name="channels",
+                                        data=channels_dataset,
+                                        parent=self))
 
         if "CTIME" in scan.mca_header_dict:
             ctime_line = scan.mca_header_dict['CTIME']
             preset_time, live_time, elapsed_time = _parse_ctime(ctime_line, analyser_index)
-            self.add_node(SpecH5Dataset(name="preset_time",
-                                        data=preset_time,
-                                        parent=self))
-            self.add_node(SpecH5Dataset(name="live_time",
-                                        data=live_time,
-                                        parent=self))
-            self.add_node(SpecH5Dataset(name="elapsed_time",
-                                        data=elapsed_time,
-                                        parent=self))
+            self.add_node(SpecH5NodeDataset(name="preset_time",
+                                            data=preset_time,
+                                            parent=self))
+            self.add_node(SpecH5NodeDataset(name="live_time",
+                                            data=live_time,
+                                            parent=self))
+            self.add_node(SpecH5NodeDataset(name="elapsed_time",
+                                            data=elapsed_time,
+                                            parent=self))
+
+
+class McaDataDataset(SpecH5LazyNodeDataset):
+    """Lazy loadable dataset for MCA data"""
+    def __init__(self, parent, analyser_index, scan):
+        commonh5.LazyLoadableDataset.__init__(
+            self, name="data", parent=parent,
+            attrs={"interpretation": "spectrum", })
+        self._scan = scan
+        self._analyser_index = analyser_index
+
+    def _create_data(self):
+        return _demultiplex_mca(self._scan, self._analyser_index)
 
 
 class MeasurementGroup(commonh5.Group, SpecH5Group):
@@ -680,9 +719,9 @@ class MeasurementGroup(commonh5.Group, SpecH5Group):
                                 attrs={"NX_class": "NXcollection", })
         for label in scan.labels:
             safe_label = label.replace("/", "%")
-            self.add_node(SpecH5Dataset(name=safe_label,
-                                        data=scan.data_column_by_name(label),
-                                        parent=self))
+            self.add_node(SpecH5NodeDataset(name=safe_label,
+                                            data=scan.data_column_by_name(label),
+                                            parent=self))
 
         num_analysers = _get_number_of_mca_analysers(scan)
         for anal_idx in range(num_analysers):
@@ -717,20 +756,20 @@ class SampleGroup(commonh5.Group, SpecH5Group):
                                 attrs={"NX_class": "NXsample", })
 
         if _unit_cell_in_scan(scan):
-            self.add_node(SpecH5Dataset(name="unit_cell",
-                                        data=_parse_unit_cell(scan.scan_header_dict["G1"]),
-                                        parent=self,
-                                        attrs={"interpretation": "scalar"}))
-            self.add_node(SpecH5Dataset(name="unit_cell_abc",
-                                        data=_parse_unit_cell(scan.scan_header_dict["G1"])[0, 0:3],
-                                        parent=self,
-                                        attrs={"interpretation": "scalar"}))
-            self.add_node(SpecH5Dataset(name="unit_cell_alphabetagamma",
-                                        data=_parse_unit_cell(scan.scan_header_dict["G1"])[0, 3:6],
-                                        parent=self,
-                                        attrs={"interpretation": "scalar"}))
+            self.add_node(SpecH5NodeDataset(name="unit_cell",
+                                            data=_parse_unit_cell(scan.scan_header_dict["G1"]),
+                                            parent=self,
+                                            attrs={"interpretation": "scalar"}))
+            self.add_node(SpecH5NodeDataset(name="unit_cell_abc",
+                                            data=_parse_unit_cell(scan.scan_header_dict["G1"])[0, 0:3],
+                                            parent=self,
+                                            attrs={"interpretation": "scalar"}))
+            self.add_node(SpecH5NodeDataset(name="unit_cell_alphabetagamma",
+                                            data=_parse_unit_cell(scan.scan_header_dict["G1"])[0, 3:6],
+                                            parent=self,
+                                            attrs={"interpretation": "scalar"}))
         if _ub_matrix_in_scan(scan):
-            self.add_node(SpecH5Dataset(name="ub_matrix",
-                                        data=_parse_UB_matrix(scan.scan_header_dict["G3"]),
-                                        parent=self,
-                                        attrs={"interpretation": "scalar"}))
+            self.add_node(SpecH5NodeDataset(name="ub_matrix",
+                                            data=_parse_UB_matrix(scan.scan_header_dict["G3"]),
+                                            parent=self,
+                                            attrs={"interpretation": "scalar"}))


### PR DESCRIPTION
These optimizations mostly solve #995.  

The previous PR #1048 already took care of caching the data, to ensure it is loaded only once. 
Now the MCA dataset is also lazy loaded, so the HDF5 tree will not become unresponsive when opening a group containing a heavy MCA dataset (unless we want to see the actual data).

The issue causing the loading to take 5 times longer than usual in a Qt application is still not fixed.