### PR TITLE
 specfile locale fix in our debian packages

### DIFF
--- a/package/debian8/rules
+++ b/package/debian8/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 export PYBUILD_NAME=silx
+export SPECFILE_USE_GNU_SOURCE=1
 
 # Make does not offer a recursive wildcard function, so here's one:
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))

--- a/package/debian9/rules
+++ b/package/debian9/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 export PYBUILD_NAME=silx
+export SPECFILE_USE_GNU_SOURCE=1
 
 # Make does not offer a recursive wildcard function, so here's one:
 rwildcard=$(wildcard $1$2) $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2))


### PR DESCRIPTION
Define SPECFILE_USE_GNU_SOURCE to enable specfile locale fix.