### PR TITLE
[plot3d] Fix isosurface level editor in parameter tree widget

### DIFF
--- a/silx/gui/plot3d/SFViewParamTree.py
+++ b/silx/gui/plot3d/SFViewParamTree.py
@@ -102,7 +102,7 @@ class SubjectItem(qt.QStandardItem):
         Overloaded method from QStandardItem. The pushData keyword tells
         the item to push data to the subject if the role is equal to EditRole.
         This is useful to let this method know if the setData method was called
-        internaly or from the view.
+        internally or from the view.
 
         :param value: the value ti set to data
         :param role: role in the item
@@ -559,8 +559,16 @@ class IsoSurfaceLevelItem(SubjectItem):
         return [subject.sigLevelChanged,
                 subject.sigVisibilityChanged]
 
+    def getEditor(self, parent, option, index):
+        return FloatEdit(parent)
+
     def setEditorData(self, editor):
+        editor.setValue(self._pullData())
         return False
+
+    def _setModelData(self, editor):
+        self._pushData(editor.value())
+        return True
 
     def _pullData(self):
         return self.subject.getLevel()


### PR DESCRIPTION
This PR allows to set any value for isosurface level from the parameter tree widget rather than limiting resolution to 10e-2.

closes #1280