### PR TITLE
[gui]Colormap dialog modal

### DIFF
--- a/silx/gui/plot/Colormap.py
+++ b/silx/gui/plot/Colormap.py
@@ -307,8 +307,8 @@ class Colormap(qt.QObject):
         """
         if vmin is not None and vmax is not None:
             if vmin >= vmax:
-                err = "Can't set vmin and vmax because vmin >= vmax"
-                err += "vmin = %s, vmax = %s" % (vmin, self._vmax)
+                err = "Can't set vmin and vmax because vmin >= vmax " \
+                      "vmin = %s, vmax = %s" % (vmin, vmax)
                 raise ValueError(err)
 
         self._vmin = vmin

--- a/silx/gui/plot/Colormap.py
+++ b/silx/gui/plot/Colormap.py
@@ -214,9 +214,9 @@ class Colormap(qt.QObject):
             value)
         """
         if vmin is not None:
-            if self._vmax is not None and vmin >= self._vmax:
-                err = "Can't set vmin because vmin >= vmax."
-                err += "vmin = %s, vmax = %s" % (vmin, self._vmax)
+            if self._vmax is not None and vmin > self._vmax:
+                err = "Can't set vmin because vmin >= vmax. " \
+                      "vmin = %s, vmax = %s" % (vmin, self._vmax)
                 raise ValueError(err)
 
         self._vmin = vmin
@@ -237,9 +237,9 @@ class Colormap(qt.QObject):
             (default)
         """
         if vmax is not None:
-            if self._vmin is not None and vmax <= self._vmin:
-                err = "Can't set vmax because vmax <= vmin."
-                err += "vmin = %s, vmax = %s" % (self._vmin, vmax)
+            if self._vmin is not None and vmax < self._vmin:
+                err = "Can't set vmax because vmax <= vmin. " \
+                      "vmin = %s, vmax = %s" % (self._vmin, vmax)
                 raise ValueError(err)
 
         self._vmax = vmax
@@ -306,7 +306,7 @@ class Colormap(qt.QObject):
             (default)
         """
         if vmin is not None and vmax is not None:
-            if vmin >= vmax:
+            if vmin > vmax:
                 err = "Can't set vmin and vmax because vmin >= vmax " \
                       "vmin = %s, vmax = %s" % (vmin, vmax)
                 raise ValueError(err)

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -34,9 +34,10 @@ Create the colormap dialog and set the colormap description and data range:
 >>> from silx.gui.plot.Colormap import Colormap
 
 >>> dialog = ColormapDialog()
+>>> colormap = Colormap(name='red', normalization='log',
+...                     vmin=1., vmax=2.)
 
->>> dialog.setColormap(Colormap(name='red', normalization='log',
-...                             vmin=1., vmax=2.))
+>>> dialog.setColormap(colormap)
 >>> dialog.setDataRange(1., 100.)  # This scale the width of the plot area
 >>> dialog.show()
 

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -475,6 +475,7 @@ class ColormapDialog(qt.QDialog):
                     self._colormap().sigChanged.disconnect(self._applyColormap)
                     self._colormap().setVRange(dataRange[0], dataRange[1])
                     self._colormap().sigChanged.connect(self._applyColormap)
+        self._plotUpdate()
 
     def _minMaxTextEdited(self, text):
         """Handle _minValue and _maxValue textEdited signal"""

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -409,7 +409,7 @@ class ColormapDialog(qt.QDialog):
             self._ignoreColormapChange = True
             self._colormap()._setFromDict(self._colormapStoredState)
             self._ignoreColormapChange = False
-            self._plotUpdate()
+            self._applyColormap()
 
     def accept(self):
         self.storeCurrentState()

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -108,8 +108,8 @@ class _BoundaryWidget(qt.QWidget):
     def getFiniteValue(self):
         return self._numVal.value()
 
-    def setValue(self, value):
-        self._autoCB.setChecked(value is None)
+    def setValue(self, value, isAuto=False):
+        self._autoCB.setChecked(isAuto or value is None)
         if value is not None:
             self._numVal.setValue(value)
 
@@ -433,9 +433,11 @@ class ColormapDialog(qt.QDialog):
                 self._colormap().getNormalization() == Colormap.LINEAR)
             self._normButtonLog.setChecked(
                 self._colormap().getNormalization() == Colormap.LOGARITHM)
-
-            self._minValue.setValue(self._colormap().getVMin())
-            self._maxValue.setValue(self._colormap().getVMax())
+            vmin = self._colormap().getVMin()
+            vmax = self._colormap().getVMax()
+            dataRange = self._colormap().getColormapRange()
+            self._minValue.setValue(vmin or dataRange[0], isAuto=vmin is None)
+            self._maxValue.setValue(vmax or dataRange[1], isAuto=vmax is None)
 
             self._ignoreColormapChange = False
             self._plotUpdate()

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -120,7 +120,7 @@ class ColormapDialog(qt.QDialog):
         normButtonGroup.setExclusive(True)
         normButtonGroup.addButton(self._normButtonLinear)
         normButtonGroup.addButton(self._normButtonLog)
