### PR TITLE
[io] Protect common dataset

### DIFF
--- a/silx/gui/hdf5/Hdf5Item.py
+++ b/silx/gui/hdf5/Hdf5Item.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "21/08/2017"
+__date__ = "25/08/2017"
 
 
 import numpy
@@ -169,6 +169,14 @@ class Hdf5Item(Hdf5Node):
                 self.__isBroken = True
             else:
                 self.__obj = obj
+                if not self.isGroupObj():
+                    try:
+                        # pre-fetch of the data
+                        self.__obj.shape
+                    except Exception as e:
+                        message = "%s broken. %s" % (self.__obj.name, e.args[0])
+                        self.__error = message
+                        self.__isBroken = True
 
         self.__key = None
 
@@ -202,6 +210,8 @@ class Hdf5Item(Hdf5Node):
 
         :rtype: qt.QIcon
         """
+        # Pre-fetch the object, in case it is broken
+        obj = self.obj
         style = qt.QApplication.style()
         if self.__isBroken:
             icon = style.standardIcon(qt.QStyle.SP_MessageBoxCritical)
@@ -216,11 +226,11 @@ class Hdf5Item(Hdf5Node):
         elif issubclass(class_, h5py.ExternalLink):
             return style.standardIcon(qt.QStyle.SP_FileLinkIcon)
         elif issubclass(class_, h5py.Dataset):
-            if len(self.obj.shape) < 4:
-                name = "item-%ddim" % len(self.obj.shape)
+            if len(obj.shape) < 4:
+                name = "item-%ddim" % len(obj.shape)
             else:
                 name = "item-ndim"
-            if str(self.obj.dtype) == "object":
+            if str(obj.dtype) == "object":
                 name = "item-object"
             icon = icons.getQIcon(name)
             return icon

--- a/silx/io/commonh5.py
+++ b/silx/io/commonh5.py
@@ -185,7 +185,21 @@ class Dataset(Node):
 
     def __init__(self, name, data, parent=None, attrs=None):
         Node.__init__(self, name, parent, attrs=attrs)
+        if data is not None:
+            self._check_data(data)
         self.__data = data
+
+    def _check_data(self, data):
+        """Check that the data provided by the dataset is valid.
+
+        :param numpy.ndarray data: Data associated to the dataset
+
+        :raises TypeError: In the case the data is not valid.
+        """
+        chartype = data.dtype.char
+        if chartype in ["U", "O"]:
+            msg = "Type of the dataset '%s' is not supported. Found '%s'."
+            raise TypeError(msg % (self.name, data.dtype))
 
     def _set_data(self, data):
         """Set the data exposed by the dataset.
@@ -195,6 +209,7 @@ class Dataset(Node):
 
         :param numpy.ndarray data: Data associated to the dataset
         """
+        self._check_data(data)
         self.__data = data
 
     def _get_data(self):
@@ -448,8 +463,10 @@ class LazyLoadableDataset(Dataset):
         """
         if not self._is_initialized:
             data = self._create_data()
-            self._set_data(data)
+            # is_initialized before set_data to avoid infinit initialization
+            # is case of wrong check of the data
             self._is_initialized = True
+            self._set_data(data)
         return super(LazyLoadableDataset, self)._get_data()
 
 

--- a/silx/io/commonh5.py
+++ b/silx/io/commonh5.py
@@ -31,7 +31,7 @@ files. They are used in :mod:`spech5` and :mod:`fabioh5`.
 
 __authors__ = ["V. Valls", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "23/08/2017"
+__date__ = "25/08/2017"
 
 import collections
 import h5py
@@ -184,8 +184,8 @@ class Dataset(Node):
     """
 
     def __init__(self, name, data, parent=None, attrs=None):
-        self.__data = data
         Node.__init__(self, name, parent, attrs=attrs)
+        self.__data = data
 
     def _set_data(self, data):
         """Set the data exposed by the dataset.

--- a/silx/io/test/test_commonh5.py
+++ b/silx/io/test/test_commonh5.py
@@ -111,6 +111,7 @@ class TestCommonH5(unittest.TestCase):
         f = commonh5.File(name="Foo", mode="r")
         try:
             f.create_dataset("foo", data=numpy.array([1]))
+            self.fail()
         except RuntimeError:
             pass
 
@@ -118,6 +119,7 @@ class TestCommonH5(unittest.TestCase):
         f = commonh5.File(name="Foo", mode="r")
         try:
             f.create_group("foo")
+            self.fail()
         except RuntimeError:
             pass
 

--- a/silx/io/test/test_commonh5.py
+++ b/silx/io/test/test_commonh5.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "23/08/2017"
+__date__ = "25/08/2017"
 
 import logging
 import numpy
@@ -119,6 +119,14 @@ class TestCommonH5(unittest.TestCase):
         try:
             f.create_group("foo")
         except RuntimeError:
+            pass
+
+    def test_create_unicode_dataset(self):
+        f = commonh5.File(name="Foo", mode="w")
+        try:
+            f.create_dataset("foo", data=numpy.array(u"aaaa"))
+            self.fail()
+        except TypeError:
             pass
 
 


### PR DESCRIPTION
- Avoid to store on datasets `object` and `unicode` types (not supported by HDF5)
- Patch the GUI to display datasets as broken if an exception occurs while reaching the data