### PR TITLE
Add function preferredColormaps to Colormap module

### DIFF
--- a/silx/gui/plot/Colormap.py
+++ b/silx/gui/plot/Colormap.py
@@ -504,3 +504,47 @@ class Colormap(qt.QObject):
             stream.writeQVariant(self.getVMax())
         stream.writeQString(self.getNormalization())
         return data
+
+
+_PREFERRED_COLORMAPS = DEFAULT_COLORMAPS
+"""
+Tuple of preferred colormap names accessed with :meth:`preferredColormaps`.
+"""
+
+
+def preferredColormaps():
+    """Returns the name of the preferred colormaps.
+
+    This list is used by widgets allowing to change the colormap
+    like the :class:`ColormapDialog` as a subset of colormap choices.
+
+    :rtype: tuple of str
+    """
+    return _PREFERRED_COLORMAPS
+
+
+def setPreferredColormaps(colormaps):
+    """Set the list of preferred colormap names.
+
+    Warning: If a colormap name is not available
+    it will be removed from the list.
+
+    :param colormaps: Not empty list of colormap names
+    :type colormaps: iterable of str
+    :raise ValueError: if the list of available preferred colormaps is empty.
+    """
+    supportedColormaps = Colormap.getSupportedColormaps()
+    colormaps = tuple(
+        cmap for cmap in colormaps if cmap in supportedColormaps)
+    if len(colormaps) == 0:
+        raise ValueError("Cannot set preferred colormaps to an empty list")
+
+    global _PREFERRED_COLORMAPS
+    _PREFERRED_COLORMAPS = colormaps
+
+
+# Initialize preferred colormaps
+setPreferredColormaps(('gray', 'reversed gray',
+                       'temperature', 'red', 'green', 'blue', 'jet',
+                       'viridis', 'magma', 'inferno', 'plasma',
+                       'hsv'))

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -401,7 +401,8 @@ class ColormapDialog(qt.QDialog):
             if self._comboBoxColormap.findData(name, qt.Qt.UserRole) == -1:
                 self._comboBoxColormap.addItem(capitalizedName, name)
 
-            self._comboBoxColormap.setCurrentText(capitalizedName)
+            index = self._comboBoxColormap.findData(name, qt.Qt.UserRole)
+            self._comboBoxColormap.setCurrentIndex(index)
 
         if normalization is not None:
             assert normalization in Colormap.NORMALIZATIONS

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -69,7 +69,7 @@ import logging
 import numpy
 
 from .. import qt
-from .Colormap import Colormap
+from .Colormap import Colormap, preferredColormaps
 from . import PlotWidget
 from silx.gui.widgets.FloatEdit import FloatEdit
 
@@ -98,14 +98,6 @@ class ColormapDialog(qt.QDialog):
         self._dataRange = None
         self._minMaxWasEdited = False
 
-        colormaps = [
-            'gray', 'reversed gray',
-            'temperature', 'red', 'green', 'blue', 'jet',
-            'viridis', 'magma', 'inferno', 'plasma']
-        if 'hsv' in Colormap.getSupportedColormaps():
-            colormaps.append('hsv')
-        self._colormapList = tuple(colormaps)
-
         # Make the GUI
         vLayout = qt.QVBoxLayout(self)
 
@@ -117,10 +109,8 @@ class ColormapDialog(qt.QDialog):
 
         # Colormap row
         self._comboBoxColormap = qt.QComboBox()
-        for cmap in self._colormapList:
-            # Capitalize first letters
-            cmap = ' '.join(w[0].upper() + w[1:] for w in cmap.split())
-            self._comboBoxColormap.addItem(cmap)
+        for cmap in preferredColormaps():
+            self._comboBoxColormap.addItem(cmap.title(), cmap)
         self._comboBoxColormap.activated[int].connect(self._notify)
         formLayout.addRow('Colormap:', self._comboBoxColormap)
 
@@ -382,8 +372,11 @@ class ColormapDialog(qt.QDialog):
             vmin = self._minValue.value()
             vmax = self._maxValue.value()
         norm = Colormap.LINEAR if isNormLinear else Colormap.LOGARITHM
+
+        name = self._comboBoxColormap.itemData(
+            self._comboBoxColormap.currentIndex(), qt.Qt.UserRole)
         colormap = Colormap(
-                        name=str(self._comboBoxColormap.currentText()).lower(),
+                        name=name,
                         normalization=norm,
                         vmin=vmin,
                         vmax=vmax)
@@ -402,9 +395,13 @@ class ColormapDialog(qt.QDialog):
         :param float vmax: The max value, ignored if autoscale is True
         """
         if name is not None:
-            assert name in self._colormapList
-            index = self._colormapList.index(name)
-            self._comboBoxColormap.setCurrentIndex(index)
+            capitalizedName = name.title()
+
+            # Check if colormap is available in the combo box
+            if self._comboBoxColormap.findData(name, qt.Qt.UserRole) == -1:
+                self._comboBoxColormap.addItem(capitalizedName, name)
+
+            self._comboBoxColormap.setCurrentText(capitalizedName)
 
         if normalization is not None:
             assert normalization in Colormap.NORMALIZATIONS

--- a/silx/gui/plot/test/testColormap.py
+++ b/silx/gui/plot/test/testColormap.py
@@ -35,6 +35,7 @@ import unittest
 import numpy
 from silx.test.utils import ParametricTestCase
 from silx.gui.plot.Colormap import Colormap
+from silx.gui.plot.Colormap import preferredColormaps, setPreferredColormaps
 
 
 class TestDictAPI(unittest.TestCase):
@@ -289,9 +290,39 @@ class TestObjectAPI(ParametricTestCase):
             colors,
             ((0, 0, 0, 255), (255, 255, 255, 255)))))
 
+
+
+class TestPreferredColormaps(unittest.TestCase):
+    """Test get|setPreferredColormaps functions"""
+
+    def setUp(self):
+        # Save preferred colormaps
+        self._colormaps = preferredColormaps()
+
+    def tearDown(self):
+        # Restore saved preferred colormaps
+        setPreferredColormaps(self._colormaps)
+
+    def test(self):
+        colormaps = 'viridis', 'magma'
+
+        setPreferredColormaps(colormaps)
+        self.assertEqual(preferredColormaps(), colormaps)
+
+        with self.assertRaises(ValueError):
+            setPreferredColormaps(())
+
+        with self.assertRaises(ValueError):
+            setPreferredColormaps(('This is not a colormap',))
+
+        colormaps = 'red', 'green'
+        setPreferredColormaps(('This is not a colormap',) + colormaps)
+        self.assertEqual(preferredColormaps(), colormaps)
+
+
 def suite():
     test_suite = unittest.TestSuite()
-    for ui in (TestDictAPI, TestObjectAPI):
+    for ui in (TestDictAPI, TestObjectAPI, TestPreferredColormaps):
         test_suite.addTest(
             unittest.defaultTestLoader.loadTestsFromTestCase(ui))
 


### PR DESCRIPTION
This PR adds a common place where to store a list of preferred colormaps to propose to the user.
It also update the `ColormapDialog` to use it. @payno let me know if you prefer that I remove this commit from the PR.

 Close #1411 