### PR TITLE
Fix PATH when using a python in debug mode

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -23,6 +23,20 @@ logging.basicConfig()
 logger = logging.getLogger("bootstrap")
 
 
+def is_debug_python():
+    """Returns true if the Python interpreter is in debug mode."""
+    try:
+        import sysconfig
+    except ImportError:  # pragma nocover
+        # Python < 2.7
+        import distutils.sysconfig as sysconfig
+
+    if sysconfig.get_config_var("Py_DEBUG"):
+        return True
+
+    return hasattr(sys, "gettotalrefcount")
+
+
 def _distutils_dir_name(dname="lib"):
     """
     Returns the name of a distutils build directory
@@ -30,6 +44,8 @@ def _distutils_dir_name(dname="lib"):
     platform = distutils.util.get_platform()
     architecture = "%s.%s-%i.%i" % (dname, platform,
                                     sys.version_info[0], sys.version_info[1])
+    if is_debug_python():
+        architecture += "-pydebug"
     return architecture
 
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -231,6 +231,20 @@ def report_rst(cov, package, version="0.0.0", base=""):
     return os.linesep.join(res)
 
 
+def is_debug_python():
+    """Returns true if the Python interpreter is in debug mode."""
+    try:
+        import sysconfig
+    except ImportError:  # pragma nocover
+        # Python < 2.7
+        import distutils.sysconfig as sysconfig
+
+    if sysconfig.get_config_var("Py_DEBUG"):
+        return True
+
+    return hasattr(sys, "gettotalrefcount")
+
+
 def build_project(name, root_dir):
     """Run python setup.py build for the project.
 
@@ -243,6 +257,8 @@ def build_project(name, root_dir):
     platform = distutils.util.get_platform()
     architecture = "lib.%s-%i.%i" % (platform,
                                      sys.version_info[0], sys.version_info[1])
+    if is_debug_python():
+        architecture += "-pydebug"
 
     if os.environ.get("PYBUILD_NAME") == name:
         # we are in the debian packaging way


### PR DESCRIPTION
Use a "-pydebug" suffix in case of Python debug interpreter, else the synchronization is not done at the right place