### PR TITLE
[plot3d] Update plot3d sample code documentation

### DIFF
--- a/doc/source/modules/gui/gallery.rst
+++ b/doc/source/modules/gui/gallery.rst
@@ -200,7 +200,6 @@ Additional widgets:
           :align: center
      - :class:`ScalarFieldView` is a :class:`Plot3DWindow` dedicated to display 3D scalar field.
        It can display iso-surfaces and an interactive cutting plane.
-       Sample code: :doc:`plot3d/viewer3dvolume_example`.
    * - .. image:: plot3d/img/Plot3DWindow.png
           :height: 150px
           :align: center
@@ -216,7 +215,7 @@ Additional widgets:
          :align: center
      - :class:`SFViewParamTree` is a :class:`QTreeView` widget that can be attached to a :class:`ScalarFieldView`.
        It displays current parameters of the :class:`ScalarFieldView` and allows to modify it.
-       Sample code: :doc:`plot3d/viewer3dvolume_example`.
+       See :ref:`plot3d-sample-code`.
 
 
 :mod:`silx.gui.widgets` Widgets

--- a/doc/source/modules/gui/plot3d/index.rst
+++ b/doc/source/modules/gui/plot3d/index.rst
@@ -32,7 +32,7 @@ The following sub-modules are available:
 Sample code
 -----------
 
-- :doc:`viewer3dvolume_example`: Sample code using :class:`ScalarFieldView`
+See :ref:`plot3d-sample-code`
 
 Internals
 ---------

--- a/doc/source/modules/gui/plot3d/scalarfieldview.rst
+++ b/doc/source/modules/gui/plot3d/scalarfieldview.rst
@@ -5,7 +5,7 @@
 
 .. automodule:: silx.gui.plot3d.ScalarFieldView
 
-For sample code using ScalarFieldView, see :doc:`viewer3dvolume_example`
+For sample code using ScalarFieldView, see :ref:`plot3d-sample-code`
 
 .. currentmodule:: silx.gui.plot3d.ScalarFieldView
 

--- a/doc/source/modules/gui/plot3d/viewer3dvolume_example.rst
+++ b/doc/source/modules/gui/plot3d/viewer3dvolume_example.rst
@@ -1,7 +1,0 @@
-viewer3DVolume.py
-=================
-
-Sample code demonstrating :mod:`silx.gui.plot3d.ScalarFieldView` widget:
-
-.. literalinclude:: ../../../../../examples/viewer3DVolume.py
-   :lines: 38-

--- a/doc/source/sample_code/index.rst
+++ b/doc/source/sample_code/index.rst
@@ -198,6 +198,8 @@ All sample codes can be downloaded as a zip file: |sample_code_archive|.
      - This script is an example to illustrate how to use axis synchronization
        tool.
 
+.. _plot3d-sample-code:
+
 :mod:`silx.gui.plot3d` sample code
 ++++++++++++++++++++++++++++++++++
 


### PR DESCRIPTION
This PR removes the sample code available from silx.gui.plot3d module documentation page.
It was duplicating the sample code gallery.