-        normButtonGroup.buttonClicked[int].connect(self._updateLinearNorm)
+        self._normButtonLinear.toggled[bool].connect(self._updateLinearNorm)
 
         normLayout = qt.QHBoxLayout()
         normLayout.setContentsMargins(0, 0, 0, 0)

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -362,7 +362,6 @@ class ColormapDialog(qt.QDialog):
         """Set the histogram to display.
 
         This update the data range with the bounds of the bins.
-        See :meth:`setDataRange`.
 
         :param hist: array-like of counts or None to hide histogram
         :param bin_edges: array-like of bins edges or None to hide histogram

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -153,19 +153,12 @@ class ColormapDialog(qt.QDialog):
         self._plotInit()
         vLayout.addWidget(self._plot)
 
-        # Close button
-        buttonsWidget = qt.QWidget()
-        vLayout.addWidget(buttonsWidget)
-
-        buttonsLayout = qt.QHBoxLayout(buttonsWidget)
-
-        okButton = qt.QPushButton('OK')
-        okButton.clicked.connect(self.accept)
-        buttonsLayout.addWidget(okButton)
-
-        cancelButton = qt.QPushButton('Cancel')
-        cancelButton.clicked.connect(self.reject)
-        buttonsLayout.addWidget(cancelButton)
+        types = qt.QDialogButtonBox.Ok | qt.QDialogButtonBox.Cancel
+        _buttons = qt.QDialogButtonBox(parent=self)
+        _buttons.setStandardButtons(types)
+        self.layout().addWidget(_buttons)
+        _buttons.accepted.connect(self.accept)
+        _buttons.rejected.connect(self.reject)
 
         # colormap window can not be resized
         self.setFixedSize(vLayout.minimumSize())

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -404,12 +404,11 @@ class ColormapDialog(qt.QDialog):
                     self._colormap.getName(), qt.Qt.UserRole)
                 self._comboBoxColormap.setCurrentIndex(index)
 
-            if self._colormap().getNormalization() is not None:
-                assert self._colormap().getNormalization() in Colormap.NORMALIZATIONS
-                self._normButtonLinear.setChecked(
-                    self._colormap().getNormalization() == Colormap.LINEAR)
-                self._normButtonLog.setChecked(
-                    self._colormap().getNormalization() == Colormap.LOGARITHM)
+            assert self._colormap().getNormalization() in Colormap.NORMALIZATIONS
+            self._normButtonLinear.setChecked(
+                self._colormap().getNormalization() == Colormap.LINEAR)
+            self._normButtonLog.setChecked(
+                self._colormap().getNormalization() == Colormap.LOGARITHM)
 
             if self._colormap().getVMin() is not None:
                 self._minValue.setValue(self._colormap().getVMin())
@@ -445,10 +444,10 @@ class ColormapDialog(qt.QDialog):
         self._plotUpdate()
 
     def _updateName(self):
-        self._colormap().sigChanged.disconnect(self._applyColormap)
-        self._colormap().setName(
-            str(self._comboBoxColormap.currentText()).lower())
         if self._colormap():
+            self._colormap().sigChanged.disconnect(self._applyColormap)
+            self._colormap().setName(
+                str(self._comboBoxColormap.currentText()).lower())
             self._colormap().sigChanged.connect(self._applyColormap)
         self._plotUpdate()
 
@@ -457,7 +456,6 @@ class ColormapDialog(qt.QDialog):
             self._colormap().sigChanged.disconnect(self._applyColormap)
             norm = Colormap.LINEAR if isNormLinear else Colormap.LOGARITHM
             self._colormap().setNormalization(norm)
-        if self._colormap():
             self._colormap().sigChanged.connect(self._applyColormap)
         self._plotUpdate()
 

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -121,20 +121,8 @@ class _ColormapNameCombox(qt.QComboBox):
 
     ORIGINAL_NAME = qt.Qt.UserRole + 1
 
-    colormaps = [
-        'gray', 'reversed gray',
-        'temperature', 'red', 'green', 'blue', 'jet',
-        'viridis', 'magma', 'inferno', 'plasma']
-
-    if 'hsv' in Colormap.getSupportedColormaps():
-        colormaps.append('hsv')
-
     def __initItems(self):
-
-
-        _colormapList = tuple(self.colormaps)
-
-        for colormapName in _colormapList:
+        for colormapName in preferredColormaps():
             index = self.count()
             self.addItem(str.title(colormapName))
             self.setItemData(index, colormapName, role=self.ORIGINAL_NAME)

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -442,10 +442,11 @@ class ColormapDialog(qt.QDialog):
             vmin = self._minValue.value()
             vmax = self._maxValue.value()
         norm = Colormap.LINEAR if isNormLinear else Colormap.LOGARITHM
-        self._colormap().setVRange(vmin, vmax)
-        self._colormap().setNormalization(norm)
-        self._colormap().setName(
-            str(self._comboBoxColormap.currentText()).lower())
+        if self._colormap():
+            self._colormap().setVRange(vmin, vmax)
+            self._colormap().setNormalization(norm)
+            self._colormap().setName(
+                str(self._comboBoxColormap.currentText()).lower())
 
         self._plotUpdate()
 

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -381,7 +381,25 @@ class ColormapDialog(qt.QDialog):
         self._applyColormap()
 
     def _applyColormap(self):
+        def reconnectButtons():
+            self._normButtonLog.toggled.connect(self._activeLogNorm)
+            self._normButtonLinear.toggled[bool].connect(
+                self._updateLinearNorm)
+            self._rangeAutoscaleButton.toggled.connect(self._autoscaleToggled)
+            self._comboBoxColormap.currentIndexChanged[int].connect(
+                self._updateName)
+
+        def disconnectButtons():
+            self._comboBoxColormap.currentIndexChanged[int].disconnect(
+                self._updateName)
+            self._normButtonLinear.toggled[bool].disconnect(
+                self._updateLinearNorm)
+            self._normButtonLog.toggled.disconnect(self._activeLogNorm)
+            self._rangeAutoscaleButton.toggled.disconnect(self._autoscaleToggled)
+
         if self._colormap():
+            self._colormap().sigChanged.disconnect(self._applyColormap)
+            disconnectButtons()
             if self._colormap().getName() is not None:
                 index = self._comboBoxColormap.findData(
                     self._colormap.getName(), qt.Qt.UserRole)
@@ -412,6 +430,8 @@ class ColormapDialog(qt.QDialog):
                 self._maxValue.setEnabled(True)
             # Do it once for all the changes
             self._plotUpdate()
+            self._colormap().sigChanged.connect(self._applyColormap)
+            reconnectButtons()
 
     def _updateMinMax(self):
         if self._rangeAutoscaleButton.isChecked():

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -437,7 +437,7 @@ class ColormapDialog(qt.QDialog):
         else:
             vmin = self._minValue.value()
             vmax = self._maxValue.value()
-        if self._colormap() and (vmin is None or vmax is None or vmin < vmax):
+        if self._colormap():
             self._colormap().sigChanged.disconnect(self._applyColormap)
             self._colormap().setVRange(vmin, vmax)
             self._colormap().sigChanged.connect(self._applyColormap)

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -153,12 +153,21 @@ class ColormapDialog(qt.QDialog):
         self._plotInit()
         vLayout.addWidget(self._plot)
 
+        # define modal buttons
         types = qt.QDialogButtonBox.Ok | qt.QDialogButtonBox.Cancel
-        _buttons = qt.QDialogButtonBox(parent=self)
-        _buttons.setStandardButtons(types)
-        self.layout().addWidget(_buttons)
-        _buttons.accepted.connect(self.accept)
-        _buttons.rejected.connect(self.reject)
+        self._buttonsModal = qt.QDialogButtonBox(parent=self)
+        self._buttonsModal.setStandardButtons(types)
+        self.layout().addWidget(self._buttonsModal)
+        self._buttonsModal.accepted.connect(self.accept)
+        self._buttonsModal.rejected.connect(self.reject)
+
+        # define non modal buttons
+        types = qt.QDialogButtonBox.Close | qt.QDialogButtonBox.Reset
+        self._buttonsNonModal = qt.QDialogButtonBox(parent=self)
+        self._buttonsNonModal.setStandardButtons(types)
+        self.layout().addWidget(self._buttonsNonModal)
+        self._buttonsNonModal.button(qt.QDialogButtonBox.Close).clicked.connect(self.accept)
+        self._buttonsNonModal.button(qt.QDialogButtonBox.Reset).clicked.connect(self.resetColormap)
 
         # colormap window can not be resized
         self.setFixedSize(vLayout.minimumSize())
@@ -166,6 +175,14 @@ class ColormapDialog(qt.QDialog):
         # Set the colormap to default values
         self.setColormap(Colormap(name='gray', normalization='linear',
                          vmin=None, vmax=None))
+
+        self.setModal(self.isModal())
+
+    def setModal(self, modal):
+        assert type(modal) is bool
+        self._buttonsNonModal.setVisible(not modal)
+        self._buttonsModal.setVisible(modal)
+        qt.QDialog.setModal(self, modal)
 
     def _plotInit(self):
         """Init the plot to display the range and the values"""

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -426,6 +426,9 @@ class ColormapDialog(qt.QDialog):
             if self._colormap().getName() is not None:
                 index = self._comboBoxColormap.findData(
                     self._colormap.getName(), qt.Qt.UserRole)
+                if index < 0:
+                    self._comboBoxColormap.addItem(name.title(), name)
+                    index = self._comboBoxColormap.findText(name)
                 self._comboBoxColormap.setCurrentIndex(index)
 
             assert self._colormap().getNormalization() in Colormap.NORMALIZATIONS
@@ -460,7 +463,7 @@ class ColormapDialog(qt.QDialog):
         if self._colormap():
             self._ignoreColormapChange = True
             self._colormap().setName(
-                str(self._comboBoxColormap.currentText()).lower())
+                str(self._comboBoxColormap.currentText()))
             self._ignoreColormapChange = False
 
     def _updateLinearNorm(self, isNormLinear):

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -96,14 +96,14 @@ class ColormapDialog(qt.QDialog):
         # Make the GUI
         vLayout = qt.QVBoxLayout(self)
 
-        formWidget = qt.QWidget()
+        formWidget = qt.QWidget(parent=self)
         vLayout.addWidget(formWidget)
         formLayout = qt.QFormLayout(formWidget)
         formLayout.setContentsMargins(10, 10, 10, 10)
         formLayout.setSpacing(0)
 
         # Colormap row
-        self._comboBoxColormap = qt.QComboBox()
+        self._comboBoxColormap = qt.QComboBox(parent=formWidget)
         for cmap in preferredColormaps():
             self._comboBoxColormap.addItem(cmap.title(), cmap)
         self._comboBoxColormap.currentIndexChanged[int].connect(self._updateName)

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -178,6 +178,9 @@ class ColormapDialog(qt.QDialog):
 
         self.setModal(self.isModal())
 
+    def close(self):
+        self.accept()
+
     def setModal(self, modal):
         assert type(modal) is bool
         self._buttonsNonModal.setVisible(not modal)

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -420,6 +420,8 @@ class ColormapDialog(qt.QDialog):
 
             self._rangeAutoscaleButton.setChecked(self._colormap().isAutoscale())
             if self._colormap().isAutoscale():
+                self._minValue.setEnabled(False)
+                self._maxValue.setEnabled(False)
                 self._minValue.setEnabled(True)
                 self._maxValue.setEnabled(True)
                 dataRange = self.getDataRange()
@@ -427,6 +429,8 @@ class ColormapDialog(qt.QDialog):
                     self._minValue.setValue(dataRange[0])
                     self._maxValue.setValue(dataRange[1])
             else:
+                self._minValue.setEnabled(True)
+                self._maxValue.setEnabled(True)
                 self._minValue.setEnabled(False)
                 self._maxValue.setEnabled(False)
             # Do it once for all the changes

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -420,11 +420,15 @@ class ColormapDialog(qt.QDialog):
 
             self._rangeAutoscaleButton.setChecked(self._colormap().isAutoscale())
             if self._colormap().isAutoscale():
+                self._minValue.setEnabled(True)
+                self._maxValue.setEnabled(True)
                 dataRange = self.getDataRange()
                 if dataRange is not None:
                     self._minValue.setValue(dataRange[0])
                     self._maxValue.setValue(dataRange[1])
-
+            else:
+                self._minValue.setEnabled(False)
+                self._maxValue.setEnabled(False)
             # Do it once for all the changes
             self._updateColormapFrmGUI()
 
@@ -447,9 +451,9 @@ class ColormapDialog(qt.QDialog):
 
     def _autoscaleToggled(self, checked):
         """Handle autoscale changes by enabling/disabling min/max fields"""
+        self._minValue.setEnabled(not checked)
+        self._maxValue.setEnabled(not checked)
         if self._colormap():
-            self._minValue.setEnabled(not checked)
-            self._maxValue.setEnabled(not checked)
             if checked:
                 self._colormap().setVRange(None, None)
             else:

--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -365,29 +365,10 @@ class ColormapAction(PlotAction):
             # hist, bin_edges = numpy.histogram(goodData, bins=256)
             # self._dialog.setHistogram(hist, bin_edges)
 
-        self._dialog.setColormap(name=colormap.getName(),
-                                 normalization=colormap.getNormalization(),
-                                 autoscale=colormap.isAutoscale(),
-                                 vmin=colormap.getVMin(),
-                                 vmax=colormap.getVMax(),
-                                 colors=colormap.getColormapLUT())
+        self._dialog.setColormap(colormap=colormap)
 
         # Run the dialog listening to colormap change
-        self._dialog.sigColormapChanged.connect(self._colormapChanged)
-        result = self._dialog.exec_()
-        self._dialog.sigColormapChanged.disconnect(self._colormapChanged)
-
-        if not result:  # Restore the previous colormap
-            self._colormapChanged(colormap)
-
-    def _colormapChanged(self, colormap):
-        # Update default colormap
-        self.plot.setDefaultColormap(colormap)
-
-        # Update active image colormap
-        activeImage = self.plot.getActiveImage()
-        if isinstance(activeImage, items.ColormapMixIn):
-            activeImage.setColormap(colormap)
+        self._dialog.show()
 
 
 class KeepAspectRatioAction(PlotAction):

--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -360,7 +360,6 @@ class ColormapAction(PlotAction):
                 dataMin, dataMax = 1., 10.
 
             self._dialog.setHistogram()  # Reset histogram if any
-            self._dialog.setDataRange(dataMin, dataMax)
             # The histogram should be done in a worker thread
             # hist, bin_edges = numpy.histogram(goodData, bins=256)
             # self._dialog.setHistogram(hist, bin_edges)

--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -37,6 +37,7 @@ from silx.gui import qt
 from silx.gui.plot import ColormapDialog
 from silx.gui.test.utils import TestCaseQt
 from silx.gui.plot.Colormap import Colormap
+from silx.test.utils import ParametricTestCase
 
 
 # Makes sure a QApplication exists
@@ -60,7 +61,7 @@ cmapDocTestSuite = doctest.DocTestSuite(ColormapDialog, tearDown=_tearDownQt)
 """Test suite of tests from the module's docstrings."""
 
 
