### PR TITLE
Rework for h5py types

### DIFF
--- a/silx/gui/data/ArrayTableModel.py
+++ b/silx/gui/data/ArrayTableModel.py
@@ -34,7 +34,7 @@ from silx.gui.data.TextFormatter import TextFormatter
 
 __authors__ = ["V.A. Sole"]
 __license__ = "MIT"
-__date__ = "24/01/2017"
+__date__ = "26/09/2017"
 
 
 _logger = logging.getLogger(__name__)
@@ -191,7 +191,7 @@ class ArrayTableModel(qt.QAbstractTableModel):
             selection = self._getIndexTuple(index.row(),
                                             index.column())
             if role == qt.Qt.DisplayRole:
-                return self._formatter.toString(self._array[selection])
+                return self._formatter.toString(self._array[selection], self._array.dtype)
 
             if role == qt.Qt.BackgroundRole and self._bgcolors is not None:
                 r, g, b = self._bgcolors[selection][0:3]
@@ -296,6 +296,8 @@ class ArrayTableModel(qt.QAbstractTableModel):
         elif copy:
             # copy requested (default)
             self._array = numpy.array(data, copy=True)
+            # Avoid to lose the monkey-patched h5py dtype
+            self._array.dtype = data.dtype
         elif not _is_array(data):
             raise TypeError("data is not a proper array. Try setting" +
                             " copy=True to convert it into a numpy array" +

--- a/silx/gui/data/ArrayTableModel.py
+++ b/silx/gui/data/ArrayTableModel.py
@@ -34,7 +34,7 @@ from silx.gui.data.TextFormatter import TextFormatter
 
 __authors__ = ["V.A. Sole"]
 __license__ = "MIT"
-__date__ = "26/09/2017"
+__date__ = "27/09/2017"
 
 
 _logger = logging.getLogger(__name__)
@@ -296,8 +296,9 @@ class ArrayTableModel(qt.QAbstractTableModel):
         elif copy:
             # copy requested (default)
             self._array = numpy.array(data, copy=True)
-            # Avoid to lose the monkey-patched h5py dtype
-            self._array.dtype = data.dtype
+            if hasattr(data, "dtype"):
+                # Avoid to lose the monkey-patched h5py dtype
+                self._array.dtype = data.dtype
         elif not _is_array(data):
             raise TypeError("data is not a proper array. Try setting" +
                             " copy=True to convert it into a numpy array" +

--- a/silx/gui/data/DataViewer.py
+++ b/silx/gui/data/DataViewer.py
@@ -223,8 +223,6 @@ class DataViewer(qt.QFrame):
         """
         if self.__useAxisSelection:
             self.__displayedData = self.__numpySelection.selectedData()
-            # Avoid to lose the monkey-patched h5py dtype
-            self.__displayedData.dtype = self.__data.dtype
         else:
             self.__displayedData = self.__data
 

--- a/silx/gui/data/DataViewer.py
+++ b/silx/gui/data/DataViewer.py
@@ -35,7 +35,7 @@ from silx.gui.data.NumpyAxesSelector import NumpyAxesSelector
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "26/04/2017"
+__date__ = "26/09/2017"
 
 
 _logger = logging.getLogger(__name__)
@@ -223,6 +223,8 @@ class DataViewer(qt.QFrame):
         """
         if self.__useAxisSelection:
             self.__displayedData = self.__numpySelection.selectedData()
+            # Avoid to lose the monkey-patched h5py dtype
+            self.__displayedData.dtype = self.__data.dtype
         else:
             self.__displayedData = self.__data
 

--- a/silx/gui/data/DataViewer.py
+++ b/silx/gui/data/DataViewer.py
@@ -35,7 +35,7 @@ from silx.gui.data.NumpyAxesSelector import NumpyAxesSelector
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "26/09/2017"
+__date__ = "27/09/2017"
 
 
 _logger = logging.getLogger(__name__)
@@ -201,7 +201,7 @@ class DataViewer(qt.QFrame):
         self.__numpySelection.clear()
         info = DataViews.DataInfo(self.__data)
         axisNames = self.__currentView.axesNames(self.__data, info)
-        if info.isArray and self.__data is not None and len(axisNames) > 0:
+        if info.isArray and self.__data is not None and axisNames is not None:
             self.__useAxisSelection = True
             self.__numpySelection.setAxisNames(axisNames)
             self.__numpySelection.setCustomAxis(self.__currentView.customAxisNames())

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -39,7 +39,7 @@ from silx.io.nxdata import NXdata
 
 __authors__ = ["V. Valls", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "25/08/2017"
+__date__ = "26/09/2017"
 
 _logger = logging.getLogger(__name__)
 
@@ -705,10 +705,10 @@ class _ScalarView(DataView):
         self.getWidget().setText("")
 
     def setData(self, data):
-        data = self.normalizeData(data)
-        if silx.io.is_dataset(data):
-            data = data[()]
-        text = self.__formatter.toString(data)
+        d = self.normalizeData(data)
+        if silx.io.is_dataset(d):
+            d = d[()]
+        text = self.__formatter.toString(d, data.dtype)
         self.getWidget().setText(text)
 
     def axesNames(self, data, info):

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -245,12 +245,12 @@ class DataView(object):
 
     def axesNames(self, data, info):
         """Returns names of the expected axes of the view, according to the
-        input data.
+        input data. A none value will disable the default axes selectior.
 
         :param data: Data to display
         :type data: numpy.ndarray or h5py.Dataset
         :param DataInfo info: Pre-computed information on the data
-        :rtype: list[str]
+        :rtype: list[str] or None
         """
         return []
 
@@ -368,7 +368,7 @@ class _EmptyView(DataView):
         DataView.__init__(self, parent, modeId=EMPTY_MODE)
 
     def axesNames(self, data, info):
-        return []
+        return None
 
     def createWidget(self, parent):
         return qt.QLabel(parent)
@@ -791,7 +791,7 @@ class _Hdf5View(DataView):
         widget.setData(data)
 
     def axesNames(self, data, info):
-        return []
+        return None
 
     def getDataPriority(self, data, info):
         widget = self.getWidget()
@@ -886,7 +886,7 @@ class _NXdataCurveView(DataView):
 
     def axesNames(self, data, info):
         # disabled (used by default axis selector widget in Hdf5Viewer)
-        return []
+        return None
 
     def clear(self):
         self.getWidget().clear()
@@ -933,7 +933,7 @@ class _NXdataXYVScatterView(DataView):
 
     def axesNames(self, data, info):
         # disabled (used by default axis selector widget in Hdf5Viewer)
-        return []
+        return None
 
     def clear(self):
         self.getWidget().clear()
@@ -982,7 +982,8 @@ class _NXdataImageView(DataView):
         return widget
 
     def axesNames(self, data, info):
-        return []
+        # disabled (used by default axis selector widget in Hdf5Viewer)
+        return None
 
     def clear(self):
         self.getWidget().clear()
@@ -1022,7 +1023,8 @@ class _NXdataStackView(DataView):
         return widget
 
     def axesNames(self, data, info):
-        return []
+        # disabled (used by default axis selector widget in Hdf5Viewer)
+        return None
 
     def clear(self):
         self.getWidget().clear()

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -123,7 +123,9 @@ class DataInfo(object):
             self.interpretation = None
 
         if hasattr(data, "dtype"):
-            self.isVoid = numpy.issubdtype(data.dtype, numpy.void)
+            if numpy.issubdtype(data.dtype, numpy.void):
+                # That's a real opaque type, else it is a structured type
+                self.isVoid = data.dtype.fields is None
             self.isNumeric = numpy.issubdtype(data.dtype, numpy.number)
             self.isRecord = data.dtype.fields is not None
             self.isComplex = numpy.issubdtype(data.dtype, numpy.complex)

--- a/silx/gui/data/Hdf5TableView.py
+++ b/silx/gui/data/Hdf5TableView.py
@@ -30,7 +30,7 @@ from __future__ import division
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "26/09/2017"
+__date__ = "27/09/2017"
 
 import functools
 import os.path
@@ -262,7 +262,7 @@ class Hdf5TableModel(HierarchicalTableView.HierarchicalTableModel):
 
     def __formatDType(self, dataset):
         """Format the numpy dtype"""
-        return self.__hdf5Formatter.humanReadableType(dataset)
+        return self.__hdf5Formatter.humanReadableType(dataset, full=True)
 
     def __formatShape(self, dataset):
         """Format the shape"""

--- a/silx/gui/data/HexaTableView.py
+++ b/silx/gui/data/HexaTableView.py
@@ -32,6 +32,7 @@ import numpy
 import collections
 from silx.gui import qt
 import silx.io.utils
+from silx.third_party import six
 from silx.gui.widgets.TableWidget import CopySelectedCellsAction
 
 __authors__ = ["V. Valls"]
@@ -71,7 +72,10 @@ class _VoidConnector(object):
         bufferPos = pos & 0b1111111111
         data = self.__getBuffer(bufferId)
         value = data[bufferPos]
-        return ord(value)
+        if six.PY2:
+            return ord(value)
+        else:
+            return value
 
     def __len__(self):
         """

--- a/silx/gui/data/HexaTableView.py
+++ b/silx/gui/data/HexaTableView.py
@@ -1,0 +1,228 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""
+This module defines model and widget to display raw data using an
+hexadecimal viewer.
+"""
+from __future__ import division
+
+import numpy
+from silx.gui import qt
+import silx.io.utils
+from silx.gui.widgets.TableWidget import CopySelectedCellsAction
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "27/09/2017"
+
+
+class HexaTableModel(qt.QAbstractTableModel):
+    """This data model provides access to a numpy void data.
+
+    Bytes are displayed one by one as a hexadecimal viewer.
+
+    The 16th first columns display bytes as hexadecimal, the last column
+    displays the same data as ASCII.
+
+    :param qt.QObject parent: Parent object
+    :param data: A numpy array or a h5py dataset
+    """
+    def __init__(self, parent=None, data=None):
+        qt.QAbstractTableModel.__init__(self, parent)
+
+        self.__data = None
+        self.setArrayData(data)
+
+        if hasattr(qt.QFontDatabase, "systemFont"):
+            self.__font = qt.QFontDatabase.systemFont(qt.QFontDatabase.FixedFont)
+        else:
+            self.__font = qt.QFont("Monospace")
+            self.__font.setStyleHint(qt.QFont.TypeWriter)
+        self.__palette = qt.QPalette()
+
+    def rowCount(self, parent_idx=None):
+        """Returns number of rows to be displayed in table"""
+        if self.__data is None:
+            return 0
+        return ((len(self.__data.item()) - 1) >> 4) + 1
+
+    def columnCount(self, parent_idx=None):
+        """Returns number of columns to be displayed in table"""
+        return 0x10 + 1
+
+    def data(self, index, role=qt.Qt.DisplayRole):
+        """QAbstractTableModel method to access data values
+        in the format ready to be displayed"""
+        if not index.isValid():
+            return None
+
+        if self.__data is None:
+            return None
+
+        row = index.row()
+        column = index.column()
+
+        if role == qt.Qt.DisplayRole:
+            if column == 0x10:
+                start = (row << 4)
+                text = ""
+                for i in range(0x10):
+                    pos = start + i
+                    if pos >= len(self.__data.item()):
+                        break
+                    data = self.__data.item()[pos]
+                    value = ord(data)
+                    if value > 0x20 and value < 0x7F:
+                        text += chr(value)
+                    else:
+                        text += "."
+                return text
+            else:
+                pos = (row << 4) + column
+                if pos < len(self.__data.item()):
+                    data = self.__data.item()[pos]
+                    return "%02X" % ord(data)
+                else:
+                    return ""
+        elif role == qt.Qt.FontRole:
+            return self.__font
+
+        elif role == qt.Qt.BackgroundColorRole:
+            pos = (row << 4) + column
+            if column != 0x10 and pos >= len(self.__data.item()):
+                return self.__palette.color(qt.QPalette.Disabled, qt.QPalette.Background)
+            else:
+                return None
+
+        return None
+
+    def headerData(self, section, orientation, role=qt.Qt.DisplayRole):
+        """Returns the 0-based row or column index, for display in the
+        horizontal and vertical headers"""
+        if section == -1:
+            # PyQt4 send -1 when there is columns but no rows
+            return None
+
+        if role == qt.Qt.DisplayRole:
+            if orientation == qt.Qt.Vertical:
+                return "%02X" % (section << 4)
+            if orientation == qt.Qt.Horizontal:
+                if section == 0x10:
+                    return "ASCII"
+                else:
+                    return "%02X" % section
+        elif role == qt.Qt.FontRole:
+            return self.__font
+        elif role == qt.Qt.TextAlignmentRole:
+            if orientation == qt.Qt.Vertical:
+                return qt.Qt.AlignRight
+            if orientation == qt.Qt.Horizontal:
+                if section == 0x10:
+                    return qt.Qt.AlignLeft
+                else:
+                    return qt.Qt.AlignCenter
+        return None
+
+    def flags(self, index):
+        """QAbstractTableModel method to inform the view whether data
+        is editable or not.
+        """
+        row = index.row()
+        column = index.column()
+        pos = (row << 4) + column
+        if column != 0x10 and pos >= len(self.__data.item()):
+            return qt.Qt.NoItemFlags
+        return qt.QAbstractTableModel.flags(self, index)
+
+    def setArrayData(self, data):
+        """Set the data array.
+
+        :param data: A numpy object or a dataset.
+        """
+        if qt.qVersion() > "4.6":
+            self.beginResetModel()
+
+        self.__data = data
+        if self.__data is not None:
+            if silx.io.utils.is_dataset(self.__data):
+                self.__data = data[()]
+            elif isinstance(self.__data, numpy.ndarray):
+                self.__data = data[()]
+
+        if qt.qVersion() > "4.6":
+            self.endResetModel()
+        else:
+            self.reset()
+
+    def arrayData(self):
+        """Returns the internal data.
+
+        :rtype: numpy.ndarray of h5py.Dataset
+        """
+        return self.__data
+
+
+class HexaTableView(qt.QTableView):
+    """TableView using HexaTableModel as default model.
+
+    It customs the column size to provide a better layout.
+    """
+    def __init__(self, parent=None):
+        """
+        Constructor
+
+        :param qt.QWidget parent: parent QWidget
+        """
+        qt.QTableView.__init__(self, parent)
+
+        model = HexaTableModel(self)
+        self.setModel(model)
+        self._copyAction = CopySelectedCellsAction(self)
+        self.addAction(self._copyAction)
+
+    def copy(self):
+        self._copyAction.trigger()
+
+    def setArrayData(self, data):
+        """Set the data array.
+
+        :param data: A numpy object or a dataset.
+        """
+        self.model().setArrayData(data)
+        self.__fixHeader()
+
+    def __fixHeader(self):
+        """Update the view according to the state of the auto-resize"""
+        header = self.horizontalHeader()
+        if qt.qVersion() < "5.0":
+            setResizeMode = header.setResizeMode
+        else:
+            setResizeMode = header.setSectionResizeMode
+
+        header.setDefaultSectionSize(30)
+        header.setStretchLastSection(True)
+        for i in range(0x10):
+            setResizeMode(i, qt.QHeaderView.Fixed)
+        setResizeMode(0x10, qt.QHeaderView.Stretch)

--- a/silx/gui/data/HexaTableView.py
+++ b/silx/gui/data/HexaTableView.py
@@ -55,9 +55,7 @@ class _VoidConnector(object):
             pos = bufferId << 10
             data = self.__data.tobytes()[pos:pos + 1024]
             self.__cache[bufferId] = data
-            print("create")
             if len(self.__cache) > 32:
-                print("remove")
                 self.__cache.popitem()
         else:
             data = self.__cache[bufferId]

--- a/silx/gui/data/RecordTableView.py
+++ b/silx/gui/data/RecordTableView.py
@@ -37,7 +37,7 @@ from silx.gui.widgets.TableWidget import CopySelectedCellsAction
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "27/01/2017"
+__date__ = "26/09/2017"
 
 
 class _MultiLineItem(qt.QItemDelegate):
@@ -206,9 +206,9 @@ class RecordTableModel(qt.QAbstractTableModel):
                 data = data[key[1]]
 
         if role == qt.Qt.DisplayRole:
-            return self.__formatter.toString(data)
+            return self.__formatter.toString(data, dtype=self.__data.dtype)
         elif role == qt.Qt.EditRole:
-            return self.__editFormatter.toString(data)
+            return self.__editFormatter.toString(data, dtype=self.__data.dtype)
         return None
 
     def headerData(self, section, orientation, role=qt.Qt.DisplayRole):
@@ -269,7 +269,6 @@ class RecordTableModel(qt.QAbstractTableModel):
             self.__is_array = True
         else:
             self.__is_array = False
-
 
         self.__fields = []
         if data is not None:

--- a/silx/gui/data/TextFormatter.py
+++ b/silx/gui/data/TextFormatter.py
@@ -27,7 +27,7 @@ data module to format data as text in the same way."""
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "26/09/2017"
+__date__ = "27/09/2017"
 
 import numpy
 import numbers
@@ -212,7 +212,8 @@ class TextFormatter(qt.QObject):
             return "".join(data)
 
     def __formatSafeAscii(self, data):
-        data = [ord(d) for d in data]
+        if six.PY2:
+            data = [ord(d) for d in data]
         data = [chr(d) if (d > 0x20 and d < 0x7F) else "\\x%02X" % d for d in data]
         if self.__useQuoteForText:
             data = [c if c != '"' else "\\" + c for c in data]

--- a/silx/gui/data/TextFormatter.py
+++ b/silx/gui/data/TextFormatter.py
@@ -27,7 +27,7 @@ data module to format data as text in the same way."""
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "18/09/2017"
+__date__ = "26/09/2017"
 
 import numpy
 import numbers
@@ -312,6 +312,14 @@ class TextFormatter(qt.QObject):
                     template = self.__floatFormat
                     params = (data.real)
             return template % params
+        elif h5py is not None and isinstance(data, h5py.h5r.Reference):
+            dtype = h5py.special_dtype(ref=h5py.Reference)
+            text = self.__formatH5pyObject(data, dtype)
+            return text
+        elif h5py is not None and isinstance(data, h5py.h5r.RegionReference):
+            dtype = h5py.special_dtype(ref=h5py.RegionReference)
+            text = self.__formatH5pyObject(data, dtype)
+            return text
         elif isinstance(data, numpy.object_) or dtype is not None:
             if dtype is None:
                 dtype = data.dtype

--- a/silx/gui/data/TextFormatter.py
+++ b/silx/gui/data/TextFormatter.py
@@ -195,7 +195,7 @@ class TextFormatter(qt.QObject):
 
     def __formatText(self, text):
         if self.__useQuoteForText:
-            text = "\"%s\"" % text.replace("\"", "\\\"")
+            text = "\"%s\"" % text.replace("\\", "\\\\").replace("\"", "\\\"")
         return text
 
     def __formatH5pyObject(self, data, dtype):

--- a/silx/gui/data/test/test_textformatter.py
+++ b/silx/gui/data/test/test_textformatter.py
@@ -24,7 +24,7 @@
 # ###########################################################################*/
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "18/09/2017"
+__date__ = "27/09/2017"
 
 import unittest
 import shutil
@@ -130,12 +130,12 @@ class TestTextFormatterWithH5py(TestCaseQt):
     def testBadAscii(self):
         d = self.create_dataset(data=b"\xF0\x9F\x92\x94")
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, 'ENCODING_ERROR:0xf09f9294')
+        self.assertEquals(result, 'b"\\xF0\\x9F\\x92\\x94"')
 
     def testVoid(self):
         d = self.create_dataset(data=numpy.void(b"abc\xF0"))
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, '0x616263f0')
+        self.assertEquals(result, 'b"\\x61\\x62\\x63\\xF0"')
 
     def testEnum(self):
         dtype = h5py.special_dtype(enum=('i', {"RED": 0, "GREEN": 1, "BLUE": 42}))
@@ -167,12 +167,12 @@ class TestTextFormatterWithH5py(TestCaseQt):
     def testArrayBadAscii(self):
         d = self.create_dataset(data=[b"\xF0\x9F\x92\x94"])
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, '[ENCODING_ERROR:0xf09f9294]')
+        self.assertEquals(result, '[b"\\xF0\\x9F\\x92\\x94"]')
 
     def testArrayVoid(self):
         d = self.create_dataset(data=numpy.void([b"abc\xF0"]))
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, '[0x616263f0]')
+        self.assertEquals(result, '[b"\\x61\\x62\\x63\\xF0"]')
 
     def testArrayEnum(self):
         dtype = h5py.special_dtype(enum=('i', {"RED": 0, "GREEN": 1, "BLUE": 42}))

