### PR TITLE
[plot] Fix ticks layout when range is empty

### DIFF
--- a/silx/gui/plot/_utils/test/test_ticklayout.py
+++ b/silx/gui/plot/_utils/test/test_ticklayout.py
@@ -31,6 +31,7 @@ __date__ = "18/10/2016"
 
 
 import unittest
+import numpy
 
 from silx.test.utils import ParametricTestCase
 
@@ -39,6 +40,19 @@ from silx.gui.plot._utils import ticklayout
 
 class TestTickLayout(ParametricTestCase):
     """Test ticks layout algorithms"""
+
+    def testTicks(self):
+        """Test of :func:`ticks`"""
+        tests = {  # (vmin, vmax): ref_ticks
+            (1., 1.): (1.,),
+            (0.5, 10.5): (2.0, 4.0, 6.0, 8.0, 10.0),
+            (0.001, 0.005): (0.001, 0.002, 0.003, 0.004, 0.005)
+            }
+
+        for (vmin, vmax), ref_ticks in tests.items():
+            with self.subTest(vmin=vmin, vmax=vmax):
+                ticks, labels = ticklayout.ticks(vmin, vmax)
+                self.assertTrue(numpy.allclose(ticks, ref_ticks))
 
     def testNiceNumbers(self):
         """Minimalistic tests of :func:`niceNumbers`"""

--- a/silx/gui/plot/_utils/ticklayout.py
+++ b/silx/gui/plot/_utils/ticklayout.py
@@ -109,7 +109,7 @@ def ticks(vMin, vMax, nbTicks=5):
     """Returns tick positions and labels using nice numbers algorithm.
 
     This enforces ticks to be within [vMin, vMax] range.
-    It returns at least 2 ticks.
+    It returns at least 1 tick (when vMin == vMax).
 
     :param float vMin: The min value on the axis
     :param float vMax: The max value on the axis
@@ -117,13 +117,19 @@ def ticks(vMin, vMax, nbTicks=5):
     :returns: tick positions and corresponding text labels
     :rtype: 2-tuple: list of float, list of string
     """
-    start, end, step, nfrac = niceNumbers(vMin, vMax, nbTicks)
-    positions = [t for t in _frange(start, end, step) if vMin <= t <= vMax]
+    assert vMin <= vMax
+    if vMin == vMax:
+        positions = [vMin]
+        nfrac = 0
 
-    # Makes sure there is at least 2 ticks
-    if len(positions) < 2:
-        positions = [vMin, vMax]
-        nfrac = numberOfDigits(vMax - vMin)
+    else:
+        start, end, step, nfrac = niceNumbers(vMin, vMax, nbTicks)
+        positions = [t for t in _frange(start, end, step) if vMin <= t <= vMax]
+
+        # Makes sure there is at least 2 ticks
+        if len(positions) < 2:
+            positions = [vMin, vMax]
+            nfrac = numberOfDigits(vMax - vMin)
 
     # Generate labels
     format_ = '%g' if nfrac == 0 else '%.{}f'.format(nfrac)


### PR DESCRIPTION
This PR makes the axis ticks layout function `ticks` works with empty range (when min==max).
This case can happen in plot3d (e.g. when displaying a single image, the axis orthogonal to the image has an empty range).
