### PR TITLE
[NXdataView] Fix issues with non unique axis labels

### DIFF
--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -1055,7 +1055,7 @@ class _NXdataImageView(DataView):
     def setData(self, data):
         data = self.normalizeData(data)
         nxd = NXdata(data)
-        signal_name = get_attr_as_string(data, "signal")
+        signal_name = nxd.signal_name
         group_name = data.name
         y_axis, x_axis = nxd.axes[-2:]
         y_label, x_label = nxd.axes_names[-2:]
@@ -1096,7 +1096,7 @@ class _NXdataStackView(DataView):
     def setData(self, data):
         data = self.normalizeData(data)
         nxd = NXdata(data)
-        signal_name = get_attr_as_string(data, "signal")
+        signal_name = nxd.signal_name
         group_name = data.name
         z_axis, y_axis, x_axis = nxd.axes[-3:]
         z_label, y_label, x_label = nxd.axes_names[-3:]

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -964,9 +964,12 @@ class _NXdataCurveView(DataView):
         else:
             x_errors = None
 
+        x_id = nxd.axes_dataset_names[-1]
+
         self.getWidget().setCurveData(nxd.signal, nxd.axes[-1],
                                       yerror=nxd.errors, xerror=x_errors,
                                       ylabel=signal_name, xlabel=nxd.axes_names[-1],
+                                      x_id=x_id,
                                       title="NXdata group " + group_name)
 
     def getDataPriority(self, data, info):
@@ -1020,9 +1023,12 @@ class _NXdataXYVScatterView(DataView):
         else:
             y_errors = None
 
+        y_id, x_id = nxd.axes_dataset_names[-2:]
+
         self.getWidget().setCurveData(y_axis, x_axis, values=nxd.signal,
                                       yerror=y_errors, xerror=x_errors,
                                       ylabel=signal_name, xlabel=x_label,
+                                      y_id=y_id, x_id=x_id,
                                       title="NXdata group " + group_name)
 
     def getDataPriority(self, data, info):
@@ -1058,10 +1064,12 @@ class _NXdataImageView(DataView):
         group_name = data.name
         y_axis, x_axis = nxd.axes[-2:]
         y_label, x_label = nxd.axes_names[-2:]
+        y_id, x_id = nxd.axes_dataset_names[-2:]
 
         self.getWidget().setImageData(
                      nxd.signal, x_axis=x_axis, y_axis=y_axis,
                      signal_name=signal_name, xlabel=x_label, ylabel=y_label,
+                     x_id=x_id, y_id=y_id,
                      title="NXdata group %s: %s" % (group_name, signal_name))
 
     def getDataPriority(self, data, info):
@@ -1099,9 +1107,11 @@ class _NXdataStackView(DataView):
         group_name = data.name
         z_axis, y_axis, x_axis = nxd.axes[-3:]
         z_label, y_label, x_label = nxd.axes_names[-3:]
+        z_id, y_id, x_id = nxd.axes_dataset_names[-3:]
 
         self.getWidget().setStackData(
                      nxd.signal, x_axis=x_axis, y_axis=y_axis, z_axis=z_axis,
+                     x_id=x_id, y_id=y_id, z_id=z_id,
                      signal_name=signal_name,
                      xlabel=x_label, ylabel=y_label, zlabel=z_label,
                      title="NXdata group %s: %s" % (group_name, signal_name))

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -957,7 +957,7 @@ class _NXdataCurveView(DataView):
     def setData(self, data):
         data = self.normalizeData(data)
         nxd = NXdata(data)
-        signal_name = get_attr_as_string(data, "signal")
+        signal_name = nxd.signal_name
         group_name = data.name
         if nxd.axes_dataset_names[-1] is not None:
             x_errors = nxd.get_axis_errors(nxd.axes_dataset_names[-1])

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -1007,7 +1007,7 @@ class _NXdataXYVScatterView(DataView):
     def setData(self, data):
         data = self.normalizeData(data)
         nxd = NXdata(data)
-        signal_name = get_attr_as_string(data, "signal")
+        signal_name = nxd.signal_name
         # signal_errors = nx.errors   # not supported
         group_name = data.name
         x_axis, y_axis = nxd.axes[-2:]