--- a/silx/gui/data/test/test_textformatter.py
+++ b/silx/gui/data/test/test_textformatter.py
@@ -122,14 +122,15 @@ class TestTextFormatterWithH5py(TestCaseQt):
         self.assertEquals(result, '"abc"')
 
     def testUnicode(self):
-        d = self.create_dataset(data=u"abc")
+        d = self.create_dataset(data=u"i\u2661cookies")
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, '"abc"')
+        self.assertEquals(len(result), 11)
+        self.assertEquals(result, u'"i\u2661cookies"')
 
     def testBadAscii(self):
-        d = self.create_dataset(data=b"abc\xF0")
+        d = self.create_dataset(data=b"\xF0\x9F\x92\x94")
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, 'ENCODING_ERROR:0x616263f0')
+        self.assertEquals(result, 'ENCODING_ERROR:0xf09f9294')
 
     def testVoid(self):
         d = self.create_dataset(data=numpy.void(b"abc\xF0"))
@@ -157,15 +158,16 @@ class TestTextFormatterWithH5py(TestCaseQt):
 
     def testArrayUnicode(self):
         dtype = h5py.special_dtype(vlen=six.text_type)
-        d = numpy.array([u"abc"], dtype=dtype)
+        d = numpy.array([u"i\u2661cookies"], dtype=dtype)
         d = self.create_dataset(data=d)
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, '["abc"]')
+        self.assertEquals(len(result), 13)
+        self.assertEquals(result, u'["i\u2661cookies"]')
 
     def testArrayBadAscii(self):
