### PR TITLE
[plot] Fix save image data as PNG 

### DIFF
--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -302,8 +302,7 @@ class ImageData(ImageBase, ColormapMixIn):
         else:
             # Apply colormap, in this case an new array is always returned
             colormap = self.getColormap()
-            image = applyColormapToData(self.getData(copy=False),
-                                        **colormap)
+            image = colormap.applyToData(self.getData(copy=False))
             return image
 
     def getAlternativeImageData(self, copy=True):


### PR DESCRIPTION
Save image data as PNG was broken (related to introduction of `Colormap` object)

This PR fixes it.