### PR TITLE
[treeview] Provide an API to select a single tree node item

### DIFF
--- a/silx/gui/hdf5/Hdf5TreeView.py
+++ b/silx/gui/hdf5/Hdf5TreeView.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "27/09/2016"
+__date__ = "18/09/2017"
 
 
 import logging
@@ -193,6 +193,38 @@ class Hdf5TreeView(qt.QTreeView):
                 if ignoreBrokenLinks and item.isBrokenObj():
                     continue
                 yield _utils.H5Node(item)
+
+    def setSelectedNode(self, groupname):
+        """
+        Select the specified node in the tree.
+
+        Works only when a single file is present.
+        """
+        indice = self.__treeview.model().index(0, 0, qt.QModelIndex())
+        # parce que on va au premier fichier
+        self.__treeview.expand(indice)
+        # h5 = self.__treeview.model().data(indice, Hdf5TreeModel.H5PY_OBJECT_ROLE)
+        if groupname != "":
+            groupname.replace("//", "/")
+            gn_l = groupname.split("/")
+            i = None
+            for tn in gn_l:
+                if tn == "":
+                    continue
+                nl = []
+                for k in range(self.model().rowCount(indice)):
+                    ind_tmp = self.model().index(k, 0, indice)
+                    nl.append(str(self.model().data(ind_tmp)))
+
+                if tn not in nl:
+                    break
+                i = nl.index(tn)
+                indice = self.model().index(i, 0, indice)
+                self.expand(indice)
+                # h5=h5[tn]
+
+            if i is not None:
+                self.setCurrentIndex(indice)
 
     def mousePressEvent(self, event):
         """Override mousePressEvent to provide a consistante compatible API

--- a/silx/gui/hdf5/Hdf5TreeView.py
+++ b/silx/gui/hdf5/Hdf5TreeView.py
@@ -196,9 +196,14 @@ class Hdf5TreeView(qt.QTreeView):
 
     def setSelectedH5Node(self, h5Object):
         """
-        Select the specified node in the tree.
+        Select the specified node of the tree using an h5py node.
 
-        Works only when a single file is present.
+        - If the item is found, parent items are expended, and then the item
+          is selected.
+        - If the item is not found, the selection do not change.
+        - A none argument allow to deselect everything
+
+        :param h5py.Npde h5Object: The node to select
         """
         if h5Object is None:
             self.setCurrentIndex(qt.QModelIndex())

--- a/silx/gui/hdf5/Hdf5TreeView.py
+++ b/silx/gui/hdf5/Hdf5TreeView.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "18/09/2017"
+__date__ = "20/09/2017"
 
 
 import logging
@@ -240,7 +240,11 @@ class Hdf5TreeView(qt.QTreeView):
                     break
                 # Start fron a new root
                 foundIndices.append(rootIndices.pop(0))
-                if path == "/":
+
+                obj = model.data(index, Hdf5TreeModel.H5PY_OBJECT_ROLE)
+                p = obj.name + "/"
+                p = p.replace("//", "/")
+                if path == p:
                     found = True
                     break
 

--- a/silx/gui/hdf5/Hdf5TreeView.py
+++ b/silx/gui/hdf5/Hdf5TreeView.py
@@ -200,6 +200,10 @@ class Hdf5TreeView(qt.QTreeView):
 
         Works only when a single file is present.
         """
+        if h5Object is None:
+            self.setCurrentIndex(qt.QModelIndex())
+            return
+
         filename = h5Object.file.filename
 
         # Seach for the right roots

--- a/silx/gui/hdf5/Hdf5TreeView.py
+++ b/silx/gui/hdf5/Hdf5TreeView.py
@@ -194,7 +194,7 @@ class Hdf5TreeView(qt.QTreeView):
                     continue
                 yield _utils.H5Node(item)
 