-        d = self.create_dataset(data=[b"abc\xF0"])
+        d = self.create_dataset(data=[b"\xF0\x9F\x92\x94"])
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, '[ENCODING_ERROR:0x616263f0]')
+        self.assertEquals(result, '[ENCODING_ERROR:0xf09f9294]')
 
     def testArrayVoid(self):
         d = self.create_dataset(data=numpy.void([b"abc\xF0"]))

--- a/silx/gui/hdf5/Hdf5Formatter.py
+++ b/silx/gui/hdf5/Hdf5Formatter.py
@@ -76,6 +76,12 @@ class Hdf5Formatter(qt.QObject):
     def humanReadableValue(self, dataset):
         if dataset.shape is None:
             return "No data"
+
+        dtype = dataset.dtype
+        if dataset.dtype.type == numpy.void:
+            if dtype.fields is None:
+                return "Raw data"
+
         if dataset.shape == tuple():
             numpy_object = dataset[()]
             text = self.__formatter.toString(numpy_object, dtype=dataset.dtype)

--- a/silx/gui/hdf5/Hdf5Formatter.py
+++ b/silx/gui/hdf5/Hdf5Formatter.py
@@ -61,6 +61,27 @@ class Hdf5Formatter(qt.QObject):
             self.__formatter = TextFormatter(self)
         self.__formatter.formatChanged.connect(self.__formatChanged)
 
