### PR TITLE
[io] Support npz in silx.io.open

### DIFF
--- a/silx/app/view.py
+++ b/silx/app/view.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "20/09/2017"
+__date__ = "21/09/2017"
 
 import sys
 import os
@@ -147,14 +147,14 @@ class Viewer(qt.QMainWindow):
         extensions["HDF5 files"] = "*.h5 *.hdf"
         extensions["NeXus files"] = "*.nx *.nxs *.h5 *.hdf"
         # no dependancy
-        extensions["Spec files"] = "*.dat *.spec *.mca"
-        extensions["Numpy binary files"] = "*.npz"
+        extensions["NeXus layout from spec files"] = "*.dat *.spec *.mca"
+        extensions["Numpy binary files"] = "*.npz *.npy"
         # expect fabio
-        extensions["EDF files"] = "*.edf"
-        extensions["TIFF image files"] = "*.tif *.tiff"
-        extensions["NumPy binary files"] = "*.npy"
-        extensions["CBF files"] = "*.cbf"
-        extensions["MarCCD image files"] = "*.mccd"
+        extensions["NeXus layout from raster images"] = "*.edf *.tif *.tiff *.cbf *.mccd"
+        extensions["NeXus layout from EDF files"] = "*.edf"
+        extensions["NeXus layout from TIFF image files"] = "*.tif *.tiff"
+        extensions["NeXus layout from CBF files"] = "*.cbf"
+        extensions["NeXus layout from MarCCD image files"] = "*.mccd"
 
         filters = []
         filters.append("All supported files (%s)" % " ".join(extensions.values()))

--- a/silx/app/view.py
+++ b/silx/app/view.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "18/08/2017"
+__date__ = "20/09/2017"
 
 import sys
 import os
@@ -148,6 +148,7 @@ class Viewer(qt.QMainWindow):
         extensions["NeXus files"] = "*.nx *.nxs *.h5 *.hdf"
         # no dependancy
         extensions["Spec files"] = "*.dat *.spec *.mca"
+        extensions["Numpy binary files"] = "*.npz"
         # expect fabio
         extensions["EDF files"] = "*.edf"
         extensions["TIFF image files"] = "*.tif *.tiff"

--- a/silx/io/rawh5.py
+++ b/silx/io/rawh5.py
@@ -1,0 +1,72 @@
+# coding: utf-8
+# /*##########################################################################
+# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+"""
+This module contains wrapper from file format to h5py. The exposed layout is
+as close as possible to the original file format.
+"""
+import numpy
+from . import commonh5
+import logging
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "20/09/2017"
+
+
+_logger = logging.getLogger(__name__)
+
+
+class _FreeDataset(commonh5.Dataset):
+
+    def _check_data(self, data):
+        """Release the constriants checked on types cause we can reach more
+        types than the one available on h5py, and it is not supposed to be
+        converted into h5py."""
+        chartype = data.dtype.char
+        if chartype in ["U", "O"]:
+            msg = "Dataset '%s' uses an unsupported type '%s'."
+            msg = msg % (self.name, data.dtype)
+            _logger.warning(msg)
+
+
+class NumpyFile(commonh5.File):
+    """
+    Expose a numpy file `npy`, or `npz` as an h5py.File-like.
+
+    :param str name: Filename to load
+    """
+    def __init__(self, name=None):
+        commonh5.File.__init__(self, name=name, mode="w")
+        np_file = numpy.load(name)
+        if hasattr(np_file, "close"):
+            # For npz (created using  by numpy.savez, numpy.savez_compressed)
+            for key, value in np_file.items():
+                dataset = _FreeDataset(key, data=value)
+                self.add_node(dataset)
+            np_file.close()
+        else:
+            # For npy (created using numpy.save)
+            value = np_file
+            dataset = _FreeDataset("data", data=value)
+            self.add_node(dataset)

--- a/silx/io/test/__init__.py
+++ b/silx/io/test/__init__.py
@@ -24,7 +24,7 @@
 
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "23/08/2017"
+__date__ = "20/09/2017"
 
 import unittest
 
@@ -38,6 +38,7 @@ from .test_fabioh5 import suite as test_fabioh5_suite
 from .test_utils import suite as test_utils_suite
 from .test_nxdata import suite as test_nxdata_suite
 from .test_commonh5 import suite as test_commonh5_suite
+from .test_rawh5 import suite as test_rawh5_suite
 
 
 def suite():
@@ -52,4 +53,5 @@ def suite():
     test_suite.addTest(test_fabioh5_suite())
     test_suite.addTest(test_nxdata_suite())
     test_suite.addTest(test_commonh5_suite())
+    test_suite.addTest(test_rawh5_suite())
     return test_suite

--- a/silx/io/test/test_rawh5.py
+++ b/silx/io/test/test_rawh5.py
@@ -1,0 +1,86 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Test for silx.gui.hdf5 module"""
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "20/09/2017"
+
+
+import unittest
+import tempfile
+import numpy
+import shutil
+from ..import rawh5
+
+
+class TestNumpyFile(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpDirectory = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmpDirectory)
+
+    def testNumpyFile(self):
+        filename = "%s/%s.npy" % (self.tmpDirectory, self.id())
+        c = numpy.random.rand(5, 5)
+        numpy.save(filename, c)
+        h5 = rawh5.NumpyFile(filename)
+        self.assertIn("data", h5)
+        self.assertEqual(h5["data"].dtype.kind, "f")
+
+    def testNumpyZFile(self):
+        filename = "%s/%s.npz" % (self.tmpDirectory, self.id())
+        a = numpy.array(u"aaaaa")
+        b = numpy.array([1, 2, 3, 4])
+        c = numpy.random.rand(5, 5)
+        d = numpy.array(b"aaaaa")
+        e = numpy.array(u"i \u2661 my mother")
+        numpy.savez(filename, a, b=b, c=c, d=d, e=e)
+        h5 = rawh5.NumpyFile(filename)
+        self.assertIn("arr_0", h5)
+        self.assertIn("b", h5)
+        self.assertIn("c", h5)
+        self.assertIn("d", h5)
+        self.assertIn("e", h5)
+        self.assertEqual(h5["arr_0"].dtype.kind, "U")
+        self.assertEqual(h5["b"].dtype.kind, "i")
+        self.assertEqual(h5["c"].dtype.kind, "f")
+        self.assertEqual(h5["d"].dtype.kind, "S")
+        self.assertEqual(h5["e"].dtype.kind, "U")
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(TestNumpyFile))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -41,7 +41,7 @@ else:
 
 __authors__ = ["P. Knobel", "V. Valls"]
 __license__ = "MIT"
