### PR TITLE
Rework ImageFileDialog URLs

### DIFF
--- a/doc/source/modules/index.rst
+++ b/doc/source/modules/index.rst
@@ -11,4 +11,3 @@ API Reference
    resources.rst
    utils/index.rst
    test/index.rst
-

--- a/doc/source/modules/io/index.rst
+++ b/doc/source/modules/io/index.rst
@@ -16,6 +16,7 @@
    specfile.rst
    specfilewrapper.rst
    spech5.rst
+   url.rst
    utils.rst
 
 Top-level functions

--- a/doc/source/modules/io/index.rst
+++ b/doc/source/modules/io/index.rst
@@ -24,6 +24,7 @@ Top-level functions
 
 .. autofunction:: silx.io.open
 .. autofunction:: silx.io.save1D
+.. autofunction:: silx.io.get_data
 
 .. autofunction:: silx.io.is_dataset
 .. autofunction:: silx.io.is_group

--- a/doc/source/modules/io/url.rst
+++ b/doc/source/modules/io/url.rst
@@ -1,0 +1,8 @@
+
+.. currentmodule:: silx.io
+
+:mod:`url`: Utils for data locators
+-----------------------------------
+
+.. automodule:: silx.io.url
+    :members:

--- a/silx/gui/dialog/ImageFileDialog.py
+++ b/silx/gui/dialog/ImageFileDialog.py
@@ -1363,7 +1363,7 @@ class ImageFileDialog(qt.QDialog):
             source = self.__formatShape(self.__data.shape)
             self.__dataInfo.setText(u"%s \u2192 %s" % (source, destination))
 
-    def __createUriFromIndex(self, index, useSlicingWidget=True):
+    def __createUrlFromIndex(self, index, useSlicingWidget=True):
         if index.model() is self.__fileModel:
             filename = self.__fileModel.filePath(index)
             dataPath = None
@@ -1397,30 +1397,30 @@ class ImageFileDialog(qt.QDialog):
             else:
                 scheme = None
 
-        uri = silx.io.url.DataUrl(file_path=filename, data_path=dataPath, data_slice=slicing, scheme=scheme)
-        return uri
+        url = silx.io.url.DataUrl(file_path=filename, data_path=dataPath, data_slice=slicing, scheme=scheme)
+        return url
 
     def __updatePath(self):
         index = self.__browser.selectedIndex()
         if index is None:
             index = self.__browser.rootIndex()
-        uri = self.__createUriFromIndex(index)
-        if uri.path() != self.__pathEdit.text():
+        url = self.__createUrlFromIndex(index)
+        if url.path() != self.__pathEdit.text():
             old = self.__pathEdit.blockSignals(True)
-            self.__pathEdit.setText(uri.path())
+            self.__pathEdit.setText(url.path())
             self.__pathEdit.blockSignals(old)
 
     def __rootIndexChanged(self, index):
-        uri = self.__createUriFromIndex(index, useSlicingWidget=False)
+        url = self.__createUrlFromIndex(index, useSlicingWidget=False)
 
-        currentUri = None
+        currentUrl = None
         if 0 <= self.__currentHistoryLocation < len(self.__currentHistory):
-            currentUri = self.__currentHistory[self.__currentHistoryLocation]
+            currentUrl = self.__currentHistory[self.__currentHistoryLocation]
 
-        if currentUri is None or currentUri != uri.path():
+        if currentUrl is None or currentUrl != url.path():
             # clean up the forward history
             self.__currentHistory = self.__currentHistory[0:self.__currentHistoryLocation + 1]
-            self.__currentHistory.append(uri.path())
+            self.__currentHistory.append(url.path())
             self.__currentHistoryLocation += 1
 
         if index.model() != self.__dataModel:
@@ -1460,36 +1460,36 @@ class ImageFileDialog(qt.QDialog):
         self.__pathChanged()
 
     def __pathChanged(self):
-        uri = silx.io.url.DataUrl(path=self.__pathEdit.text())
-        if uri.is_valid() or uri.path() == "":
-            if uri.path() in ["", "/"] or uri.file_path() in ["", "/"]:
+        url = silx.io.url.DataUrl(path=self.__pathEdit.text())
+        if url.is_valid() or url.path() == "":
+            if url.path() in ["", "/"] or url.file_path() in ["", "/"]:
                 self.__fileModel_setRootPath(qt.QDir.rootPath())
-            elif os.path.exists(uri.file_path()):
+            elif os.path.exists(url.file_path()):
                 rootIndex = None
-                if os.path.isdir(uri.file_path()):
-                    self.__fileModel_setRootPath(uri.file_path())
-                    index = self.__fileModel.index(uri.file_path())
-                elif os.path.isfile(uri.file_path()):
-                    if uri.scheme() == "silx":
-                        loaded = self.__openSilxFile(uri.file_path())
-                    elif uri.scheme() == "fabio":
-                        loaded = self.__openFabioFile(uri.file_path())
+                if os.path.isdir(url.file_path()):
+                    self.__fileModel_setRootPath(url.file_path())
+                    index = self.__fileModel.index(url.file_path())
+                elif os.path.isfile(url.file_path()):
+                    if url.scheme() == "silx":
+                        loaded = self.__openSilxFile(url.file_path())
+                    elif url.scheme() == "fabio":
+                        loaded = self.__openFabioFile(url.file_path())
                     else:
-                        loaded = self.__openFile(uri.file_path())
+                        loaded = self.__openFile(url.file_path())
                     if loaded:
                         if self.__h5 is not None:
                             rootIndex = self.__dataModel.indexFromH5Object(self.__h5)
                         elif self.__fabio is not None:
-                            index = self.__fileModel.index(uri.file_path())
+                            index = self.__fileModel.index(url.file_path())
                             rootIndex = index
                     if rootIndex is None:
-                        index = self.__fileModel.index(uri.file_path())
+                        index = self.__fileModel.index(url.file_path())
                         index = index.parent()
 
                 if rootIndex is not None:
                     if rootIndex.model() == self.__dataModel:
