### PR TITLE
Matplotlib 2.1.0 bug with log scale

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2647,6 +2647,13 @@ class PlotWidget(qt.QMainWindow):
         xAuto = self._xAxis.isAutoScale()
         yAuto = self._yAxis.isAutoScale()
 
+        # With log axes, autoscale if limits are <= 0
+        # This avoids issues with toggling log scale with matplotlib 2.1.0
+        if self._xAxis.getScale() == self._xAxis.LOGARITHMIC and xLimits[0] <= 0:
+            xAuto = True
+        if self._yAxis.getScale() == self._yAxis.LOGARITHMIC and (yLimits[0] <= 0 or y2Limits[0] <= 0):
+            yAuto = True
+
         if not xAuto and not yAuto:
             _logger.debug("Nothing to autoscale")
         else:  # Some axes to autoscale

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -602,16 +602,10 @@ class BackendMatplotlib(BackendBase.BackendBase):
     # Graph axes
 
     def setXAxisLogarithmic(self, flag):
-        if matplotlib.__version__ >= "2.0.0":
-            self.ax.cla()
-            self.ax2.cla()
         self.ax2.set_xscale('log' if flag else 'linear')
         self.ax.set_xscale('log' if flag else 'linear')
 
     def setYAxisLogarithmic(self, flag):
-        if matplotlib.__version__ >= "2.0.0":
-            self.ax.cla()
-            self.ax2.cla()
         self.ax2.set_yscale('log' if flag else 'linear')
         self.ax.set_yscale('log' if flag else 'linear')
 
@@ -834,7 +828,16 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
         yLimits = self.ax.get_ybound()
         yRightLimits = self.ax2.get_ybound()
 
-        FigureCanvasQTAgg.draw(self)
+        # Starting with mpl 2.1.0, toggling autoscale raises a ValueError
+        # in some situations. See #1081, #1136, #1163,
+        if matplotlib.__version__ >= "2.0.0":
+            try:
+                FigureCanvasQTAgg.draw(self)
+            except ValueError:
+                pass
+        else:
+            FigureCanvasQTAgg.draw(self)
+
         if self._overlays or self._graphCursor:
             # Save background
             self._background = self.copy_from_bbox(self.fig.bbox)

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -833,8 +833,10 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
         if matplotlib.__version__ >= "2.0.0":
             try:
                 FigureCanvasQTAgg.draw(self)
-            except ValueError:
-                pass
+            except ValueError as err:
+                _logger.debug(
+                    "ValueError caught while calling FigureCanvasQTAgg.draw: "
+                    "'%s'", err)
         else:
             FigureCanvasQTAgg.draw(self)
 


### PR DESCRIPTION
Change the way to fix #1081 because `cla()` caused lots of side effects.

I kept `>= "2.0.0"` as a condition because of #1136. We need to test if this issue is still solved.