-class TestColormapDialog(TestCaseQt):
+class TestColormapDialog(TestCaseQt, ParametricTestCase):
     def setUp(self):
         self.colormap = Colormap(name='gray', vmin=0.0, vmax=1.0,
                                  normalization='linear')
@@ -114,7 +115,30 @@ class TestColormapDialog(TestCaseQt):
 
     def testSetColormapIsCorrect(self):
         """Make sure the interface fir the colormap when set a new colormap"""
-        pass
+        self.colormap.setName('red')
+        for norm in (Colormap.NORMALIZATIONS):
+            for autoscale in (True, False):
+                if autoscale is True:
+                    self.colormap.setVRange(None, None)
+                else:
+                    self.colormap.setVRange(11, 101)
+                self.colormap.setNormalization(norm)
+                with self.subTest(colormap=self.colormap):
+                    self.colormapDiag.setColormap(self.colormap)
+                    self.assertTrue(
+                        self.colormapDiag._normButtonLinear.isChecked() == (norm is Colormap.LINEAR))
+                    self.assertTrue(
+                        self.colormapDiag._comboBoxColormap.currentText() == 'Red')
+                    self.assertTrue(
+                        self.colormapDiag._rangeAutoscaleButton.isChecked() == autoscale)
+                    if autoscale is False:
+                        self.assertTrue(self.colormapDiag._minValue.value() == 11)
+                        self.assertTrue(self.colormapDiag._maxValue.value() == 101)
+                        self.assertFalse(self.colormapDiag._minValue.isEnabled())
+                        self.assertFalse(self.colormapDiag._maxValue.isEnabled())
+                    else:
+                        self.assertTrue(self.colormapDiag._minValue.isEnabled())
+                        self.assertTrue(self.colormapDiag._maxValue.isEnabled())
 
     def testColormapDel(self):
         """Check behavior if the colormap has been deleted outside"""