-                        if uri.data_path() is not None:
-                            dataPath = uri.data_path()
+                        if url.data_path() is not None:
+                            dataPath = url.data_path()
                             if dataPath in self.__h5:
                                 obj = self.__h5[dataPath]
                             else:
@@ -1524,14 +1524,14 @@ class ImageFileDialog(qt.QDialog):
                     self.__browser.setRootIndex(index, model=self.__fileModel)
                     self.__clearData()
 
-                self.__slicing.setVisible(uri.data_slice() is not None)
-                if uri.data_slice() is not None:
-                    self.__slicing.setSlicing(uri.data_slice())
+                self.__slicing.setVisible(url.data_slice() is not None)
+                if url.data_slice() is not None:
+                    self.__slicing.setSlicing(url.data_slice())
             else:
-                self.__errorWhileLoadingFile = (uri.file_path(), "File not found")
+                self.__errorWhileLoadingFile = (url.file_path(), "File not found")
                 self.__clearData()
         else:
-            self.__errorWhileLoadingFile = (uri.file_path(), "Path invalid")
+            self.__errorWhileLoadingFile = (url.file_path(), "Path invalid")
             self.__clearData()
 
     # Selected file
@@ -1573,7 +1573,7 @@ class ImageFileDialog(qt.QDialog):
         self.__pathChanged()
 
     def selectedPath(self):
-        """Returns the URI from the file path to the image.
+        """Returns the URL from the file path to the image.
 
         If the dialog is not validated, the path can be an intermediat
         selected path, or an invalid path.

--- a/silx/gui/dialog/ImageFileDialog.py
+++ b/silx/gui/dialog/ImageFileDialog.py
@@ -28,13 +28,13 @@ This module contains an :class:`ImageFileDialog`.
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "08/12/2017"
+__date__ = "11/12/2017"
 
 import sys
 import os
 import logging
 import numpy
-import silx.io
+import silx.io.url
 from silx.gui.plot import actions
 from silx.gui import qt
 from silx.gui.plot.PlotWidget import PlotWidget
@@ -49,100 +49,6 @@ except ImportError:
 
 
 _logger = logging.getLogger(__name__)
-
-
-class _ImageUri(object):
-
-    def __init__(self, path=None, filename=None, dataPath=None, slicing=None, scheme=None):
-        self.__isValid = False
-        if path is not None:
-            self.__fromPath(path)
-        else:
-            self.__filename = filename
-            self.__dataPath = dataPath
-            self.__slice = slicing
-            self.__scheme = scheme
-            self.__path = None
-            if self.__filename in ["", "/"]:
-                self.__isValid = self.__dataPath is None and self.__slice is None
-            else:
-                self.__isValid = self.__filename is not None
-            if self.__scheme not in [None, "silx", "fabio"]:
-                self.__isValid = False
-
-    def __fromPath(self, path):
-        elements = path.split("::", 1)
-        self.__path = path
-
-        scheme_and_filename = elements[0].split(":", 1)
-        if len(scheme_and_filename) == 2:
-            if len(scheme_and_filename[0]) <= 2:
-                # Windows driver
-                self.__scheme = None
-                self.__filename = elements[0]
-            else:
-                self.__scheme = scheme_and_filename[0]
-                self.__filename = scheme_and_filename[1]
-        else:
-            self.__scheme = None
-            self.__filename = scheme_and_filename[0]
-        self.__slice = None
-        self.__dataPath = None
-        if len(elements) == 1:
-            pass
-        else:
-            selector = elements[1]
-            selectors = selector.split("[", 1)
-            self.__dataPath = selectors[0]
-            if len(selectors) == 2:
-                slicing = selectors[1].split("]", 1)
-                if len(slicing) < 2 or slicing[1] != "":
-                    self.__isValid = False
-                    return
-                slicing = slicing[0].split(",")
-                try:
-                    slicing = [int(s) for s in slicing]
-                    self.__slice = slicing
-                except ValueError:
-                    self.__isValid = False
-                    return
-
-        self.__isValid = self.__scheme in [None, "silx", "fabio"]
-
-    def isValid(self):
-        return self.__isValid
-
-    def path(self):
-        if self.__path is not None:
-            return self.__path
-
-        path = ""
-        selector = ""
-        if self.__filename is not None:
-            path += self.__filename
-        if self.__dataPath is not None:
-            selector += self.__dataPath
-        if self.__slice is not None:
-            selector += "[%s]" % ",".join([str(s) for s in self.__slice])
-
-        if selector != "":
-            path = path + "::" + selector
-
-        if self.__scheme is not None:
-            path = self.__scheme + ":" + path
-        return path
-
-    def filename(self):
-        return self.__filename
-
-    def dataPath(self):
-        return self.__dataPath
-
-    def slice(self):
-        return self.__slice
-
-    def scheme(self):
-        return self.__scheme
 
 
 class _IconProvider(object):
@@ -1491,7 +1397,7 @@ class ImageFileDialog(qt.QDialog):
             else:
                 scheme = None
 
-        uri = _ImageUri(filename=filename, dataPath=dataPath, slicing=slicing, scheme=scheme)
+        uri = silx.io.url.DataUrl(file_path=filename, data_path=dataPath, data_slice=slicing, scheme=scheme)
         return uri
 
     def __updatePath(self):
@@ -1554,36 +1460,36 @@ class ImageFileDialog(qt.QDialog):
         self.__pathChanged()
 
     def __pathChanged(self):
-        uri = _ImageUri(path=self.__pathEdit.text())
-        if uri.isValid():
-            if uri.filename() in ["", "/"]:
+        uri = silx.io.url.DataUrl(path=self.__pathEdit.text())
+        if uri.is_valid() or uri.path() == "":
+            if uri.path() in ["", "/"] or uri.file_path() in ["", "/"]:
                 self.__fileModel_setRootPath(qt.QDir.rootPath())
-            elif os.path.exists(uri.filename()):
+            elif os.path.exists(uri.file_path()):
                 rootIndex = None
-                if os.path.isdir(uri.filename()):
-                    self.__fileModel_setRootPath(uri.filename())
-                    index = self.__fileModel.index(uri.filename())
-                elif os.path.isfile(uri.filename()):
+                if os.path.isdir(uri.file_path()):
+                    self.__fileModel_setRootPath(uri.file_path())
+                    index = self.__fileModel.index(uri.file_path())
+                elif os.path.isfile(uri.file_path()):
                     if uri.scheme() == "silx":
