### PR TITLE
[silx view/io] Support filename::path

### DIFF
--- a/silx/app/test/test_view.py
+++ b/silx/app/test/test_view.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "14/09/2017"
+__date__ = "29/09/2017"
 
 
 import unittest
@@ -110,7 +110,6 @@ class TestLauncher(unittest.TestCase):
     def testWrongOption(self):
         try:
             result = view.main(["view", "--foo"])
-            self.assertNotEqual(result, 0)
         except SystemExit as e:
             result = e.args[0]
         self.assertNotEqual(result, 0)
@@ -118,10 +117,9 @@ class TestLauncher(unittest.TestCase):
     def testWrongFile(self):
         try:
             result = view.main(["view", "__file.not.found__"])
-            self.assertNotEqual(result, 0)
         except SystemExit as e:
             result = e.args[0]
-        self.assertNotEqual(result, 0)
+        self.assertEqual(result, 0)
 
     def testFile(self):
         # sys.executable is an existing readable file

--- a/silx/app/view.py
+++ b/silx/app/view.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "21/09/2017"
+__date__ = "28/09/2017"
 
 import sys
 import os
@@ -219,7 +219,6 @@ def main(argv):
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         'files',
-        type=argparse.FileType('rb'),
         nargs=argparse.ZERO_OR_MORE,
         help='Data file to show (h5 file, edf files, spec files)')
     parser.add_argument(
@@ -281,10 +280,12 @@ def main(argv):
     window = Viewer()
     window.resize(qt.QSize(640, 480))
 
-    for f in options.files:
-        filename = f.name
-        f.close()
-        window.appendFile(filename)
+    for filename in options.files:
+        try:
+            window.appendFile(filename)
+        except IOError as e:
+            _logger.error(e.args[0])
+            _logger.debug("Backtrace", exc_info=True)
 
     window.show()
     result = app.exec_()

--- a/silx/gui/hdf5/_utils.py
+++ b/silx/gui/hdf5/_utils.py
@@ -28,7 +28,7 @@ package `silx.gui.hdf5` package.
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "28/09/2017"
+__date__ = "29/09/2017"
 
 
 import logging
@@ -245,12 +245,12 @@ class H5Node(object):
         while item is not None:
             # stop before the root item (item without parent)
             if item.parent.parent is None:
-                result.append(item.obj.name)
+                name = item.obj.name
+                if name != "/":
+                    result.append(item.obj.name)
                 break
             else:
                 result.append(item.basename)
-            if item.parent.parent is None:
-                break
             item = item.parent
         if item is None:
             raise RuntimeError("The item does not have parent holding h5py.File")

--- a/silx/gui/hdf5/_utils.py
+++ b/silx/gui/hdf5/_utils.py
@@ -28,7 +28,7 @@ package `silx.gui.hdf5` package.
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "28/08/2017"
+__date__ = "28/09/2017"
 
 
 import logging
@@ -141,7 +141,10 @@ class H5Node(object):
         self.__h5py_item = h5py_item
 
     def __getattr__(self, name):
-        return object.__getattribute__(self.__h5py_object, name)
+        if hasattr(self.__h5py_object, name):
+            attr = getattr(self.__h5py_object, name)
+            return attr
+        raise AttributeError("H5Node has no attribute %s" % name)
 
     def __get_target(self, obj):
         """
@@ -242,30 +245,40 @@ class H5Node(object):
         while item is not None:
             # stop before the root item (item without parent)
             if item.parent.parent is None:
+                result.append(item.obj.name)
                 break
-            result.append(item.basename)
+            else:
+                result.append(item.basename)
+            if item.parent.parent is None:
+                break
             item = item.parent
         if item is None:
             raise RuntimeError("The item does not have parent holding h5py.File")
         if result == []:
             return "/"
-        result.append("")
+        if not result[-1].startswith("/"):
+            result.append("")
         result.reverse()
-        return "/".join(result)
+        name = "/".join(result)
+        return name
 
-    def __file_item(self):
-        """Returns the parent item holding the :class:`h5py.File` object
+    def __get_local_file(self):
+        """Returns the file of the root of this tree
 
         :rtype: h5py.File
-        :raises RuntimeError: If no file are found
         """
         item = self.__h5py_item
-        while item is not None:
+        while item.parent.parent is not None:
             class_ = item.h5pyClass
             if class_ is not None and issubclass(class_, h5py.File):
-                return item
+                break
             item = item.parent
-        raise RuntimeError("The item does not have parent holding h5py.File")
+
+        class_ = item.h5pyClass
+        if class_ is not None and issubclass(class_, h5py.File):
+            return item.obj
+        else:
+            return item.obj.file
 
     @property
     def local_file(self):
@@ -277,8 +290,7 @@ class H5Node(object):
         :rtype: h5py.File
         :raises RuntimeException: If no file are found
         """
-        item = self.__file_item()
-        return item.obj
+        return self.__get_local_file()
 
     @property
     def local_filename(self):

--- a/silx/io/test/test_utils.py
+++ b/silx/io/test/test_utils.py
@@ -343,6 +343,25 @@ class TestOpen(unittest.TestCase):
             self.assertIsNotNone(f)
             self.assertIsInstance(f, h5py.File)
 
+    def testH5_withPath(self):
+        if h5py is None:
+            self.skipTest("H5py is missing")
+
+        f = utils.open(self.h5_filename + "::/group/group/dataset")
+        self.assertIsNotNone(f)
+        self.assertEqual(f.h5py_class, h5py.Dataset)
+        self.assertEqual(f[()], 50)
+        f.close()
+
+    def testH5With_withPath(self):
+        if h5py is None:
+            self.skipTest("H5py is missing")
+
+        with utils.open(self.h5_filename + "::/group/group") as f:
+            self.assertIsNotNone(f)
+            self.assertEqual(f.h5py_class, h5py.Group)
+            self.assertIn("dataset", f)
+
     def testSpec(self):
         f = utils.open(self.spec_filename)
         self.assertIsNotNone(f)

--- a/silx/io/test/test_utils.py
+++ b/silx/io/test/test_utils.py
@@ -492,15 +492,12 @@ class TestNodes(unittest.TestCase):
 
 
 def suite():
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
     test_suite = unittest.TestSuite()
-    test_suite.addTest(
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestSave))
-    test_suite.addTest(
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestH5Ls))
-    test_suite.addTest(
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestOpen))
-    test_suite.addTest(
-        unittest.defaultTestLoader.loadTestsFromTestCase(TestNodes))
+    test_suite.addTest(loadTests(TestSave))
+    test_suite.addTest(loadTests(TestH5Ls))
+    test_suite.addTest(loadTests(TestOpen))
+    test_suite.addTest(loadTests(TestNodes))
     return test_suite
 
 

--- a/silx/io/test/test_utils.py
+++ b/silx/io/test/test_utils.py
@@ -23,7 +23,7 @@
 # ############################################################################*/
 """Tests for utils module"""
 
-
+import io
 import numpy
 import os
 import re
@@ -47,7 +47,7 @@ except ImportError:
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "11/01/2017"
+__date__ = "28/09/2017"
 
 
 expected_spec1 = r"""#F .*
@@ -289,20 +289,48 @@ class TestH5Ls(unittest.TestCase):
 class TestOpen(unittest.TestCase):
     """Test `silx.io.utils.open` function."""
 
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp_directory = tempfile.mkdtemp()
+        cls.createResources(cls.tmp_directory)
+
+    @classmethod
+    def createResources(cls, directory):
+
+        if h5py is not None:
+            cls.h5_filename = os.path.join(directory, "test.h5")
+            h5 = h5py.File(cls.h5_filename, mode="w")
+            h5["group/group/dataset"] = 50
+            h5.close()
+
+        cls.spec_filename = os.path.join(directory, "test.dat")
+        utils.savespec(cls.spec_filename, [1], [1.1], xlabel="x", ylabel="y",
+                       fmt=["%d", "%.2f"], close_file=True, scan_number=1)
+
+        if fabio is not None:
+            cls.edf_filename = os.path.join(directory, "test.edf")
+            header = fabio.fabioimage.OrderedDict()
+            header["integer"] = "10"
+            data = numpy.array([[10, 50], [50, 10]])
+            fabiofile = fabio.edfimage.EdfImage(data, header)
+            fabiofile.write(cls.edf_filename)
+
+        cls.txt_filename = os.path.join(directory, "test.txt")
+        f = io.open(cls.txt_filename, "w+t")
+        f.write(u"Kikoo")
+        f.close()
+
+        cls.missing_filename = os.path.join(directory, "test.missing")
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tmp_directory)
+
     def testH5(self):
         if h5py is None:
             self.skipTest("H5py is missing")
 
