### PR TITLE
Fix qt5 tests

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -28,7 +28,6 @@ environment:
         # Python 3.6
         - PYTHON_DIR: "C:\\Python36-x64"
           QT_BINDING: "PyQt5"
-          QT_PINNED_VERSION: "==5.8.2"
           WITH_GL_TEST: True
 
         # Python 2.7
@@ -85,7 +84,7 @@ before_test:
     - pip install --pre -r requirements.txt
 
     # Install selected Qt binding
-    - "pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ %QT_BINDING%%QT_PINNED_VERSION%"
+    - "pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ %QT_BINDING%"
 
     # Install the generated wheel package to test it
     # Make sure silx does not come from cache or pypi

--- a/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/silx/gui/hdf5/Hdf5TreeModel.py
@@ -130,7 +130,6 @@ class LoadingItemRunnable(qt.QRunnable):
         item = Hdf5Item(text=text, obj=h5obj, parent=oldItem.parent, populateAll=True)
         return item
 
-    @qt.Slot()
     def run(self):
         """Process the file loading. The worker is used as holder
         of the data and the signal. The result is sent as a signal.

--- a/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/silx/gui/hdf5/Hdf5TreeModel.py
@@ -587,6 +587,9 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
             row = self.__root.childCount()
         self.insertNode(row, Hdf5Item(text=text, obj=h5pyObject, parent=self.__root))
 
+    def hasPendingOperations(self):
+        return len(self.__runnerSet) > 0
+
     def insertFileAsync(self, filename, row=-1):
         if not os.path.isfile(filename):
             raise IOError("Filename '%s' must be a file path" % filename)

--- a/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/silx/gui/hdf5/Hdf5TreeModel.py
@@ -599,9 +599,9 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         # start loading the real one
         runnable = LoadingItemRunnable(filename, item)
         runnable.itemReady.connect(self.__itemReady)
-        self.__runnerSet.add(runnable)
         runnable.runnerFinished.connect(self.__releaseRunner)
-        qt.QThreadPool.globalInstance().start(runnable)
+        self.__runnerSet.add(runnable)
+        qt.silxGlobalThreadPool().start(runnable)
 
     def __releaseRunner(self, runner):
         self.__runnerSet.remove(runner)

--- a/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/silx/gui/hdf5/Hdf5TreeModel.py
@@ -282,6 +282,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         self.__root.removeChildAtIndex(row)
         self.endRemoveRows()
         if newItem is not None:
+            rootIndex = qt.QModelIndex()
             self.__openedFiles.append(newItem.obj)
             self.beginInsertRows(rootIndex, row, row)
             self.__root.insertChild(row, newItem)

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -69,6 +69,14 @@ class TestHdf5TreeModel(TestCaseQt):
         if h5py is None:
             self.skipTest("h5py is not available")
 
+    def waitForPendingOperations(self, model):
+        for i in range(10):
+            if not model.hasPendingOperations():
+                break
+            self.qWait(10)
+        else:
+            raise RuntimeError("Still waiting for a pending operation")
+
     @contextmanager
     def h5TempFile(self):
         # create tmp file
@@ -120,8 +128,8 @@ class TestHdf5TreeModel(TestCaseQt):
                 self.assertEquals(model.rowCount(qt.QModelIndex()), 0)
                 model.insertFileAsync(filename)
                 index = model.index(0, 0, qt.QModelIndex())
-                self.assertIsInstance(model.nodeFromIndex(index), hdf5.Hdf5Item.Hdf5LoadingItem)
-                self.qWait(0.2)
+                self.assertIsInstance(model.nodeFromIndex(index), hdf5.Hdf5LoadingItem.Hdf5LoadingItem)
+                self.waitForPendingOperations(model)
                 index = model.index(0, 0, qt.QModelIndex())
                 self.assertIsInstance(model.nodeFromIndex(index), hdf5.Hdf5Item.Hdf5Item)
             finally:

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -115,21 +115,17 @@ class TestHdf5TreeModel(TestCaseQt):
 
     def testInsertFilenameAsync(self):
         with self.h5TempFile() as filename:
-            model = hdf5.Hdf5TreeModel()
-            self.assertEquals(model.rowCount(qt.QModelIndex()), 0)
-            model.insertFileAsync(filename)
-            index = model.index(0, 0, qt.QModelIndex())
-            self.assertIsInstance(model.nodeFromIndex(index), hdf5.Hdf5LoadingItem.Hdf5LoadingItem)
-            time.sleep(0.1)
-            self.qapp.processEvents()
-            time.sleep(0.1)
-            index = model.index(0, 0, qt.QModelIndex())
-            self.assertIsInstance(model.nodeFromIndex(index), hdf5.Hdf5Item.Hdf5Item)
-            self.assertEquals(model.rowCount(qt.QModelIndex()), 1)
-            # clean up
-            index = model.index(0, 0, qt.QModelIndex())
-            h5File = model.data(index, hdf5.Hdf5TreeModel.H5PY_OBJECT_ROLE)
-            h5File.close()
+            try:
+                model = hdf5.Hdf5TreeModel()
+                self.assertEquals(model.rowCount(qt.QModelIndex()), 0)
+                model.insertFileAsync(filename)
+                index = model.index(0, 0, qt.QModelIndex())
+                self.assertIsInstance(model.nodeFromIndex(index), hdf5.Hdf5Item.Hdf5LoadingItem)
+                self.qWait(0.2)
+                index = model.index(0, 0, qt.QModelIndex())
+                self.assertIsInstance(model.nodeFromIndex(index), hdf5.Hdf5Item.Hdf5Item)
+            finally:
+                model = None
 
     def testInsertObject(self):
         h5 = commonh5.File("/foo/bar/1.mock", "w")

--- a/silx/gui/icons.py
+++ b/silx/gui/icons.py
@@ -328,7 +328,8 @@ def getQIcon(name):
     """
     if name not in _cached_icons:
         qfile = getQFile(name)
