### PR TITLE
Fix plot errors with latest version of matplotlib

### DIFF
--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -143,7 +143,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                 errorbarColor = color
 
             # On Debian 7 at least, Nx1 array yerr does not seems supported
-            if (yerror is not None and yerror.ndim == 2 and
+            if (isinstance(yerror, numpy.ndarray) and yerror.ndim == 2 and
                     yerror.shape[1] == 1 and len(x) != 1):
                 yerror = numpy.ravel(yerror)
 

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -441,7 +441,10 @@ class BackendMatplotlib(BackendBase.BackendBase):
             item._infoText.remove()
             item._infoText = None
         self._overlays.discard(item)
-        item.remove()
+        try:
+            item.remove()
+        except ValueError:
+            pass  # Already removed e.g., in set[X|Y]AxisLogarithmic
 
     # Interaction methods
 
@@ -592,10 +595,16 @@ class BackendMatplotlib(BackendBase.BackendBase):
     # Graph axes
 
     def setXAxisLogarithmic(self, flag):
+        if matplotlib.__version__ >= "2.1.0":
+            self.ax.cla()
+            self.ax2.cla()
         self.ax2.set_xscale('log' if flag else 'linear')
         self.ax.set_xscale('log' if flag else 'linear')
 
     def setYAxisLogarithmic(self, flag):
+        if matplotlib.__version__ >= "2.1.0":
+            self.ax.cla()
+            self.ax2.cla()
         self.ax2.set_yscale('log' if flag else 'linear')
         self.ax.set_yscale('log' if flag else 'linear')
 

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -29,6 +29,7 @@ __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "27/06/2017"
 
+import collections
 from copy import deepcopy
 import logging
 import weakref
@@ -872,24 +873,24 @@ class Points(Item, SymbolMixIn, AlphaMixIn):
 
         :param copy: True (Default) to get a copy,
                      False to use internal representation (do not modify!)
-        :rtype: numpy.ndarray or None
+        :rtype: numpy.ndarray, float or None
         """
-        if self._xerror is None:
-            return None
-        else:
+        if isinstance(self._xerror, numpy.ndarray):
             return numpy.array(self._xerror, copy=copy)
+        else:
+            return self._xerror  # float or None
 
     def getYErrorData(self, copy=True):
         """Returns the y error of the points
 
         :param copy: True (Default) to get a copy,
                      False to use internal representation (do not modify!)
-        :rtype: numpy.ndarray or None
+        :rtype: numpy.ndarray, float or None
         """
-        if self._yerror is None:
-            return None
-        else:
+        if isinstance(self._yerror, numpy.ndarray):
             return numpy.array(self._yerror, copy=copy)
+        else:
+            return self._yerror  # float or None
 
     def setData(self, x, y, xerror=None, yerror=None, copy=True):
         """Set the data of the curve.
@@ -913,9 +914,15 @@ class Points(Item, SymbolMixIn, AlphaMixIn):
         assert x.ndim == y.ndim == 1
 
         if xerror is not None:
-            xerror = numpy.array(xerror, copy=copy)
+            if isinstance(xerror, collections.Iterable):
+                xerror = numpy.array(xerror, copy=copy)
+            else:
+                xerror = float(xerror)
         if yerror is not None:
-            yerror = numpy.array(yerror, copy=copy)
+            if isinstance(yerror, collections.Iterable):
+                yerror = numpy.array(yerror, copy=copy)
+            else:
+                yerror = float(yerror)
         # TODO checks on xerror, yerror
         self._x, self._y = x, y
         self._xerror, self._yerror = xerror, yerror


### PR DESCRIPTION
This PR should fix errors spotted by CI that happens with new version of matplotlib: v2.1.0rc1:

- silx.gui.plot.test.testPlotWidget.TestPlotCurveLog.testPlotCurveErrorLogXY
- silx.gui.plot.test.testPlotWidget.TestPlotCurveLog.testPlotCurveToggleLog

It does not change anything about PySide that also seems to be broken on CI...