### PR TITLE
[silx view] Fix physical/access path

### DIFF
--- a/silx/gui/hdf5/_utils.py
+++ b/silx/gui/hdf5/_utils.py
@@ -145,7 +145,7 @@ class H5Node(object):
 
     def __get_target(self, obj):
         """
-        Return the closes target of the provided object.
+        Return the actual physical target of the provided object.
 
         Objects can contains links in the middle of the path, this function
         check each groups and remove this prefix in case of the link by the

--- a/silx/gui/hdf5/_utils.py
+++ b/silx/gui/hdf5/_utils.py
@@ -170,7 +170,7 @@ class H5Node(object):
                 subpath = "/".join(elements)
                 external_obj = obj.parent.get(self.basename + "/" + subpath)
                 return self.__get_target(external_obj)
-            elif isinstance(link, (h5py.SoftLink)):
+            elif silx.io.utils.is_softlink(link):
                 # Restart from this stat
                 path = ""
                 root_elements = link.path.split("/")

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -478,7 +478,9 @@ class TestH5Node(TestCaseQt):
         h5 = h5py.File(filename, mode="w")
         h5["group/dataset"] = 50
         h5["link/soft_link"] = h5py.SoftLink("/group/dataset")
+        h5["link/soft_link_to_group"] = h5py.SoftLink("/group")
         h5["link/soft_link_to_link"] = h5py.SoftLink("/link/soft_link")
+        h5["link/soft_link_to_file"] = h5py.SoftLink("/")
         h5["link/external_link"] = h5py.ExternalLink(externalFilename, "/target/dataset")
         h5["link/external_link_to_link"] = h5py.ExternalLink(externalFilename, "/target/link")
         h5["broken_link/external_broken_file"] = h5py.ExternalLink(externalFilename + "_not_exists", "/target/link")
@@ -648,6 +650,28 @@ class TestH5Node(TestCaseQt):
         self.assertEqual(h5node.physical_name, "/group/not_exists")
         self.assertEqual(h5node.local_basename, "soft_link_to_broken_link")
         self.assertEqual(h5node.local_name, "/broken_link/soft_link_to_broken_link")
+
+    def testDatasetFromSoftLinkToGroup(self):
+        path = ["base.h5", "link", "soft_link_to_group", "dataset"]
+        h5node = self.getH5NodeFromPath(self.model, path)
+
+        self.assertEqual(h5node.physical_filename, h5node.local_filename)
+        self.assertIn("base.h5", h5node.physical_filename)
+        self.assertEqual(h5node.physical_basename, "dataset")
+        self.assertEqual(h5node.physical_name, "/group/dataset")
+        self.assertEqual(h5node.local_basename, "dataset")
+        self.assertEqual(h5node.local_name, "/link/soft_link_to_group/dataset")
+
+    def testDatasetFromSoftLinkToFile(self):
+        path = ["base.h5", "link", "soft_link_to_file", "link", "soft_link_to_group", "dataset"]
+        h5node = self.getH5NodeFromPath(self.model, path)
+
+        self.assertEqual(h5node.physical_filename, h5node.local_filename)
+        self.assertIn("base.h5", h5node.physical_filename)
+        self.assertEqual(h5node.physical_basename, "dataset")
+        self.assertEqual(h5node.physical_name, "/group/dataset")
+        self.assertEqual(h5node.local_basename, "dataset")
+        self.assertEqual(h5node.local_name, "/link/soft_link_to_file/link/soft_link_to_group/dataset")
 
 
 class TestHdf5(TestCaseQt):

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "23/08/2017"
+__date__ = "28/08/2017"
 
 
 import time
@@ -34,6 +34,7 @@ import os
 import unittest
 import tempfile
 import numpy
+import shutil
 from contextlib import contextmanager
 from silx.gui import qt
 from silx.gui.test.utils import TestCaseQt
@@ -455,6 +456,200 @@ class TestNexusSortFilterProxyModel(TestCaseQt):
         self.assertListEqual(names, ["100aaa", "aaa100"])
 
 
+class TestH5Node(TestCaseQt):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestH5Node, cls).setUpClass()
+        cls.tmpDirectory = tempfile.mkdtemp()
+        cls.h5Filename = cls.createResource(cls.tmpDirectory)
+        cls.model = cls.createModel(cls.h5Filename)
+
+    @classmethod
+    def createResource(cls, directory):
+        filename = os.path.join(directory, "base.h5")
+        externalFilename = os.path.join(directory, "base__external.h5")
+
+        externalh5 = h5py.File(externalFilename, mode="w")
+        externalh5["target/dataset"] = 50
+        externalh5["target/link"] = h5py.SoftLink("/target/dataset")
+        externalh5.close()
+
+        h5 = h5py.File(filename, mode="w")
+        h5["group/dataset"] = 50
+        h5["link/soft_link"] = h5py.SoftLink("/group/dataset")
+        h5["link/soft_link_to_link"] = h5py.SoftLink("/link/soft_link")
+        h5["link/external_link"] = h5py.ExternalLink(externalFilename, "/target/dataset")
+        h5["link/external_link_to_link"] = h5py.ExternalLink(externalFilename, "/target/link")
+        h5["broken_link/external_broken_file"] = h5py.ExternalLink(externalFilename + "_not_exists", "/target/link")
+        h5["broken_link/external_broken_link"] = h5py.ExternalLink(externalFilename, "/target/not_exists")
+        h5["broken_link/soft_broken_link"] = h5py.SoftLink("/group/not_exists")
+        h5["broken_link/soft_link_to_broken_link"] = h5py.SoftLink("/group/not_exists")
+        h5.close()
+
+        return filename
+
+    @classmethod
+    def createModel(cls, filename):
+        model = hdf5.Hdf5TreeModel()
+        model.appendFile(filename)
+        return model
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmpDirectory)
+        super(TestH5Node, cls).tearDownClass()
+
+    def getIndexFromPath(self, model, path):
+        """
+        :param qt.QAbstractItemModel: model
+        """
+        index = qt.QModelIndex()
+        for name in path:
+            for row in range(model.rowCount(index)):
+                i = model.index(row, 0, index)
+                label = model.data(i)
+                if label == name:
+                    index = i
+                    break
+            else:
+                raise RuntimeError("Path not found")
+        return index
+
+    def getH5NodeFromPath(self, model, path):
+        index = self.getIndexFromPath(model, path)
+        item = model.data(index, hdf5.Hdf5TreeModel.H5PY_ITEM_ROLE)
+        h5node = hdf5.H5Node(item)
+        return h5node
+
+    def testFile(self):
+        path = ["base.h5"]
+        h5node = self.getH5NodeFromPath(self.model, path)
+
+        self.assertEqual(h5node.physical_filename, h5node.local_filename)
+        self.assertIn("base.h5", h5node.physical_filename)
+        self.assertEqual(h5node.physical_basename, "")
+        self.assertEqual(h5node.physical_name, "/")
+        self.assertEqual(h5node.local_basename, "")
+        self.assertEqual(h5node.local_name, "/")
+
+    def testGroup(self):
+        path = ["base.h5", "group"]
+        h5node = self.getH5NodeFromPath(self.model, path)
+
+        self.assertEqual(h5node.physical_filename, h5node.local_filename)
+        self.assertIn("base.h5", h5node.physical_filename)
+        self.assertEqual(h5node.physical_basename, "group")
+        self.assertEqual(h5node.physical_name, "/group")
+        self.assertEqual(h5node.local_basename, "group")
+        self.assertEqual(h5node.local_name, "/group")
+
+    def testDataset(self):
+        path = ["base.h5", "group", "dataset"]
+        h5node = self.getH5NodeFromPath(self.model, path)
+
+        self.assertEqual(h5node.physical_filename, h5node.local_filename)
+        self.assertIn("base.h5", h5node.physical_filename)
+        self.assertEqual(h5node.physical_basename, "dataset")
+        self.assertEqual(h5node.physical_name, "/group/dataset")
+        self.assertEqual(h5node.local_basename, "dataset")
+        self.assertEqual(h5node.local_name, "/group/dataset")
+
+    def testSoftLink(self):
+        path = ["base.h5", "link", "soft_link"]
+        h5node = self.getH5NodeFromPath(self.model, path)
+
+        self.assertEqual(h5node.physical_filename, h5node.local_filename)
+        self.assertIn("base.h5", h5node.physical_filename)
+        self.assertEqual(h5node.physical_basename, "dataset")
+        self.assertEqual(h5node.physical_name, "/group/dataset")
+        self.assertEqual(h5node.local_basename, "soft_link")
+        self.assertEqual(h5node.local_name, "/link/soft_link")
+
+    def testSoftLinkToLink(self):
+        path = ["base.h5", "link", "soft_link_to_link"]
+        h5node = self.getH5NodeFromPath(self.model, path)
+
+        self.assertEqual(h5node.physical_filename, h5node.local_filename)
+        self.assertIn("base.h5", h5node.physical_filename)
+        self.assertEqual(h5node.physical_basename, "dataset")
+        self.assertEqual(h5node.physical_name, "/group/dataset")
+        self.assertEqual(h5node.local_basename, "soft_link_to_link")
+        self.assertEqual(h5node.local_name, "/link/soft_link_to_link")
+
+    def testExternalLink(self):
+        path = ["base.h5", "link", "external_link"]
+        h5node = self.getH5NodeFromPath(self.model, path)
+
+        self.assertNotEqual(h5node.physical_filename, h5node.local_filename)
+        self.assertIn("base.h5", h5node.local_filename)
+        self.assertIn("base__external.h5", h5node.physical_filename)
+        self.assertEqual(h5node.physical_basename, "dataset")
+        self.assertEqual(h5node.physical_name, "/target/dataset")
+        self.assertEqual(h5node.local_basename, "external_link")
+        self.assertEqual(h5node.local_name, "/link/external_link")
+
+    def testExternalLinkToLink(self):
+        path = ["base.h5", "link", "external_link_to_link"]
+        h5node = self.getH5NodeFromPath(self.model, path)
+
+        self.assertNotEqual(h5node.physical_filename, h5node.local_filename)
+        self.assertIn("base.h5", h5node.local_filename)
+        self.assertIn("base__external.h5", h5node.physical_filename)
+
+        self.assertNotEqual(h5node.physical_filename, h5node.local_filename)
+        self.assertEqual(h5node.physical_basename, "dataset")
+        self.assertEqual(h5node.physical_name, "/target/dataset")
+        self.assertEqual(h5node.local_basename, "external_link_to_link")
+        self.assertEqual(h5node.local_name, "/link/external_link_to_link")
+
+    def testExternalBrokenFile(self):
+        path = ["base.h5", "broken_link", "external_broken_file"]
+        h5node = self.getH5NodeFromPath(self.model, path)
+
+        self.assertNotEqual(h5node.physical_filename, h5node.local_filename)
+        self.assertIn("base.h5", h5node.local_filename)
+        self.assertIn("not_exists", h5node.physical_filename)
+        self.assertEqual(h5node.physical_basename, "link")
+        self.assertEqual(h5node.physical_name, "/target/link")
+        self.assertEqual(h5node.local_basename, "external_broken_file")
+        self.assertEqual(h5node.local_name, "/broken_link/external_broken_file")
+
+    def testExternalBrokenLink(self):
+        path = ["base.h5", "broken_link", "external_broken_link"]
+        h5node = self.getH5NodeFromPath(self.model, path)
+
+        self.assertNotEqual(h5node.physical_filename, h5node.local_filename)
+        self.assertIn("base.h5", h5node.local_filename)
+        self.assertIn("__external", h5node.physical_filename)
+        self.assertEqual(h5node.physical_basename, "not_exists")
+        self.assertEqual(h5node.physical_name, "/target/not_exists")
+        self.assertEqual(h5node.local_basename, "external_broken_link")
+        self.assertEqual(h5node.local_name, "/broken_link/external_broken_link")
+
+    def testSoftBrokenLink(self):
+        path = ["base.h5", "broken_link", "soft_broken_link"]
+        h5node = self.getH5NodeFromPath(self.model, path)
+
+        self.assertEqual(h5node.physical_filename, h5node.local_filename)
+        self.assertIn("base.h5", h5node.physical_filename)
+        self.assertEqual(h5node.physical_basename, "not_exists")
+        self.assertEqual(h5node.physical_name, "/group/not_exists")
+        self.assertEqual(h5node.local_basename, "soft_broken_link")
+        self.assertEqual(h5node.local_name, "/broken_link/soft_broken_link")
+
+    def testSoftLinkToBrokenLink(self):
+        path = ["base.h5", "broken_link", "soft_link_to_broken_link"]
+        h5node = self.getH5NodeFromPath(self.model, path)
+
+        self.assertEqual(h5node.physical_filename, h5node.local_filename)
+        self.assertIn("base.h5", h5node.physical_filename)
+        self.assertEqual(h5node.physical_basename, "not_exists")
+        self.assertEqual(h5node.physical_name, "/group/not_exists")
+        self.assertEqual(h5node.local_basename, "soft_link_to_broken_link")
+        self.assertEqual(h5node.local_name, "/broken_link/soft_link_to_broken_link")
+
+
 class TestHdf5(TestCaseQt):
     """Test to check that icons module."""
 
@@ -474,12 +669,11 @@ class TestHdf5(TestCaseQt):
 
 def suite():
     test_suite = unittest.TestSuite()
-    test_suite.addTest(
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestHdf5TreeModel))
-    test_suite.addTest(
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestNexusSortFilterProxyModel))
-    test_suite.addTest(
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestHdf5))
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(TestHdf5TreeModel))
+    test_suite.addTest(loadTests(TestNexusSortFilterProxyModel))
+    test_suite.addTest(loadTests(TestHdf5))
+    test_suite.addTest(loadTests(TestH5Node))
     return test_suite
 
 

--- a/silx/io/commonh5.py
+++ b/silx/io/commonh5.py
@@ -430,6 +430,15 @@ class Dataset(Node):
         else:
             return self[()] >= other
 
+    def __getattr__(self, item):
+        """Proxy to underlying numpy array methods.
+        """
+        data = self._get_data()
+        if hasattr(data, item):
+            return getattr(data, item)
+
+        raise AttributeError("Dataset has no attribute %s" % item)
+
 
 class LazyLoadableDataset(Dataset):
     """Abstract dataset which provides a lazy loading of the data.