-        icon = qt.QIcon(qfile.fileName())
+        pixmap = qt.QPixmap(qfile.fileName())
+        icon = qt.QIcon(pixmap)
         _cached_icons[name] = icon
     else:
         icon = _cached_icons[name]

--- a/silx/gui/qt/_utils.py
+++ b/silx/gui/qt/_utils.py
@@ -30,15 +30,15 @@ __license__ = "MIT"
 __date__ = "30/11/2016"
 
 import sys
-from ._qt import BINDING, QImageReader
+from . import _qt as qt
 
 
 def supportedImageFormats():
     """Return a set of string of file format extensions supported by the
     Qt runtime."""
-    if sys.version_info[0] < 3 or BINDING == 'PySide':
+    if sys.version_info[0] < 3 or qt.BINDING == 'PySide':
         convert = str
     else:
         convert = lambda data: str(data, 'ascii')
-    formats = QImageReader.supportedImageFormats()
+    formats = qt.QImageReader.supportedImageFormats()
     return set([convert(data) for data in formats])

--- a/silx/gui/qt/_utils.py
+++ b/silx/gui/qt/_utils.py
@@ -42,3 +42,19 @@ def supportedImageFormats():
         convert = lambda data: str(data, 'ascii')
     formats = qt.QImageReader.supportedImageFormats()
     return set([convert(data) for data in formats])
+
+
+__globalThreadPoolInstance = None
+"""Store the own silx global thread pool"""
+
+
+def silxGlobalThreadPool():
+    """"Manage an own QThreadPool to avoid issue on Qt5 Windows with the
+    default Qt global thread pool.
+
+    :rtype: qt.QThreadPool
+    """
+    global __globalThreadPoolInstance
+    if __globalThreadPoolInstance is  None:
+        __globalThreadPoolInstance = qt.QThreadPool()
+    return __globalThreadPoolInstance

