### PR TITLE
Update project homepage and zenodo URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,12 +140,11 @@ See the `LICENSE <https://github.com/silx-kit/silx/blob/master/LICENSE>`_ and `c
 Citation
 --------
 
-silx releases can be cited by their DOI on Zenodo: |DOI:10.5281/zenodo.1003146|
+silx releases can be cited by their DOI on Zenodo: |zenodo DOI|
 
 .. |Travis Status| image:: https://travis-ci.org/silx-kit/silx.svg?branch=master
    :target: https://travis-ci.org/silx-kit/silx
 .. |Appveyor Status| image:: https://ci.appveyor.com/api/projects/status/qgox9ei0wxwfagrb/branch/master?svg=true
    :target: https://ci.appveyor.com/project/ESRF/silx
-.. |DOI:10.5281/zenodo.1000472| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.1000472.svg
-   :target: https://doi.org/10.5281/zenodo.1000472
-
+.. |zenodo DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.591709.svg
+   :target: https://doi.org/10.5281/zenodo.591709

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -6,7 +6,7 @@ development of data assessment, reduction and analysis applications at synchrotr
 radiation facilities.
 It aims at providing reading/writing different file formats, data reduction routines
 and a set of Qt widgets to browse and visualize data.
-Silx can be cited by its DOIs referenced on `Zenodo <https://doi.org/10.5281/zenodo.1003146>`_.
+Silx can be cited by its DOIs referenced on `Zenodo <https://doi.org/10.5281/zenodo.591709>`_.
 
 The current version provides reading `SPEC <https://certif.com/spec.html>`_ file
 format, histogramming, fitting, curves and image plot widget with a set of

--- a/setup.py
+++ b/setup.py
@@ -753,7 +753,7 @@ def get_project_configuration(dry_run):
 
     setup_kwargs.update(name=PROJECT,
                         version=get_version(),
-                        url="https://github.com/silx-kit/silx",
+                        url="http://www.silx.org/",
                         author="data analysis unit",
                         author_email="silx@esrf.fr",
                         classifiers=classifiers,


### PR DESCRIPTION
This PR point project URL to www.silx.org and update zenodo URL to point to silx umbrella DOI (so it will always point to the latest release).

Related to #1292