-                        loaded = self.__openSilxFile(uri.filename())
+                        loaded = self.__openSilxFile(uri.file_path())
                     elif uri.scheme() == "fabio":
-                        loaded = self.__openFabioFile(uri.filename())
+                        loaded = self.__openFabioFile(uri.file_path())
                     else:
-                        loaded = self.__openFile(uri.filename())
+                        loaded = self.__openFile(uri.file_path())
                     if loaded:
                         if self.__h5 is not None:
                             rootIndex = self.__dataModel.indexFromH5Object(self.__h5)
                         elif self.__fabio is not None:
-                            index = self.__fileModel.index(uri.filename())
+                            index = self.__fileModel.index(uri.file_path())
                             rootIndex = index
                     if rootIndex is None:
-                        index = self.__fileModel.index(uri.filename())
+                        index = self.__fileModel.index(uri.file_path())
                         index = index.parent()
 
                 if rootIndex is not None:
                     if rootIndex.model() == self.__dataModel:
-                        if uri.dataPath() is not None:
-                            dataPath = uri.dataPath()
+                        if uri.data_path() is not None:
+                            dataPath = uri.data_path()
                             if dataPath in self.__h5:
                                 obj = self.__h5[dataPath]
                             else:
@@ -1618,14 +1524,14 @@ class ImageFileDialog(qt.QDialog):
                     self.__browser.setRootIndex(index, model=self.__fileModel)
                     self.__clearData()
 
-                self.__slicing.setVisible(uri.slice() is not None)
-                if uri.slice() is not None:
-                    self.__slicing.setSlicing(uri.slice())
+                self.__slicing.setVisible(uri.data_slice() is not None)
+                if uri.data_slice() is not None:
+                    self.__slicing.setSlicing(uri.data_slice())
             else:
-                self.__errorWhileLoadingFile = (uri.filename(), "File not found")
+                self.__errorWhileLoadingFile = (uri.file_path(), "File not found")
                 self.__clearData()
         else:
-            self.__errorWhileLoadingFile = (uri.filename(), "Path invalid")
+            self.__errorWhileLoadingFile = (uri.file_path(), "Path invalid")
             self.__clearData()
 
     # Selected file

--- a/silx/io/__init__.py
+++ b/silx/io/__init__.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "30/11/2017"
+__date__ = "11/12/2017"
 
 
 from .utils import open  # pylint:disable=redefined-builtin
@@ -37,6 +37,7 @@ from .utils import is_file
 from .utils import is_group
 from .utils import is_softlink
 from .utils import supported_extensions
+from .utils import get_data
 
 # avoid to import open with "import *"
 __all = locals().keys()

--- a/silx/io/test/__init__.py
+++ b/silx/io/test/__init__.py
@@ -24,7 +24,7 @@
 
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "20/09/2017"
+__date__ = "08/12/2017"
 
 import unittest
 
@@ -39,6 +39,7 @@ from .test_utils import suite as test_utils_suite
 from .test_nxdata import suite as test_nxdata_suite
 from .test_commonh5 import suite as test_commonh5_suite
 from .test_rawh5 import suite as test_rawh5_suite
+from .test_url import suite as test_url_suite
 
 
 def suite():
@@ -54,4 +55,5 @@ def suite():
     test_suite.addTest(test_nxdata_suite())
     test_suite.addTest(test_commonh5_suite())
     test_suite.addTest(test_rawh5_suite())
+    test_suite.addTest(test_url_suite())
     return test_suite

--- a/silx/io/test/test_url.py
+++ b/silx/io/test/test_url.py
@@ -40,7 +40,7 @@ class TestDataUrl(unittest.TestCase):
         self.assertEqual(url.scheme(), expected[2])
         self.assertEqual(url.file_path(), expected[3])
         self.assertEqual(url.data_path(), expected[4])
-        self.assertEqual(url.slice(), expected[5])
+        self.assertEqual(url.data_slice(), expected[5])
 
     def test_fabio_absolute(self):
         url = DataUrl("fabio:///data/image.edf::[2]")
@@ -173,23 +173,23 @@ class TestDataUrl(unittest.TestCase):
         self.assertUrl(url, expected)
 
     def test_create_relative_url(self):
-        url = DataUrl(scheme="silx", file_path="./foo.h5", data_path="/", slicing=(5, 1))
+        url = DataUrl(scheme="silx", file_path="./foo.h5", data_path="/", data_slice=(5, 1))
         self.assertEqual(url.path(), "silx:./foo.h5::/[5,1]")
 
     def test_create_absolute_url(self):
-        url = DataUrl(scheme="silx", file_path="/foo.h5", data_path="/", slicing=(5, 1))
+        url = DataUrl(scheme="silx", file_path="/foo.h5", data_path="/", data_slice=(5, 1))
         self.assertEqual(url.path(), "silx:///foo.h5::/[5,1]")
 
     def test_create_absolute_windows_url(self):
-        url = DataUrl(scheme="silx", file_path="C:/foo.h5", data_path="/", slicing=(5, 1))
+        url = DataUrl(scheme="silx", file_path="C:/foo.h5", data_path="/", data_slice=(5, 1))
         self.assertEqual(url.path(), "silx:///C:/foo.h5::/[5,1]")
 
     def test_create_slice_url(self):
-        url = DataUrl(scheme="silx", file_path="/foo.h5", data_path="/", slicing=(5, 1, Ellipsis, slice(None)))
+        url = DataUrl(scheme="silx", file_path="/foo.h5", data_path="/", data_slice=(5, 1, Ellipsis, slice(None)))
         self.assertEqual(url.path(), "silx:///foo.h5::/[5,1,...,:]")
 
     def test_wrong_url(self):
-        url = DataUrl(scheme="silx", file_path="/foo.h5", slicing=(5, 1))
+        url = DataUrl(scheme="silx", file_path="/foo.h5", data_slice=(5, 1))
         self.assertFalse(url.is_valid())
 
 

