### PR TITLE
[doc] Update license information in doc and README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,11 @@
 The silx toolkit is a software library and one of its goals is not to impose any license to the end user.
 
-Silx follows the permisive MIT license although it may include contributions following other licenses not interfering with the previous goal. Detailed information can be found in the copyright file.
+Silx follows the permissive MIT license although it may include contributions following other licenses not interfering with the previous goal. Detailed information can be found in the copyright file.
 
-Silx uses the Qt library for its graphical user interfaces. A word of caution is to be provided. If users develop and distribute software using modules accessing Qt by means of Riverbank Computing Qt bindings PyQt4 or PyQt5, those users will be conditioned by the license of their PyQt4/5 software (GPL or commercial). If the end user does not own a commercial license of PyQt4 or PyQt5 and wishes to be free of any distribution condition, (s)he should be able to use PySide because it uses the LGPL license.
+Silx uses the Qt library for its graphical user interfaces.
+A word of caution is to be provided.
+If users develop and distribute software using modules accessing Qt by means of Riverbank Computing Qt bindings PyQt4 or PyQt5, those users will be conditioned by the license of their PyQt4/5 software (GPL or commercial).
+If the end user does not own a commercial license of PyQt4 or PyQt5 and wishes to be free of any distribution condition, (s)he should be able to use PySide because it uses the LGPL license.
 
 The MIT license follows:
 

--- a/README.rst
+++ b/README.rst
@@ -110,8 +110,8 @@ Some examples are available in the source code repository. For example::
 License
 -------
 
-The source code of silx is licensed under the MIT and LGPL licenses.
-See the `copyright file <https://github.com/silx-kit/silx/blob/master/copyright>`_ for details.
+The source code of silx is licensed under the MIT license.
+See the `LICENSE <https://github.com/silx-kit/silx/blob/master/LICENSE>`_ and `copyright <https://github.com/silx-kit/silx/blob/master/copyright>`_ files for details.
 
 Citation
 --------

--- a/copyright
+++ b/copyright
@@ -64,44 +64,9 @@ License: BSD-3
  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-License: GPL-3.0+
- This package is free software; you can redistribute it and/or modify
- it under the terms of the GNU General Public License as published by
- the Free Software Foundation; either version 3 of the License, or
- (at your option) any later version.
- .
- This package is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- GNU General Public License for more details.
- .
- You should have received a copy of the GNU General Public License
- along with this program. If not, see <http://www.gnu.org/licenses/>
- .
- On Debian systems, the complete text of the GNU General
- Public License version 3 can be found in "/usr/share/common-licenses/GPL-3".
-
 License: public-domain
  You can use this free for any purpose. It's in the public domain. It
  has no warranty
-
-License: LGPL-2.1+
- This library is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation; either
- version 2.1 of the License, or (at your option) any later version.
- .
- This library is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
- .
- You should have received a copy of the GNU Lesser General Public
- License along with this library; if not, write to the Free Software
- Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
- .
- On Debian systems, the complete text of the GNU Lesser General Public
- License can be found in "/usr/share/common-licenses/LGPL-2.1".
 
 License: CC0
  Statement of Purpose

--- a/doc/source/license.rst
+++ b/doc/source/license.rst
@@ -1,7 +1,9 @@
 License
 =======
 
-The source code of *silx* is mostly licensed under the `MIT <https://opensource.org/licenses/MIT>`_ and `LGPL 2.1 <https://opensource.org/licenses/LGPL-2.1>`_ licenses.
+The source code of *silx* is licensed under the `MIT <https://opensource.org/licenses/MIT>`_ license:
+
+.. include:: ../../LICENSE
 
 The following list provides the copyright and license of the different source files of the project:
 


### PR DESCRIPTION
This PR removes LGPL license from the licence doc page and the readme.