-        # create a file
-        tmp = tempfile.NamedTemporaryFile(suffix=".h5", delete=True)
-        tmp.file.close()
-        h5 = h5py.File(tmp.name, "w")
-        g = h5.create_group("arrays")
-        g.create_dataset("scalar", data=10)
-        h5.close()
-
-        # load it
-        f = utils.open(tmp.name)
+        f = utils.open(self.h5_filename)
         self.assertIsNotNone(f)
         self.assertIsInstance(f, h5py.File)
         f.close()
@@ -311,42 +339,19 @@ class TestOpen(unittest.TestCase):
         if h5py is None:
             self.skipTest("H5py is missing")
 
-        # create a file
-        tmp = tempfile.NamedTemporaryFile(suffix=".h5", delete=True)
-        tmp.file.close()
-        h5 = h5py.File(tmp.name, "w")
-        g = h5.create_group("arrays")
-        g.create_dataset("scalar", data=10)
-        h5.close()
-
-        # load it
-        with utils.open(tmp.name) as f:
+        with utils.open(self.h5_filename) as f:
             self.assertIsNotNone(f)
             self.assertIsInstance(f, h5py.File)
 
     def testSpec(self):
-        # create a file
-        tmp = tempfile.NamedTemporaryFile(mode="w+t", suffix=".dat", delete=True)
-        tmp.file.close()
-        utils.savespec(tmp.name, [1], [1.1], xlabel="x", ylabel="y",
-                       fmt=["%d", "%.2f"], close_file=True, scan_number=1)
-
-        # load it
-        f = utils.open(tmp.name)
+        f = utils.open(self.spec_filename)
         self.assertIsNotNone(f)
         if h5py is not None:
             self.assertEquals(f.h5py_class, h5py.File)
         f.close()
 
     def testSpecWith(self):