--- a/silx/io/test/test_commonh5.py
+++ b/silx/io/test/test_commonh5.py
@@ -25,15 +25,18 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "25/08/2017"
+__date__ = "28/08/2017"
 
 import logging
 import numpy
 import unittest
+import tempfile
+import shutil
 
 _logger = logging.getLogger(__name__)
 
 import silx.io
+import silx.io.utils
 
 try:
     import h5py
@@ -46,34 +49,151 @@ except ImportError:
     commonh5 = None
 
 
-class TestCommonH5(unittest.TestCase):
+class TestCommonFeatures(unittest.TestCase):
+    """Test common features supported by h5py and our implementation."""
 
-    def setUp(self):
-        if h5py is None:
-            self.skipTest("h5py is needed")
-        if commonh5 is None:
-            self.skipTest("silx.io.commonh5 is needed")
+    @classmethod
+    def createFile(cls):
+        return None
+
+    @classmethod
+    def setUpClass(cls):
+        # Set to None cause create_resource can raise an excpetion
+        cls.h5 = None
+        cls.h5 = cls.create_resource()
+        if cls.h5 is None:
+            raise unittest.SkipTest("File not created")
+
+    @classmethod
+    def create_resource(cls):
+        """Must be implemented"""
+        return None
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.h5 = None
 
     def test_file(self):