@@ -1027,9 +1027,10 @@ class _NXdataXYVScatterView(DataView):
 
         self.getWidget().setCurveData(y_axis, x_axis, values=nxd.signal,
                                       yerror=y_errors, xerror=x_errors,
-                                      ylabel=signal_name, xlabel=x_label,
+                                      ylabel=y_label, xlabel=x_label,
                                       y_id=y_id, x_id=x_id,
-                                      title="NXdata group " + group_name)
+                                      title="NXdata group " + group_name +
+                                            ", coloured by " + signal_name)
 
     def getDataPriority(self, data, info):
         data = self.normalizeData(data)

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -964,12 +964,9 @@ class _NXdataCurveView(DataView):
         else:
             x_errors = None
 
-        x_id = nxd.axes_dataset_names[-1]
-
         self.getWidget().setCurveData(nxd.signal, nxd.axes[-1],
                                       yerror=nxd.errors, xerror=x_errors,
                                       ylabel=signal_name, xlabel=nxd.axes_names[-1],
-                                      x_id=x_id,
                                       title="NXdata group " + group_name)
 
     def getDataPriority(self, data, info):
@@ -1023,12 +1020,9 @@ class _NXdataXYVScatterView(DataView):
         else:
             y_errors = None
 
-        y_id, x_id = nxd.axes_dataset_names[-2:]
-
         self.getWidget().setCurveData(y_axis, x_axis, values=nxd.signal,
                                       yerror=y_errors, xerror=x_errors,
                                       ylabel=y_label, xlabel=x_label,
-                                      y_id=y_id, x_id=x_id,
                                       title="NXdata group " + group_name +
                                             ", coloured by " + signal_name)
 
@@ -1065,12 +1059,10 @@ class _NXdataImageView(DataView):
         group_name = data.name
         y_axis, x_axis = nxd.axes[-2:]
         y_label, x_label = nxd.axes_names[-2:]
-        y_id, x_id = nxd.axes_dataset_names[-2:]
 
         self.getWidget().setImageData(
                      nxd.signal, x_axis=x_axis, y_axis=y_axis,
                      signal_name=signal_name, xlabel=x_label, ylabel=y_label,
-                     x_id=x_id, y_id=y_id,
                      title="NXdata group %s: %s" % (group_name, signal_name))
 
     def getDataPriority(self, data, info):
@@ -1108,11 +1100,9 @@ class _NXdataStackView(DataView):
         group_name = data.name
         z_axis, y_axis, x_axis = nxd.axes[-3:]
         z_label, y_label, x_label = nxd.axes_names[-3:]
-        z_id, y_id, x_id = nxd.axes_dataset_names[-3:]
 
         self.getWidget().setStackData(
                      nxd.signal, x_axis=x_axis, y_axis=y_axis, z_axis=z_axis,
-                     x_id=x_id, y_id=y_id, z_id=z_id,
                      signal_name=signal_name,
                      xlabel=x_label, ylabel=y_label, zlabel=z_label,
                      title="NXdata group %s: %s" % (group_name, signal_name))

--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -96,7 +96,6 @@ class ArrayCurvePlot(qt.QWidget):
     def setCurveData(self, y, x=None, values=None,
                      yerror=None, xerror=None,
                      ylabel=None, xlabel=None,
-                     y_id=None, x_id=None,
                      title=None):
         """
 
@@ -115,8 +114,6 @@ class ArrayCurvePlot(qt.QWidget):
         :param xerror: 1-D dataset of errors for x, or None
         :param ylabel: Label for Y axis
         :param xlabel: Label for X axis
-        :param str y_id: Unique name for Y axis.
-        :param str x_id: Unique name for X axis.
         :param title: Graph title
         """
         self.__signal = y
@@ -131,7 +128,7 @@ class ArrayCurvePlot(qt.QWidget):
             self._selector.selectionChanged.disconnect(self._updateCurve)
             self.__selector_is_connected = False
         self._selector.setData(y)
-        self._selector.setAxisNames([y_id or "Y"])
+        self._selector.setAxisNames(["Y"])
 
         if len(y.shape) < 2:
             self.selectorDock.hide()
@@ -250,7 +247,6 @@ class ArrayImagePlot(qt.QWidget):
                      x_axis=None, y_axis=None,
                      signal_name=None,
                      xlabel=None, ylabel=None,