--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -87,10 +87,33 @@ class TestColormapDialog(TestCaseQt):
 
     def testGUIAccept(self):
         """Make sure the colormap is modify if go through accept"""
-        pass
+        assert self.colormap.isAutoscale() is False
+        self.colormapDiag.show()
+        self.colormapDiag.setColormap(self.colormap)
+        self.colormapDiag._rangeAutoscaleButton.setChecked(True)
+        self.colormapDiag.accept()
+        self.assertTrue(self.colormap.isAutoscale() is True)
 
     def testGUIReject(self):
         """Make sure the colormap is modify if go through reject"""
+        assert self.colormap.isAutoscale() is False
+        self.colormapDiag.show()
+        self.colormapDiag.setColormap(self.colormap)
+        self.colormapDiag._rangeAutoscaleButton.setChecked(True)
+        self.colormapDiag.reject()
+        self.assertTrue(self.colormap.isAutoscale() is False)
+
+    def testGUIClose(self):
+        """Make sure the colormap is modify if go through reject"""
+        assert self.colormap.isAutoscale() is False
+        self.colormapDiag.show()
+        self.colormapDiag.setColormap(self.colormap)
+        self.colormapDiag._rangeAutoscaleButton.setChecked(True)
+        self.colormapDiag.close()
+        self.assertTrue(self.colormap.isAutoscale() is False)
+
+    def testSetColormapIsCorrect(self):
+        """Make sure the interface fir the colormap when set a new colormap"""
         pass
 
     def testColormapDel(self):

--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -88,7 +88,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         colormapDiag2.setColormap(self.colormap)
         self.colormapDiag.setColormap(self.colormap)
 
-        self.colormapDiag._comboBoxColormap.setCurrentIndex(3)
+        self.colormapDiag._comboBoxColormap.setCurrentName('red')
         self.colormapDiag._normButtonLog.setChecked(True)
         self.assertTrue(self.colormap.getName() == 'red')
         self.assertTrue(self.colormapDiag.getColormap().getName() == 'red')
@@ -96,7 +96,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.assertTrue(self.colormap.getVMin() == 10)
         self.assertTrue(self.colormap.getVMax() == 20)
         # checked second colormap dialog
-        self.assertTrue(colormapDiag2._comboBoxColormap.currentText() == 'Red')
+        self.assertTrue(colormapDiag2._comboBoxColormap.getCurrentName() == 'red')
         self.assertTrue(colormapDiag2._normButtonLog.isChecked())
         self.assertTrue(int(colormapDiag2._minValue.getValue()) == 10)
         self.assertTrue(int(colormapDiag2._maxValue.getValue()) == 20)
