### PR TITLE
Support fabio file series on FabioH5

### DIFF
--- a/silx/io/fabioh5.py
+++ b/silx/io/fabioh5.py
@@ -740,17 +740,26 @@ class EdfFabioReader(FabioReader):
             else:
                 raise Exception("State unexpected (base_key: %s)" % base_key)
 
+    def _get_first_header(self):
+        """
+        ..note:: This function can be cached
+        """
+        fabio_file = self.fabio_file()
+        if isinstance(fabio_file, fabio.file_series.file_series):
+            return fabio_file.jump_image(0).header
+        return fabio_file.header
+
     def has_ub_matrix(self):
         """Returns true if a UB matrix is available.
 
         :rtype: bool
         """
-        header = self.fabio_file().header
+        header = self._get_first_header()
         expected_keys = set(["UB_mne", "UB_pos", "sample_mne", "sample_pos"])
         return expected_keys.issubset(header)
 
     def parse_ub_matrix(self):
-        header = self.fabio_file().header
+        header = self._get_first_header()
         ub_data = self._get_mnemonic_key("UB", header)
         s_data = self._get_mnemonic_key("sample", header)
         if len(ub_data) > 9:

--- a/silx/io/fabioh5.py
+++ b/silx/io/fabioh5.py
@@ -84,6 +84,19 @@ def supported_extensions():
     return _fabio_extensions
 
 
+class _FileSeries(fabio.file_series.file_series):
+    """
+    .. note:: Overwrite a function to fix an issue in fabio.
+    """
+    def jump(self, num):
+        """
+        Goto a position in sequence
+        """
+        assert num < len(self) and num >= 0, "num out of range"
+        self._current = num
+        return self[self._current]
+
+
 class FrameData(commonh5.LazyLoadableDataset):
     """Expose a cube of image from a Fabio file using `FabioReader` as
     cache."""

--- a/silx/io/fabioh5.py
+++ b/silx/io/fabioh5.py
@@ -312,12 +312,17 @@ class FabioReader(object):
             self.__fabio_file = fabio.open(file_name)
             self.__must_be_closed = True
         elif fabio_image is not None:
-            self.__fabio_file = fabio_image
+            if isinstance(fabio_image, fabio.fabioimage.FabioImage):
+                self.__fabio_file = fabio_image
+            else:
+                raise TypeError("FabioImage expected but %s found.", fabio_image.__class__)
         elif file_series is not None:
             if isinstance(file_series, list):
-                self.__fabio_file = fabio.file_series.file_series(file_series)
+                self.__fabio_file = _FileSeries(file_series)
             elif isinstance(file_series, fabio.file_series.file_series):
                 self.__fabio_file = file_series
+            else:
+                raise TypeError("file_series or list expected but %s found.", file_series.__class__)
 
     def close(self):
         """Close the object, and free up associated resources.

--- a/silx/io/test/test_fabioh5.py
+++ b/silx/io/test/test_fabioh5.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "04/10/2017"
+__date__ = "07/12/2017"
 
 import os
 import sys
@@ -406,11 +406,75 @@ class TestFabioH5WithEdf(unittest.TestCase):
         self.assertNotIn("/scan_0/instrument/detector_0/others/HeaderID", self.h5_image)
 
 
+class TestFabioH5WithFileSeries(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        if fabio is None:
+            raise unittest.SkipTest("fabio is needed")
+        if h5py is None:
+            raise unittest.SkipTest("h5py is needed")
+
+        cls.tmp_directory = tempfile.mkdtemp()
+
+        cls.edf_filenames = []
+
+        for i in range(10):
+            filename = os.path.join(cls.tmp_directory, "test_%04d.edf" % i)
+            cls.edf_filenames.append(filename)
+
+            header = {
+                "image_id": "%d" % i,
+                "integer": "-100",
+                "float": "1.0",
+                "string": "hi!",
+                "list_integer": "100 50 0",
+                "list_float": "1.0 2.0 3.5",
+                "string_looks_like_list": "2000 hi!",
+            }
+            data = numpy.array([[i, 11], [12, 13], [14, 15]], dtype=numpy.int64)
+            fabio_image = fabio.edfimage.edfimage(data, header)
+            fabio_image.write(filename)
+
+    @classmethod
+    def tearDownClass(cls):
+        if sys.platform == "win32" and fabio is not None:
+            # gc collect is needed to close a file descriptor
+            # opened by fabio and not released.
+            # https://github.com/silx-kit/fabio/issues/167
+            import gc
+            gc.collect()
+        shutil.rmtree(cls.tmp_directory)
+
+    def _testH5Image(self, h5_image):
+        # test data
+        dataset = h5_image["/scan_0/instrument/detector_0/data"]
+        self.assertEquals(dataset.h5py_class, h5py.Dataset)
+        self.assertTrue(isinstance(dataset[()], numpy.ndarray))
+        self.assertEquals(dataset.dtype.kind, "i")
+        self.assertEquals(dataset.shape, (10, 3, 2))
+        self.assertEquals(list(dataset[:, 0, 0]), list(range(10)))
+        self.assertEquals(dataset.attrs["interpretation"], "image")
+        # test metatdata
+        dataset = h5_image["/scan_0/instrument/detector_0/others/image_id"]
+        self.assertEquals(list(dataset[...]), list(range(10)))
+
+    def testFileList(self):
+        h5_image = fabioh5.File(file_series=self.edf_filenames)
+        self._testH5Image(h5_image)
+
+    def testFileSeries(self):
+        file_series = fabioh5._FileSeries(self.edf_filenames)
+        h5_image = fabioh5.File(file_series=file_series)
+        self._testH5Image(h5_image)
+
+
 def suite():
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
     test_suite = unittest.TestSuite()
     test_suite.addTest(loadTests(TestFabioH5))
     test_suite.addTest(loadTests(TestFabioH5WithEdf))
+    test_suite.addTest(loadTests(TestFabioH5WithFileSeries))
     return test_suite
 
 


### PR DESCRIPTION
Support file series from FabIO.

About the implementation:
- It only support 1 frame per images (else an assertion will be raised). We can change that but it have a pre-computation cost.
- It was not done to be efficient (but to be implemented fast), files are read 3 times. We can improve that, but let see what's happen on real examples.

I would like to re-implement file_series in fabio as a container of frames. It can create something much more convenient to use. In the mid time i hope the current implementation is enough.