-                     x_id=None, y_id=None,
                      title=None):
         """
 
@@ -265,8 +261,6 @@ class ArrayImagePlot(qt.QWidget):
         :param signal_name: Label used in the legend
         :param xlabel: Label for X axis
         :param ylabel: Label for Y axis
-        :param str x_id: Unique name for X axis.
-        :param str y_id: Unique name for Y axis.
         :param title: Graph title
         """
         if self.__selector_is_connected:
@@ -281,7 +275,7 @@ class ArrayImagePlot(qt.QWidget):
         self.__y_axis_name = ylabel
 
         self._selector.setData(signal)
-        self._selector.setAxisNames([y_id or "Y", x_id or "X"])
+        self._selector.setAxisNames(["Y", "X"])
 
         if len(signal.shape) < 3:
             self.selectorDock.hide()
@@ -412,7 +406,6 @@ class ArrayStackPlot(qt.QWidget):
                      x_axis=None, y_axis=None, z_axis=None,
                      signal_name=None,
                      xlabel=None, ylabel=None, zlabel=None,
-                     x_id=None, y_id=None, z_id=None,
                      title=None):
         """
 
@@ -431,9 +424,6 @@ class ArrayStackPlot(qt.QWidget):
         :param xlabel: Label for X axis
         :param ylabel: Label for Y axis
         :param zlabel: Label for Z axis
-        :param str x_id: Unique name for X axis.
-        :param str y_id: Unique name for Y axis.
-        :param str z_id: Unique name for Z axis.
         :param title: Graph title
         """
         if self.__selector_is_connected:
@@ -450,7 +440,7 @@ class ArrayStackPlot(qt.QWidget):
         self.__z_axis_name = zlabel
 
         self._selector.setData(signal)
-        self._selector.setAxisNames([y_id or "Y", x_id or "X", z_id or "Z"])
+        self._selector.setAxisNames(["Y", "X", "Z"])
 
         self._stack_view.setGraphTitle(title or "")
         # by default, the z axis is the image position (dimension not plotted)

--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -89,13 +89,15 @@ class ArrayCurvePlot(qt.QWidget):
 
         layout = qt.QGridLayout()
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self._plot,  0, 0)
+        layout.addWidget(self._plot, 0, 0)
 
         self.setLayout(layout)
 
     def setCurveData(self, y, x=None, values=None,
                      yerror=None, xerror=None,
-                     ylabel=None, xlabel=None, title=None):
+                     ylabel=None, xlabel=None,
+                     y_id=None, x_id=None,
+                     title=None):
         """
 
         :param y: dataset to be represented by the y (vertical) axis.
@@ -113,6 +115,8 @@ class ArrayCurvePlot(qt.QWidget):
         :param xerror: 1-D dataset of errors for x, or None
         :param ylabel: Label for Y axis
         :param xlabel: Label for X axis
+        :param str y_id: Unique name for Y axis.
+        :param str x_id: Unique name for X axis.
         :param title: Graph title
         """
         self.__signal = y
@@ -127,7 +131,7 @@ class ArrayCurvePlot(qt.QWidget):
             self._selector.selectionChanged.disconnect(self._updateCurve)
             self.__selector_is_connected = False
         self._selector.setData(y)
-        self._selector.setAxisNames([ylabel or "Y"])
+        self._selector.setAxisNames([y_id or "Y"])
 
         if len(y.shape) < 2:
             self.selectorDock.hide()
@@ -246,6 +250,7 @@ class ArrayImagePlot(qt.QWidget):
                      x_axis=None, y_axis=None,
                      signal_name=None,
                      xlabel=None, ylabel=None,
+                     x_id=None, y_id=None,
                      title=None):
         """
 
@@ -260,6 +265,8 @@ class ArrayImagePlot(qt.QWidget):
         :param signal_name: Label used in the legend
         :param xlabel: Label for X axis
         :param ylabel: Label for Y axis
+        :param str x_id: Unique name for X axis.
+        :param str y_id: Unique name for Y axis.
         :param title: Graph title
         """
         if self.__selector_is_connected:
@@ -274,7 +281,7 @@ class ArrayImagePlot(qt.QWidget):
         self.__y_axis_name = ylabel
 
         self._selector.setData(signal)