+    def textFormatter(self):
+        """Returns the used text formatter
+
+        :rtype: TextFormatter
+        """
+        return self.__formatter
+
+    def setTextFormatter(self, textFormatter):
+        """Set the text formatter to be used
+
+        :param TextFormatter textFormatter: The text formatter to use
+        """
+        if textFormatter is None:
+            raise ValueError("Formatter expected but None found")
+        if self.__formatter is textFormatter:
+            return
+        self.__formatter.formatChanged.disconnect(self.__formatChanged)
+        self.__formatter = textFormatter
+        self.__formatter.formatChanged.connect(self.__formatChanged)
+        self.__formatChanged()
+
     def __formatChanged(self):
         self.formatChanged.emit()
 

--- a/silx/gui/hdf5/Hdf5Formatter.py
+++ b/silx/gui/hdf5/Hdf5Formatter.py
@@ -1,0 +1,137 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This package provides a class sharred by widgets to format HDF5 data as
+text."""
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "26/09/2017"
+
+import numpy
+from silx.third_party import six
+from silx.gui import qt
+from silx.gui.data.TextFormatter import TextFormatter
+
+try:
+    import h5py
+except ImportError:
+    h5py = None
+
+
+class Hdf5Formatter(qt.QObject):
+    """Formatter to convert HDF5 data to string.
+    """
+
+    formatChanged = qt.Signal()
+    """Emitted when properties of the formatter change."""
+
+    def __init__(self, parent=None, textFormatter=None):
+        """
+        Constructor
+
+        :param qt.QObject parent: Owner of the object
+        :param TextFormatter formatter: Text formatter
+        """
+        qt.QObject.__init__(self, parent)
+        if textFormatter is not None:
+            self.__formatter = textFormatter
+        else:
+            self.__formatter = TextFormatter(self)
+        self.__formatter.formatChanged.connect(self.__formatChanged)
+
+    def __formatChanged(self):
+        self.formatChanged.emit()
+
+    def humanReadableShape(self, dataset):
+        if dataset.shape is None:
+            return "none"
+        if dataset.shape == tuple():
+            return "scalar"
+        shape = [str(i) for i in dataset.shape]
+        text = u" \u00D7 ".join(shape)
+        return text
+
+    def humanReadableValue(self, dataset):
+        if dataset.shape is None:
+            return "No data"
+        if dataset.shape == tuple():
+            numpy_object = dataset[()]
+            text = self.__formatter.toString(numpy_object, dtype=dataset.dtype)
+        else:
+            if dataset.size < 5 and dataset.compression is None:
+                numpy_object = dataset[0:5]
+                text = self.__formatter.toString(numpy_object, dtype=dataset.dtype)
+            else:
+                dimension = len(dataset.shape)
+                if dataset.compression is not None:
+                    text = "Compressed %dD data" % dimension
+                else:
+                    text = "%dD data" % dimension
+        return text
+
+    def humanReadableType(self, dataset, full=False):
+        return self.humanReadableDType(dataset.dtype, full)
+
+    def humanReadableDType(self, dtype, full=False):
+        if dtype == six.binary_type or numpy.issubdtype(dtype, numpy.string_):
+            text = "string"
+            if full:
+                text = "ASCII " + text
+            return text
+        elif dtype == six.text_type or numpy.issubdtype(dtype, numpy.unicode_):
+            text = "string"
+            if full:
+                text = "UTF-8 " + text
+            return text
+        elif dtype.type == numpy.object_:
+            ref = h5py.check_dtype(ref=dtype)
+            if ref is not None:
+                return "reference"
+            vlen = h5py.check_dtype(vlen=dtype)
+            if vlen is not None:
+                text = self.humanReadableDType(vlen, full=full)
+                if full:
+                    text = "variable-length " + text
+                return text
+            return "object"
+        elif dtype.type == numpy.bool_:
+            return "bool"
+        elif dtype.type == numpy.void:
+            if dtype.fields is None:
+                return "opaque"
+            else:
+                if not full:
+                    return "compound"
+                else:
+                    compound = [d[0] for d in dtype.fields.values()]
+                    compound = [self.humanReadableDType(d) for d in compound]
+                    return "compound(%s)" % ", ".join(compound)
+        elif numpy.issubdtype(dtype, numpy.integer):
+            if h5py is not None:
+                enumType = h5py.check_dtype(enum=dtype)
+                if enumType is not None:
+                    return "enum"
+
+        return str(dtype)

--- a/silx/gui/hdf5/Hdf5Formatter.py
+++ b/silx/gui/hdf5/Hdf5Formatter.py
@@ -162,3 +162,57 @@ class Hdf5Formatter(qt.QObject):
                     return "enum"
 
         return str(dtype)
+
+    def humanReadableHdf5Type(self, dataset):
+        """Format the internal HDF5 type as a string"""
+        t = dataset.id.get_type()
+        class_ = t.get_class()
+        if class_ == h5py.h5t.NO_CLASS:
+            return "NO_CLASS"
+        elif class_ == h5py.h5t.INTEGER:
+            return "INTEGER"
+        elif class_ == h5py.h5t.FLOAT:
+            return "FLOAT"
+        elif class_ == h5py.h5t.TIME:
+            return "TIME"
+        elif class_ == h5py.h5t.STRING:
+            charset = t.get_cset()
+            strpad = t.get_strpad()
+            text = ""
+
+            if strpad == h5py.h5t.STR_NULLTERM:
+                text += "NULLTERM"
+            elif strpad == h5py.h5t.STR_NULLPAD:
+                text += "NULLPAD"
+            elif strpad == h5py.h5t.STR_SPACEPAD:
+                text += "SPACEPAD"
+            else:
+                text += "UNKNOWN_STRPAD"
+
+            if t.is_variable_str():
+                text += " VARIABLE"
+
+            if charset == h5py.h5t.CSET_ASCII:
+                text += " ASCII"
+            elif charset == h5py.h5t.CSET_UTF8:
+                text += " UTF8"
+            else:
+                text += " UNKNOWN_CSET"
+
+            return text + " STRING"
+        elif class_ == h5py.h5t.BITFIELD:
+            return "BITFIELD"
+        elif class_ == h5py.h5t.OPAQUE:
+            return "OPAQUE"
+        elif class_ == h5py.h5t.COMPOUND:
+            return "COMPOUND"
+        elif class_ == h5py.h5t.REFERENCE:
+            return "REFERENCE"
+        elif class_ == h5py.h5t.ENUM:
+            return "ENUM"
+        elif class_ == h5py.h5t.VLEN:
+            return "VLEN"
+        elif class_ == h5py.h5t.ARRAY:
+            return "ARRAY"
+        else:
+            return "UNKNOWN_CLASS"

--- a/silx/gui/hdf5/Hdf5Formatter.py
+++ b/silx/gui/hdf5/Hdf5Formatter.py
@@ -27,7 +27,7 @@ text."""
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "26/09/2017"
+__date__ = "27/09/2017"
 
 import numpy
 from silx.third_party import six