@@ -187,7 +187,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
                     self.assertTrue(
                         self.colormapDiag._normButtonLinear.isChecked() == (norm is Colormap.LINEAR))
                     self.assertTrue(
-                        self.colormapDiag._comboBoxColormap.currentText() == 'Red')
+                        self.colormapDiag._comboBoxColormap.getCurrentName() == 'red')
                     self.assertTrue(
                         self.colormapDiag._minValue.isAutoChecked() == autoscale)
                     self.assertTrue(
@@ -208,7 +208,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.colormapDiag.show()
         del self.colormap
         self.assertTrue(self.colormapDiag.getColormap() is None)
-        self.colormapDiag._comboBoxColormap.setCurrentIndex(2)
+        self.colormapDiag._comboBoxColormap.setCurrentName('blue')
 
     def testColormapEditedOutside(self):
         """Make sure the GUI is still up to date if the colormap is modified
@@ -218,7 +218,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
 
         self.colormap.setName('red')
         self.assertTrue(
-            self.colormapDiag._comboBoxColormap.currentText() == 'Red')
+            self.colormapDiag._comboBoxColormap.getCurrentName() == 'red')
         self.colormap.setNormalization(Colormap.LOGARITHM)
         self.assertFalse(self.colormapDiag._normButtonLinear.isChecked())
         self.colormap.setVRange(11, 201)
@@ -257,7 +257,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         """
         def getFirstNotPreferredColormap():
             cms = Colormap.getSupportedColormaps()
-            preferred = self.colormapDiag._colormapList
+            preferred = ColormapDialog._ColormapNameCombox.colormaps
             for cm in cms:
                 if cm not in preferred:
                     return cm
@@ -269,12 +269,12 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.colormapDiag.setColormap(colormap)
         self.colormapDiag.show()
         cb = self.colormapDiag._comboBoxColormap
-        self.assertTrue(cb.currentText().lower() == colormapName.lower())
+        self.assertTrue(cb.getCurrentName() == colormapName)
         cb.setCurrentIndex(0)
-        index = cb.findText(colormapName)
+        index = cb.findColormap(colormapName)
         assert index is not 0  # if 0 then the rest of the test has no sense
         cb.setCurrentIndex(index)
-        self.assertTrue(cb.currentText().lower() == colormapName.lower())
+        self.assertTrue(cb.getCurrentName() == colormapName)
 
 
 class TestColormapAction(TestCaseQt):

--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -147,7 +147,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.colormapDiag.setColormap(self.colormap)
         self.colormapDiag._rangeAutoscaleButton.setChecked(True)
         self.colormapDiag.close()
-        self.assertTrue(self.colormap.isAutoscale() is False)
+        self.assertTrue(self.colormap.isAutoscale() is True)
 
     def testSetColormapIsCorrect(self):
         """Make sure the interface fir the colormap when set a new colormap"""

--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -73,7 +73,6 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.colormapDiag.setAttribute(qt.Qt.WA_DeleteOnClose)
 
     def tearDown(self):
-        self.colormapDiag.close()
         del self.colormapDiag
         ParametricTestCase.tearDown(self)
         TestCaseQt.tearDown(self)
@@ -139,6 +138,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
             button=qt.Qt.LeftButton
         )
         self.assertTrue(self.colormap.isAutoscale() is False)
+        self.colormapDiag.close()
 
     def testGUIClose(self):
         """Make sure the colormap is modify if go through reject"""

--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -88,7 +88,6 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         colormapDiag2.setColormap(self.colormap)
         self.colormapDiag.setColormap(self.colormap)
 
-        self.colormapDiag._rangeAutoscaleButton.setChecked(False)
         self.colormapDiag._comboBoxColormap.setCurrentIndex(3)
         self.colormapDiag._normButtonLog.setChecked(True)
         self.assertTrue(self.colormap.getName() == 'red')
@@ -99,8 +98,8 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         # checked second colormap dialog
         self.assertTrue(colormapDiag2._comboBoxColormap.currentText() == 'Red')
         self.assertTrue(colormapDiag2._normButtonLog.isChecked())
-        self.assertTrue(int(colormapDiag2._minValue.value()) == 10)
-        self.assertTrue(int(colormapDiag2._maxValue.value()) == 20)
+        self.assertTrue(int(colormapDiag2._minValue.getValue()) == 10)
+        self.assertTrue(int(colormapDiag2._maxValue.getValue()) == 20)
         colormapDiag2.close()
 
     def testGUIModalOk(self):
@@ -109,7 +108,9 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.colormapDiag.setModal(True)
         self.colormapDiag.show()
         self.colormapDiag.setColormap(self.colormap)
-        self.colormapDiag._rangeAutoscaleButton.setChecked(True)
+        self.assertTrue(self.colormap.getVMin() is not None)
+        self.colormapDiag._minValue.setValue(None)
+        self.assertTrue(self.colormap.getVMin() is None)
         self.mouseClick(
             widget=self.colormapDiag._buttonsModal.button(qt.QDialogButtonBox.Ok),
             button=qt.Qt.LeftButton
@@ -122,36 +123,42 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.colormapDiag.setModal(True)
         self.colormapDiag.show()
         self.colormapDiag.setColormap(self.colormap)
-        self.colormapDiag._rangeAutoscaleButton.setChecked(True)
+        self.assertTrue(self.colormap.getVMin() is not None)
+        self.colormapDiag._minValue.setValue(None)
+        self.assertTrue(self.colormap.getVMin() is None)
         self.mouseClick(
             widget=self.colormapDiag._buttonsModal.button(qt.QDialogButtonBox.Cancel),
             button=qt.Qt.LeftButton
         )
-        self.assertTrue(self.colormap.isAutoscale() is False)
+        self.assertTrue(self.colormap.getVMin() is not None)
 
     def testGUIModalClose(self):
         assert self.colormap.isAutoscale() is False
         self.colormapDiag.setModal(False)
         self.colormapDiag.show()
         self.colormapDiag.setColormap(self.colormap)
-        self.colormapDiag._rangeAutoscaleButton.setChecked(True)
+        self.assertTrue(self.colormap.getVMin() is not None)
+        self.colormapDiag._minValue.setValue(None)
+        self.assertTrue(self.colormap.getVMin() is None)
         self.mouseClick(
             widget=self.colormapDiag._buttonsNonModal.button(qt.QDialogButtonBox.Close),
             button=qt.Qt.LeftButton
         )
-        self.assertTrue(self.colormap.isAutoscale() is True)
+        self.assertTrue(self.colormap.getVMin() is None)
 
     def testGUIModalReset(self):
         assert self.colormap.isAutoscale() is False
         self.colormapDiag.setModal(False)
         self.colormapDiag.show()
         self.colormapDiag.setColormap(self.colormap)
-        self.colormapDiag._rangeAutoscaleButton.setChecked(True)
+        self.assertTrue(self.colormap.getVMin() is not None)
+        self.colormapDiag._minValue.setValue(None)
+        self.assertTrue(self.colormap.getVMin() is None)
         self.mouseClick(
             widget=self.colormapDiag._buttonsNonModal.button(qt.QDialogButtonBox.Reset),
             button=qt.Qt.LeftButton
         )
-        self.assertTrue(self.colormap.isAutoscale() is False)
+        self.assertTrue(self.colormap.getVMin() is not None)
         self.colormapDiag.close()
 
     def testGUIClose(self):
@@ -159,9 +166,11 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         assert self.colormap.isAutoscale() is False
         self.colormapDiag.show()
         self.colormapDiag.setColormap(self.colormap)
-        self.colormapDiag._rangeAutoscaleButton.setChecked(True)
+        self.assertTrue(self.colormap.getVMin() is not None)
+        self.colormapDiag._minValue.setValue(None)
+        self.assertTrue(self.colormap.getVMin() is None)
         self.colormapDiag.close()
-        self.assertTrue(self.colormap.isAutoscale() is True)
+        self.assertTrue(self.colormap.getVMin() is None)
 
     def testSetColormapIsCorrect(self):
         """Make sure the interface fir the colormap when set a new colormap"""
@@ -180,15 +189,17 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
                     self.assertTrue(
                         self.colormapDiag._comboBoxColormap.currentText() == 'Red')
                     self.assertTrue(
-                        self.colormapDiag._rangeAutoscaleButton.isChecked() == autoscale)
+                        self.colormapDiag._minValue.isAutoChecked() == autoscale)
+                    self.assertTrue(
+                        self.colormapDiag._maxValue.isAutoChecked() == autoscale)
                     if autoscale is False:
-                        self.assertTrue(self.colormapDiag._minValue.value() == 11)
-                        self.assertTrue(self.colormapDiag._maxValue.value() == 101)
+                        self.assertTrue(self.colormapDiag._minValue.getValue() == 11)
+                        self.assertTrue(self.colormapDiag._maxValue.getValue() == 101)
                         self.assertTrue(self.colormapDiag._minValue.isEnabled())
                         self.assertTrue(self.colormapDiag._maxValue.isEnabled())
                     else:
-                        self.assertFalse(self.colormapDiag._minValue.isEnabled())
-                        self.assertFalse(self.colormapDiag._maxValue.isEnabled())
+                        self.assertFalse(self.colormapDiag._minValue._numVal.isEnabled())
+                        self.assertFalse(self.colormapDiag._maxValue._numVal.isEnabled())
 
     def testColormapDel(self):
         """Check behavior if the colormap has been deleted outside. For now
@@ -211,15 +222,17 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.colormap.setNormalization(Colormap.LOGARITHM)
         self.assertFalse(self.colormapDiag._normButtonLinear.isChecked())
         self.colormap.setVRange(11, 201)
-        self.assertTrue(self.colormapDiag._minValue.value() == 11)
-        self.assertTrue(self.colormapDiag._maxValue.value() == 201)
-        self.assertTrue(self.colormapDiag._minValue.isEnabled())
-        self.assertTrue(self.colormapDiag._maxValue.isEnabled())
-        self.assertFalse(self.colormapDiag._rangeAutoscaleButton.isChecked())
+        self.assertTrue(self.colormapDiag._minValue.getValue() == 11)
+        self.assertTrue(self.colormapDiag._maxValue.getValue() == 201)
+        self.assertTrue(self.colormapDiag._minValue._numVal.isEnabled())
+        self.assertTrue(self.colormapDiag._maxValue._numVal.isEnabled())
+        self.assertFalse(self.colormapDiag._minValue.isAutoChecked())
+        self.assertFalse(self.colormapDiag._maxValue.isAutoChecked())
         self.colormap.setVRange(None, None)
-        self.assertFalse(self.colormapDiag._minValue.isEnabled())
-        self.assertFalse(self.colormapDiag._maxValue.isEnabled())
-        self.assertTrue(self.colormapDiag._rangeAutoscaleButton.isChecked())
+        self.assertFalse(self.colormapDiag._minValue._numVal.isEnabled())
+        self.assertFalse(self.colormapDiag._maxValue._numVal.isEnabled())
+        self.assertTrue(self.colormapDiag._minValue.isAutoChecked())
+        self.assertTrue(self.colormapDiag._maxValue.isAutoChecked())
 
     def testSetColormapScenario(self):
         colormap1 = Colormap(name='gray', vmin=10.0, vmax=20.0,

--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -141,8 +141,13 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
                         self.assertTrue(self.colormapDiag._maxValue.isEnabled())
 
     def testColormapDel(self):
-        """Check behavior if the colormap has been deleted outside"""
-        pass
+        """Check behavior if the colormap has been deleted outside. For now
+        we make sure the colormap is still running and nothing more"""
+        self.colormapDiag.setColormap(self.colormap)
+        self.colormapDiag.show()
+        del self.colormap
+        self.assertTrue(self.colormapDiag.getColormap() is None)
+        self.colormapDiag.setDataRange(0, 20)
 
     def testColormapEditedOutside(self):
         """Make sure the GUI is still up to date if the colormap is modified

--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -139,11 +139,11 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
                     if autoscale is False:
                         self.assertTrue(self.colormapDiag._minValue.value() == 11)
                         self.assertTrue(self.colormapDiag._maxValue.value() == 101)
-                        self.assertFalse(self.colormapDiag._minValue.isEnabled())
-                        self.assertFalse(self.colormapDiag._maxValue.isEnabled())
-                    else:
                         self.assertTrue(self.colormapDiag._minValue.isEnabled())
                         self.assertTrue(self.colormapDiag._maxValue.isEnabled())
+                    else:
+                        self.assertFalse(self.colormapDiag._minValue.isEnabled())
+                        self.assertFalse(self.colormapDiag._maxValue.isEnabled())
 
     def testColormapDel(self):
         """Check behavior if the colormap has been deleted outside. For now
@@ -157,8 +157,32 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
     def testColormapEditedOutside(self):
         """Make sure the GUI is still up to date if the colormap is modified
         outside"""
-        pass
+        self.colormapDiag.setColormap(self.colormap)
+        self.colormapDiag.show()
 
+        print(1)
+        self.colormap.setName('red')
+        self.assertTrue(
+            self.colormapDiag._comboBoxColormap.currentText() == 'Red')
+        print(2)
+
+        self.colormap.setNormalization(Colormap.LOGARITHM)
+        print(3)
+
+        self.assertFalse(self.colormapDiag._normButtonLinear.isChecked())
+        print(4)
+
+        self.colormap.setVRange(11, 201)
+        self.assertTrue(self.colormapDiag._minValue.value() == 11)
+        self.assertTrue(self.colormapDiag._maxValue.value() == 201)
+        self.assertTrue(self.colormapDiag._minValue.isEnabled())
+        self.assertTrue(self.colormapDiag._maxValue.isEnabled())
+        self.assertFalse(self.colormapDiag._rangeAutoscaleButton.isChecked())
+
+        self.colormap.setVRange(None, None)
+        self.assertFalse(self.colormapDiag._minValue.isEnabled())
+        self.assertFalse(self.colormapDiag._maxValue.isEnabled())
+        self.assertTrue(self.colormapDiag._rangeAutoscaleButton.isChecked())
 
 def suite():
     test_suite = unittest.TestSuite()

--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -35,6 +35,8 @@ import unittest
 from silx.gui.test.utils import qWaitForWindowExposedAndActivate
 from silx.gui import qt
 from silx.gui.plot import ColormapDialog
+from silx.gui.test.utils import TestCaseQt
+from silx.gui.plot.Colormap import Colormap
 
 
 # Makes sure a QApplication exists
@@ -58,9 +60,55 @@ cmapDocTestSuite = doctest.DocTestSuite(ColormapDialog, tearDown=_tearDownQt)
 """Test suite of tests from the module's docstrings."""
 
 