--- a/silx/io/test/test_url.py
+++ b/silx/io/test/test_url.py
@@ -1,0 +1,204 @@
+# coding: utf-8
+# /*##########################################################################
+# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+"""Tests for url module"""
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "08/12/2017"
+
+
+import unittest
+from ..url import DataUrl
+
+
+class TestDataUrl(unittest.TestCase):
+
+    def assertUrl(self, url, expected):
+        self.assertEqual(url.is_valid(), expected[0])
+        self.assertEqual(url.is_absolute(), expected[1])
+        self.assertEqual(url.scheme(), expected[2])
+        self.assertEqual(url.file_path(), expected[3])
+        self.assertEqual(url.data_path(), expected[4])
+        self.assertEqual(url.slice(), expected[5])
+
+    def test_fabio_absolute(self):
+        url = DataUrl("fabio:///data/image.edf::[2]")
+        expected = [True, True, "fabio", "/data/image.edf", None, (2, )]
+        self.assertUrl(url, expected)
+
+    def test_fabio_absolute_windows(self):
+        url = DataUrl("fabio:///C:/data/image.edf::[2]")
+        expected = [True, True, "fabio", "C:/data/image.edf", None, (2, )]
+        self.assertUrl(url, expected)
+
+    def test_silx_absolute(self):
+        url = DataUrl("silx:///data/image.h5::/data/dataset[1,5]")
+        expected = [True, True, "silx", "/data/image.h5", "/data/dataset", (1, 5)]
+        self.assertUrl(url, expected)
+
+    def test_silx_absolute2(self):
+        url = DataUrl("silx:///data/image.edf::/scan_0/detector/data")
+        expected = [True, True, "silx", "/data/image.edf", "/scan_0/detector/data", None]
+        self.assertUrl(url, expected)
+
+    def test_silx_absolute_windows(self):
+        url = DataUrl("silx:///C:/data/image.h5::/scan_0/detector/data")
+        expected = [True, True, "silx", "C:/data/image.h5", "/scan_0/detector/data", None]
+        self.assertUrl(url, expected)
+
+    def test_silx_relative(self):
+        url = DataUrl("silx:./image.h5")
+        expected = [True, False, "silx", "./image.h5", None, None]
+        self.assertUrl(url, expected)
+
+    def test_fabio_relative(self):
+        url = DataUrl("fabio:./image.edf")
+        expected = [True, False, "fabio", "./image.edf", None, None]
+        self.assertUrl(url, expected)
+
+    def test_silx_relative2(self):
+        url = DataUrl("silx:image.h5")
+        expected = [True, False, "silx", "image.h5", None, None]
+        self.assertUrl(url, expected)
+
+    def test_fabio_relative2(self):
+        url = DataUrl("fabio:image.edf")
+        expected = [True, False, "fabio", "image.edf", None, None]
+        self.assertUrl(url, expected)
+
+    def test_file_relative(self):
+        url = DataUrl("image.edf")
+        expected = [True, False, None, "image.edf", None, None]
+        self.assertUrl(url, expected)
+
+    def test_file_relative2(self):
+        url = DataUrl("./foo/bar/image.edf")
+        expected = [True, False, None, "./foo/bar/image.edf", None, None]
+        self.assertUrl(url, expected)
+
+    def test_file_relative3(self):
+        url = DataUrl("foo/bar/image.edf")
+        expected = [True, False, None, "foo/bar/image.edf", None, None]
+        self.assertUrl(url, expected)
+
+    def test_file_absolute(self):
+        url = DataUrl("/data/image.edf")
+        expected = [True, True, None, "/data/image.edf", None, None]
+        self.assertUrl(url, expected)
+
+    def test_file_absolute_windows(self):
+        url = DataUrl("C:/data/image.edf")
+        expected = [True, True, None, "C:/data/image.edf", None, None]
+        self.assertUrl(url, expected)
+
+    def test_absolute_with_path(self):
+        url = DataUrl("/foo/foobar.h5::/foo/bar")
+        expected = [True, True, None, "/foo/foobar.h5", "/foo/bar", None]
+        self.assertUrl(url, expected)
+
+    def test_windows_file_data_slice(self):
+        url = DataUrl("C:/foo/foobar.h5::/foo/bar[5,1]")
+        expected = [True, True, None, "C:/foo/foobar.h5", "/foo/bar", (5, 1)]
+        self.assertUrl(url, expected)
+
+    def test_scheme_file_data_slice(self):
+        url = DataUrl("silx:/foo/foobar.h5::/foo/bar[5,1]")
+        expected = [True, True, "silx", "/foo/foobar.h5", "/foo/bar", (5, 1)]
+        self.assertUrl(url, expected)
+
+    def test_scheme_windows_file_data_slice(self):
+        url = DataUrl("silx:C:/foo/foobar.h5::/foo/bar[5,1]")
+        expected = [True, True, "silx", "C:/foo/foobar.h5", "/foo/bar", (5, 1)]
+        self.assertUrl(url, expected)
+
+    def test_empty(self):
+        url = DataUrl("")
+        expected = [True, False, None, "", None, None]
+        self.assertUrl(url, expected)
+
+    def test_unknown_scheme(self):
+        url = DataUrl("foo:/foo/foobar.h5::/foo/bar[5,1]")
+        expected = [False, True, "foo", "/foo/foobar.h5", "/foo/bar", (5, 1)]
+        self.assertUrl(url, expected)
+
+    def test_slice(self):
+        url = DataUrl("/a.h5::/b[5,1]")
+        expected = [True, True, None, "/a.h5", "/b", (5, 1)]
+        self.assertUrl(url, expected)
+
+    def test_slice_ellipsis(self):
+        url = DataUrl("/a.h5::/b[...]")
+        expected = [True, True, None, "/a.h5", "/b", (Ellipsis, )]
+        self.assertUrl(url, expected)
+
+    def test_slice_slicing(self):
+        url = DataUrl("/a.h5::/b[:]")
+        expected = [True, True, None, "/a.h5", "/b", (slice(None), )]
+        self.assertUrl(url, expected)
+
+    def test_slice_missing_element(self):
+        url = DataUrl("/a.h5::/b[5,,1]")
+        expected = [False, True, None, "/a.h5", "/b", None]
+        self.assertUrl(url, expected)
+
+    def test_slice_non_termination(self):
+        url = DataUrl("/a.h5::/b[5")
+        expected = [False, True, None, "/a.h5", "/b", None]
+        self.assertUrl(url, expected)
+
+    def test_slice_no_elements(self):
+        url = DataUrl("/a.h5::/b[]")
+        expected = [False, True, None, "/a.h5", "/b", None]
+        self.assertUrl(url, expected)
+
+    def test_create_relative_url(self):
+        url = DataUrl(scheme="silx", file_path="./foo.h5", data_path="/", slicing=(5, 1))
+        self.assertEqual(url.path(), "silx:./foo.h5::/[5,1]")
+
+    def test_create_absolute_url(self):
+        url = DataUrl(scheme="silx", file_path="/foo.h5", data_path="/", slicing=(5, 1))
+        self.assertEqual(url.path(), "silx:///foo.h5::/[5,1]")
+
+    def test_create_absolute_windows_url(self):
+        url = DataUrl(scheme="silx", file_path="C:/foo.h5", data_path="/", slicing=(5, 1))
+        self.assertEqual(url.path(), "silx:///C:/foo.h5::/[5,1]")
+
+    def test_create_slice_url(self):
+        url = DataUrl(scheme="silx", file_path="/foo.h5", data_path="/", slicing=(5, 1, Ellipsis, slice(None)))
+        self.assertEqual(url.path(), "silx:///foo.h5::/[5,1,...,:]")
+
+    def test_wrong_url(self):
+        url = DataUrl(scheme="silx", file_path="/foo.h5", slicing=(5, 1))
+        self.assertFalse(url.is_valid())
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(TestDataUrl))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/silx/io/test/test_url.py
+++ b/silx/io/test/test_url.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "08/12/2017"
+__date__ = "11/12/2017"
 
 
 import unittest