-        self._selector.setAxisNames([ylabel or "Y", xlabel or "X"])
+        self._selector.setAxisNames([y_id or "Y", x_id or "X"])
 
         if len(signal.shape) < 3:
             self.selectorDock.hide()
@@ -405,6 +412,7 @@ class ArrayStackPlot(qt.QWidget):
                      x_axis=None, y_axis=None, z_axis=None,
                      signal_name=None,
                      xlabel=None, ylabel=None, zlabel=None,
+                     x_id=None, y_id=None, z_id=None,
                      title=None):
         """
 
@@ -423,6 +431,9 @@ class ArrayStackPlot(qt.QWidget):
         :param xlabel: Label for X axis
         :param ylabel: Label for Y axis
         :param zlabel: Label for Z axis
+        :param str x_id: Unique name for X axis.
+        :param str y_id: Unique name for Y axis.
+        :param str z_id: Unique name for Z axis.
         :param title: Graph title
         """
         if self.__selector_is_connected:
@@ -439,7 +450,7 @@ class ArrayStackPlot(qt.QWidget):
         self.__z_axis_name = zlabel
 
         self._selector.setData(signal)
-        self._selector.setAxisNames([ylabel or "Y", xlabel or "X", zlabel or "Z"])
+        self._selector.setAxisNames([y_id or "Y", x_id or "X", z_id or "Z"])
 
         self._stack_view.setGraphTitle(title or "")
         # by default, the z axis is the image position (dimension not plotted)

--- a/silx/gui/data/NumpyAxesSelector.py
+++ b/silx/gui/data/NumpyAxesSelector.py
@@ -258,9 +258,12 @@ class NumpyAxesSelector(qt.QWidget):
         The size of the list will constrain the dimension of the resulting
         array.
 
-        :param list[str] axesNames: List of string identifying axis names
+        :param list[str] axesNames: List of distinct strings identifying axis names
         """
         self.__axisNames = list(axesNames)
+        assert len(set(self.__axisNames)) == len(self.__axisNames),\
+            "Non-unique axes names: %s" % self.__axisNames
+
         delta = len(self.__axis) - len(self.__axisNames)
         if delta < 0:
             delta = 0
@@ -415,7 +418,6 @@ class NumpyAxesSelector(qt.QWidget):
             else:
                 selection.append(slice(None))
                 axisNames.append(name)
-
         self.__selection = tuple(selection)
         # get a view with few fixed dimensions
         # with a h5py dataset, it create a copy

--- a/silx/io/nxdata.py
+++ b/silx/io/nxdata.py
@@ -246,9 +246,7 @@ class NXdata(object):
         """
 
         self.signal_dataset_name = get_attr_as_string(self.group, "signal")
-        """Name of the signal dataset.
-        This name is guaranteed to be different from all the axes dataset
-        names (:attr:`axes_dataset_names`)."""
+        """Name of the signal dataset."""
 
         self.signal = self.group[get_attr_as_string(self.group, "signal")]
         """Signal dataset in this NXdata group.

--- a/silx/io/nxdata.py
+++ b/silx/io/nxdata.py
@@ -245,9 +245,20 @@ class NXdata(object):
         """h5py-like group object compliant with NeXus NXdata specification.
         """
 
+        self.signal_dataset_name = get_attr_as_string(self.group, "signal")
+        """Name of the signal dataset.
+        This name is guaranteed to be different from all the axes dataset
+        names (:attr:`axes_dataset_names`)."""
+
         self.signal = self.group[get_attr_as_string(self.group, "signal")]
         """Signal dataset in this NXdata group.
         """
+
+        self.signal_name = get_attr_as_string(self.signal, "long_name")
+        """Signal long name, as specified in the @long_name attribute of the
+        signal dataset. If not specified, the dataset name is used."""
+        if self.signal_name is None:
+            self.signal_name = self.signal_dataset_name
 
         # ndim will be available in very recent h5py versions only
         self.signal_ndim = getattr(self.signal, "ndim",


### PR DESCRIPTION
When two axes use the same @long_name attribute, we got  an error because we relied on these names to be unique.

This PR fixes this bug and adds an assertion in `NumpyAxesSelector.setAxisNames` to enforce unicity of names.

It also fixes the bug of the signal name being used by mistake as ylabel instead of the Y axis name , and adds support of a `@long_name` attribute on the signal dataset. 