+class TestColormapDialog(TestCaseQt):
+    def setUp(self):
+        self.colormap = Colormap(name='gray', vmin=0.0, vmax=1.0,
+                                 normalization='linear')
+
+        self.colormapDiag = ColormapDialog.ColormapDialog()
+        self.colormapDiag.setAttribute(qt.Qt.WA_DeleteOnClose)
+
+    def tearDown(self):
+        self.colormapDiag.close()
+        del self.colormapDiag
+
+    def testGUIEdition(self):
+        """Make sure the colormap is correctly edited"""
+        self.colormapDiag.setColormap(self.colormap)
+        self.colormapDiag._rangeAutoscaleButton.setChecked(False)
+        self.colormapDiag._comboBoxColormap.setCurrentIndex(3)
+        self.colormapDiag._normButtonLog.setChecked(True)
+        self.colormapDiag.setDataRange(10.0, 20.0)
+        self.assertTrue(self.colormap.getName() == 'red')
+        self.assertTrue(self.colormapDiag.getColormap().getName() == 'red')
+        self.assertTrue(self.colormap.getNormalization() == 'log')
+        self.assertTrue(self.colormap.getVMin() == 10)
+        self.assertTrue(self.colormap.getVMax() == 20)
+
+    def testGUIAccept(self):
+        """Make sure the colormap is modify if go through accept"""
+        pass
+
+    def testGUIReject(self):
+        """Make sure the colormap is modify if go through reject"""
+        pass
+
+    def testColormapDel(self):
+        """Check behavior if the colormap has been deleted outside"""
+        pass
+
+    def testColormapEditedOutside(self):
+        """Make sure the GUI is still up to date if the colormap is modified
+        outside"""
+        pass
+
+
 def suite():
     test_suite = unittest.TestSuite()
     test_suite.addTest(cmapDocTestSuite)
+    for testClass in (TestColormapDialog, ):
+        test_suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(
+            testClass))
     return test_suite
 
 

--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -36,7 +36,7 @@ from silx.gui.test.utils import qWaitForWindowExposedAndActivate
 from silx.gui import qt
 from silx.gui.plot import ColormapDialog
 from silx.gui.test.utils import TestCaseQt
-from silx.gui.plot.Colormap import Colormap
+from silx.gui.plot.Colormap import Colormap, preferredColormaps
 from silx.test.utils import ParametricTestCase
 from silx.gui.plot.PlotWindow import PlotWindow
 
@@ -257,7 +257,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         """
         def getFirstNotPreferredColormap():
             cms = Colormap.getSupportedColormaps()
-            preferred = ColormapDialog._ColormapNameCombox.colormaps
+            preferred = preferredColormaps()
             for cm in cms:
                 if cm not in preferred:
                     return cm

--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -62,7 +62,10 @@ cmapDocTestSuite = doctest.DocTestSuite(ColormapDialog, tearDown=_tearDownQt)
 
 
 class TestColormapDialog(TestCaseQt, ParametricTestCase):
+    """Test the ColormapDialog."""
     def setUp(self):
+        TestCaseQt.setUp(self)
+        ParametricTestCase.setUp(self)
         self.colormap = Colormap(name='gray', vmin=0.0, vmax=1.0,
                                  normalization='linear')
 
@@ -72,6 +75,8 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
     def tearDown(self):
         self.colormapDiag.close()
         del self.colormapDiag
+        ParametricTestCase.tearDown(self)
+        TestCaseQt.tearDown(self)
 
     def testGUIEdition(self):
         """Make sure the colormap is correctly edited"""

--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -191,29 +191,22 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.colormapDiag.setColormap(self.colormap)
         self.colormapDiag.show()
 
-        print(1)
         self.colormap.setName('red')
         self.assertTrue(
             self.colormapDiag._comboBoxColormap.currentText() == 'Red')
-        print(2)
-
         self.colormap.setNormalization(Colormap.LOGARITHM)
-        print(3)
-
         self.assertFalse(self.colormapDiag._normButtonLinear.isChecked())
-        print(4)
-
         self.colormap.setVRange(11, 201)
         self.assertTrue(self.colormapDiag._minValue.value() == 11)
         self.assertTrue(self.colormapDiag._maxValue.value() == 201)
         self.assertTrue(self.colormapDiag._minValue.isEnabled())
         self.assertTrue(self.colormapDiag._maxValue.isEnabled())
         self.assertFalse(self.colormapDiag._rangeAutoscaleButton.isChecked())
-
         self.colormap.setVRange(None, None)
         self.assertFalse(self.colormapDiag._minValue.isEnabled())
         self.assertFalse(self.colormapDiag._maxValue.isEnabled())
         self.assertTrue(self.colormapDiag._rangeAutoscaleButton.isChecked())
+
 
 def suite():
     test_suite = unittest.TestSuite()

--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -66,7 +66,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
     def setUp(self):
         TestCaseQt.setUp(self)
         ParametricTestCase.setUp(self)
-        self.colormap = Colormap(name='gray', vmin=0.0, vmax=1.0,
+        self.colormap = Colormap(name='gray', vmin=10.0, vmax=20.0,
                                  normalization='linear')
 
         self.colormapDiag = ColormapDialog.ColormapDialog()
@@ -84,29 +84,60 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.colormapDiag._rangeAutoscaleButton.setChecked(False)
         self.colormapDiag._comboBoxColormap.setCurrentIndex(3)
         self.colormapDiag._normButtonLog.setChecked(True)
-        self.colormapDiag.setDataRange(10.0, 20.0)
         self.assertTrue(self.colormap.getName() == 'red')
         self.assertTrue(self.colormapDiag.getColormap().getName() == 'red')
         self.assertTrue(self.colormap.getNormalization() == 'log')
         self.assertTrue(self.colormap.getVMin() == 10)
         self.assertTrue(self.colormap.getVMax() == 20)
 
-    def testGUIAccept(self):
+    def testGUIModalOk(self):
         """Make sure the colormap is modify if go through accept"""
         assert self.colormap.isAutoscale() is False
+        self.colormapDiag.setModal(True)
         self.colormapDiag.show()
         self.colormapDiag.setColormap(self.colormap)
         self.colormapDiag._rangeAutoscaleButton.setChecked(True)
-        self.colormapDiag.accept()
+        self.mouseClick(
+            widget=self.colormapDiag._buttonsModal.button(qt.QDialogButtonBox.Ok),
+            button=qt.Qt.LeftButton
+        )
         self.assertTrue(self.colormap.isAutoscale() is True)
 
-    def testGUIReject(self):
+    def testGUIModalCancel(self):
         """Make sure the colormap is modify if go through reject"""
         assert self.colormap.isAutoscale() is False
+        self.colormapDiag.setModal(True)
         self.colormapDiag.show()
         self.colormapDiag.setColormap(self.colormap)
         self.colormapDiag._rangeAutoscaleButton.setChecked(True)
-        self.colormapDiag.reject()
+        self.mouseClick(
+            widget=self.colormapDiag._buttonsModal.button(qt.QDialogButtonBox.Cancel),
+            button=qt.Qt.LeftButton
+        )
+        self.assertTrue(self.colormap.isAutoscale() is False)
+
+    def testGUIModalClose(self):
+        assert self.colormap.isAutoscale() is False
+        self.colormapDiag.setModal(False)
+        self.colormapDiag.show()
+        self.colormapDiag.setColormap(self.colormap)
+        self.colormapDiag._rangeAutoscaleButton.setChecked(True)
+        self.mouseClick(
+            widget=self.colormapDiag._buttonsNonModal.button(qt.QDialogButtonBox.Close),
+            button=qt.Qt.LeftButton
+        )
+        self.assertTrue(self.colormap.isAutoscale() is True)
+
+    def testGUIModalReset(self):
+        assert self.colormap.isAutoscale() is False
+        self.colormapDiag.setModal(False)
+        self.colormapDiag.show()
+        self.colormapDiag.setColormap(self.colormap)
+        self.colormapDiag._rangeAutoscaleButton.setChecked(True)
+        self.mouseClick(
+            widget=self.colormapDiag._buttonsNonModal.button(qt.QDialogButtonBox.Reset),
+            button=qt.Qt.LeftButton
+        )
         self.assertTrue(self.colormap.isAutoscale() is False)
 
     def testGUIClose(self):
@@ -152,7 +183,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.colormapDiag.show()
         del self.colormap
         self.assertTrue(self.colormapDiag.getColormap() is None)
-        self.colormapDiag.setDataRange(0, 20)
+        self.colormapDiag._comboBoxColormap.setCurrentIndex(2)
 
     def testColormapEditedOutside(self):
         """Make sure the GUI is still up to date if the colormap is modified

