### PR TITLE
[specfile tests] Close specfile objects

### DIFF
--- a/silx/io/test/test_specfile.py
+++ b/silx/io/test/test_specfile.py
@@ -27,7 +27,7 @@ __authors__ = ["P. Knobel", "V.A. Sole"]
 __license__ = "MIT"
 __date__ = "03/08/2017"
 
-import gc
+
 import locale
 import logging
 import numpy
@@ -177,16 +177,9 @@ class TestSpecFile(unittest.TestCase):
         self.scan1_no_fhdr_crash = self.sf_no_fhdr_crash[0]
 
     def tearDown(self):
-        del self.sf
-        del self.sf_no_fhdr
-        del self.scan1
-        del self.scan1_2
-        del self.scan25
-        del self.scan1_no_fhdr
-        del self.sf_no_fhdr_crash
-        del self.scan1_no_fhdr_crash
-        del self.empty_scan
-        gc.collect()
+        self.sf.close()
+        self.sf_no_fhdr.close()
+        self.sf_no_fhdr_crash.close()
 
     def test_open(self):
         self.assertIsInstance(self.sf, SpecFile)
@@ -399,13 +392,12 @@ class TestSFLocale(unittest.TestCase):
     def tearDownClass(cls):
         os.unlink(cls.fname)
         locale.setlocale(locale.LC_NUMERIC, loc)  # restore saved locale
-        gc.collect()
 
     def crunch_data(self):
         self.sf3 = SpecFile(self.fname)
         self.assertAlmostEqual(self.sf3[0].data_line(1)[2],
                                1.56)
-        del self.sf3
+        self.sf3.close()
 
     @unittest.skipIf(not try_DE, "de_DE.utf8 locale not installed")
     def test_locale_de_DE(self):

--- a/silx/io/test/test_specfilewrapper.py
+++ b/silx/io/test/test_specfilewrapper.py
@@ -27,7 +27,6 @@ __authors__ = ["P. Knobel"]
 __license__ = "MIT"
 __date__ = "15/05/2017"
 
-import gc
 import locale
 import logging
 import numpy
@@ -120,17 +119,9 @@ class TestSpecfilewrapper(unittest.TestCase):
             os.write(fd, bytes(sftext, 'ascii'))
         os.close(fd)
 
-        fd2, cls.fname2 = tempfile.mkstemp(text=False)
-        if sys.version < '3.0':
-            os.write(fd2, sftext[370:-97])
-        else:
-            os.write(fd2, bytes(sftext[370:-97], 'ascii'))
-        os.close(fd2)
-
     @classmethod
     def tearDownClass(cls):
         os.unlink(cls.fname1)
-        os.unlink(cls.fname2)
 
     def setUp(self):
         self.sf = Specfile(self.fname1)
@@ -139,11 +130,7 @@ class TestSpecfilewrapper(unittest.TestCase):
         self.scan25 = self.sf.select("25.1")
 
     def tearDown(self):
-        del self.sf
-        del self.scan1
-        del self.scan1_2
-        del self.scan25
-        gc.collect()
+        self.sf.close()
 
     def test_number_of_scans(self):
         self.assertEqual(3, len(self.sf))

--- a/silx/io/test/test_spech5.py
+++ b/silx/io/test/test_spech5.py
@@ -22,7 +22,6 @@
 #
 # ############################################################################*/
 """Tests for spech5"""
-import gc
 from numpy import array_equal
 import os
 import io
@@ -230,9 +229,7 @@ class TestSpecH5(unittest.TestCase):
         self.sfh5 = SpecH5(self.fname)
 
     def tearDown(self):
-        # fix Win32 permission error when deleting temp file
-        del self.sfh5
-        gc.collect()
+        self.sfh5.close()
 
     def testContainsFile(self):
         self.assertIn("/1.2/measurement", self.sfh5)
@@ -593,6 +590,7 @@ class TestSpecH5(unittest.TestCase):
             name_list = []
             # check if the object is working
             self.sfh5.visit(name_list.append)
+            sfh5.close()
 
 
 sftext_multi_mca_headers = """
@@ -638,9 +636,7 @@ class TestSpecH5MultiMca(unittest.TestCase):
         self.sfh5 = SpecH5(self.fname)
 
     def tearDown(self):
-        # fix Win32 permission error when deleting temp file
-        del self.sfh5
-        gc.collect()
+        self.sfh5.close()
 
     def testMcaCalib(self):
         mca0_calib = self.sfh5["/1.1/measurement/mca_0/info/calibration"]
@@ -770,9 +766,7 @@ class TestSpecH5NoDataCols(unittest.TestCase):
         self.sfh5 = SpecH5(self.fname)
 
     def tearDown(self):
-        # fix Win32 permission error when deleting temp file
-        del self.sfh5
-        gc.collect()
+        self.sfh5.close()
 
     def testScan1(self):
         # 1.1: single analyser, single spectrum, 151 channels
@@ -843,9 +837,7 @@ class TestSpecH5SlashInLabels(unittest.TestCase):
         self.sfh5 = SpecH5(self.fname)
 
     def tearDown(self):
-        # fix Win32 permission error when deleting temp file
-        del self.sfh5
-        gc.collect()
+        self.sfh5.close()
 
     def testLabels(self):
         """Ensure `/` is substituted with `%` and

--- a/silx/io/test/test_spectoh5.py
+++ b/silx/io/test/test_spectoh5.py
@@ -120,6 +120,7 @@ class TestConvertSpecHDF5(unittest.TestCase):
 
     def tearDown(self):
         self.h5f.close()
+        self.sfh5.close()
         os.unlink(self.h5_fname)
 
     def testAppendToHDF5(self):

--- a/silx/io/test/test_spectoh5.py
+++ b/silx/io/test/test_spectoh5.py
@@ -106,6 +106,10 @@ class TestConvertSpecHDF5(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        # gc collect is needed to close a file descriptor
+        # opened by fabio and not released.
+        # https://github.com/silx-kit/fabio/issues/167
+        gc.collect()
         os.unlink(cls.spec_fname)
 
     def setUp(self):
@@ -115,11 +119,8 @@ class TestConvertSpecHDF5(unittest.TestCase):
         self.h5f = h5py.File(self.h5_fname, "a")
 
     def tearDown(self):
-        del self.sfh5
         self.h5f.close()
-        del self.h5f
         os.unlink(self.h5_fname)
-        gc.collect()
 
     def testAppendToHDF5(self):
         write_to_h5(self.sfh5, self.h5f, h5path="/foo/bar/spam")


### PR DESCRIPTION
This PR closes files properly in tests, so that we don't need to call `gc.collect()` before deleting the test files.

There is still a problem with `test_spectoh5`, caused by `convert(self.spec_fname, self.h5_fname)`. This line still requires a `gc.collect` for a reason unknown.