@@ -134,7 +134,7 @@ class TestDataUrl(unittest.TestCase):
 
     def test_empty(self):
         url = DataUrl("")
-        expected = [True, False, None, "", None, None]
+        expected = [False, False, None, "", None, None]
         self.assertUrl(url, expected)
 
     def test_unknown_scheme(self):

--- a/silx/io/test/test_utils.py
+++ b/silx/io/test/test_utils.py
@@ -33,6 +33,7 @@ import unittest
 import sys
 
 from .. import utils
+import silx.io.url
 
 try:
     import h5py
@@ -48,7 +49,7 @@ except ImportError:
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "10/10/2017"
+__date__ = "11/12/2017"
 
 
 expected_spec1 = r"""#F .*
@@ -498,6 +499,137 @@ class TestNodes(unittest.TestCase):
         self.assertFalse(utils.is_dataset(obj))
 
 
+class TestGetData(unittest.TestCase):
+    """Test `silx.io.utils.get_data` function."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tmp_directory = tempfile.mkdtemp()
+        cls.createResources(cls.tmp_directory)
+
+    @classmethod
+    def createResources(cls, directory):
+
+        if h5py is not None:
+            cls.h5_filename = os.path.join(directory, "test.h5")
+            h5 = h5py.File(cls.h5_filename, mode="w")
+            h5["group/group/scalar"] = 50
+            h5["group/group/array"] = [1, 2, 3, 4, 5]
+            h5["group/group/array2d"] = [[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]]
+            h5.close()
+
+        cls.spec_filename = os.path.join(directory, "test.dat")
+        utils.savespec(cls.spec_filename, [1], [1.1], xlabel="x", ylabel="y",
+                       fmt=["%d", "%.2f"], close_file=True, scan_number=1)
+
+        if fabio is not None:
+            cls.edf_filename = os.path.join(directory, "test.edf")
+            cls.edf_multiframe_filename = os.path.join(directory, "test_multi.edf")
+            header = fabio.fabioimage.OrderedDict()
+            header["integer"] = "10"
+            data = numpy.array([[10, 50], [50, 10]])
+            fabiofile = fabio.edfimage.EdfImage(data, header)
+            fabiofile.write(cls.edf_filename)
+            fabiofile.appendFrame(data=data, header=header)
+            fabiofile.write(cls.edf_multiframe_filename)
+
+        cls.txt_filename = os.path.join(directory, "test.txt")
+        f = io.open(cls.txt_filename, "w+t")
+        f.write(u"Kikoo")
+        f.close()
+
+        cls.missing_filename = os.path.join(directory, "test.missing")
+
+    @classmethod
+    def tearDownClass(cls):
+        if sys.platform == "win32" and fabio is not None:
+            # gc collect is needed to close a file descriptor
+            # opened by fabio and not released.
+            # https://github.com/silx-kit/fabio/issues/167
+            import gc
+            gc.collect()
+        shutil.rmtree(cls.tmp_directory)
+
+    def test_hdf5_scalar(self):
+        if h5py is None:
+            self.skipTest("H5py is missing")
+        url = "silx:%s::/group/group/scalar" % self.h5_filename
+        data = utils.get_data(url=url)
+        self.assertEqual(data, 50)
+
+    def test_hdf5_array(self):
+        if h5py is None:
+            self.skipTest("H5py is missing")
+        url = "silx:%s::/group/group/array" % self.h5_filename
+        data = utils.get_data(url=url)
+        self.assertEqual(data.shape, (5, ))
+        self.assertEqual(data[0], 1)
+
+    def test_hdf5_array_slice(self):
+        if h5py is None:
+            self.skipTest("H5py is missing")
+        url = "silx:%s::/group/group/array2d[1]" % self.h5_filename
+        data = utils.get_data(url=url)
+        self.assertEqual(data.shape, (5, ))
+        self.assertEqual(data[0], 6)
+
+    def test_hdf5_array_slice_out_of_range(self):
+        if h5py is None:
+            self.skipTest("H5py is missing")
+        url = "silx:%s::/group/group/array2d[5]" % self.h5_filename
+        self.assertRaises(ValueError, utils.get_data, url)
+
+    def test_edf_using_silx(self):
+        if h5py is None:
+            self.skipTest("H5py is missing")
+        if fabio is None:
+            self.skipTest("H5py is missing")
+        url = "silx:%s::/scan_0/instrument/detector_0/data" % self.edf_filename
+        data = utils.get_data(url=url)
+        self.assertEqual(data.shape, (2, 2))
+        self.assertEqual(data[0, 0], 10)
+
+    def test_fabio_frame(self):
+        if fabio is None:
+            self.skipTest("H5py is missing")
+        url = "fabio:%s::[1]" % self.edf_multiframe_filename
+        data = utils.get_data(url=url)
+        self.assertEqual(data.shape, (2, 2))
+        self.assertEqual(data[0, 0], 10)
+
+    def test_fabio_singleframe(self):
+        if fabio is None:
+            self.skipTest("H5py is missing")
+        url = "fabio:%s::[0]" % self.edf_filename
+        data = utils.get_data(url=url)
+        self.assertEqual(data.shape, (2, 2))
+        self.assertEqual(data[0, 0], 10)
+
+    def test_fabio_too_much_frames(self):
+        if fabio is None:
+            self.skipTest("H5py is missing")
+        url = "fabio:%s::[...]" % self.edf_multiframe_filename
+        self.assertRaises(ValueError, utils.get_data, url)
+
+    def test_fabio_no_frame(self):
+        url = "fabio:%s::" % self.edf_filename
+        self.assertRaises(ValueError, utils.get_data, url)
+
+    def test_unsupported_scheme(self):
+        url = "foo:/foo/bar"
+        self.assertRaises(ValueError, utils.get_data, url)
+
+    def test_no_scheme(self):
+        if fabio is None:
+            self.skipTest("H5py is missing")
+        url = "%s::/group/group/array2d[5]" % self.h5_filename
+        self.assertRaises((ValueError, IOError), utils.get_data, url)
+
+    def test_file_not_exists(self):
+        url = "silx:/foo/bar"
+        self.assertRaises(IOError, utils.get_data, url)
+
+
 def suite():
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
     test_suite = unittest.TestSuite()
