### PR TITLE
[plot3d] Improve axes indicator

### DIFF
--- a/silx/gui/_glutils/gl.py
+++ b/silx/gui/_glutils/gl.py
@@ -101,7 +101,10 @@ def enabled(capacity, enable=True):
     :param bool enable:
         True (default) to enable during context, False to disable
     """
-    if enable:
+    if bool(enable) == glGetBoolean(capacity):
+        # Already in the right state: noop
+        yield
+    elif enable:
         glEnable(capacity)
         yield
         glDisable(capacity)

--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -54,11 +54,24 @@ class _OverviewViewport(scene.Viewport):
     :param Camera camera: The camera to track.
     """
 
+    _SIZE = 100
+    """Size in pixels of the overview square"""
+
     def __init__(self, camera=None):
         super(_OverviewViewport, self).__init__()
-        self.size = 100, 100
+        self.size = self._SIZE, self._SIZE
+        self.background = None  # Disable clear
 
         self.scene.transforms = [transform.Scale(2.5, 2.5, 2.5)]
+
+        # Add a point to draw the background (in a group with depth mask)
+        backgroundPoint = primitives.ColorPoints(
+            vertices=[(0., 0., 0.)],
+            colors=(1., 1., 1., 0.5),
+            sizes=self._SIZE)
+        noDepthGroup = primitives.GroupNoDepth(mask=True, notest=True)
+        noDepthGroup.children.append(backgroundPoint)
+        self.scene.children.append(noDepthGroup)
 
         axes = primitives.Axes()
         self.scene.children.append(axes)
@@ -108,7 +121,6 @@ class Plot3DWidget(glu.OpenGLWidget):
 
         # Main viewport
         self.viewport = scene.Viewport()
-        self.viewport.background = 0.2, 0.2, 0.2, 1.
 
         self._sceneScale = transform.Scale(1., 1., 1.)
         self.viewport.scene.transforms = [self._sceneScale,
@@ -209,7 +221,6 @@ class Plot3DWidget(glu.OpenGLWidget):
         """
         color = rgba(color)
         self.viewport.background = color
-        self.overview.background = color[0]*0.5, color[1]*0.5, color[2]*0.5, 1.
 
     def getBackgroundColor(self):
         """Returns the RGBA background color (QColor)."""

--- a/silx/gui/plot3d/scene/primitives.py
+++ b/silx/gui/plot3d/scene/primitives.py
@@ -1107,7 +1107,7 @@ class ColorPoints(Geometry):
     varying float vSymbol;
     varying vec4 vColor;
 
-    $clippingDecl;
+    $clippingDecl
 
     /* Circle */
     #define SYMBOL_CIRCLE 1.0

--- a/silx/gui/plot3d/scene/primitives.py
+++ b/silx/gui/plot3d/scene/primitives.py
@@ -961,7 +961,7 @@ class Points(Geometry):
     varying float vSymbol;
     varying float vNormValue;
 
-    $clippinDecl
+    $clippingDecl
 
     /* Circle */
     #define SYMBOL_CIRCLE 1.0
@@ -1684,6 +1684,29 @@ class GroupDepthOffset(core.Group):
         # gl.glDepthFunc(gl.GL_LEQUAL)
         # TODO use epsilon for all rendering?
         # TODO issue with picking in depth buffer!
+
+
+class GroupNoDepth(core.Group):
+    """A group rendering its children without writing to the depth buffer
+
+    :param bool mask: True (default) to disable writing in the depth buffer
+    :param bool notest: True (default) to disable depth test
+    """
+
+    def __init__(self, children=(), mask=True, notest=True):
+        super(GroupNoDepth, self).__init__(children)
+        self._mask = bool(mask)
+        self._notest = bool(notest)
+
+    def renderGL2(self, ctx):
+        if self._mask:
+            gl.glDepthMask(gl.GL_FALSE)
+
+        with gl.disabled(gl.GL_DEPTH_TEST, disable=self._notest):
+            super(GroupNoDepth, self).renderGL2(ctx)
+
+        if self._mask:
+            gl.glDepthMask(gl.GL_TRUE)
 
 
 class GroupBBox(core.PrivateGroup):

--- a/silx/gui/plot3d/scene/primitives.py
+++ b/silx/gui/plot3d/scene/primitives.py
@@ -1176,8 +1176,7 @@ class ColorPoints(Geometry):
     _ATTR_INFO = _POINTS_ATTR_INFO
 
     def __init__(self, vertices, colors=(1., 1., 1., 1.), sizes=1.,
-                 indices=None, symbols=0.,
-                 minValue=None, maxValue=None):
+                 indices=None, symbols=0.):
         super(ColorPoints, self).__init__('points', indices,
                                           position=vertices,
                                           color=colors,

--- a/silx/gui/plot3d/scene/viewport.py
+++ b/silx/gui/plot3d/scene/viewport.py
@@ -198,12 +198,17 @@ class Viewport(event.Notifier):
 
     @property
     def background(self):
-        """Background color of the viewport (4-tuple of float in [0, 1]"""
+        """Viewport's background color (4-tuple of float in [0, 1] or None)
+
+        The background color is used to clear to viewport.
+        If None, the viewport is not cleared
+        """
         return self._background
 
     @background.setter
     def background(self, color):
-        color = rgba(color)
+        if color is not None:
+            color = rgba(color)
         if self._background != color:
             self._background = color
             self._changed()
@@ -295,12 +300,16 @@ class Viewport(event.Notifier):
         gl.glHint(gl.GL_LINE_SMOOTH_HINT, gl.GL_NICEST)
         gl.glEnable(gl.GL_LINE_SMOOTH)
 
-        gl.glClearColor(*self.background)
+        if self.background is None:
+            gl.glClear(gl.GL_STENCIL_BUFFER_BIT |
+                       gl.GL_DEPTH_BUFFER_BIT)
+        else:
+            gl.glClearColor(*self.background)
 
-        # Prepare OpenGL
-        gl.glClear(gl.GL_COLOR_BUFFER_BIT |
-                   gl.GL_STENCIL_BUFFER_BIT |
-                   gl.GL_DEPTH_BUFFER_BIT)
+            # Prepare OpenGL
+            gl.glClear(gl.GL_COLOR_BUFFER_BIT |
+                       gl.GL_STENCIL_BUFFER_BIT |
+                       gl.GL_DEPTH_BUFFER_BIT)
 
         ctx = RenderContext(self, glContext)
         self.scene.render(ctx)


### PR DESCRIPTION
This PR improves the look of the top-right axes orientation indicator by displaying the axes in a semi-transparent circle rather than in an opaque square.

Closes #993 