### PR TITLE
[plot] Fix resize with keep aspect ratio not sending limits changed signal

### DIFF
--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -727,6 +727,8 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
         FigureCanvasQTAgg.__init__(self, self.fig)
         self.setParent(parent)
 
+        self._limitsBeforeResize = None
+
         FigureCanvasQTAgg.setSizePolicy(
             self, qt.QSizePolicy.Expanding, qt.QSizePolicy.Expanding)
         FigureCanvasQTAgg.updateGeometry(self)
@@ -827,8 +829,12 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
     # replot control
 
     def resizeEvent(self, event):
+        # Store current limits
+        self._limitsBeforeResize = (
+            self.ax.get_xbound(), self.ax.get_ybound(), self.ax2.get_ybound())
+
         FigureCanvasQTAgg.resizeEvent(self, event)
-        if self._overlays or self._graphCursor:
+        if self.isKeepDataAspectRatio() or self._overlays or self._graphCursor:
             # This is needed with matplotlib 1.5.x and 2.0.x
             self._plot._setDirtyPlot()
 
@@ -852,11 +858,6 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
 
         This is directly called by matplotlib for widget resize.
         """
-        # Store previous limits
-        xLimits = self.ax.get_xbound()
-        yLimits = self.ax.get_ybound()
-        yRightLimits = self.ax2.get_ybound()
-
         # Starting with mpl 2.1.0, toggling autoscale raises a ValueError
         # in some situations. See #1081, #1136, #1163,
         if matplotlib.__version__ >= "2.0.0":
@@ -876,12 +877,16 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
             self._background = None  # Reset background
 
         # Check if limits changed due to a resize of the widget
-        if xLimits != self.ax.get_xbound():
-            self._plot.getXAxis()._emitLimitsChanged()
-        if yLimits != self.ax.get_ybound():
-            self._plot.getYAxis(axis='left')._emitLimitsChanged()
-        if yRightLimits != self.ax2.get_ybound():
-            self._plot.getYAxis(axis='left')._emitLimitsChanged()
+        if self._limitsBeforeResize is not None:
+            xLimits, yLimits, yRightLimits = self._limitsBeforeResize
+            self._limitsBeforeResize = None
+
+            if xLimits != self.ax.get_xbound():
+                self._plot.getXAxis()._emitLimitsChanged()
+            if yLimits != self.ax.get_ybound():
+                self._plot.getYAxis(axis='left')._emitLimitsChanged()
+            if yRightLimits != self.ax2.get_ybound():
+                self._plot.getYAxis(axis='left')._emitLimitsChanged()
 
         self._drawOverlays()
 

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -886,7 +886,7 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
             if yLimits != self.ax.get_ybound():
                 self._plot.getYAxis(axis='left')._emitLimitsChanged()
             if yRightLimits != self.ax2.get_ybound():
-                self._plot.getYAxis(axis='left')._emitLimitsChanged()
+                self._plot.getYAxis(axis='right')._emitLimitsChanged()
 
         self._drawOverlays()
 


### PR DESCRIPTION
This issue occurs with matplotlib 1.5.x and 2.0.x but not with 1.4.2 and 2.1.0.
The moment at which matplotlib is changing the limits in the case of a resize of the widget when keeping aspect ratio of the plot is different from one version of matplotlib to another.

This patch fixes this issue by storing the limits during `resizeEvent` and checking it after redraw.
I tested it on Debian 8 with matplotlib: 1.4.2 (py2), 1.5.3 (py3), 2.0.0 (py3), 2.0.2 (py3), 2.1.0 (py3).

Closes #1330