### PR TITLE
[plot3d] Fix display issue in silx view due to transparency

### DIFF
--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -300,6 +300,7 @@ _texFragShd = """
 
     void main(void) {
         gl_FragColor = texture2D(tex, coords);
+        gl_FragColor.a = 1.0;
     }
     """
 
@@ -437,7 +438,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
     @staticmethod
     def _setBlendFuncGL():
-        # glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA)
+        # gl.glBlendFunc(gl.GL_SRC_ALPHA, gl.GL_ONE_MINUS_SRC_ALPHA)
         gl.glBlendFuncSeparate(gl.GL_SRC_ALPHA,
                                gl.GL_ONE_MINUS_SRC_ALPHA,
                                gl.GL_ONE,

--- a/silx/gui/plot3d/scene/window.py
+++ b/silx/gui/plot3d/scene/window.py
@@ -244,6 +244,7 @@ class Window(event.Notifier):
 
         void main(void) {
             gl_FragColor = texture2D(texture, textureCoord);
+            gl_FragColor.a = 1.0;
         }
         """)
 


### PR DESCRIPTION
Some areas of the 3D view with transparent isosurface were really transparent and showing the underlying widget in `silx view` with PyQt5...
This PR makes sure the displayed image is opaque with `Plot3DWidget` (and with plot GL backend).

closes #1126