### PR TITLE
[SaveAction] Axis labels when saving multiple curves as SPEC.

### DIFF
--- a/silx/gui/plot/actions/io.py
+++ b/silx/gui/plot/actions/io.py
@@ -226,11 +226,13 @@ class SaveAction(PlotAction):
         curve = curves[0]
         scanno = 1
         try:
+            xlabel = curve.getXLabel() or self.plot.getGraphXlabel()
+            ylabel = curve.getYLabel() or self.plot.getGraphYlabel(curve.getYAxis())
             specfile = savespec(filename,
                                 curve.getXData(copy=False),
                                 curve.getYData(copy=False),
-                                curve.getXLabel(),
-                                curve.getYLabel(),
+                                xlabel,
+                                ylabel,
                                 fmt="%.7g", scan_number=1, mode="w",
                                 write_file_header=True,
                                 close_file=False)
@@ -241,12 +243,14 @@ class SaveAction(PlotAction):
         for curve in curves[1:]:
             try:
                 scanno += 1
+                xlabel = curve.getXLabel() or self.plot.getGraphXlabel()
+                ylabel = curve.getYLabel() or self.plot.getGraphYlabel(curve.getYAxis())
                 specfile = savespec(specfile,
                                     curve.getXData(copy=False),
                                     curve.getYData(copy=False),
-                                    curve.getXLabel(),
-                                    curve.getYLabel(),
-                                    fmt="%.7g", scan_number=scanno, mode="w",
+                                    xlabel,
+                                    ylabel,
+                                    fmt="%.7g", scan_number=scanno,
                                     write_file_header=False,
                                     close_file=False)
             except IOError:

--- a/silx/gui/plot/actions/io.py
+++ b/silx/gui/plot/actions/io.py
@@ -226,8 +226,8 @@ class SaveAction(PlotAction):
         curve = curves[0]
         scanno = 1
         try:
-            xlabel = curve.getXLabel() or self.plot.getGraphXlabel()
-            ylabel = curve.getYLabel() or self.plot.getGraphYlabel(curve.getYAxis())
+            xlabel = curve.getXLabel() or self.plot.getGraphXLabel()
+            ylabel = curve.getYLabel() or self.plot.getGraphYLabel(curve.getYAxis())
             specfile = savespec(filename,
                                 curve.getXData(copy=False),
                                 curve.getYData(copy=False),
@@ -243,8 +243,8 @@ class SaveAction(PlotAction):
         for curve in curves[1:]:
             try:
                 scanno += 1
-                xlabel = curve.getXLabel() or self.plot.getGraphXlabel()
-                ylabel = curve.getYLabel() or self.plot.getGraphYlabel(curve.getYAxis())
+                xlabel = curve.getXLabel() or self.plot.getGraphXLabel()
+                ylabel = curve.getYLabel() or self.plot.getGraphYLabel(curve.getYAxis())
                 specfile = savespec(specfile,
                                     curve.getXData(copy=False),
                                     curve.getYData(copy=False),

--- a/silx/gui/plot/test/__init__.py
+++ b/silx/gui/plot/test/__init__.py
@@ -24,7 +24,7 @@
 # ###########################################################################*/
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "04/08/2017"
+__date__ = "28/11/2017"
 
 
 import unittest
@@ -52,6 +52,7 @@ from . import testUtilsAxis
 from . import testLimitConstraints
 from . import testComplexImageView
 from . import testImageView
+from . import testSaveAction
 
 
 def suite():
@@ -79,5 +80,6 @@ def suite():
          testUtilsAxis.suite(),
          testLimitConstraints.suite(),
          testComplexImageView.suite(),
-         testImageView.suite()])
+         testImageView.suite(),
+         testSaveAction.suite()])
     return test_suite

--- a/silx/gui/plot/test/testSaveAction.py
+++ b/silx/gui/plot/test/testSaveAction.py
@@ -1,0 +1,97 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Test the plot's save action (consistency of output)"""
+
+__authors__ = ["P. Knobel"]
+__license__ = "MIT"
+__date__ = "28/11/2011"
+
+
+import unittest
+import tempfile
+import os
+
+from silx.gui.plot import PlotWidget
+from silx.gui.plot.actions.io import SaveAction
+
+
+class TestSaveAction(unittest.TestCase):
+
+    def setUp(self):
+        self.plot = PlotWidget(backend='none')
+        self.saveAction = SaveAction(plot=self.plot)
+
+        self.tempdir = tempfile.mkdtemp()
+        self.out_fname = os.path.join(self.tempdir, "out.dat")
+
+    def tearDown(self):
+        os.unlink(self.out_fname)
+        os.rmdir(self.tempdir)
+
+    def testSaveMultipleCurvesAsSpec(self):
+        """Test that labels are properly used."""
+        self.plot.setGraphXLabel("graph x label")
+        self.plot.setGraphYLabel("graph y label")
+
+        self.plot.addCurve([0, 1], [1, 2], "curve with labels",
+                           xlabel="curve0 X", ylabel="curve0 Y")
+        self.plot.addCurve([-1, 3], [-6, 2], "curve with X label",
+                           xlabel="curve1 X")
+        self.plot.addCurve([-2, 0], [8, 12], "curve with Y label",
+                           ylabel="curve2 Y")
+        self.plot.addCurve([3, 1], [7, 6], "curve with no labels")
+
+        self.saveAction._saveCurves(self.out_fname,
+                                    SaveAction.ALL_CURVES_FILTERS[0])  # "All curves as SpecFile (*.dat)"
+
+        with open(self.out_fname, "rb") as f:
+            file_content = f.read()
+            if hasattr(file_content, "decode"):
+                file_content = file_content.decode()
+
+            # case with all curve labels specified
+            self.assertIn("#S 1 curve0 Y", file_content)
+            self.assertIn("#L curve0 X  curve0 Y", file_content)
+
+            # graph X&Y labels are used when no curve label is specified
+            self.assertIn("#S 2 graph y label", file_content)
+            self.assertIn("#L curve0 X  curve0 Y", file_content)
+
+            self.assertIn("#S 3 curve2 Y", file_content)
+            self.assertIn("#L graph x label  curve2 Y", file_content)
+
+            self.assertIn("#S 4 graph y label", file_content)
+            self.assertIn("#L graph x label  graph y label", file_content)
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    test_suite.addTest(
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestSaveAction))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/silx/gui/plot/test/testSaveAction.py
+++ b/silx/gui/plot/test/testSaveAction.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "28/11/2011"
+__date__ = "28/11/2017"
 
 
 import unittest


### PR DESCRIPTION
When a curve does not define a specific label for an axis, use the graph label instead of None.

This was already done for saving single curves as SPEC.