### PR TITLE
Fix hdf5node tree

### DIFF
--- a/silx/gui/hdf5/Hdf5Node.py
+++ b/silx/gui/hdf5/Hdf5Node.py
@@ -27,6 +27,8 @@ __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "16/06/2017"
 
+import weakref
+
 
 class Hdf5Node(object):
     """Abstract tree node
@@ -43,7 +45,9 @@ class Hdf5Node(object):
             everything is lazy loaded.
         """
         self.__child = None
-        self.__parent = parent
+        self.__parent = None
+        if parent is not None:
+            self.__parent = weakref.ref(parent)
         if populateAll:
             self.__child = []
             self._populateChild(populateAll=True)
@@ -54,7 +58,12 @@ class Hdf5Node(object):
 
         :rtype: Hdf5Node
         """
-        return self.__parent
+        if self.__parent is None:
+            return None
+        parent = self.__parent()
+        if parent is None:
+            self.__parent = parent
+        return parent
 
     def setParent(self, parent):
         """Redefine the parent of the node.
@@ -63,7 +72,10 @@ class Hdf5Node(object):
 
         :param Hdf5Node parent: The new parent
         """
-        self.__parent = parent
+        if parent is None:
+            self.__parent = None
+        else:
+            self.__parent = weakref.ref(parent)
 
     def appendChild(self, child):
         """Append a child to the node.

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -29,7 +29,6 @@ __license__ = "MIT"
 __date__ = "01/09/2017"
 
 
-import sys
 import time
 import os
 import unittest
@@ -587,9 +586,6 @@ class TestH5Node(TestCaseQt):
         self.assertEqual(h5node.local_name, "/link/soft_link_to_link")
 
     def testExternalLink(self):
-        if sys.platform == "win32":
-            # FIXME it have to be removed
-            self.skipTest("Creates issue on win32. See https://github.com/silx-kit/silx/issues/1073")
         path = ["base.h5", "link", "external_link"]
         h5node = self.getH5NodeFromPath(self.model, path)
 
@@ -602,9 +598,6 @@ class TestH5Node(TestCaseQt):
         self.assertEqual(h5node.local_name, "/link/external_link")
 
     def testExternalLinkToLink(self):
-        if sys.platform == "win32":
-            # FIXME it have to be removed
-            self.skipTest("Creates issue on win32. See https://github.com/silx-kit/silx/issues/1073")
         path = ["base.h5", "link", "external_link_to_link"]
         h5node = self.getH5NodeFromPath(self.model, path)
 


### PR DESCRIPTION
Use weakref for parent. It allows to destroy everything without use of the gc.

Closes #1073