-__date__ = "20/09/2017"
+__date__ = "21/09/2017"
 
 
 logger = logging.getLogger(__name__)
@@ -383,8 +383,9 @@ def open(filename):  # pylint:disable=redefined-builtin
 
     Format supported:
     - h5 files, if `h5py` module is installed
-    - SPEC files
-    - a set of raster image formats (tiff, edf...) if `fabio` is installed
+    - SPEC files exposed as a NeXus layout
+    - raster files exposed as a NeXus layout (if `fabio` is installed)
+    - Numpy files ('npy' and 'npz' files)
 
     The file is opened in read-only mode.
 
@@ -397,11 +398,13 @@ def open(filename):  # pylint:disable=redefined-builtin
 
     debugging_info = []
 
+    _, extension = os.path.splitext(filename)
+
     if not h5py_missing:
         if h5py.is_hdf5(filename):
             return h5py.File(filename, "r")
 
-    if filename.endswith(".npz"):
+    if extension in [".npz", ".npy"]:
         try:
             from . import rawh5
             return rawh5.NumpyFile(filename)

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -41,7 +41,7 @@ else:
 
 __authors__ = ["P. Knobel", "V. Valls"]
 __license__ = "MIT"
-__date__ = "28/08/2017"
+__date__ = "20/09/2017"
 
 
 logger = logging.getLogger(__name__)
@@ -395,11 +395,20 @@ def open(filename):  # pylint:disable=redefined-builtin
     if not os.path.isfile(filename):
         raise IOError("Filename '%s' must be a file path" % filename)
 
+    debugging_info = []
+
     if not h5py_missing:
         if h5py.is_hdf5(filename):
             return h5py.File(filename, "r")
 
-    debugging_info = []
+    if filename.endswith(".npz"):
+        try:
+            from . import rawh5
+            return rawh5.NumpyFile(filename)
+        except (IOError, ValueError) as e:
+            debugging_info.append((sys.exc_info(),
+                                  "File '%s' can't be read as a numpy file." % filename))
+
     try:
         from . import fabioh5
         return fabioh5.File(filename)


### PR DESCRIPTION
This PR allow to load `npz` files using `silx.io.open`.

numpy supports more types than h5py can support, especially 'U' (UTF-32 strings) and 'O' (python object), then we can't be sure everything will be displayed properly. But for common data types it should be fine.

`npy` files still using FabioH5 and then are exposed using the NeXus layout.

Closes #1152

![screenshot from 2017-09-20 14 42 19](https://user-images.githubusercontent.com/7579321/30644399-875ba4f2-9e12-11e7-98d8-130bd0ab2d85.png)