-        # create a file
-        tmp = tempfile.NamedTemporaryFile(mode="w+t", suffix=".dat", delete=True)
-        tmp.file.close()
-        utils.savespec(tmp.name, [1], [1.1], xlabel="x", ylabel="y",
-                       fmt=["%d", "%.2f"], close_file=True, scan_number=1)
-
-        # load it
-        with utils.open(tmp.name) as f:
+        with utils.open(self.spec_filename) as f:
             self.assertIsNotNone(f)
             if h5py is not None:
                 self.assertEquals(f.h5py_class, h5py.File)
@@ -357,17 +362,7 @@ class TestOpen(unittest.TestCase):
         if fabio is None:
             self.skipTest("Fabio is missing")
 
-        # create a file
-        tmp = tempfile.NamedTemporaryFile(suffix=".edf", delete=True)
-        tmp.file.close()
-        header = fabio.fabioimage.OrderedDict()
-        header["integer"] = "10"
-        data = numpy.array([[10, 50], [50, 10]])
-        fabiofile = fabio.edfimage.EdfImage(data, header)
-        fabiofile.write(tmp.name)
-
-        # load it
-        f = utils.open(tmp.name)
+        f = utils.open(self.edf_filename)
         self.assertIsNotNone(f)
         self.assertEquals(f.h5py_class, h5py.File)
         f.close()
@@ -378,32 +373,16 @@ class TestOpen(unittest.TestCase):
         if fabio is None:
             self.skipTest("Fabio is missing")
 
-        # create a file
-        tmp = tempfile.NamedTemporaryFile(suffix=".edf", delete=True)
-        tmp.file.close()
-        header = fabio.fabioimage.OrderedDict()
-        header["integer"] = "10"
-        data = numpy.array([[10, 50], [50, 10]])
-        fabiofile = fabio.edfimage.EdfImage(data, header)
-        fabiofile.write(tmp.name)
-
-        # load it
-        with utils.open(tmp.name) as f:
+        with utils.open(self.edf_filename) as f:
             self.assertIsNotNone(f)
             self.assertEquals(f.h5py_class, h5py.File)
 
     def testUnsupported(self):
