### PR TITLE
[nxdata] Support older NXdata specification

### DIFF
--- a/silx/io/nxdata.py
+++ b/silx/io/nxdata.py
@@ -491,7 +491,7 @@ class NXdata(object):
                 axes_dataset_names = []
                 numbers = [a[0] for a in numbered_names]
                 names = [a[1] for a in numbered_names]
-                for i in ndims:
+                for i in range(ndims):
                     if i in numbers:
                         axes_dataset_names.append(names[numbers.index(i)])
                     else:


### PR DESCRIPTION
Closes #1407 
This PR adds support for legacy NXdata specifications, if there is no `group@signal` attribute and/or no `group@axes` attribute.  

 - [x] support @signal attribute on dataset (only main signal @signal=1, other indices > 1 are ignored)
 - [x] support @axes attribute on signal dataset
 - [x] support @axis attribute on individual axis datasets