### PR TITLE
Correct incoherence in copyright dates (See header files).

### DIFF
--- a/silx/io/specfile/include/Lists.h
+++ b/silx/io/specfile/include/Lists.h
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (C) 1995-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/silx/io/specfile/include/SpecFile.h
+++ b/silx/io/specfile/include/SpecFile.h
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (C) 1995-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -77,6 +77,7 @@
 #define  ROW            0  /* data_info index for no. of data rows  */
 #define  COL            1  /* data_info index for no. of data columns*/
 #define  REG            2  /* data_info index for regular            */
+
 #define  H              0
 #define  K              1
 #define  L              2

--- a/silx/io/specfile/include/SpecFileP.h
+++ b/silx/io/specfile/include/SpecFileP.h
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (C) 1995-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/silx/io/specfile/src/sfdata.c
+++ b/silx/io/specfile/src/sfdata.c
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (C) 1995-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/silx/io/specfile/src/sfheader.c
+++ b/silx/io/specfile/src/sfheader.c
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (C) 1995-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/silx/io/specfile/src/sfindex.c
+++ b/silx/io/specfile/src/sfindex.c
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (C) 1995-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/silx/io/specfile/src/sfinit.c
+++ b/silx/io/specfile/src/sfinit.c
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (C) 1995-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/silx/io/specfile/src/sflabel.c
+++ b/silx/io/specfile/src/sflabel.c
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (C) 1995-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/silx/io/specfile/src/sflists.c
+++ b/silx/io/specfile/src/sflists.c
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (C) 1995-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/silx/io/specfile/src/sfmca.c
+++ b/silx/io/specfile/src/sfmca.c
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (C) 2000-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/silx/io/specfile/src/sftools.c
+++ b/silx/io/specfile/src/sftools.c
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (C) 1995-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/silx/io/specfile/src/sfwrite.c
+++ b/silx/io/specfile/src/sfwrite.c
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (C) 1995-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The ancient header information refers to 1995 and not to 2004. The 2004 date is in fact the copyright date for PyMca. The SpecFile C code is much older.