### PR TITLE
0.6.1 cherry picks to master

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Beside this, we provide a certain number of wheels (pre-compiled binary packages
 onto a pre-existing Python installation:
 
 - On Windows, binary wheels are available for Python 2.7, 3.5 and 3.6.
-- On MacOS, binary wheels are available for Python 2.7, 3.4, 3.5 and 3.6.
+- On MacOS, binary wheels are available for Python 2.7, 3.5 and 3.6.
 - On Linux, manylinux1 binary wheels are available for Python 2.7, 3.4, 3.5 and 3.6.
 
 Those builds are made from "up-date" systems at the time of the release, i.e. they use

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -2,7 +2,7 @@
 Installation steps
 ==================
 
-*silx* supports `Python <https://www.python.org/>`_ versions 2.7, 3.4 and 3.5.
+*silx* supports `Python <https://www.python.org/>`_ versions 2.7, 3.4 or later.
 
 To install *silx* on Windows, read the `Windows instructions`_.
 


### PR DESCRIPTION
These are typos fixed whilereleasing 0.6.1, to be merged into the master.