-    def setSelectedNode(self, h5Object):
+    def setSelectedH5Node(self, h5Object):
         """
         Select the specified node in the tree.
 

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -788,6 +788,19 @@ class TestHdf5TreeView(TestCaseQt):
         selected = list(view.selectedH5Nodes())[0]
         self.assertEqual(item.name, selected.h5py_object.name)
 
+    def testSelection_SelectNone(self):
+        tree = commonh5.File("/foo/bar/1.mock", "w")
+
+        model = hdf5.Hdf5TreeModel()
+        model.insertH5pyObject(tree)
+        view = hdf5.Hdf5TreeView()
+        view.setModel(model)
+        view.setSelectedH5Node(tree)
+        view.setSelectedH5Node(None)
+
+        selection = list(view.selectedH5Nodes())
+        self.assertEqual(len(selection), 0)
+
 
 def suite():
     test_suite = unittest.TestSuite()

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -749,22 +749,20 @@ class TestHdf5TreeView(TestCaseQt):
         tree = commonh5.File("/foo/bar/1.mock", "w")
         group = tree.create_group("a1")
         group.create_group("b").create_group("b").create_group("d")
-        item = group
 
         model = hdf5.Hdf5TreeModel()
         model.insertH5pyObject(group)
         view = hdf5.Hdf5TreeView()
         view.setModel(model)
-        view.setSelectedH5Node(item)
+        view.setSelectedH5Node(group)
 
         selected = list(view.selectedH5Nodes())[0]
-        self.assertIs(item, selected.h5py_object)
+        self.assertIs(group, selected.h5py_object)
 
     def testSelection_FileFromSubTree(self):
         tree = commonh5.File("/foo/bar/1.mock", "w")
         group = tree.create_group("a1")
         group.create_group("b").create_group("b").create_group("d")
-        item = group
 
         model = hdf5.Hdf5TreeModel()
         model.insertH5pyObject(group)

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -760,6 +760,21 @@ class TestHdf5TreeView(TestCaseQt):
         selected = list(view.selectedH5Nodes())[0]
         self.assertIs(item, selected.h5py_object)
 
+    def testSelection_FileFromSubTree(self):
+        tree = commonh5.File("/foo/bar/1.mock", "w")
+        group = tree.create_group("a1")
+        group.create_group("b").create_group("b").create_group("d")
+        item = group
+
+        model = hdf5.Hdf5TreeModel()
+        model.insertH5pyObject(group)
+        view = hdf5.Hdf5TreeView()
+        view.setModel(model)
+        view.setSelectedH5Node(tree)
+
+        selection = list(view.selectedH5Nodes())
+        self.assertEquals(len(selection), 0)
+
     def testSelection_Tree(self):
         tree1 = commonh5.File("/foo/bar/1.mock", "w")
         tree2 = commonh5.File("/foo/bar/2.mock", "w")

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "20/09/2017"
+__date__ = "22/09/2017"
 
 
 import time
@@ -698,7 +698,7 @@ class TestHdf5TreeView(TestCaseQt):
 
     def testSelection_Simple(self):
         tree = commonh5.File("/foo/bar/1.mock", "w")
-        item = tree.create_group("a").create_group("b").create_group("b").create_group("d")
+        item = tree.create_group("a/b/c/d")
         item.create_group("e").create_group("f")
 
         model = hdf5.Hdf5TreeModel()
@@ -713,7 +713,7 @@ class TestHdf5TreeView(TestCaseQt):
     def testSelection_NotFound(self):
         tree2 = commonh5.File("/foo/bar/2.mock", "w")
         tree = commonh5.File("/foo/bar/1.mock", "w")
-        item = tree.create_group("a").create_group("b").create_group("c").create_group("d")
+        item = tree.create_group("a/b/c/d")
         item.create_group("e").create_group("f")
 
         model = hdf5.Hdf5TreeModel()
@@ -728,11 +728,11 @@ class TestHdf5TreeView(TestCaseQt):
     def testSelection_ManyGroupFromSameFile(self):
         tree = commonh5.File("/foo/bar/1.mock", "w")
         group1 = tree.create_group("a1")
-        group1.create_group("b").create_group("b").create_group("d")
-        group2 = tree.create_group("a1")
-        item = group2.create_group("b").create_group("c").create_group("d")
-        group3 = tree.create_group("a1")
-        group3.create_group("b").create_group("b").create_group("d")
+        group2 = tree.create_group("a2")
+        group3 = tree.create_group("a3")
+        group1.create_group("b/c/d")
+        item = group2.create_group("b/c/d")
+        group3.create_group("b/c/d")
 
         model = hdf5.Hdf5TreeModel()
         model.insertH5pyObject(group1)
@@ -748,7 +748,7 @@ class TestHdf5TreeView(TestCaseQt):
     def testSelection_RootFromSubTree(self):
         tree = commonh5.File("/foo/bar/1.mock", "w")
         group = tree.create_group("a1")
-        group.create_group("b").create_group("b").create_group("d")
+        group.create_group("b/c/d")
 
         model = hdf5.Hdf5TreeModel()
         model.insertH5pyObject(group)
@@ -777,9 +777,9 @@ class TestHdf5TreeView(TestCaseQt):
         tree1 = commonh5.File("/foo/bar/1.mock", "w")
         tree2 = commonh5.File("/foo/bar/2.mock", "w")
         tree3 = commonh5.File("/foo/bar/3.mock", "w")
-        tree1.create_group("a").create_group("b").create_group("c")
-        tree2.create_group("a").create_group("b").create_group("c")
-        tree3.create_group("a").create_group("b").create_group("c")
+        tree1.create_group("a/b/c")
+        tree2.create_group("a/b/c")
+        tree3.create_group("a/b/c")
         item = tree2
 
         model = hdf5.Hdf5TreeModel()

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "01/09/2017"
+__date__ = "18/09/2017"
 
 
 import time
@@ -680,11 +680,11 @@ class TestH5Node(TestCaseQt):
         self.assertEqual(h5node.local_name, "/link/soft_link_to_file/link/soft_link_to_group/dataset")
 
 
-class TestHdf5(TestCaseQt):
+class TestHdf5TreeView(TestCaseQt):
     """Test to check that icons module."""
 
     def setUp(self):
-        super(TestHdf5, self).setUp()
+        super(TestHdf5TreeView, self).setUp()
         if h5py is None:
             self.skipTest("h5py is not available")
 
@@ -696,13 +696,105 @@ class TestHdf5(TestCaseQt):
         view = hdf5.Hdf5TreeView()
         view._createContextMenu(qt.QPoint(0, 0))
 
+    def testSelection_Simple(self):
+        tree = commonh5.File("/foo/bar/1.mock", "w")
+        item = tree.create_group("a").create_group("b").create_group("b").create_group("d")
+        item.create_group("e").create_group("f")
+
+        model = hdf5.Hdf5TreeModel()
+        model.insertH5pyObject(tree)
+        view = hdf5.Hdf5TreeView()
+        view.setModel(model)
+        view.setSelectedNode(item)
+
+        selected = list(view.selectedH5Nodes())[0]
+        self.assertIs(item, selected.h5py_object)
+
+    def testSelection_NotFound(self):
+        tree2 = commonh5.File("/foo/bar/2.mock", "w")
+        tree = commonh5.File("/foo/bar/1.mock", "w")
+        item = tree.create_group("a").create_group("b").create_group("c").create_group("d")
+        item.create_group("e").create_group("f")
+
+        model = hdf5.Hdf5TreeModel()
+        model.insertH5pyObject(tree)
+        view = hdf5.Hdf5TreeView()
+        view.setModel(model)
+        view.setSelectedNode(tree2)
+
+        selection = list(view.selectedH5Nodes())
+        self.assertEqual(len(selection), 0)
+
+    def testSelection_ManyGroupFromSameFile(self):
+        tree = commonh5.File("/foo/bar/1.mock", "w")
+        group1 = tree.create_group("a1")
+        group1.create_group("b").create_group("b").create_group("d")
+        group2 = tree.create_group("a1")
+        item = group2.create_group("b").create_group("c").create_group("d")
+        group3 = tree.create_group("a1")
+        group3.create_group("b").create_group("b").create_group("d")
+
+        model = hdf5.Hdf5TreeModel()
+        model.insertH5pyObject(group1)
+        model.insertH5pyObject(group2)
+        model.insertH5pyObject(group3)
+        view = hdf5.Hdf5TreeView()
+        view.setModel(model)
+        view.setSelectedNode(item)
+
+        selected = list(view.selectedH5Nodes())[0]
+        self.assertIs(item, selected.h5py_object)
+
+    def testSelection_Tree(self):
+        tree1 = commonh5.File("/foo/bar/1.mock", "w")
+        tree2 = commonh5.File("/foo/bar/2.mock", "w")
+        tree3 = commonh5.File("/foo/bar/3.mock", "w")
+        tree1.create_group("a").create_group("b").create_group("c")
+        tree2.create_group("a").create_group("b").create_group("c")
+        tree3.create_group("a").create_group("b").create_group("c")
+        item = tree2
+
+        model = hdf5.Hdf5TreeModel()
+        model.insertH5pyObject(tree1)
+        model.insertH5pyObject(tree2)
+        model.insertH5pyObject(tree3)
+        view = hdf5.Hdf5TreeView()
+        view.setModel(model)
+        view.setSelectedNode(item)
+
+        selected = list(view.selectedH5Nodes())[0]
+        self.assertIs(item, selected.h5py_object)
+
+    def testSelection_RecurssiveLink(self):
+        """
+        Recurssive link selection
+
+        This example is not really working as expected cause commonh5 do not
+        support recurssive links.
+        But item.name == "/a/b" and the result is found.
+        """
+        tree = commonh5.File("/foo/bar/1.mock", "w")
+        group = tree.create_group("a")
+        group.add_node(commonh5.SoftLink("b", "/"))
+
+        item = tree["/a/b/a/b/a/b/a/b/a/b/a/b/a/b/a/b"]
+
+        model = hdf5.Hdf5TreeModel()
+        model.insertH5pyObject(tree)
+        view = hdf5.Hdf5TreeView()
+        view.setModel(model)
+        view.setSelectedNode(item)
+
+        selected = list(view.selectedH5Nodes())[0]
+        self.assertEqual(item.name, selected.h5py_object.name)
+
 
 def suite():
     test_suite = unittest.TestSuite()
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
     test_suite.addTest(loadTests(TestHdf5TreeModel))
     test_suite.addTest(loadTests(TestNexusSortFilterProxyModel))
-    test_suite.addTest(loadTests(TestHdf5))
+    test_suite.addTest(loadTests(TestHdf5TreeView))
     test_suite.addTest(loadTests(TestH5Node))
     return test_suite
 

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -705,7 +705,7 @@ class TestHdf5TreeView(TestCaseQt):
         model.insertH5pyObject(tree)
         view = hdf5.Hdf5TreeView()
         view.setModel(model)
-        view.setSelectedNode(item)
+        view.setSelectedH5Node(item)
 
         selected = list(view.selectedH5Nodes())[0]
         self.assertIs(item, selected.h5py_object)
@@ -720,7 +720,7 @@ class TestHdf5TreeView(TestCaseQt):
         model.insertH5pyObject(tree)
         view = hdf5.Hdf5TreeView()
         view.setModel(model)
-        view.setSelectedNode(tree2)
+        view.setSelectedH5Node(tree2)
 
         selection = list(view.selectedH5Nodes())
         self.assertEqual(len(selection), 0)
@@ -740,7 +740,7 @@ class TestHdf5TreeView(TestCaseQt):
         model.insertH5pyObject(group3)
         view = hdf5.Hdf5TreeView()
         view.setModel(model)
-        view.setSelectedNode(item)
+        view.setSelectedH5Node(item)
 
         selected = list(view.selectedH5Nodes())[0]
         self.assertIs(item, selected.h5py_object)
@@ -760,7 +760,7 @@ class TestHdf5TreeView(TestCaseQt):
         model.insertH5pyObject(tree3)
         view = hdf5.Hdf5TreeView()
         view.setModel(model)
-        view.setSelectedNode(item)
+        view.setSelectedH5Node(item)
 
         selected = list(view.selectedH5Nodes())[0]
         self.assertIs(item, selected.h5py_object)
@@ -783,7 +783,7 @@ class TestHdf5TreeView(TestCaseQt):
         model.insertH5pyObject(tree)
         view = hdf5.Hdf5TreeView()
         view.setModel(model)
-        view.setSelectedNode(item)
+        view.setSelectedH5Node(item)
 
         selected = list(view.selectedH5Nodes())[0]
         self.assertEqual(item.name, selected.h5py_object.name)

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "18/09/2017"
+__date__ = "20/09/2017"
 
 
 import time
@@ -738,6 +738,21 @@ class TestHdf5TreeView(TestCaseQt):
         model.insertH5pyObject(group1)
         model.insertH5pyObject(group2)
         model.insertH5pyObject(group3)
+        view = hdf5.Hdf5TreeView()
+        view.setModel(model)
+        view.setSelectedH5Node(item)
+
+        selected = list(view.selectedH5Nodes())[0]
+        self.assertIs(item, selected.h5py_object)
+
+    def testSelection_RootFromSubTree(self):
+        tree = commonh5.File("/foo/bar/1.mock", "w")
+        group = tree.create_group("a1")
+        group.create_group("b").create_group("b").create_group("d")
+        item = group
+
+        model = hdf5.Hdf5TreeModel()
+        model.insertH5pyObject(group)
         view = hdf5.Hdf5TreeView()
         view.setModel(model)
         view.setSelectedH5Node(item)


### PR DESCRIPTION
This API allow to select an item of the Hdf5TreeView using an h5py node. This can be useful for dialog windows.

Feature requested by Alessandro Mirone.

- If the item is found, parent items are expended, and then the item is selected.
- If the item is not found, the selection do not change.
- A none argument allow to deselect everything
