### PR TITLE
Remove Python3.5 from Appveyor tests

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -30,12 +30,6 @@ environment:
           QT_BINDING: "PyQt5"
           QT_PINNED_VERSION: "==5.8.2"
           WITH_GL_TEST: True
-  
-        # Python 3.5
-        - PYTHON_DIR: "C:\\Python35-x64"
-          QT_BINDING: "PyQt5"
-          QT_PINNED_VERSION: "==5.8.2"
-          WITH_GL_TEST: True
 
         # Python 2.7
         - PYTHON_DIR: "C:\\Python27-x64"


### PR DESCRIPTION
So we only test latest python3 version and win 25% of Windows CI time.