### PR TITLE
[plot] Improve marker implementation in matplotlib backend

### DIFF
--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -189,7 +189,7 @@ class BackendBase(object):
 
     def addMarker(self, x, y, legend, text, color,
                   selectable, draggable,
-                  symbol, constraint, overlay):
+                  symbol, constraint):
         """Add a point, vertical line or horizontal line marker to the plot.
 
         :param float x: Horizontal position of the marker in graph coordinates.
@@ -221,9 +221,6 @@ class BackendBase(object):
         :type constraint: None or a callable that takes the coordinates of
                           the current cursor position in the plot as input
                           and that returns the filtered coordinates.
-        :param bool overlay: True if marker is an overlay (Default: False).
-                             This allows for rendering optimization if this
-                             marker is changed often.
         :return: Handle used by the backend to univocally access the marker
         """
         return legend

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -443,6 +443,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
         if overlay:
             line.set_animated(True)
+            if hasattr(line, '_infoText'):
+                line._infoText.set_animated(True)
             self._overlays.add(line)
 
         return line
@@ -846,6 +848,8 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
             # This assume that items are only on left/bottom Axes
             for item in self._overlays:
                 self.ax.draw_artist(item)
+                if hasattr(item, "_infoText"):  # For markers text
+                    self.ax.draw_artist(item._infoText)
 
             for item in self._graphCursor:
                 self.ax.draw_artist(item)

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -380,7 +380,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
     def addMarker(self, x, y, legend, text, color,
                   selectable, draggable,
-                  symbol, constraint, overlay):
+                  symbol, constraint):
         legend = "__MARKER__" + legend
 
         xmin, xmax = self.getGraphXLimits()

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -498,8 +498,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
         return container
 
     def _updateMarkers(self):
-        xmin, xmax = self.getGraphXLimits()
-        ymin, ymax = self.getGraphYLimits(axis='left')
+        xmin, xmax = self.ax.get_xbound()
+        ymin, ymax = self.ax.get_ybound()
         for item in self._overlays:
             if isinstance(item, _MarkerContainer):
                 item.updateMarkerText(xmin, xmax, ymin, ymax)

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -394,17 +394,13 @@ class BackendMatplotlib(BackendBase.BackendBase):
                                 markersize=10.)[-1]
 
             if text is not None and xmin <= x <= xmax and ymin <= y <= ymax:
-                xtmp, ytmp = self.ax.transData.transform_point((x, y))
-                inv = self.ax.transData.inverted()
-                xtmp, ytmp = inv.transform_point((xtmp, ytmp))
-
                 if symbol is None:
                     valign = 'baseline'
                 else:
                     valign = 'top'
                     text = "  " + text
 
-                line._infoText = self.ax.text(x, ytmp, text,
+                line._infoText = self.ax.text(x, y, text,
                                               color=color,
                                               horizontalalignment='left',
                                               verticalalignment=valign)

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -383,6 +383,9 @@ class BackendMatplotlib(BackendBase.BackendBase):
                   symbol, constraint, overlay):
         legend = "__MARKER__" + legend
 
+        xmin, xmax = self.getGraphXLimits()
+        ymin, ymax = self.getGraphYLimits(axis='left')
+
         if x is not None and y is not None:
             line = self.ax.plot(x, y, label=legend,
                                 linestyle=" ",
@@ -390,7 +393,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                                 marker=symbol,
                                 markersize=10.)[-1]
 
-            if text is not None:
+            if text is not None and xmin <= x <= xmax and ymin <= y <= ymax:
                 xtmp, ytmp = self.ax.transData.transform_point((x, y))
                 inv = self.ax.transData.inverted()
                 xtmp, ytmp = inv.transform_point((xtmp, ytmp))
@@ -408,9 +411,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
         elif x is not None:
             line = self.ax.axvline(x, label=legend, color=color)
-            if text is not None:
+            if text is not None and xmin <= x <= xmax:
                 text = " " + text
-                ymin, ymax = self.getGraphYLimits(axis='left')
                 delta = abs(ymax - ymin)
                 if ymin > ymax:
                     ymax = ymin
@@ -423,9 +425,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
         elif y is not None:
             line = self.ax.axhline(y, label=legend, color=color)
 
-            if text is not None:
+            if text is not None and ymin <= y <= ymax:
                 text = " " + text
-                xmin, xmax = self.getGraphXLimits()
                 delta = abs(xmax - xmin)
                 if xmin > xmax:
                     xmax = xmin
@@ -441,11 +442,11 @@ class BackendMatplotlib(BackendBase.BackendBase):
         if selectable or draggable:
             line.set_picker(5)
 
-        if overlay:
-            line.set_animated(True)
-            if hasattr(line, '_infoText'):
-                line._infoText.set_animated(True)
-            self._overlays.add(line)
+        # All markers are overlays
+        line.set_animated(True)
+        if hasattr(line, '_infoText'):
+            line._infoText.set_animated(True)
+        self._overlays.add(line)
 
         return line
 

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1110,8 +1110,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
     def addMarker(self, x, y, legend, text, color,
                   selectable, draggable,
-                  symbol, constraint, overlay):
-        # TODO handle overlay
+                  symbol, constraint):
 
         if symbol is None:
             symbol = '+'

--- a/silx/gui/plot/items/marker.py
+++ b/silx/gui/plot/items/marker.py
@@ -69,8 +69,7 @@ class _BaseMarker(Item, DraggableMixIn, ColorMixIn):
             selectable=self.isSelectable(),
             draggable=self.isDraggable(),
             symbol=symbol,
-            constraint=self.getConstraint(),
-            overlay=self.isOverlay())
+            constraint=self.getConstraint())
 
     def isOverlay(self):
         """Return true if marker is drawn as an overlay.


### PR DESCRIPTION
This PR improves matplotlib plot backend marker text support:

- Closes #1348: Marker text does not move with marker 
- Hides marker text when marker is not visible in the plot area
- Update line marker text position when plot limits change
- Refactor marker in the backend
- Remove unused overlay argument in backend addMarker