### PR TITLE
[plot] Refactor matplotlib backend draw control

### DIFF
--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -803,6 +803,12 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
 
     # replot control
 
+    def resizeEvent(self, event):
+        FigureCanvasQTAgg.resizeEvent(self, event)
+        if self._overlays or self._graphCursor:
+            # This is needed with matplotlib 1.5.x and 2.0.x
+            self._plot._setDirtyPlot()
+
     def _drawOverlays(self):
         """Draw overlays if any."""
         if self._overlays or self._graphCursor:


### PR DESCRIPTION
This PR refactors the way replot/draw of matplotlib backend is handled.
It avoids recursive repaint with matplotlib v2.1.0 and PyQt5.

Closes #1273