### PR TITLE
[plot3d] ScalarFieldView support transforming data with a 3x3 matrix (for non orthogonal support)

### DIFF
--- a/silx/gui/plot3d/SFViewParamTree.py
+++ b/silx/gui/plot3d/SFViewParamTree.py
@@ -665,7 +665,7 @@ class DataSetItem(qt.QStandardItem):
 
         self.setEditable(False)
 
-        klasses = [DataTypeItem, DataShapeItem, OffsetItem, ScaleItem]
+        klasses = [DataTypeItem, DataShapeItem, OffsetItem]
         for klass in klasses:
             titleItem = qt.QStandardItem(klass.itemName)
             titleItem.setEditable(False)
@@ -681,6 +681,10 @@ class DataSetItem(qt.QStandardItem):
             titleItem.setEditable(False)
             valueItem = MatrixItem(subject, row)
             matrixItem.appendRow([titleItem, valueItem])
+
+        titleItem = qt.QStandardItem(ScaleItem.itemName)
+        titleItem.setEditable(False)
+        self.appendRow([titleItem, ScaleItem(subject)])
 
 
 # Isosurface ##################################################################

--- a/silx/gui/plot3d/SFViewParamTree.py
+++ b/silx/gui/plot3d/SFViewParamTree.py
@@ -1217,9 +1217,10 @@ class PlaneOrientationItem(SubjectItem):
         return [self.subject.getCutPlanes()[0].sigPlaneChanged]
 
     def _pullData(self):
-        currentNormal = self.subject.getCutPlanes()[0].getNormal()
+        currentNormal = self.subject.getCutPlanes()[0].getNormal(
+            coordinates='scene')
         for _, text, _, normal in self._PLANE_ACTIONS:
-            if numpy.array_equal(normal, currentNormal):
+            if numpy.allclose(normal, currentNormal):
                 return text
         return ''
 
@@ -1236,7 +1237,7 @@ class PlaneOrientationItem(SubjectItem):
     def __editorChanged(self, index):
         normal = self._PLANE_ACTIONS[index][3]
         plane = self.subject.getCutPlanes()[0]
-        plane.setNormal(normal)
+        plane.setNormal(normal, coordinates='scene')
         plane.moveToCenter()
 
     def setEditorData(self, editor):

--- a/silx/gui/plot3d/SFViewParamTree.py
+++ b/silx/gui/plot3d/SFViewParamTree.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -604,7 +604,7 @@ class DataChangedItem(SubjectItem):
     def getSignals(self):
         subject = self.subject
         if subject:
-            return subject.sigDataChanged
+            return subject.sigDataChanged, subject.sigTransformChanged
         return None
 
     def _init(self):
@@ -646,6 +646,17 @@ class ScaleItem(DataChangedItem):
         return ((scale is not None) and str(scale)) or 'N/A'
 
 
+class MatrixItem(DataChangedItem):
+
+    def __init__(self, subject, row, *args):
+        self.__row = row
+        super(MatrixItem, self).__init__(subject, *args)
+
+    def _pullData(self):
+        matrix = self.subject.getTransformMatrix()
+        return str(matrix[self.__row])
+
+
 class DataSetItem(qt.QStandardItem):
 
     def __init__(self, subject, *args):
@@ -659,6 +670,17 @@ class DataSetItem(qt.QStandardItem):
             titleItem = qt.QStandardItem(klass.itemName)
             titleItem.setEditable(False)
             self.appendRow([titleItem, klass(subject)])
+
+        matrixItem = qt.QStandardItem('matrix')
+        matrixItem.setEditable(False)
+        valueItem = qt.QStandardItem()
+        self.appendRow([matrixItem, valueItem])
+
+        for row in range(3):
+            titleItem = qt.QStandardItem()
+            titleItem.setEditable(False)
+            valueItem = MatrixItem(subject, row)
+            matrixItem.appendRow([titleItem, valueItem])
 
 
 # Isosurface ##################################################################

--- a/silx/gui/plot3d/ScalarFieldView.py
+++ b/silx/gui/plot3d/ScalarFieldView.py
@@ -730,7 +730,12 @@ class ScalarFieldView(Plot3DWindow):
         self._dataRange = None
 
         self._group = primitives.BoundedGroup()