-        node = commonh5.File("foo")
+        node = self.h5
         self.assertTrue(silx.io.is_file(node))
         self.assertTrue(silx.io.is_group(node))
         self.assertFalse(silx.io.is_dataset(node))
         self.assertEqual(len(node.attrs), 0)
 
     def test_group(self):
-        node = commonh5.Group("foo")
+        node = self.h5["group"]
         self.assertFalse(silx.io.is_file(node))
         self.assertTrue(silx.io.is_group(node))
         self.assertFalse(silx.io.is_dataset(node))
         self.assertEqual(len(node.attrs), 0)
+        if h5py is not None:
+            class_ = self.h5.get("group", getclass=True)
+            classlink = self.h5.get("group", getlink=True, getclass=True)
+            self.assertEqual(class_, h5py.Group)
+            self.assertEqual(classlink, h5py.HardLink)
 
     def test_dataset(self):
-        node = commonh5.Dataset("foo", data=numpy.array([1]))
+        node = self.h5["group/dataset"]
         self.assertFalse(silx.io.is_file(node))
         self.assertFalse(silx.io.is_group(node))
         self.assertTrue(silx.io.is_dataset(node))
         self.assertEqual(len(node.attrs), 0)
+        if h5py is not None:
+            class_ = self.h5.get("group/dataset", getclass=True)
+            classlink = self.h5.get("group/dataset", getlink=True, getclass=True)
+            self.assertEqual(class_, h5py.Dataset)
+            self.assertEqual(classlink, h5py.HardLink)
+
+    def test_soft_link(self):
+        node = self.h5["link/soft_link"]
+        self.assertEqual(node.name, "/link/soft_link")
+        if h5py is not None:
+            class_ = self.h5.get("link/soft_link", getclass=True)
+            link = self.h5.get("link/soft_link", getlink=True)
+            classlink = self.h5.get("link/soft_link", getlink=True, getclass=True)
+            self.assertEqual(class_, h5py.Dataset)
+            self.assertTrue(isinstance(link, (h5py.SoftLink, commonh5.SoftLink)))
+            self.assertTrue(silx.io.utils.is_softlink(link))
+            self.assertEqual(classlink, h5py.SoftLink)
+
+    def test_external_link(self):
+        node = self.h5["link/external_link"]
+        self.assertEqual(node.name, "/target/dataset")
+        if h5py is not None:
+            class_ = self.h5.get("link/external_link", getclass=True)
+            classlink = self.h5.get("link/external_link", getlink=True, getclass=True)
+            self.assertEqual(class_, h5py.Dataset)
+            self.assertEqual(classlink, h5py.ExternalLink)
+
+    def test_external_link_to_link(self):
+        node = self.h5["link/external_link_to_link"]
+        self.assertEqual(node.name, "/target/link")
+        if h5py is not None:
+            class_ = self.h5.get("link/external_link_to_link", getclass=True)
+            classlink = self.h5.get("link/external_link_to_link", getlink=True, getclass=True)
+            self.assertEqual(class_, h5py.Dataset)
+            self.assertEqual(classlink, h5py.ExternalLink)
+
+
+class TestCommonFeatures_h5py(TestCommonFeatures):
+    """Check if h5py is compliant with what we expect."""
+
+    @classmethod
+    def create_resource(cls):
+        cls.tmp_dir = tempfile.mkdtemp()
+
+        externalh5 = h5py.File(cls.tmp_dir + "/external.h5", mode="w")
+        externalh5["target/dataset"] = 50
+        externalh5["target/link"] = h5py.SoftLink("/target/dataset")
+        externalh5.close()
+
+        h5 = h5py.File(cls.tmp_dir + "/base.h5", mode="w")
+        h5["group/dataset"] = 50
+        h5["link/soft_link"] = h5py.SoftLink("/group/dataset")
+        h5["link/external_link"] = h5py.ExternalLink("external.h5", "/target/dataset")
+        h5["link/external_link_to_link"] = h5py.ExternalLink("external.h5", "/target/link")
+
+        return h5
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestCommonFeatures_h5py, cls).tearDownClass()
+        if hasattr(cls, "tmp_dir") and cls.tmp_dir is not None:
+            shutil.rmtree(cls.tmp_dir)
+
+
+class TestCommonFeatures_commonH5(TestCommonFeatures):
+    """Check if commonh5 is compliant with h5py."""
+
+    @classmethod
+    def create_resource(cls):
+        h5 = commonh5.File("base.h5", "w")
+        h5.create_group("group").create_dataset("dataset", data=numpy.int32(50))
+
+        link = h5.create_group("link")
+        link.add_node(commonh5.SoftLink("soft_link", "/group/dataset"))
+
+        return h5
+
+    def test_external_link(self):
+        # not applicable
+        pass
+
+    def test_external_link_to_link(self):
+        # not applicable
+        pass
+
+
+class TestSpecificCommonH5(unittest.TestCase):
+    """Test specific features from commonh5.
+
+    Test of shared features should be done by TestCommonFeatures."""
+
+    def setUp(self):
+        if h5py is None:
+            self.skipTest("h5py is needed")
+        if commonh5 is None:
+            self.skipTest("silx.io.commonh5 is needed")
 
     def test_node_attrs(self):
         node = commonh5.Node("Foo", attrs={"a": 1})