@@ -119,7 +119,8 @@ class Hdf5Formatter(qt.QObject):
         return text
 
     def humanReadableType(self, dataset, full=False):
-        return self.humanReadableDType(dataset.dtype, full)
+        dtype = dataset.dtype
+        return self.humanReadableDType(dtype, full)
 
     def humanReadableDType(self, dtype, full=False):
         if dtype == six.binary_type or numpy.issubdtype(dtype, numpy.string_):
@@ -161,7 +162,17 @@ class Hdf5Formatter(qt.QObject):
                 if enumType is not None:
                     return "enum"
 
-        return str(dtype)
+        text = str(dtype.newbyteorder('N'))
+        if full:
+            if dtype.byteorder == "<":
+                text = "Little-endian " + text
+            elif dtype.byteorder == ">":
+                text = "Big-endian " + text
+            elif dtype.byteorder == "=":
+                text = "Native " + text
+
+        dtype = dtype.newbyteorder('N')
+        return text
 
     def humanReadableHdf5Type(self, dataset):
         """Format the internal HDF5 type as a string"""

--- a/silx/gui/hdf5/Hdf5Item.py
+++ b/silx/gui/hdf5/Hdf5Item.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "28/08/2017"
+__date__ = "22/09/2017"
 
 
 import numpy