-        self._group.transforms = [
+
+        self._dataBBoxGroup = primitives.GroupBBox()
+        self._dataBBoxGroup.children = [self._group]
+        self._dataBBoxGroup.axesVisible = False
+        self._dataBBoxGroup.color = self._foregroundColor
+        self._dataBBoxGroup.transforms = [
             self._dataTranslate, self._dataTransform, self._dataScale]
 
         self._selectionBox = primitives.Box()
@@ -760,7 +765,7 @@ class ScalarFieldView(Plot3DWindow):
         self._group.children.append(self._isogroup)
 
         self._bbox = axes.LabelledAxes()
-        self._bbox.children = [self._group]
+        self._bbox.children = [self._dataBBoxGroup]
         self.getPlot3DWidget().viewport.scene.children.append(self._bbox)
 
         self._initPanPlaneAction()
@@ -1122,7 +1127,9 @@ class ScalarFieldView(Plot3DWindow):
 
         :param bool visible: True to show axes, False to hide
         """
-        self._bbox.boxVisible = bool(visible)
+        visible = bool(visible)
+        self._bbox.boxVisible = visible
+        self._dataBBoxGroup.boxVisible = visible
 
     def setAxesLabels(self, xlabel=None, ylabel=None, zlabel=None):
         """Set the text labels of the axes.
@@ -1182,6 +1189,7 @@ class ScalarFieldView(Plot3DWindow):
     def _updateColors(self):
         """Update item depending on foreground/highlight color"""
         self._bbox.tickColor = self._foregroundColor
+        self._dataBBoxGroup.color = self._foregroundColor
         self._selectionBox.strokeColor = self._foregroundColor
         if self.getInteractiveMode() == 'plane':
             self._cutPlane.setStrokeColor(self._highlightColor)

--- a/silx/gui/plot3d/ScalarFieldView.py
+++ b/silx/gui/plot3d/ScalarFieldView.py
@@ -754,6 +754,7 @@ class ScalarFieldView(Plot3DWindow):
         self._dataBBoxGroup = primitives.GroupBBox()
         self._dataBBoxGroup.children = [self._group]
         self._dataBBoxGroup.axesVisible = False
+        self._dataBBoxGroup.strokeWidth = 1.
         self._dataBBoxGroup.color = self._foregroundColor
         self._dataBBoxGroup.transforms = [
             self._dataTranslate, self._dataTransform, self._dataScale]

--- a/silx/gui/plot3d/ScalarFieldView.py
+++ b/silx/gui/plot3d/ScalarFieldView.py
@@ -342,6 +342,7 @@ class CutPlane(qt.QObject):
 
         # Plane with texture on the data bounding box
         self._dataPlane = cutplane.CutPlane(normal=(0, 1, 0))
+        self._dataPlane.strokeVisible = False
         self._dataPlane.alpha = 1.
         self._dataPlane.visible = self._visible
 

--- a/silx/gui/plot3d/ScalarFieldView.py
+++ b/silx/gui/plot3d/ScalarFieldView.py
@@ -356,6 +356,14 @@ class CutPlane(qt.QObject):
         """Return the cut plane scene node."""
         return self._planeStroke, self._dataPlane
 
+    def _keepPlaneInBBox(self):
+        """Makes sure the plane intersect its parent bounding box if any"""
+        bounds = self._planeStroke.parent.bounds(dataBounds=True)
+        if bounds is not None:
+            self._planeStroke.plane.point = numpy.clip(
+                self._planeStroke.plane.point,
+                a_min=bounds[0], a_max=bounds[1])
+
     def _sfViewDataChanged(self):
         """Handle data change in the ScalarFieldView this plane belongs to"""
         self._dataPlane.setData(self.sender().getData(), copy=False)
@@ -368,6 +376,8 @@ class CutPlane(qt.QObject):
         # Update colormap range when autoscale
         if self.getColormap().isAutoscale():
             self._updateSceneColormap()
+
+        self._keepPlaneInBBox()
 
     def _planeChanged(self, source, *args, **kwargs):
         """Handle events from the plane primitive"""
@@ -424,6 +434,21 @@ class CutPlane(qt.QObject):
         """
         return self._planeStroke.plane.point
 
+    def setPoint(self, point, constraint=True):
+        """Set a point contained in the plane.
+
+        Warning: The plane might not intersect the bounding box of the data.
+
+        :param point: (x, y, z) position
+        :type point: 3-tuple of float
+        :param bool constraint:
+            True (default) to make sure the plane intersect data bounding box,
+            False to set the plane without any constraint.
+        """
+        self._planeStroke.plane.point = point
+        if constraint:
+            self._keepPlaneInBBox()
+
     def getParameters(self):
         """Returns the plane equation parameters: a*x + b*y + c*z + d = 0
 
@@ -431,6 +456,21 @@ class CutPlane(qt.QObject):
         :rtype: numpy.ndarray
         """
         return self._planeStroke.plane.parameters
+
+    def setParameters(self, parameters, constraint=True):
+        """Set the plane equation parameters: a*x + b*y + c*z + d = 0
+
+        Warning: The plane might not intersect the bounding box of the data.
+
+        :param parameters: (a, b, c, d) plane equation parameters.
+        :type parameters: 4-tuple of float
+        :param bool constraint:
+            True (default) to make sure the plane intersect data bounding box,
+            False to set the plane without any constraint.
+        """
+        self._planeStroke.plane.parameters = parameters
+        if constraint:
+            self._keepPlaneInBBox()
 
     # Visibility
 

--- a/silx/gui/plot3d/ScalarFieldView.py
+++ b/silx/gui/plot3d/ScalarFieldView.py
@@ -721,6 +721,7 @@ class ScalarFieldView(Plot3DWindow):
         # Transformations
         self._dataScale = transform.Scale()
         self._dataTranslate = transform.Translate()
+        self._dataTransform = transform.Matrix()   # default to identity
 
         self._foregroundColor = 1., 1., 1., 1.
         self._highlightColor = 0.7, 0.7, 0., 1.
@@ -729,7 +730,8 @@ class ScalarFieldView(Plot3DWindow):
         self._dataRange = None
 
         self._group = primitives.BoundedGroup()
-        self._group.transforms = [self._dataTranslate, self._dataScale]
+        self._group.transforms = [
+            self._dataTranslate, self._dataTransform, self._dataScale]
 
         self._selectionBox = primitives.Box()
         self._selectionBox.strokeSmooth = False
@@ -1084,6 +1086,27 @@ class ScalarFieldView(Plot3DWindow):
         """Returns the offset set by :meth:`setTranslation` as a numpy.ndarray.
         """
         return self._dataTranslate.translation
+
+    def setTransformMatrix(self, matrix3x3):
+        """Set the transform matrix applied to the data.
+
+        :param numpy.ndarray matrix: 3x3 transform matrix
+        """
+        matrix3x3 = numpy.array(matrix3x3, copy=True, dtype=numpy.float32)
+        if not numpy.all(numpy.equal(matrix3x3, self.getTransformMatrix())):
+            matrix = numpy.identity(4, dtype=numpy.float32)
+            matrix[:3, :3] = matrix3x3
+            self._dataTransform.setMatrix(matrix)
+            self.centerScene()  # Reset viewpoint
+
+    def getTransformMatrix(self):
+        """Returns the transform matrix applied to the data.
+
+        See :meth:`setTransformMatrix`.
+
+        :rtype: numpy.ndarray
+        """
+        return self._dataTransform.getMatrix()[:3, :3]
 
     # Axes labels
 

--- a/silx/gui/plot3d/ScalarFieldView.py
+++ b/silx/gui/plot3d/ScalarFieldView.py
@@ -678,13 +678,13 @@ class _CutPlaneImage(object):
         # Init attributes with default values
         self._isValid = False
         self._data = numpy.zeros((0, 0), dtype=numpy.float32)
+        self._index = 0
         self._xLabel = ''
         self._yLabel = ''
         self._normalLabel = ''
-        self._scale = 1., 1.
-        self._translation = 0., 0.
-        self._index = 0
-        self._position = 0.
+        self._scale = float('nan'), float('nan')
+        self._translation = float('nan'), float('nan')
+        self._position = float('nan')
 
         sfView = cutPlane.parent()
         if not sfView or not cutPlane.isValid():
@@ -731,21 +731,25 @@ class _CutPlaneImage(object):
 
         self._isValid = True
         self._data = numpy.array(slice_, copy=True)
-
-        labels = sfView.getAxesLabels()
-        scale = sfView.getScale()
-        translation = sfView.getTranslation()
-
-        self._xLabel = labels[xAxisIndex]
-        self._yLabel = labels[yAxisIndex]
-        self._normalLabel = labels[normalAxisIndex]
-
-        self._scale = scale[xAxisIndex], scale[yAxisIndex]
-        self._translation = translation[xAxisIndex], translation[yAxisIndex]
-
         self._index = index
-        self._position = float(index * scale[normalAxisIndex] +
-                               translation[normalAxisIndex])
+
+        # Only store extra information when no transform matrix is set
+        # Otherwise this information can be meaningless
+        if numpy.all(numpy.equal(sfView.getTransformMatrix(),
+                                 numpy.identity(3, dtype=numpy.float32))):
+            labels = sfView.getAxesLabels()
+            self._xLabel = labels[xAxisIndex]
+            self._yLabel = labels[yAxisIndex]
+            self._normalLabel = labels[normalAxisIndex]
+
+            scale = sfView.getScale()
+            self._scale = scale[xAxisIndex], scale[yAxisIndex]
+
+            translation = sfView.getTranslation()
+            self._translation = translation[xAxisIndex], translation[yAxisIndex]
+
+            self._position = float(index * scale[normalAxisIndex] +
+                                   translation[normalAxisIndex])
 
     def isValid(self):
         """Returns True if the cut plane image is defined (bool)"""

--- a/silx/gui/plot3d/ScalarFieldView.py
+++ b/silx/gui/plot3d/ScalarFieldView.py
@@ -850,13 +850,7 @@ class ScalarFieldView(Plot3DWindow):
         self._dataRange = None
 
         self._group = primitives.BoundedGroup()
-
-        self._dataBBoxGroup = primitives.GroupBBox()
-        self._dataBBoxGroup.children = [self._group]
-        self._dataBBoxGroup.axesVisible = False
-        self._dataBBoxGroup.strokeWidth = 1.
-        self._dataBBoxGroup.color = self._foregroundColor
-        self._dataBBoxGroup.transforms = [
+        self._group.transforms = [
             self._dataTranslate, self._dataTransform, self._dataScale]
 
         self._bbox = axes.LabelledAxes()

--- a/silx/gui/plot3d/ScalarFieldView.py
+++ b/silx/gui/plot3d/ScalarFieldView.py
@@ -859,7 +859,7 @@ class ScalarFieldView(Plot3DWindow):
             self._dataTranslate, self._dataTransform, self._dataScale]
 
         self._bbox = axes.LabelledAxes()
-        self._bbox.children = [self._dataBBoxGroup]
+        self._bbox.children = [self._group]
         self.getPlot3DWidget().viewport.scene.children.append(self._bbox)
 
         self._selectionBox = primitives.Box()
@@ -1254,7 +1254,6 @@ class ScalarFieldView(Plot3DWindow):
         """
         visible = bool(visible)
         self._bbox.boxVisible = visible
-        self._dataBBoxGroup.boxVisible = visible
 
     def setAxesLabels(self, xlabel=None, ylabel=None, zlabel=None):
         """Set the text labels of the axes.
@@ -1314,7 +1313,6 @@ class ScalarFieldView(Plot3DWindow):
     def _updateColors(self):
         """Update item depending on foreground/highlight color"""
         self._bbox.tickColor = self._foregroundColor
-        self._dataBBoxGroup.color = self._foregroundColor
         self._selectionBox.strokeColor = self._foregroundColor
         if self.getInteractiveMode() == 'plane':
             self._cutPlane.setStrokeColor(self._highlightColor)

--- a/silx/gui/plot3d/scene/primitives.py
+++ b/silx/gui/plot3d/scene/primitives.py
@@ -2312,23 +2312,21 @@ class GroupBBox(core.PrivateGroup):
 
         # Using 1 of 3 primitives to render axes and/or bounding box
         # To avoid z-fighting between axes and bounding box
-        lineWidth = 2.
         self._boxWithAxes = BoxWithAxes(color)
         self._boxWithAxes.smooth = False
         self._boxWithAxes.transforms = self._boxTransforms
-        self._boxWithAxes.width = lineWidth
 
         self._box = Box(stroke=color, fill=(1., 1., 1., 0.))
         self._box.strokeSmooth = False
         self._box.transforms = self._boxTransforms
         self._box.visible = False
-        self._box.strokeWidth = lineWidth
 
         self._axes = Axes()
         self._axes.smooth = False
         self._axes.transforms = self._boxTransforms
         self._axes.visible = False
-        self._axes.width = lineWidth
+
+        self.strokeWidth = 2.
 
         self._children = [self._boxWithAxes, self._box, self._axes, self._group]
 
@@ -2362,7 +2360,7 @@ class GroupBBox(core.PrivateGroup):
     def children(self, iterable):
         self._group.children = iterable
 
-    # Give access to box color
+    # Give access to box color and stroke width
 
     @property
     def color(self):
@@ -2373,6 +2371,18 @@ class GroupBBox(core.PrivateGroup):
     def color(self, color):
         self._box.strokeColor = color
         self._boxWithAxes.color = color
+
+    @property
+    def strokeWidth(self):
+        """The width of the stroke lines in pixels (float)"""
+        return self._box.strokeWidth
+
+    @strokeWidth.setter
+    def strokeWidth(self, width):
+        width = float(width)
+        self._box.strokeWidth = width
+        self._boxWithAxes.width = width
+        self._axes.width = width
 
     # Toggle axes visibility
 

--- a/silx/gui/plot3d/scene/primitives.py
+++ b/silx/gui/plot3d/scene/primitives.py
@@ -888,6 +888,7 @@ class PlaneInGroup(core.PrivateGroup):
         self._color = None
         self.color = 1., 1., 1., 1.  # Set _color
         self._width = 2.
+        self._strokeVisible = True
 
         self._plane = utils.Plane(point, normal)
         self._plane.addListener(self._planeChanged)
@@ -924,6 +925,17 @@ class PlaneInGroup(core.PrivateGroup):
         self._width = float(width)
         if self._outline is not None:
             self._outline.width = self._width  # Sync width
+
+    @property
+    def strokeVisible(self):
+        """Whether surrounding stroke is visible or not (bool)."""
+        return self._strokeVisible
+
+    @strokeVisible.setter
+    def strokeVisible(self, visible):
+        self._strokeVisible = bool(visible)
+        if self._outline is not None:
+            self._outline.visible = self._strokeVisible
 
     # Plane access
 
@@ -995,6 +1007,7 @@ class PlaneInGroup(core.PrivateGroup):
                                       mode='loop',
                                       colors=self.color)
                 self._outline.width = self._width
+                self._outline.visible = self._strokeVisible
                 self._children.append(self._outline)
 
             # Update vertices, TODO only when necessary

--- a/silx/gui/plot3d/scene/transform.py
+++ b/silx/gui/plot3d/scene/transform.py
@@ -317,7 +317,7 @@ class Transform(event.Notifier):
     def transformPoint(self, point, direct=True, perspectiveDivide=False):
         """Apply the transform to a point.
 
-        If len(point) == 3, apply persective divide if possible.
+        If len(point) == 3, apply perspective divide if possible.
 
         :param point: Array-like vector of 3 or 4 coordinates.
         :param bool direct: Whether to apply the direct (True, the default)

--- a/silx/gui/plot3d/scene/utils.py
+++ b/silx/gui/plot3d/scene/utils.py
@@ -540,3 +540,19 @@ class Plane(event.Notifier):
     def move(self, step):
         """Move the plane of step along the normal."""
         self.point += step * self.normal
+
+    def segmentIntersection(self, s0, s1):
+        """Compute the plane intersection with segment [s0, s1].
+
+        :param s0: First end of the segment
+        :type s0: 1D numpy.ndarray-like of length 3
+        :param s1: Second end of the segment
+        :type s1: 1D numpy.ndarray-like of length 3
+        :return: The intersection points. The number of points goes
+                 from 0 (no intersection) to 2 (segment in the plane)
+        :rtype: list of 1D numpy.ndarray
+        """
+        if not self.isPlane:
+            return []
+        else:
+            return segmentPlaneIntersect(s0, s1, self.normal, self.point)


### PR DESCRIPTION
This PR adds support of a 3x3 matrix in the data transformation (`get|setTransformMatrix`).
This is meant to display a dataset defined in a non-orthogonal coordinate system.
The displayed axes with ticks are the orthogonal axes and by default the cutting plane can be set to the direction of the 3 orthogonal axes (you can define other cut plane orientation from the API).

This PR breaks the API because the cutting plane was previously defined in the "array" coordinates and it is now defined in "data" coordinates with transformations applied.
This PR updates the `CutPlane` class API.

closes #951