@@ -135,7 +255,9 @@ class TestCommonH5(unittest.TestCase):
 def suite():
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
     test_suite = unittest.TestSuite()
-    test_suite.addTest(loadTests(TestCommonH5))
+    test_suite.addTest(loadTests(TestCommonFeatures_h5py))
+    test_suite.addTest(loadTests(TestCommonFeatures_commonH5))
+    test_suite.addTest(loadTests(TestSpecificCommonH5))
     return test_suite
 
 

--- a/silx/io/test/test_fabioh5.py
+++ b/silx/io/test/test_fabioh5.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "28/08/2017"
+__date__ = "29/08/2017"
 
 import logging
 import numpy
@@ -299,13 +299,15 @@ class TestFabioH5(unittest.TestCase):
         detector1 = self.h5_image["/scan_0/instrument/detector_0"]
         detector2 = self.h5_image["/scan_0/measurement/image_0/info"]
         self.assertIsNot(detector1, detector2)
-        self.assertEqual(detector1.items(), detector2.items())
+        self.assertEqual(list(detector1.items()), list(detector2.items()))
+        self.assertEqual(self.h5_image.get(detector2.name, getlink=True).path, detector1.name)
 
     def test_detector_data_link(self):
         data1 = self.h5_image["/scan_0/instrument/detector_0/data"]
         data2 = self.h5_image["/scan_0/measurement/image_0/data"]
         self.assertIsNot(data1, data2)
         self.assertIs(data1._get_data(), data2._get_data())
