### PR TITLE
[plot] Add a method to sample a Colormap into a color array

### DIFF
--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -533,12 +533,7 @@ class _ColorScale(qt.QWidget):
             return
 
         indices = numpy.linspace(0., 1., self._NB_CONTROL_POINTS)
-        colormapDisp = Colormap.Colormap(name=colormap.getName(),
-                                         normalization=Colormap.Colormap.LINEAR,
-                                         vmin=None,
-                                         vmax=None,
-                                         colors=colormap.getColormapLUT())
-        colors = colormapDisp.applyToData(indices)
+        colors = colormap.getColors(nbColors=self._NB_CONTROL_POINTS)
         self._gradient = qt.QLinearGradient(0, 1, 0, 0)
         self._gradient.setCoordinateMode(qt.QGradient.StretchToDeviceMode)
         self._gradient.setStops(

--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -533,7 +533,7 @@ class _ColorScale(qt.QWidget):
             return
 
         indices = numpy.linspace(0., 1., self._NB_CONTROL_POINTS)
-        colors = colormap.getColors(nbColors=self._NB_CONTROL_POINTS)
+        colors = colormap.getNColors(nbColors=self._NB_CONTROL_POINTS)
         self._gradient = qt.QLinearGradient(0, 1, 0, 0)
         self._gradient.setCoordinateMode(qt.QGradient.StretchToDeviceMode)
         self._gradient.setStops(

--- a/silx/gui/plot/Colormap.py
+++ b/silx/gui/plot/Colormap.py
@@ -116,8 +116,8 @@ class Colormap(qt.QObject):
         else:
             self._colors = numpy.array(colors, copy=True)
 
-    def getColors(self, nbColors=None):
-        """Returns the color table of the colormap.
+    def getNColors(self, nbColors=None):
+        """Returns N colors computed by sampling the colormap regularly.
 
         :param nbColors:
             The number of colors in the returned array or None for the default value.

--- a/silx/gui/plot/Colormap.py
+++ b/silx/gui/plot/Colormap.py
@@ -116,6 +116,34 @@ class Colormap(qt.QObject):
         else:
             self._colors = numpy.array(colors, copy=True)
 
+    def getColors(self, nbColors=None):
+        """Returns the color table of the colormap.
+
+        :param nbColors:
+            The number of colors in the returned array or None for the default value.
+            The default value is 256 for colormap with a name (see :meth:`setName`) and
+            it is the size of the LUT for colormap defined with :meth:`setColormapLUT`.
+        :type nbColors: int or None
+        :return: 2D array of uint8 of shape (nbColors, 4)
+        :rtype: numpy.ndarray
+        """
+        # Handle default value for nbColors
+        if nbColors is None:
+            lut = self.getColormapLUT()
+            if lut is not None:  # In this case the LUT is returned directly
+                return lut
+            else:  # Default to 256
+                nbColors = 256
+
+        nbColors = int(nbColors)
+
+        colormap = self.copy()
+        colormap.setNormalization(Colormap.LINEAR)
+        colormap.setVRange(vmin=None, vmax=None)
+        colors = colormap.applyToData(
+            numpy.arange(nbColors, dtype=numpy.int))
+        return colors
+
     def setName(self, name):
         """Set the name of the colormap and load the colors corresponding to
         the name

--- a/silx/gui/plot/Colormap.py
+++ b/silx/gui/plot/Colormap.py
@@ -163,7 +163,10 @@ class Colormap(qt.QObject):
         :return: the list of colors for the colormap. None if not set
         :rtype: numpy.ndarray
         """
-        return self._colors
+        if self._colors is None:
+            return None
+        else:
+            return numpy.array(self._colors, copy=True)
 
     def setColormapLUT(self, colors):
         """Set the colors of the colormap.

--- a/silx/gui/plot/Colormap.py
+++ b/silx/gui/plot/Colormap.py
@@ -145,12 +145,12 @@ class Colormap(qt.QObject):
         return colors
 
     def setName(self, name):
-        """Set the name of the colormap and load the colors corresponding to
-        the name
+        """Set the name of the colormap to use.
 
-        :param str name: the name of the colormap (should be in ['gray',
+        :param str name: The name of the colormap.
+            At least the following names are supported: 'gray',
             'reversed gray', 'temperature', 'red', 'green', 'blue', 'jet',
-            'viridis', 'magma', 'inferno', 'plasma']
+            'viridis', 'magma', 'inferno', 'plasma'.
         """
         assert name in self.getSupportedColormaps()
         self._name = str(name)
@@ -158,10 +158,10 @@ class Colormap(qt.QObject):
         self.sigChanged.emit()
 
     def getColormapLUT(self):
-        """Return the list of colors for the colormap. None if not set
+        """Return the list of colors for the colormap or None if not set
         
-        :return: the list of colors for the colormap. None if not set
-        :rtype: numpy.ndarray
+        :return: the list of colors for the colormap or None if not set
+        :rtype: numpy.ndarray or None
         """
         if self._colors is None:
             return None
@@ -173,7 +173,7 @@ class Colormap(qt.QObject):
 
         :param numpy.ndarray colors: the colors of the LUT
 
-        .. warning: this will set the value of name to an empty string
+        .. warning: this will set the value of name to None
         """
         self._setColors(colors)
         if len(colors) is 0:

--- a/silx/gui/plot/Colormap.py
+++ b/silx/gui/plot/Colormap.py
@@ -62,7 +62,7 @@ class Colormap(qt.QObject):
             Nx3 or Nx4 numpy array of RGB(A) colors,
             either uint8 or float in [0, 1].
             If 'name' is None, then this array is used as the colormap.
-    :param str norm: Normalization: 'linear' (default) or 'log'
+    :param str normalization: Normalization: 'linear' (default) or 'log'
     :param float vmin:
         Lower bound of the colormap or None for autoscale (default)
     :param float vmax:
@@ -79,6 +79,7 @@ class Colormap(qt.QObject):
     """Tuple of managed normalizations"""
 
     sigChanged = qt.Signal()
+    """Signal emitted when the colormap has changed."""
 
     def __init__(self, name='gray', colors=None, normalization=LINEAR, vmin=None, vmax=None):
         qt.QObject.__init__(self)
@@ -129,16 +130,15 @@ class Colormap(qt.QObject):
         self.sigChanged.emit()
 
     def getColormapLUT(self):
-        """Return the list of colors for the colormap. None if not setted
+        """Return the list of colors for the colormap. None if not set
         
-        :return: the list of colors for the colormap. None if not setted
+        :return: the list of colors for the colormap. None if not set
         :rtype: numpy.ndarray
         """
         return self._colors
 
     def setColormapLUT(self, colors):
-        """
-        Set the colors of the colormap.
+        """Set the colors of the colormap.
 
         :param numpy.ndarray colors: the colors of the LUT
 
@@ -267,8 +267,7 @@ class Colormap(qt.QObject):
         return vmin, vmax
 
     def setVRange(self, vmin, vmax):
-        """
-        Set bounds to the colormap
+        """Set the bounds of the colormap
 
         :param vmin: Lower bound of the colormap or None for autoscale
             (default)
@@ -361,9 +360,9 @@ class Colormap(qt.QObject):
         return colormap
 
     def copy(self):
-        """
+        """Return a copy of the Colormap.
 
-        :return: a copy of the Colormap object
+        :rtype: Colormap
         """
         return Colormap(name=self._name,
                         colors=copy_mdl.copy(self._colors),

--- a/silx/gui/plot/Colormap.py
+++ b/silx/gui/plot/Colormap.py
@@ -130,8 +130,8 @@ class Colormap(qt.QObject):
         # Handle default value for nbColors
         if nbColors is None:
             lut = self.getColormapLUT()
-            if lut is not None:  # In this case the LUT is returned directly
-                return lut
+            if lut is not None:  # In this case uses LUT length
+                nbColors = len(lut)
             else:  # Default to 256
                 nbColors = 256
 

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1032,17 +1032,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                 data = numpy.array(data, dtype=numpy.float32, order='C')
 
             colormapIsLog = colormap.getNormalization() == 'log'
-
             cmapRange = colormap.getColormapRange(data=data)
-
-            # Retrieve colormap LUT from name and color array
-            colormapDisp = Colormap(name=colormap.getName(),
-                                    normalization=Colormap.LINEAR,
-                                    vmin=0,
-                                    vmax=255,
-                                    colors=colormap.getColormapLUT())
-            colormapLut = colormapDisp.applyToData(
-                numpy.arange(256, dtype=numpy.uint8))
+            colormapLut = colormap.getColors(nbColors=256)
 
             image = GLPlotColormap(data,
                                    origin,

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1033,7 +1033,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
             colormapIsLog = colormap.getNormalization() == 'log'
             cmapRange = colormap.getColormapRange(data=data)
-            colormapLut = colormap.getColors(nbColors=256)
+            colormapLut = colormap.getNColors(nbColors=256)
 
             image = GLPlotColormap(data,
                                    origin,

--- a/silx/gui/plot/test/testColormap.py
+++ b/silx/gui/plot/test/testColormap.py
@@ -277,6 +277,17 @@ class TestObjectAPI(ParametricTestCase):
                     self.assertEqual(image.shape[-1], 4)
                     self.assertEqual(image.shape[:-1], data.shape)
 
+    def testGetNColors(self):
+        """Test getNColors method"""
+        # specific LUT
+        colormap = Colormap(name=None,
+                            colors=((0, 0, 0), (1, 1, 1)),
+                            vmin=1000,
+                            vmax=2000)
+        colors = colormap.getNColors()
+        self.assertTrue(numpy.all(numpy.equal(
+            colors,
+            ((0, 0, 0, 255), (255, 255, 255, 255)))))
 
 def suite():
     test_suite = unittest.TestSuite()

--- a/silx/gui/plot3d/ScalarFieldView.py
+++ b/silx/gui/plot3d/ScalarFieldView.py
@@ -609,7 +609,7 @@ class CutPlane(qt.QObject):
         colormap = self.getColormap()
         sceneCMap = self._plane.colormap
 
-        sceneCMap.colormap = colormap.getColors()
+        sceneCMap.colormap = colormap.getNColors()
 
         sceneCMap.norm = colormap.getNormalization()
         range_ = colormap.getColormapRange(data=self._dataRange)

--- a/silx/gui/plot3d/ScalarFieldView.py
+++ b/silx/gui/plot3d/ScalarFieldView.py
@@ -609,14 +609,7 @@ class CutPlane(qt.QObject):
         colormap = self.getColormap()
         sceneCMap = self._plane.colormap
 
-        indices = numpy.linspace(0., 1., 256)
-        colormapDisp = Colormap(name=colormap.getName(),
-                                normalization=Colormap.LINEAR,
-                                vmin=None,
-                                vmax=None,
-                                colors=colormap.getColormapLUT())
-        colors = colormapDisp.applyToData(indices)
-        sceneCMap.colormap = colors
+        sceneCMap.colormap = colormap.getColors()
 
         sceneCMap.norm = colormap.getNormalization()
         range_ = colormap.getColormapRange(data=self._dataRange)


### PR DESCRIPTION
This PR adds a `Colormap.getNColors` method that returns an array of color sampled linearly from the colormap LUT (not taking into account normalization and range).
This allows to share code between `ColoBar`, plot OpenGL backend and plot3d.

Closes  #1132

There is an issue while getting the color LUT this way, see #1317