@@ -240,8 +240,6 @@ class Hdf5Item(Hdf5Node):
                 name = "item-%ddim" % len(obj.shape)
             else:
                 name = "item-ndim"
-            if str(obj.dtype) == "object":
-                name = "item-object"
             icon = icons.getQIcon(name)
             return icon
         return None

--- a/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/silx/gui/hdf5/Hdf5TreeModel.py
@@ -234,7 +234,6 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         self.__icons.append(icons.getQIcon("item-2dim"))
         self.__icons.append(icons.getQIcon("item-3dim"))
         self.__icons.append(icons.getQIcon("item-ndim"))
-        self.__icons.append(icons.getQIcon("item-object"))
 
         self.__openedFiles = []
         """Store the list of files opened by the model itself."""

--- a/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/silx/gui/hdf5/Hdf5TreeModel.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "22/08/2017"
+__date__ = "22/09/2017"
 
 
 import os
@@ -228,6 +228,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
 
         # store used icons to avoid the cache to release it
         self.__icons = []
+        self.__icons.append(icons.getQIcon("item-none"))
         self.__icons.append(icons.getQIcon("item-0dim"))
         self.__icons.append(icons.getQIcon("item-1dim"))
         self.__icons.append(icons.getQIcon("item-2dim"))


### PR DESCRIPTION
Folling the presentation of Gerd Heber on HDF5, it is more or less possible to display and store ASCII and UTF-8 properly using `h5py`.

This document http://docs.h5py.org/en/latest/special.html explains how to store and retrieve HDF5 datatypes which are not supported by numpy. Mostly enum, ref and UTF-8 variable-length.

The current master:
- Store UTF-8 as HDF5 ASCII type, which is very bad
- Tries to decode ASCII as UTF-8, which is also bad
- Do not support ref, enum, UTF-8 properly

This PR improve things:
- Fixes the formatter to display special types properly (enum, ref, strings, vlen)
- Fixes informations displayed in the tree (which can be tested using `/tmp_14_days/valls/all_types.h5`)
- Fixes informations displayed in the HDF5 info view (now the real HDF5 type is also displayed)
- Fixes views and intermediate structures to propagate h5py special types properly (h5py monkey-patch the numpy dtype, sometime it is lost)
- Provides an hexadecimal viewer for opaque types.

There is still work to do on fabioh5.