-        # create a file
-        tmp = tempfile.NamedTemporaryFile(mode="w+t", suffix=".txt", delete=True)
-        tmp.write("Kikoo")
-        tmp.close()
-
-        # load it
-        self.assertRaises(IOError, utils.open, tmp.name)
+        self.assertRaises(IOError, utils.open, self.txt_filename)
 
     def testNotExists(self):
         # load it
-        self.assertRaises(IOError, utils.open, "#$.")
+        self.assertRaises(IOError, utils.open, self.missing_filename)
 
 
 class TestNodes(unittest.TestCase):

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -28,7 +28,9 @@ import os.path
 import sys
 import time
 import logging
+
 from silx.utils.deprecation import deprecated
+from silx.utils.proxy import Proxy
 
 try:
     import h5py
@@ -41,7 +43,7 @@ else:
 
 __authors__ = ["P. Knobel", "V. Valls"]
 __license__ = "MIT"
-__date__ = "21/09/2017"
+__date__ = "28/09/2017"
 
 
 logger = logging.getLogger(__name__)
@@ -377,7 +379,7 @@ def h5ls(h5group, lvl=0):
     return h5repr
 
 
-def open(filename):  # pylint:disable=redefined-builtin
+def _open(filename):
     """
     Load a file as an `h5py.File`-like object.
 
@@ -434,6 +436,84 @@ def open(filename):  # pylint:disable=redefined-builtin
     for exc_info, message in debugging_info:
         logger.debug(message, exc_info=exc_info)
     raise IOError("File '%s' can't be read as HDF5" % filename)
+
+
+class _MainNode(Proxy):
+    """A main node is a sub node of the HDF5 tree which is responsible of the
+    closure of the file.
+
+    It is a proxy to the sub node, plus support context manager and `close`
+    method usually provided by `h5py.File`.
+
+    :param h5_node: Target to the proxy.
+    :param h5_file: Main file. This object became the owner of this file.
+    """
+
+    def __init__(self, h5_node, h5_file):
+        super(_MainNode, self).__init__(h5_node)
+        self.__file = h5_file
+        self.__class = get_h5py_class(h5_node)
+
+    @property
+    def h5py_class(self):
+        """Returns the h5py classes which is mimicked by this class. It can be
+        one of `h5py.File, h5py.Group` or `h5py.Dataset`.
+
+        :rtype: Class
+        """
+        return self.__class
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def close(self):
+        """Close the file"""
+        self.__file.close()
+        self.__file = None
+
+
+def open(filename):  # pylint:disable=redefined-builtin
+    """
+    Open a file as an `h5py`-like object.
+
+    Format supported:
+    - h5 files, if `h5py` module is installed
+    - SPEC files exposed as a NeXus layout
+    - raster files exposed as a NeXus layout (if `fabio` is installed)
+    - Numpy files ('npy' and 'npz' files)
+
+    The filename can be trailled an HDF5 path using the separator `::`. In this
+    case the object returned is a proxy to the target node, implementing the
+    `close` function and supporting `with` context.
+
+    The file is opened in read-only mode.
+
+    :param str filename: A filename which can containt an HDF5 path by using
+        `::` separator.
+    :raises: IOError if the file can't be loaded or path can't be found
+    :rtype: h5py-like node
+    """
+    if "::" in filename:
+        filename, h5_path = filename.split("::")
+    else:
+        filename, h5_path = filename, "/"
+
+    h5_file = _open(filename)
+
+    if h5_path in ["/", ""]:
+        # Short cut
+        return h5_file
+
+    if h5_path not in h5_file:
+        msg = "File '%s' do not contains path '%s'." % (filename, h5_path)
+        raise IOError(msg)
+
+    node = h5_file[h5_path]
+    proxy = _MainNode(node, h5_file)
+    return proxy
 
 
 @deprecated

--- a/silx/utils/proxy.py
+++ b/silx/utils/proxy.py
@@ -1,0 +1,204 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Module containing proxy objects"""
+
+from __future__ import absolute_import, print_function, division
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "02/10/2017"
+
+from silx.third_party import six
+
+
+class Proxy(object):
+    """Create a proxy of an object.
+
+    Provides default methods and property using :meth:`__getattr__` and special
+    method by redefining them one by one.
+    Special methods are defined as properties, as a result if the `obj` method
+    is not defined, the property code fail and the special method will not be
+    visible.
+    """
+
+    __slots__ = ["__obj", "__weakref__"]
+
+    def __init__(self, obj):
+        object.__setattr__(self, "_Proxy__obj", obj)
+
+    __class__ = property(lambda self: self.__obj.__class__)
+
+    def __getattr__(self, name):
+        return getattr(self.__obj, name)
+
+    __setattr__ = property(lambda self: self.__obj.__setattr__)
+    __delattr__ = property(lambda self: self.__obj.__delattr__)
+
+    # binary comparator methods
+
+    __lt__ = property(lambda self: self.__obj.__lt__)
+    __le__ = property(lambda self: self.__obj.__le__)
+    __eq__ = property(lambda self: self.__obj.__eq__)
+    __ne__ = property(lambda self: self.__obj.__ne__)
+    __gt__ = property(lambda self: self.__obj.__gt__)
+    __ge__ = property(lambda self: self.__obj.__ge__)
+
+    if six.PY2:
+        __cmp__ = property(lambda self: self.__obj.__cmp__)
+
+    # binary numeric methods
+
+    __add__ = property(lambda self: self.__obj.__add__)
+    __radd__ = property(lambda self: self.__obj.__radd__)
+    __iadd__ = property(lambda self: self.__obj.__iadd__)
+    __sub__ = property(lambda self: self.__obj.__sub__)
+    __rsub__ = property(lambda self: self.__obj.__rsub__)
+    __isub__ = property(lambda self: self.__obj.__isub__)
+    __mul__ = property(lambda self: self.__obj.__mul__)
+    __rmul__ = property(lambda self: self.__obj.__rmul__)
+    __imul__ = property(lambda self: self.__obj.__imul__)
+
+    if six.PY2:
+        # Only part of Python 2
+        # Python 3 uses __truediv__ and __floordiv__
+        __div__ = property(lambda self: self.__obj.__div__)
+        __rdiv__ = property(lambda self: self.__obj.__rdiv__)
+        __idiv__ = property(lambda self: self.__obj.__idiv__)
+
+    __truediv__ = property(lambda self: self.__obj.__truediv__)
+    __rtruediv__ = property(lambda self: self.__obj.__rtruediv__)
+    __itruediv__ = property(lambda self: self.__obj.__itruediv__)
+    __floordiv__ = property(lambda self: self.__obj.__floordiv__)
+    __rfloordiv__ = property(lambda self: self.__obj.__rfloordiv__)
+    __ifloordiv__ = property(lambda self: self.__obj.__ifloordiv__)
+    __mod__ = property(lambda self: self.__obj.__mod__)
+    __rmod__ = property(lambda self: self.__obj.__rmod__)
+    __imod__ = property(lambda self: self.__obj.__imod__)
+    __divmod__ = property(lambda self: self.__obj.__divmod__)
+    __rdivmod__ = property(lambda self: self.__obj.__rdivmod__)
+    __pow__ = property(lambda self: self.__obj.__pow__)
+    __rpow__ = property(lambda self: self.__obj.__rpow__)
+    __ipow__ = property(lambda self: self.__obj.__ipow__)
+    __lshift__ = property(lambda self: self.__obj.__lshift__)
+    __rlshift__ = property(lambda self: self.__obj.__rlshift__)
+    __ilshift__ = property(lambda self: self.__obj.__ilshift__)
+    __rshift__ = property(lambda self: self.__obj.__rshift__)
+    __rrshift__ = property(lambda self: self.__obj.__rrshift__)
+    __irshift__ = property(lambda self: self.__obj.__irshift__)
+
+    # binary logical methods
+
+    __and__ = property(lambda self: self.__obj.__and__)
+    __rand__ = property(lambda self: self.__obj.__rand__)
+    __iand__ = property(lambda self: self.__obj.__iand__)
+    __xor__ = property(lambda self: self.__obj.__xor__)
+    __rxor__ = property(lambda self: self.__obj.__rxor__)
+    __ixor__ = property(lambda self: self.__obj.__ixor__)
+    __or__ = property(lambda self: self.__obj.__or__)
+    __ror__ = property(lambda self: self.__obj.__ror__)
+    __ior__ = property(lambda self: self.__obj.__ior__)
+
+    # unary methods
+
+    __neg__ = property(lambda self: self.__obj.__neg__)
+    __pos__ = property(lambda self: self.__obj.__pos__)
+    __abs__ = property(lambda self: self.__obj.__abs__)
+    __invert__ = property(lambda self: self.__obj.__invert__)
+    if six.PY3:
+        __floor__ = property(lambda self: self.__obj.__floor__)
+        __ceil__ = property(lambda self: self.__obj.__ceil__)
+        __round__ = property(lambda self: self.__obj.__round__)
+
+    # cast
+
+    __repr__ = property(lambda self: self.__obj.__repr__)
+    __str__ = property(lambda self: self.__obj.__str__)
+    __complex__ = property(lambda self: self.__obj.__complex__)
+    __int__ = property(lambda self: self.__obj.__int__)
+    __float__ = property(lambda self: self.__obj.__float__)
+    __hash__ = property(lambda self: self.__obj.__hash__)
+    if six.PY2:
+        __long__ = property(lambda self: self.__obj.__long__)
+        __oct__ = property(lambda self: self.__obj.__oct__)
+        __hex__ = property(lambda self: self.__obj.__hex__)
+        __unicode__ = property(lambda self: self.__obj.__unicode__)
+        __nonzero__ = property(lambda self: lambda: bool(self.__obj))
+    if six.PY3:
+        __bytes__ = property(lambda self: self.__obj.__bytes__)
+        __bool__ = property(lambda self: lambda: bool(self.__obj))
+        __format__ = property(lambda self: self.__obj.__format__)
+
+    # container
+
+    __len__ = property(lambda self: self.__obj.__len__)
+    if six.PY3:
+        __length_hint__ = property(lambda self: self.__obj.__length_hint__)
+    __getitem__ = property(lambda self: self.__obj.__getitem__)
+    __missing__ = property(lambda self: self.__obj.__missing__)
+    __setitem__ = property(lambda self: self.__obj.__setitem__)
+    __delitem__ = property(lambda self: self.__obj.__delitem__)
+    __iter__ = property(lambda self: self.__obj.__iter__)
+    __reversed__ = property(lambda self: self.__obj.__reversed__)
+    __contains__ = property(lambda self: self.__obj.__contains__)
+
+    if six.PY2:
+        __getslice__ = property(lambda self: self.__obj.__getslice__)
+        __setslice__ = property(lambda self: self.__obj.__setslice__)
+        __delslice__ = property(lambda self: self.__obj.__delslice__)
+
+    # pickle
+
+    __reduce__ = property(lambda self: self.__obj.__reduce__)
+    __reduce_ex__ = property(lambda self: self.__obj.__reduce_ex__)
+
+    # async
+
+    if six.PY3:
+        __await__ = property(lambda self: self.__obj.__await__)
+        __aiter__ = property(lambda self: self.__obj.__aiter__)
+        __anext__ = property(lambda self: self.__obj.__anext__)
+        __aenter__ = property(lambda self: self.__obj.__aenter__)
+        __aexit__ = property(lambda self: self.__obj.__aexit__)
+
+    # other
+
+    __index__ = property(lambda self: self.__obj.__index__)
+    if six.PY2:
+        __coerce__ = property(lambda self: self.__obj.__coerce__)
+
+    if six.PY3:
+        __next__ = property(lambda self: self.__obj.__next__)
+
+    __enter__ = property(lambda self: self.__obj.__enter__)
+    __exit__ = property(lambda self: self.__obj.__exit__)
+
+    __concat__ = property(lambda self: self.__obj.__concat__)
+    __iconcat__ = property(lambda self: self.__obj.__iconcat__)
+
+    if six.PY2:
+        __repeat__ = property(lambda self: self.__obj.__repeat__)
+        __irepeat__ = property(lambda self: self.__obj.__irepeat__)
+
+    __call__ = property(lambda self: self.__obj.__call__)