@@ -505,6 +637,7 @@ def suite():
     test_suite.addTest(loadTests(TestH5Ls))
     test_suite.addTest(loadTests(TestOpen))
     test_suite.addTest(loadTests(TestNodes))
+    test_suite.addTest(loadTests(TestGetData))
     return test_suite
 
 

--- a/silx/io/url.py
+++ b/silx/io/url.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "08/12/2017"
+__date__ = "11/12/2017"
 
 
 import sys
@@ -76,19 +76,21 @@ class DataUrl(object):
 
     def __check_validity(self):
         """Check the validity of the attributes."""
-        if self.__file_path in ["", "/"]:
-            self.__is_valid = self.__data_path is None and self.__slice is None
-        else:
-            self.__is_valid = self.__file_path is not None
-
-        if self.__scheme not in [None, "silx", "fabio"]:
+        if self.__file_path in [None, ""]:
             self.__is_valid = False
+            return
 
-        if self.__scheme == "fabio":
-            self.__is_valid = self.__is_valid and self.__data_path is None
+        if self.__scheme is None:
+            self.__is_valid = True
+        elif self.__scheme == "fabio":
+            self.__is_valid = self.__data_path is None
         elif self.__scheme == "silx":
+            # If there is a slice you must have a data path
+            # But you can have a data path without slice
             slice_implies_data = (self.__data_path is None and self.__slice is None) or self.__data_path is not None