+        self.assertEqual(self.h5_image.get(data2.name, getlink=True).path, data1.name)
 
 
 def suite():

--- a/silx/io/test/test_fabioh5.py
+++ b/silx/io/test/test_fabioh5.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "23/08/2017"
+__date__ = "28/08/2017"
 
 import logging
 import numpy
@@ -298,12 +298,14 @@ class TestFabioH5(unittest.TestCase):
     def test_detector_link(self):
         detector1 = self.h5_image["/scan_0/instrument/detector_0"]
         detector2 = self.h5_image["/scan_0/measurement/image_0/info"]
-        self.assertIs(detector1, detector2)
+        self.assertIsNot(detector1, detector2)
+        self.assertEqual(detector1.items(), detector2.items())
 
     def test_detector_data_link(self):
         data1 = self.h5_image["/scan_0/instrument/detector_0/data"]
         data2 = self.h5_image["/scan_0/measurement/image_0/data"]
-        self.assertIs(data1, data2)
+        self.assertIsNot(data1, data2)
+        self.assertIs(data1._get_data(), data2._get_data())
 
 
 def suite():

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -41,7 +41,7 @@ else:
 
 __authors__ = ["P. Knobel", "V. Valls"]
 __license__ = "MIT"
-__date__ = "20/07/2017"
+__date__ = "28/08/2017"
 
 
 logger = logging.getLogger(__name__)
@@ -455,7 +455,7 @@ def get_h5py_class(obj):
     """
     if hasattr(obj, "h5py_class"):
         return obj.h5py_class
-    elif isinstance(obj, (h5py.File, h5py.Group, h5py.Dataset)):
+    elif isinstance(obj, (h5py.File, h5py.Group, h5py.Dataset, h5py.SoftLink)):
         return obj.__class__
     else:
         return None


### PR DESCRIPTION
- Fix the way node paths are computed with our commonh5 objects (now it match h5py)
- Fix the physical path, which is the hdf5 path when every intermediate links are removed
- A lot of test cases to be sure it is h5py compliant, and that we display the right thing

The screenshot shows that the path `/soft_link_to_group/dataset` is a link to `/group/dataset` and it is not trivial. Previous computation was based on wrong assertion.

Closes #1059

![screenshot from 2017-08-28 17 23 09](https://user-images.githubusercontent.com/7579321/29780400-e5029e6c-8c15-11e7-830d-e2732886ac68.png)