--- a/silx/utils/test/__init__.py
+++ b/silx/utils/test/__init__.py
@@ -24,7 +24,7 @@
 # ###########################################################################*/
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "22/06/2017"
+__date__ = "02/10/2017"
 
 
 import unittest
@@ -33,6 +33,7 @@ from . import test_html
 from . import test_array_like
 from . import test_launcher
 from . import test_deprecation
+from . import test_proxy
 
 
 def suite():
@@ -42,4 +43,5 @@ def suite():
     test_suite.addTest(test_array_like.suite())
     test_suite.addTest(test_launcher.suite())
     test_suite.addTest(test_deprecation.suite())
+    test_suite.addTest(test_proxy.suite())
     return test_suite

--- a/silx/utils/test/test_proxy.py
+++ b/silx/utils/test/test_proxy.py
@@ -1,0 +1,295 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Tests for weakref module"""
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "02/10/2017"
+
+
+import unittest
+import pickle
+import numpy
+from ..proxy import Proxy
+
+
+class Thing(object):
+
+    def __init__(self, value):
+        self.value = value
+
+    def __getitem__(self, selection):
+        return selection + 1
+
+    def method(self, value):
+        return value + 2
+
+
+class InheritedProxy(Proxy):
+    """Inheriting the proxy allow to specialisze methods"""
+
+    def __init__(self, obj, value):
+        Proxy.__init__(self, obj)
+        self.value = value + 2
+
+    def __getitem__(self, selection):
+        return selection + 3
+
+    def method(self, value):
+        return value + 4
+
+
+class TestProxy(unittest.TestCase):
+    """Test that the proxy behave as expected"""
+
+    def text_init(self):
+        obj = Thing(10)
+        p = Proxy(obj)
+        self.assertTrue(isinstance(p, Thing))
+        self.assertTrue(isinstance(p, Proxy))
+
+    # methods and properties
+
+    def test_has_special_method(self):
+        obj = Thing(10)
+        p = Proxy(obj)
+        self.assertTrue(hasattr(p, "__getitem__"))
+
+    def test_missing_special_method(self):
+        obj = Thing(10)
+        p = Proxy(obj)
+        self.assertFalse(hasattr(p, "__and__"))
+
+    def test_method(self):
+        obj = Thing(10)
+        p = Proxy(obj)
+        self.assertEqual(p.method(10), obj.method(10))
+
+    def test_property(self):
+        obj = Thing(10)
+        p = Proxy(obj)
+        self.assertEqual(p.value, obj.value)
+
+    # special functions
+
+    def test_getitem(self):
+        obj = Thing(10)
+        p = Proxy(obj)
+        self.assertEqual(p[10], obj[10])
+
+    def test_setitem(self):
+        obj = numpy.array([10, 20, 30])
+        p = Proxy(obj)
+        p[0] = 20
+        self.assertEqual(obj[0], 20)
+
+    def test_slice(self):
+        obj = numpy.arange(20)
+        p = Proxy(obj)
+        expected = obj[0:10:2]
+        result = p[0:10:2]
+        self.assertEqual(list(result), list(expected))
+
+    # binary comparator methods
+
+    def test_lt(self):
+        obj = numpy.array([20])
+        p = Proxy(obj)
+        expected = obj < obj
+        result = p < p
+        self.assertEqual(result, expected)
+
+    # binary numeric methods
+
+    def test_add(self):
+        obj = numpy.array([20])
+        proxy = Proxy(obj)
+        expected = obj + obj
+        result = proxy + proxy
+        self.assertEqual(result, expected)
+
+    def test_iadd(self):
+        expected = numpy.array([20])
+        expected += 10
+        obj = numpy.array([20])
+        result = Proxy(obj)
+        result += 10
+        self.assertEqual(result, expected)
+
+    def test_radd(self):
+        obj = numpy.array([20])
+        p = Proxy(obj)
+        expected = 10 + obj
+        result = 10 + p
+        self.assertEqual(result, expected)
+
+    # binary logical methods
+
+    def test_and(self):
+        obj = numpy.array([20])
+        p = Proxy(obj)
+        expected = obj & obj
+        result = p & p
+        self.assertEqual(result, expected)
+
+    def test_iand(self):
+        expected = numpy.array([20])
+        expected &= 10
+        obj = numpy.array([20])
+        result = Proxy(obj)
+        result &= 10
+        self.assertEqual(result, expected)
+
+    def test_rand(self):
+        obj = numpy.array([20])
+        p = Proxy(obj)
+        expected = 10 & obj
+        result = 10 & p
+        self.assertEqual(result, expected)
+
+    # unary methods
+
+    def test_neg(self):
+        obj = numpy.array([20])
+        p = Proxy(obj)
+        expected = -obj
+        result = -p
+        self.assertEqual(result, expected)
+
+    def test_round(self):
+        obj = 20.5
+        p = Proxy(obj)
+        expected = round(obj)
+        result = round(p)
+        self.assertEqual(result, expected)
+
+    # cast
+
+    def test_bool(self):
+        obj = True
+        p = Proxy(obj)
+        if p:
+            pass
+        else:
+            self.fail()
+
+    def test_str(self):
+        obj = Thing(10)
+        p = Proxy(obj)
+        expected = str(obj)
+        result = str(p)
+        self.assertEqual(result, expected)
+
+    def test_repr(self):
+        obj = Thing(10)
+        p = Proxy(obj)
+        expected = repr(obj)
+        result = repr(p)
+        self.assertEqual(result, expected)
+
+    def test_text_bool(self):
+        obj = ""
+        p = Proxy(obj)
+        if p:
+            self.fail()
+        else:
+            pass
+
+    def test_text_str(self):
+        obj = "a"
+        p = Proxy(obj)
+        expected = str(obj)
+        result = str(p)
+        self.assertEqual(result, expected)
+
+    def test_text_repr(self):
+        obj = "a"
+        p = Proxy(obj)
+        expected = repr(obj)
+        result = repr(p)
+        self.assertEqual(result, expected)
+
+    def test_hash(self):
+        obj = [0, 1, 2]
+        p = Proxy(obj)
+        with self.assertRaises(TypeError):
+            hash(p)
+        obj = (0, 1, 2)
+        p = Proxy(obj)
+        hash(p)
+
+
+class TestInheritedProxy(unittest.TestCase):
+    """Test that inheriting the Proxy class behave as expected"""
+
+    # methods and properties
+
+    def test_method(self):
+        obj = Thing(10)
+        p = InheritedProxy(obj, 11)
+        self.assertEqual(p.method(10), 11 + 3)
+
+    def test_property(self):
+        obj = Thing(10)
+        p = InheritedProxy(obj, 11)
+        self.assertEqual(p.value, 11 + 2)
+
+    # special functions
+
+    def test_getitem(self):
+        obj = Thing(10)
+        p = InheritedProxy(obj, 11)
+        self.assertEqual(p[12], 12 + 3)
+
+
+class TestPickle(unittest.TestCase):
+
+    def test_dumps(self):
+        obj = Thing(10)
+        p = Proxy(obj)
+        expected = pickle.dumps(obj)
+        result = pickle.dumps(p)
+        self.assertEqual(result, expected)
+
+    def test_loads(self):
+        obj = Thing(10)
+        p = Proxy(obj)
+        obj2 = pickle.loads(pickle.dumps(p))
+        self.assertTrue(isinstance(obj2, Thing))
+        self.assertFalse(isinstance(obj2, Proxy))
+        self.assertEqual(obj.value, obj2.value)
+
+
+def suite():
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite = unittest.TestSuite()
+    test_suite.addTest(loadTests(TestProxy))
+    test_suite.addTest(loadTests(TestPickle))
+    test_suite.addTest(loadTests(TestInheritedProxy))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
Merge first https://github.com/silx-kit/silx/pull/1223, i can then rebase this PR if you like.

- Add a generic proxy for python object (`silx.utils.proxy.Proxy`)
- Implement `filename::path` in `silx.io.open()`
   - The implementation returns a proxy to the target node which also owns the opened file
   - This proxy provides API of the target object, plus common API of opened files (`close` method and context management)
- Update `silx view` to avoid to check files before using `silx.io.open`
   - As result the viewer is always displayed anyway the files from the command line exist or not.

Closes  #1157 

```
valls@linkdick ~/workspace/silx.git (support-path-in-filename) $ ./bootstrap.py silx view 201606id01-FZP-S0013-result-new.npz::obj ../all_types.h5::float toto ../data/cant_be_read.h5
ERROR:silx.app.view:Filename 'toto' must be a file path
ERROR:silx.app.view:Unable open file (unable to open file: name = '/workspace/valls/data/cant_be_read.h5', errno = 13, error message = 'Permission denied', flags = 0, o_flags = 0)
```

![screenshot from 2017-09-28 18 27 08](https://user-images.githubusercontent.com/7579321/30978555-2e9e741a-a47b-11e7-90ad-446c42373219.png)