--- a/silx/gui/qt/_utils.py
+++ b/silx/gui/qt/_utils.py
@@ -56,5 +56,8 @@ def silxGlobalThreadPool():
     """
     global __globalThreadPoolInstance
     if __globalThreadPoolInstance is  None:
-        __globalThreadPoolInstance = qt.QThreadPool()
+        tp = qt.QThreadPool()
+        # This pointless command fixes a segfault with PyQt 5.9.1 on Windows
+        tp.setMaxThreadCount(tp.maxThreadCount())
+        __globalThreadPoolInstance = tp
     return __globalThreadPoolInstance

--- a/silx/gui/widgets/ThreadPoolPushButton.py
+++ b/silx/gui/widgets/ThreadPoolPushButton.py
@@ -201,7 +201,7 @@ class ThreadPoolPushButton(WaitingPushButton):
             return
         self.__runnerStarted()
         runner = self._createRunner(self.__callable, self.__args, self.__kwargs)
-        qt.QThreadPool.globalInstance().start(runner)
+        qt.silxGlobalThreadPool().start(runner)
         self.__runnerSet.add(runner)
 
     def __releaseRunner(self, runner):

--- a/silx/gui/widgets/ThreadPoolPushButton.py
+++ b/silx/gui/widgets/ThreadPoolPushButton.py
@@ -207,6 +207,9 @@ class ThreadPoolPushButton(WaitingPushButton):
     def __releaseRunner(self, runner):
         self.__runnerSet.remove(runner)
 
+    def hasPendingOperations(self):
+        return len(self.__runnerSet) > 0
+
     def _createRunner(self, function, args, kwargs):
         """Create a QRunnable from a callable object.
 

--- a/silx/gui/widgets/test/test_threadpoolpushbutton.py
+++ b/silx/gui/widgets/test/test_threadpoolpushbutton.py
@@ -44,6 +44,14 @@ class TestThreadPoolPushButton(TestCaseQt):
         super(TestThreadPoolPushButton, self).setUp()
         self._result = []
 
+    def waitForPendingOperations(self, object):
+        for i in range(50):
+            if not object.hasPendingOperations():
+                break
+            self.qWait(10)
+        else:
+            raise RuntimeError("Still waiting for a pending operation")
+
     def _trace(self, name, delay=0):
         self._result.append(name)
         if delay != 0:
@@ -61,7 +69,7 @@ class TestThreadPoolPushButton(TestCaseQt):
         button.executeCallable()
         time.sleep(0.1)
         self.assertListEqual(self._result, ["a"])
-        self.qapp.processEvents()
+        self.waitForPendingOperations(button)
 
     def testMultiExecution(self):
         button = ThreadPoolPushButton()
@@ -69,9 +77,8 @@ class TestThreadPoolPushButton(TestCaseQt):
         number = qt.QThreadPool.globalInstance().maxThreadCount() * 2
         for _ in range(number):
             button.executeCallable()
-        time.sleep(number * 0.01 + 0.1)
+        self.waitForPendingOperations(button)
         self.assertListEqual(self._result, ["a"] * number)
-        self.qapp.processEvents()
 
     def testSaturateThreadPool(self):
         button = ThreadPoolPushButton()
@@ -79,9 +86,8 @@ class TestThreadPoolPushButton(TestCaseQt):
         number = qt.QThreadPool.globalInstance().maxThreadCount() * 2
         for _ in range(number):
             button.executeCallable()
-        time.sleep(number * 0.1 + 0.1)
+        self.waitForPendingOperations(button)
         self.assertListEqual(self._result, ["a"] * number)
-        self.qapp.processEvents()
 
     def testSuccess(self):
         listener = SignalListener()

--- a/silx/gui/widgets/test/test_threadpoolpushbutton.py
+++ b/silx/gui/widgets/test/test_threadpoolpushbutton.py
@@ -74,7 +74,7 @@ class TestThreadPoolPushButton(TestCaseQt):
     def testMultiExecution(self):
         button = ThreadPoolPushButton()
         button.setCallable(self._trace, "a", 0)
-        number = qt.QThreadPool.globalInstance().maxThreadCount() * 2
+        number = qt.QThreadPool.globalInstance().maxThreadCount()
         for _ in range(number):
             button.executeCallable()
         self.waitForPendingOperations(button)


### PR DESCRIPTION
Last Qt 5.9.[1-2] segfault in some cases in Windows
- If you reuse more than one time index generated by `createIndex`
- If you use the global thread pool provided by Qt
- You have to explicitly set the max thread of the thread pool
- You must not use `Qt.QIcon(filename=)` (you have to use an intermediate pixmap)

This PR:
- creates a `qt.silxGlobalThreadPool` to avoid to use the one from Qt
- Clean up the Hdf5Model and tests to avoid to reuse indexes on a sequence of methods

Both problem looks anyway to be an issue relative to PyQt5. And it should be fixed there. I stiil have to send a feed back to the PyQt mailing list.

Close #936