### PR TITLE
[plot3d] Fix bug when cut plane is on array edges by adding offset in shader

### DIFF
--- a/silx/gui/plot3d/scene/cutplane.py
+++ b/silx/gui/plot3d/scene/cutplane.py
@@ -53,6 +53,7 @@ class ColormapMesh3D(Geometry):
     uniform mat4 transformMat;
     //uniform mat3 matrixInvTranspose;
     uniform vec3 dataScale;
+    uniform vec3 texCoordsOffset;
 
     varying vec4 vCameraPosition;
     varying vec3 vPosition;
@@ -64,7 +65,7 @@ class ColormapMesh3D(Geometry):
         vCameraPosition = transformMat * vec4(position, 1.0);
         //vNormal = matrixInvTranspose * normalize(normal);
         vPosition = position;
-        vTexCoords = dataScale * position;
+        vTexCoords = dataScale * position + texCoordsOffset;
         vNormal = normal;
         gl_Position = matrix * vec4(position, 1.0);
     }
@@ -113,6 +114,8 @@ class ColormapMesh3D(Geometry):
                                              normal=normal)
 
         self.isBackfaceVisible = True
+        self.textureOffset = 0., 0., 0.
+        """Offset to add to texture coordinates"""
 
     def setData(self, data, copy=True):
         data = numpy.array(data, copy=copy, order='C')
@@ -209,6 +212,7 @@ class ColormapMesh3D(Geometry):
         shape = self._data.shape
         scales = 1./shape[2], 1./shape[1], 1./shape[0]
         gl.glUniform3f(program.uniforms['dataScale'], *scales)
+        gl.glUniform3f(program.uniforms['texCoordsOffset'], *self.textureOffset)
 
         gl.glUniform1i(program.uniforms['data'], self._texture.texUnit)
 
@@ -281,15 +285,6 @@ class CutPlane(PlaneInGroup):
 
             contourVertices = self.contourVertices
 
-            if (self.interpolation == 'nearest' and
-                    contourVertices is not None and len(contourVertices)):
-                # Avoid cut plane co-linear with array bin edges
-                for index, normal in enumerate(((1., 0., 0.), (0., 1., 0.), (0., 0., 1.))):
-                    if (numpy.all(numpy.equal(self.plane.normal, normal)) and
-                            int(self.plane.point[index]) == self.plane.point[index]):
-                        contourVertices += self.plane.normal * 0.01  # Add an offset
-                        break
-
             if self._mesh is None and self._data is not None:
                 self._mesh = ColormapMesh3D(contourVertices,
                                             normal=self.plane.normal,
@@ -309,6 +304,23 @@ class CutPlane(PlaneInGroup):
                     self._mesh.visible = True
                     self._mesh.setAttribute('normal', self.plane.normal)
                     self._mesh.setAttribute('position', contourVertices)
+
+            needTextureOffset = False
+            if self.interpolation == 'nearest':
+                # If cut plane is co-linear with array bin edges add texture offset
+                planePt = self.plane.point
+                for index, normal in enumerate(((1., 0., 0.),
+                                                (0., 1., 0.),
+                                                (0., 0., 1.))):
+                    if (numpy.all(numpy.equal(self.plane.normal, normal)) and
+                            int(planePt[index]) == planePt[index]):
+                        needTextureOffset = True
+                        break
+
+            if needTextureOffset:
+                self._mesh.textureOffset = self.plane.normal * 1e-6
+            else:
+                self._mesh.textureOffset = 0., 0., 0.
 
         super(CutPlane, self).prepareGL2(ctx)
 


### PR DESCRIPTION
This PR fixes a bug with scalar field view cut plane with nearest interpolation.
The offset to avoid texture glitches is now applied in the vertex shader rather than on the vertices.
It does not accumulate anymore.

Closes #1340