-            self.__is_valid = self.__is_valid and slice_implies_data
+            self.__is_valid = slice_implies_data
+        else:
+            self.__is_valid = False
 
     def __parse_from_path(self, path):
         """Parse the path and initialize attributes.

--- a/silx/io/url.py
+++ b/silx/io/url.py
@@ -1,0 +1,254 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""URL module"""
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "08/12/2017"
+
+
+import sys
+
+
+class DataUrl(object):
+    """Non-mutable object to parse and reach information identifying a link to
+    a data.
+
+    It supports:
+    - path to file and path inside file to the data
+    - data slicing
+    - fabio or silx access to the data
+    - absolute and relative file access
+
+    >>> # fabio access using absolute path
+    >>> DataUrl("fabio:///data/image.edf::[2]")
+    >>> DataUrl("fabio:///C:/data/image.edf::[2]")
+
+    >>> # silx access using absolute path
+    >>> DataUrl("silx:///data/image.h5::/data/dataset[1,5]")
+    >>> DataUrl("silx:///data/image.edf::/scan_0/detector/data")
+    >>> DataUrl("silx:///C:/data/image.edf::/scan_0/detector/data")
+
+    >>> # Relative path access
+    >>> DataUrl("silx:./image.h5")
+    >>> DataUrl("fabio:./image.edf")
+    >>> DataUrl("silx:image.h5")
+    >>> DataUrl("fabio:image.edf")
+
+    >>> # Is also support parsing of file access for convenience
+    >>> DataUrl("./foo/bar/image.edf")
+    >>> DataUrl("C:/data/")
+    """
+
+    def __init__(self, path=None, file_path=None, data_path=None, slicing=None, scheme=None):
+        self.__is_valid = False
+        if path is not None:
+            self.__parse_from_path(path)
+        else:
+            self.__file_path = file_path
+            self.__data_path = data_path
+            self.__slice = slicing
+            self.__scheme = scheme
+            self.__path = None
+            self.__check_validity()
+
+    def __check_validity(self):
+        """Check the validity of the attributes."""
+        if self.__file_path in ["", "/"]:
+            self.__is_valid = self.__data_path is None and self.__slice is None
+        else:
+            self.__is_valid = self.__file_path is not None
+
+        if self.__scheme not in [None, "silx", "fabio"]:
+            self.__is_valid = False
+
+        if self.__scheme == "fabio":
+            self.__is_valid = self.__is_valid and self.__data_path is None
+        elif self.__scheme == "silx":
+            slice_implies_data = (self.__data_path is None and self.__slice is None) or self.__data_path is not None
+            self.__is_valid = self.__is_valid and slice_implies_data
+
+    def __parse_from_path(self, path):
+        """Parse the path and initialize attributes.
+
+        :param str path: Path representing the URL.
+        """
+        def str_to_slice(string):
+            if string == "...":
+                return Ellipsis
+            elif string == ":":
+                return slice(None)
+            else:
+                return int(string)
+
+        elements = path.split("::", 1)
+        self.__path = path
+
+        scheme_and_filepath = elements[0].split(":", 1)
+        if len(scheme_and_filepath) == 2:
+            if len(scheme_and_filepath[0]) <= 2:
+                # Windows driver
+                self.__scheme = None
+                file_path = elements[0]
+            else:
+                self.__scheme = scheme_and_filepath[0]
+                file_path = scheme_and_filepath[1]
+        else:
+            self.__scheme = None
+            file_path = scheme_and_filepath[0]
+
+        if file_path.startswith("///"):
+            # absolute path
+            file_path = file_path[3:]
+            if len(file_path) > 2 and (file_path[1] == ":" or file_path[2] == ":"):
+                # Windows driver
+                pass
+            else:
+                file_path = "/" + file_path
+        self.__file_path = file_path
+
+        self.__slice = None
+        self.__data_path = None
+        if len(elements) == 1:
+            pass
+        else:
+            selector = elements[1]
+            selectors = selector.split("[", 1)
+            data_path = selectors[0]
+            if len(data_path) == 0:
+                data_path = None
+            self.__data_path = data_path
+
+            if len(selectors) == 2:
+                slicing = selectors[1].split("]", 1)
+                if len(slicing) < 2 or slicing[1] != "":
+                    self.__is_valid = False
+                    return
+                slicing = slicing[0].split(",")
+                try:
+                    slicing = tuple(str_to_slice(s) for s in slicing)
+                    self.__slice = slicing
+                except ValueError:
+                    self.__is_valid = False
+                    return
+
+        self.__check_validity()
+
+    def is_valid(self):
+        """Returns true if the URL is valid. Else attributes can be None.
+
+        :rtype: bool
+        """
+        return self.__is_valid
+
+    def path(self):
+        """Returns the string representing the URL.
+
+        :rtype: str
+        """
+        if self.__path is not None:
+            return self.__path
+
+        def slice_to_string(slicing):
+            if slicing == Ellipsis:
+                return "..."
+            elif slicing == slice(None):
+                return ":"
+            elif isinstance(slicing, int):
+                return str(slicing)
+            else:
+                raise TypeError("Unexpected slicing type. Found %s" % type(slicing))
+
+        path = ""
+        selector = ""
+        if self.__file_path is not None:
+            path += self.__file_path
+        if self.__data_path is not None:
+            selector += self.__data_path
+        if self.__slice is not None:
+            selector += "[%s]" % ",".join([slice_to_string(s) for s in self.__slice])
+
+        if selector != "":
+            path = path + "::" + selector
+
+        if self.__scheme is not None:
+            if self.is_absolute():
+                if path.startswith("/"):
+                    path = self.__scheme + "://" + path
+                else:
+                    path = self.__scheme + ":///" + path
+            else:
+                path = self.__scheme + ":" + path
+
+        return path
+
+    def is_absolute(self):
+        """Returns true if the file path is an absolute path.
+
+        :rtype: bool
+        """
+        file_path = self.file_path()
+        if len(file_path) > 0:
+            if file_path[0] == "/":
+                return True
+        if len(file_path) > 2:
+            # Windows
+            if file_path[1] == ":" or file_path[2] == ":":
+                return True
+        elif len(file_path) > 1:
+            # Windows
+            if file_path[1] == ":":
+                return True
+        return False
+
+    def file_path(self):
+        """Returns the path to the file containing the data.
+
+        :rtype: str
+        """
+        return self.__file_path
+
+    def data_path(self):
+        """Returns the path inside the file to the data.
+
+        :rtype: str
+        """
+        return self.__data_path
+
+    def slice(self):
+        """Returns the slicing applyed to the data.
+
+        It is a tuple containing numbers, slice or ellipses.
+
+        :rtype: Tuple[int, slice, Ellipse]
+        """
+        return self.__slice
+
+    def scheme(self):
+        """Returns the scheme. It can be None if no scheme is specified.
+
+        :rtype: Union[str, None]
+        """
+        return self.__scheme

--- a/silx/io/url.py
+++ b/silx/io/url.py
@@ -29,14 +29,12 @@ __license__ = "MIT"
 __date__ = "11/12/2017"
 
 
-import sys
-
-
 class DataUrl(object):
-    """Non-mutable object to parse and reach information identifying a link to
-    a data.
+    """Non-mutable object to parse a string representing a resource data
+    locator.
 
     It supports:
+
     - path to file and path inside file to the data
     - data slicing
     - fabio or silx access to the data
@@ -60,11 +58,26 @@ class DataUrl(object):
     >>> # Is also support parsing of file access for convenience
     >>> DataUrl("./foo/bar/image.edf")
     >>> DataUrl("C:/data/")
-    """
 
+    :param str path: Path representing a link to a data. If specified, other
+        arguments are not used.
+    :param str file_path: Link to the file containing the the data.
+        None if there is no data selection.
+    :param str data_path: Data selection applyed to the data file selected.
+        None if there is no data selection.
+    :param Tuple[int,slice,Ellipse] slicing: Slicing applyed of the selected
+        data. None if no slicing applyed.
+    :param Union[str,None] scheme: Scheme of the URL. "silx", "fabio" or None
+        is supported. Other strings can be provided, but :meth:`is_valid` while
+        be false.
+    """
     def __init__(self, path=None, file_path=None, data_path=None, slicing=None, scheme=None):
         self.__is_valid = False
         if path is not None:
+            assert(file_path is None)
+            assert(data_path is None)
+            assert(slicing is None)
+            assert(scheme is None)
             self.__parse_from_path(path)
         else:
             self.__file_path = file_path

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -827,7 +827,7 @@ def get_data(url):
             fabio_file = fabio.open(url.file_path())
         except Exception:
             logger.debug("Error while opening %s with fabio", url.file_path(), exc_info=True)