--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -81,8 +81,13 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         TestCaseQt.tearDown(self)
 
     def testGUIEdition(self):
-        """Make sure the colormap is correctly edited"""
+        """Make sure the colormap is correctly edited and also that the
+        modification are correctly updated if an other colormapdialog is
+        editing the same colormap"""
+        colormapDiag2 = ColormapDialog.ColormapDialog()
+        colormapDiag2.setColormap(self.colormap)
         self.colormapDiag.setColormap(self.colormap)
+
         self.colormapDiag._rangeAutoscaleButton.setChecked(False)
         self.colormapDiag._comboBoxColormap.setCurrentIndex(3)
         self.colormapDiag._normButtonLog.setChecked(True)
@@ -91,6 +96,12 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.assertTrue(self.colormap.getNormalization() == 'log')
         self.assertTrue(self.colormap.getVMin() == 10)
         self.assertTrue(self.colormap.getVMax() == 20)
+        # checked second colormap dialog
+        self.assertTrue(colormapDiag2._comboBoxColormap.currentText() == 'Red')
+        self.assertTrue(colormapDiag2._normButtonLog.isChecked())
+        self.assertTrue(int(colormapDiag2._minValue.value()) == 10)
+        self.assertTrue(int(colormapDiag2._maxValue.value()) == 20)
+        colormapDiag2.close()
 
     def testGUIModalOk(self):
         """Make sure the colormap is modify if go through accept"""
@@ -273,6 +284,20 @@ class TestColormapAction(TestCaseQt):
         self.plot.remove('img3')
         self.plot.remove('img1')
         self.assertTrue(self.colormapDialog.getColormap() is self.defaultColormap)
+
+    def testShowHideColormapDialog(self):
+        self.assertFalse(self.plot.getColormapAction().isChecked())
+        self.plot.getColormapAction()._actionTriggered()
+        # _qapp.processEvents()
+        # self.assertTrue(self.plot.getColormapAction().isChecked())
+        self.plot.addImage(data=numpy.random.rand(10, 10), legend='img1',
+                           replace=False, origin=(0, 0),
+                           colormap=self.colormap1)
+        self.colormap1.setName('red')
+        self.plot.getColormapAction()._actionTriggered()
+        self.colormap1.setName('blue')
+        self.colormapDialog.close()
+        self.assertFalse(self.plot.getColormapAction().isChecked())
 
 
 def suite():

--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -235,6 +235,8 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.assertTrue(self.colormapDiag._maxValue.isAutoChecked())
 
     def testSetColormapScenario(self):
+        """Test of a simple scenario of a colormap dialog editing several
+        colormap"""
         colormap1 = Colormap(name='gray', vmin=10.0, vmax=20.0,
                              normalization='linear')
         colormap2 = Colormap(name='red', vmin=10.0, vmax=20.0,
@@ -248,6 +250,31 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         del colormap2
         self.colormapDiag.setColormap(colormap3)
         del colormap3
+
+    def testNotPreferredColormap(self):
+        """Test that the colormapEditor is able to edit a colormap which is not
+        part of the 'prefered colormap'
+        """
+        def getFirstNotPreferredColormap():
+            cms = Colormap.getSupportedColormaps()
+            preferred = self.colormapDiag._colormapList
+            for cm in cms:
+                if cm not in preferred:
+                    return cm
+            return None
+
+        colormapName = getFirstNotPreferredColormap()
+        assert colormapName is not None
+        colormap = Colormap(name=colormapName)
+        self.colormapDiag.setColormap(colormap)
+        self.colormapDiag.show()
+        cb = self.colormapDiag._comboBoxColormap
+        self.assertTrue(cb.currentText().lower() == colormapName.lower())
+        cb.setCurrentIndex(0)
+        index = cb.findText(colormapName)
+        assert index is not 0  # if 0 then the rest of the test has no sense
+        cb.setCurrentIndex(index)
+        self.assertTrue(cb.currentText().lower() == colormapName.lower())
 
 
 class TestColormapAction(TestCaseQt):


### PR DESCRIPTION
should fix #1192 

- [x] have a gui valid for modal and non-modal 
- [x] take an object in set colormap
- [x] listen to the colormap state
- [x] edit the colormap
- [x] check sync between two colormapdialog editing the same colormap
- [x] replace autoscale button and use one button 'auto' per boundary
- [x] unit tests
- [x] add colormap name to the combobox if not existing yet
- [x] update the colormapAction