### PR TITLE
Additional workaround for matplotlib 2.1.0

### DIFF
--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -602,10 +602,32 @@ class BackendMatplotlib(BackendBase.BackendBase):
     # Graph axes
 
     def setXAxisLogarithmic(self, flag):
+        # Workaround for matplotlib 2.1.0 when one tries to set an axis
+        # to log scale with both limits <= 0
+        # In this case a draw with positive limits is needed first
+        if flag and matplotlib.__version__ >= '2.1.0':
+            xlim = self.ax.get_xlim()
+            if xlim[0] <= 0 and xlim[1] <= 0:
+                self.ax.set_xlim(1, 10)
+                self.draw()
+
         self.ax2.set_xscale('log' if flag else 'linear')
         self.ax.set_xscale('log' if flag else 'linear')
 
     def setYAxisLogarithmic(self, flag):
+        # Workaround for matplotlib 2.1.0 when one tries to set an axis
+        # to log scale with both limits <= 0
+        # In this case a draw with positive limits is needed first
+        if flag and matplotlib.__version__ >= '2.1.0':
+            redraw = False
+            for axis in (self.ax, self.ax2):
+                ylim = axis.get_ylim()
+                if ylim[0] <= 0 and ylim[1] <= 0:
+                    axis.set_ylim(1, 10)
+                    redraw = True
+            if redraw:
+                self.draw()
+
         self.ax2.set_yscale('log' if flag else 'linear')
         self.ax.set_yscale('log' if flag else 'linear')
 

--- a/silx/gui/plot/items/axis.py
+++ b/silx/gui/plot/items/axis.py
@@ -220,7 +220,7 @@ class Axis(qt.QObject):
         for item in self._plot._getItems(withhidden=True):
             item._updated()
         self._plot._invalidateDataRange()
-        self._plot.resetZoom()
+        self._plot._forceResetZoom()
 
         self.sigScaleChanged.emit(self._scale)
         if emitLog:

--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -31,6 +31,7 @@ __date__ = "06/03/2017"
 
 
 import logging
+import numpy
 
 from .. import Colors
 from .core import (Points, LabelsMixIn, ColorMixIn, YAxisMixIn,
@@ -75,7 +76,7 @@ class Curve(Points, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixIn):
         xFiltered, yFiltered, xerror, yerror = self.getData(
             copy=False, displayed=True)
 
-        if len(xFiltered) == 0:
+        if len(xFiltered) == 0 or not numpy.any(numpy.isfinite(xFiltered)):
             return None  # No data to display, do not add renderer to backend
 
         return backend.addCurve(xFiltered, yFiltered, self.getLegend(),


### PR DESCRIPTION
This PR complements PR  #1307 with an extra `PlotWidget._forceResetZoom` method and a workaround for matplotlib 2.1.0 when both axis limits are <=0 when setting log scale.