-            IOError("Error while opening %s with fabio (use debug for more information)" % url.path())
+            raise IOError("Error while opening %s with fabio (use debug for more information)" % url.path())
 
         if fabio_file.nframes == 1:
             if index != 0:

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -38,6 +38,7 @@ from silx.utils.deprecation import deprecated
 from silx.utils.proxy import Proxy
 from silx.third_party import six
 from silx.third_party import enum
+import silx.io.url
 
 try:
     import h5py
@@ -754,3 +755,91 @@ def is_softlink(obj):
     """
     t = get_h5_class(obj)
     return t == H5Type.SOFT_LINK
+
+
+def get_data(url):
+    """Returns a numpy data from an URL.
+
+    Examples:
+
+    >>> # 1st frame from an EDF using silx.io.open
+    >>> data = silx.io.get_data("silx:/users/foo/image.edf::/scan_0/instrument/detector_0/data[0]")
+
+    >>> # 1st frame from an EDF using fabio
+    >>> data = silx.io.get_data("fabio:/users/foo/image.edf::[0]")
+
+    Yet 2 schemes are supported by the function.
+
+    - If `silx` scheme is used, the file is opened using
+        :meth:`silx.io.open`
+        and the data is reach using usually NeXus paths.
+    - If `fabio` scheme is used, the file is opened using :meth:`fabio.open`
+        from the FabIO library.
+        No data path have to be specified, but each frames can be accessed
+        using the data slicing.
+        This shortcut of :meth:`silx.io.open` allow to have a faster access to
+        the data.
+
+    .. seealso:: :class:`silx.io.url.DataUrl`
+
+    :param Union[str,silx.io.url.DataUrl]: A data URL
+    :rtype: Union[numpy.ndarray, numpy.generic]
+    :raises ImportError: If the mandatory library to read the file is not
+        available.
+    :raises ValueError: If the URL is not valid or do not match the data
+    :raises IOError: If the file is not found or in case of internal error of
+        :meth:`fabio.open` or :meth:`silx.io.open`. In this last case more
+        informations are displayed in debug mode.
+    """
+    if not isinstance(url, silx.io.url.DataUrl):
+        url = silx.io.url.DataUrl(url)
+
+    if not url.is_valid():
+        raise ValueError("URL '%s' is not valid" % url.path())
+
+    if not os.path.exists(url.file_path()):
+        raise IOError("File '%s' not found" % url.file_path())
+
+    if url.scheme() == "silx":
+        data_path = url.data_path()
+        data_slice = url.data_slice()
+
+        with open(url.file_path()) as h5:
+            if data_path not in h5:
+                raise ValueError("Data path from URL '%s' not found" % url.path())
+            data = h5[data_path]
+            if data_slice is not None:
+                data = data[data_slice]
+            else:
+                # works for scalar and array
+                data = data[()]
+
+    elif url.scheme() == "fabio":
+        import fabio
+        data_slice = url.data_slice()
+        if data_slice is None or len(data_slice) != 1:
+            raise ValueError("Fabio slice expect a single frame, but %s found" % data_slice)
+        index = data_slice[0]
+        if not isinstance(index, int):
+            raise ValueError("Fabio slice expect a single integer, but %s found" % data_slice)
+
+        try:
+            fabio_file = fabio.open(url.file_path())
+        except Exception:
+            logger.debug("Error while opening %s with fabio", url.file_path(), exc_info=True)
+            IOError("Error while opening %s with fabio (use debug for more information)" % url.path())
+
+        if fabio_file.nframes == 1:
+            if index != 0:
+                raise ValueError("Only a single frame availalbe. Slice %s out of range" % index)
+            data = fabio_file.data
+        else:
+            data = fabio_file.getframe(index).data
+
+        # There is no explicit close
+        fabio_file = None
+
+    else:
+        raise ValueError("Scheme '%s' not supported" % url.scheme())
+
+    return data

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["P. Knobel", "V. Valls"]
 __license__ = "MIT"
-__date__ = "05/12/2017"
+__date__ = "11/12/2017"
 
 import numpy
 import os.path
@@ -707,6 +707,9 @@ def get_h5py_class(obj):
     :param obj: An object
     :return: An h5py object
     """
+    if h5py is None:
+        logger.error("get_h5py_class/is_file/is_group/is_dataset requires h5py")
+        raise h5py_import_error
     if hasattr(obj, "h5py_class"):
         return obj.h5py_class
     type_ = get_h5_class(obj)
@@ -751,11 +754,3 @@ def is_softlink(obj):
     """
     t = get_h5_class(obj)
     return t == H5Type.SOFT_LINK
-
-
-if h5py is None:
-    def raise_h5py_missing(obj):
-        logger.error("get_h5py_class/is_file/is_group/is_dataset requires h5py")
-        raise h5py_import_error
-
-    get_h5py_class = raise_h5py_missing


### PR DESCRIPTION
Here is an implementation of a `DataUrl`.

Closes #1389
Closes #1390 

- It was designed to reach data from `fabio` or `silx.io.open` with support of slicing.
- It can parse regular files
- It supports absolute (`silx:///data.h5`) and relative (`silx:data.h5`) file path
- It supports Windows drives

Here is few examples, but you better to check the tests:
```
# fabio access using absolute path
DataUrl("fabio:///data/image.edf::[2]")
DataUrl("fabio:///C:/data/image.edf::[2]")

# silx access using absolute path
DataUrl("silx:///data/image.h5::/data/dataset[1,5]")
DataUrl("silx:///data/image.edf::/scan_0/detector/data")
DataUrl("silx:///C:/data/image.edf::/scan_0/detector/data")

# Relative path access
DataUrl("silx:./image.h5")
DataUrl("fabio:./image.edf")
DataUrl("silx:image.h5")
DataUrl("fabio:image.edf")

# Is also support parsing of file access for convenience
DataUrl("./foo/bar/image.edf")
DataUrl("C:/data/")
```

It is a redesign of the `_ImageUrl` class available on `silx.gui.dialog.ImageFileDialog`.
- To have something closer to the default URLs (especially for absolute file paths)
- Something which can be used with other widgets like #1395 
- And outside the widgets with a dedicated `silx.io` API.