### PR TITLE
Support for directory in npz

### DIFF
--- a/silx/io/rawh5.py
+++ b/silx/io/rawh5.py
@@ -31,7 +31,7 @@ import logging
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "20/09/2017"
+__date__ = "21/09/2017"
 
 
 _logger = logging.getLogger(__name__)
@@ -62,8 +62,7 @@ class NumpyFile(commonh5.File):
         if hasattr(np_file, "close"):
             # For npz (created using  by numpy.savez, numpy.savez_compressed)
             for key, value in np_file.items():
-                dataset = _FreeDataset(key, data=value)
-                self.add_node(dataset)
+                self[key] = _FreeDataset(None, data=value)
             np_file.close()
         else:
             # For npy (created using numpy.save)

--- a/silx/io/test/test_rawh5.py
+++ b/silx/io/test/test_rawh5.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "20/09/2017"
+__date__ = "21/09/2017"
 
 
 import unittest
@@ -73,6 +73,16 @@ class TestNumpyFile(unittest.TestCase):
         self.assertEqual(h5["c"].dtype.kind, "f")
         self.assertEqual(h5["d"].dtype.kind, "S")
         self.assertEqual(h5["e"].dtype.kind, "U")
+
+    def testNumpyZFileContainingDirectories(self):
+        filename = "%s/%s.npz" % (self.tmpDirectory, self.id())
+        data = {}
+        data['a/b/c'] = numpy.arange(10)
+        data['a/b/e'] = numpy.arange(10)
+        numpy.savez(filename, **data)
+        h5 = rawh5.NumpyFile(filename)
+        self.assertIn("a/b/c", h5)
+        self.assertIn("a/b/e", h5)
 
 
 def suite():


### PR DESCRIPTION
This PR improve compatibility of commonh5 with h5py:
- Allow to use `create_group` with paths like `a/b/c`
- Allow to set a dataset using set item: `group["a"] = 10`
- Altogether allow to use `file["a/b/c"] = 10`

This make the fix on `npz` format trivial.

Closes #1180