### PR TITLE
[silx view] Use a common colormap for all the views

### DIFF
--- a/examples/colormapDialog.py
+++ b/examples/colormapDialog.py
@@ -27,7 +27,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "05/01/2018"
+__date__ = "08/01/2018"
 
 import functools
 import numpy
@@ -77,6 +77,9 @@ class ColormapDialogExample(qt.QMainWindow):
 
         layout.addSpacing(10)
 
+        button = qt.QPushButton("Set no colormap")
+        button.clicked.connect(self.setNoColormap)
+        layout.addWidget(button)
         button = qt.QPushButton("Set colormap 1")
         button.clicked.connect(self.setColormap1)
         layout.addWidget(button)
@@ -136,6 +139,11 @@ class ColormapDialogExample(qt.QMainWindow):
 
     def removeColorDialog(self, dialog):
         self.colorDialogs.remove(dialog)
+
+    def setNoColormap(self):
+        self.colorBar.setColormap(None)
+        for dialog in self.colorDialogs:
+            dialog.setColormap(None)
 
     def setColormap1(self):
         self.colorBar.setColormap(self.colormap1)

--- a/examples/colormapDialog.py
+++ b/examples/colormapDialog.py
@@ -128,6 +128,9 @@ class ColormapDialogExample(qt.QMainWindow):
         button = qt.QPushButton("Set shepp logan phantom")
         button.clicked.connect(self.setSheppLoganPhantom)
         layout.addWidget(button)
+        button = qt.QPushButton("Set data with non finite")
+        button.clicked.connect(self.setDataWithNonFinite)
+        layout.addWidget(button)
 
         layout.addStretch()
 
@@ -214,6 +217,21 @@ class ColormapDialogExample(qt.QMainWindow):
             from scipy import ndimage
             data = ndimage.gaussian_filter(data, sigma=20)
         data = numpy.random.poisson(data)
+        self.data = data
+        for dialog in self.colorDialogs:
+            dialog.setData(data)
+
+    def setDataWithNonFinite(self):
+        from silx.image import phantomgenerator
+        data = phantomgenerator.PhantomGenerator.get2DPhantomSheppLogan(256)
+        data = data * 1000
+        if scipy is not None:
+            from scipy import ndimage
+            data = ndimage.gaussian_filter(data, sigma=20)
+        data = numpy.random.poisson(data)
+        data[10] = float("nan")
+        data[50] = float("+inf")
+        data[100] = float("-inf")
         self.data = data
         for dialog in self.colorDialogs:
             dialog.setData(data)

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -37,10 +37,11 @@ from silx.io import nxdata
 from silx.gui.hdf5 import H5Node
 from silx.io.nxdata import NXdata, get_attr_as_string
 from silx.gui.plot.Colormap import Colormap
+from silx.gui.plot.actions.control import ColormapAction
 
 __authors__ = ["V. Valls", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "21/12/2017"
+__date__ = "03/01/2018"
 
 _logger = logging.getLogger(__name__)
 
@@ -176,6 +177,9 @@ class DataView(object):
     _defaultColormap = None
     """Store a default colormap shared with all the views"""
 
+    _defaultColorDialog = None
+    """Store a default color dialog shared with all the views"""
+
     def __init__(self, parent, modeId=None, icon=None, label=None):
         """Constructor
 
@@ -200,6 +204,16 @@ class DataView(object):
         if DataView._defaultColormap is None:
             DataView._defaultColormap = Colormap(name="viridis")
         return DataView._defaultColormap
+
+    @staticmethod
+    def defaultColorDialog():
+        """Returns a shared color dialog as default for all the views.
+
+        :rtype: ColorDialog
+        """
+        if DataView._defaultColorDialog is None:
+            DataView._defaultColorDialog = ColormapAction._createDialog(qt.QApplication.instance().activeWindow())
+        return DataView._defaultColorDialog
 
     def icon(self):
         """Returns the default icon"""
@@ -472,6 +486,7 @@ class _Plot2dView(DataView):
         from silx.gui import plot
         widget = plot.Plot2D(parent=parent)
         widget.setDefaultColormap(self.defaultColormap())
+        widget.getColormapAction().setColorDialog(self.defaultColorDialog())
         widget.getIntensityHistogramAction().setVisible(True)
         widget.setKeepDataAspectRatio(True)
         widget.getXAxis().setLabel('X')
@@ -605,6 +620,7 @@ class _ComplexImageView(DataView):
         from silx.gui.plot.ComplexImageView import ComplexImageView
         widget = ComplexImageView(parent=parent)
         widget.setColormap(self.defaultColormap())
+        widget.getPlot().getColormapAction().setColorDialog(self.defaultColorDialog())
         widget.getPlot().getIntensityHistogramAction().setVisible(True)
         widget.getPlot().setKeepDataAspectRatio(True)
         widget.getXAxis().setLabel('X')
@@ -698,6 +714,7 @@ class _StackView(DataView):
         from silx.gui import plot
         widget = plot.StackView(parent=parent)
         widget.setColormap(self.defaultColormap())
+        widget.getPlot().getColormapAction().setColorDialog(self.defaultColorDialog())
         widget.setKeepDataAspectRatio(True)
         widget.setLabels(self.axesNames(None, None))
         # hide default option panel
@@ -1063,6 +1080,7 @@ class _NXdataImageView(DataView):
         from silx.gui.data.NXdataWidgets import ArrayImagePlot
         widget = ArrayImagePlot(parent)
         widget.getPlot().setDefaultColormap(self.defaultColormap())
+        widget.getPlot().getColormapAction().setColorDialog(self.defaultColorDialog())
         return widget
 
     def axesNames(self, data, info):
@@ -1105,6 +1123,7 @@ class _NXdataStackView(DataView):
         from silx.gui.data.NXdataWidgets import ArrayStackPlot
         widget = ArrayStackPlot(parent)
         widget.getStackView().setColormap(self.defaultColormap())
+        widget.getStackView().getPlot().getColormapAction().setColorDialog(self.defaultColorDialog())
         return widget
 
     def axesNames(self, data, info):

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -40,7 +40,7 @@ from silx.gui.plot.Colormap import Colormap
 
 __authors__ = ["V. Valls", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "20/12/2017"
+__date__ = "21/12/2017"
 
 _logger = logging.getLogger(__name__)
 
@@ -604,6 +604,7 @@ class _ComplexImageView(DataView):
     def createWidget(self, parent):
         from silx.gui.plot.ComplexImageView import ComplexImageView
         widget = ComplexImageView(parent=parent)
+        widget.setColormap(self.defaultColormap())
         widget.getPlot().getIntensityHistogramAction().setVisible(True)
         widget.getPlot().setKeepDataAspectRatio(True)
         widget.getXAxis().setLabel('X')

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -41,7 +41,7 @@ from silx.gui.plot.actions.control import ColormapAction
 
 __authors__ = ["V. Valls", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "03/01/2018"
+__date__ = "16/01/2018"
 
 _logger = logging.getLogger(__name__)
 
@@ -214,6 +214,13 @@ class DataView(object):
         if DataView._defaultColorDialog is None:
             DataView._defaultColorDialog = ColormapAction._createDialog(qt.QApplication.instance().activeWindow())
         return DataView._defaultColorDialog
+
+    @staticmethod
+    def _cleanUpCache():
+        """Clean up the cache. Needed for tests"""
+        DataView._defaultColormap = None
+        DataView._defaultColorDialog = None
+        print("_cleanUpCache")
 
     def icon(self):
         """Returns the default icon"""

--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -26,7 +26,7 @@
 """
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "23/10/2017"
+__date__ = "20/12/2017"
 
 import numpy
 
@@ -92,6 +92,13 @@ class ArrayCurvePlot(qt.QWidget):
         layout.addWidget(self._plot, 0, 0)
 
         self.setLayout(layout)
+
+    def getPlot(self):
+        """Returns the plot used for the display
+
+        :rtype: Plot1D
+        """
+        return self._plot
 
     def setCurveData(self, y, x=None, values=None,
                      yerror=None, xerror=None,
@@ -242,6 +249,13 @@ class ArrayImagePlot(qt.QWidget):
         self._plot.addTabbedDockWidget(self.selectorDock)
 
         self.setLayout(layout)
+
+    def getPlot(self):
+        """Returns the plot used for the display
+
+        :rtype: Plot2D
+        """
+        return self._plot
 
     def setImageData(self, signal,
                      x_axis=None, y_axis=None,
@@ -401,6 +415,13 @@ class ArrayStackPlot(qt.QWidget):
         layout.addWidget(self._selector)
 
         self.setLayout(layout)
+
+    def getStackView(self):
+        """Returns the plot used for the display
+
+        :rtype: StackView
+        """
+        return self._stack_view
 
     def setStackData(self, signal,
                      x_axis=None, y_axis=None, z_axis=None,

--- a/silx/gui/data/test/test_dataviewer.py
+++ b/silx/gui/data/test/test_dataviewer.py
@@ -24,7 +24,7 @@
 # ###########################################################################*/
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "22/08/2017"
+__date__ = "16/01/2018"
 
 import os
 import tempfile
@@ -207,6 +207,7 @@ class AbstractDataViewerTests(TestCaseQt):
         self.assertEquals(widget.displayedView().modeId(), DataViewer.RAW_MODE)
         widget.setDisplayMode(DataViewer.EMPTY_MODE)
         self.assertEquals(widget.displayedView().modeId(), DataViewer.EMPTY_MODE)
+        DataView._cleanUpCache()
 
     def test_create_default_views(self):
         widget = self.create_widget()
@@ -265,6 +266,7 @@ class TestDataView(TestCaseQt):
         dataViewClass = DataViews._Plot2dView
         widget = self.createDataViewWithData(dataViewClass, data[0])
         self.qWaitForWindowExposed(widget)
+        DataView._cleanUpCache()
 
     def testCubeWithComplex(self):
         self.skipTest("OpenGL widget not yet tested")
@@ -276,12 +278,14 @@ class TestDataView(TestCaseQt):
         dataViewClass = DataViews._Plot3dView
         widget = self.createDataViewWithData(dataViewClass, data)
         self.qWaitForWindowExposed(widget)
+        DataView._cleanUpCache()
 
     def testImageStackWithComplex(self):
         data = self.createComplexData()
         dataViewClass = DataViews._StackView
         widget = self.createDataViewWithData(dataViewClass, data)
         self.qWaitForWindowExposed(widget)
+        DataView._cleanUpCache()
 
 
 def suite():

--- a/silx/gui/plot/Colormap.py
+++ b/silx/gui/plot/Colormap.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import
 
 __authors__ = ["T. Vincent", "H.Payno"]
 __license__ = "MIT"
-__date__ = "29/11/2017"
+__date__ = "08/01/2018"
 
 from silx.gui import qt
 import copy as copy_mdl
@@ -310,6 +310,9 @@ class Colormap(qt.QObject):
                 err = "Can't set vmin and vmax because vmin >= vmax " \
                       "vmin = %s, vmax = %s" % (vmin, vmax)
                 raise ValueError(err)
+
+        if self._vmin == vmin and self._vmax == vmax:
+            return
 
         self._vmin = vmin
         self._vmax = vmax

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -786,6 +786,8 @@ class ColormapDialog(qt.QDialog):
             return
 
         oldColormap = self.getColormap()
+        if oldColormap is colormap:
+            return
         if oldColormap is not None:
             oldColormap.sigChanged.disconnect(self._applyColormap)
         self._colormap = weakref.ref(colormap)

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -825,8 +825,10 @@ class ColormapDialog(qt.QDialog):
 
         vmin = self._minValue.getValue()
         vmax = self._maxValue.getValue()
-        if self._colormap():
-            self._colormap().setVRange(vmin, vmax)
+        self._ignoreColormapChange = True
+        colormap = self._colormap()
+        if colormap is not None:
+            colormap.setVRange(vmin, vmax)
         self._ignoreColormapChange = False
         self._plotUpdate()
 

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -384,6 +384,11 @@ class ColormapDialog(qt.QDialog):
         self.visibleChanged.emit(True)
         super(ColormapDialog, self).showEvent(event)
 
+    def closeEvent(self, event):
+        if not self.isModal():
+            self.accept()
+        super(ColormapDialog, self).closeEvent(event)
+
     def hideEvent(self, event):
         self.visibleChanged.emit(False)
         super(ColormapDialog, self).hideEvent(event)

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -697,7 +697,7 @@ class ColormapDialog(qt.QDialog):
                   state when validated
         """
         colormap = self.getColormap()
-        if colormap is not None:
+        if colormap is not None and self._colormapStoredState is not None:
             self._ignoreColormapChange = True
             colormap._setFromDict(self._colormapStoredState)
             self._ignoreColormapChange = False
@@ -769,8 +769,9 @@ class ColormapDialog(qt.QDialog):
         save the current value sof the colormap if the user want to undo is
         modifications
         """
-        if self._colormap():
-            self._colormapStoredState = self._colormap()._toDict()
+        colormap = self.getColormap()
+        if colormap is not None:
+            self._colormapStoredState = colormap._toDict()
 
     def reject(self):
         self.resetColormap()
@@ -798,21 +799,23 @@ class ColormapDialog(qt.QDialog):
     def _applyColormap(self):
         if self._ignoreColormapChange is True:
             return
-        if self._colormap():
+
+        colormap = self.getColormap()
+        if colormap is not None:
             self._ignoreColormapChange = True
 
-            if self._colormap().getName() is not None:
-                name = self._colormap().getName()
+            if colormap.getName() is not None:
+                name = colormap.getName()
                 self._comboBoxColormap.setCurrentName(name)
 
-            assert self._colormap().getNormalization() in Colormap.NORMALIZATIONS
+            assert colormap.getNormalization() in Colormap.NORMALIZATIONS
             self._normButtonLinear.setChecked(
-                self._colormap().getNormalization() == Colormap.LINEAR)
+                colormap.getNormalization() == Colormap.LINEAR)
             self._normButtonLog.setChecked(
-                self._colormap().getNormalization() == Colormap.LOGARITHM)
-            vmin = self._colormap().getVMin()
-            vmax = self._colormap().getVMax()
-            dataRange = self._colormap().getColormapRange()
+                colormap.getNormalization() == Colormap.LOGARITHM)
+            vmin = colormap.getVMin()
+            vmax = colormap.getVMax()
+            dataRange = colormap.getColormapRange()
             self._minValue.setValue(vmin or dataRange[0], isAuto=vmin is None)
             self._maxValue.setValue(vmax or dataRange[1], isAuto=vmax is None)
 

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -101,7 +101,7 @@ class _BoundaryWidget(qt.QWidget):
         self.layout().addWidget(self._autoCB)
         self._autoCB.setChecked(False)
 
-        self._autoCB.toggled.connect(self._numVal.setDisabled)
+        self._autoCB.toggled.connect(self._autoToggled)
         self.sigValueChanged = self._autoCB.toggled
         self.textEdited = self._numVal.textEdited
         self.editingFinished = self._numVal.editingFinished
@@ -120,6 +120,10 @@ class _BoundaryWidget(qt.QWidget):
             return self._numVal.value()
         else:
             return self._dataValue
+
+    def _autoToggled(self, enabled):
+        self._numVal.setEnabled(not enabled)
+        self._updateDisplayedText()
 
     def _updateDisplayedText(self):
         # if dataValue is finite

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -224,6 +224,9 @@ class ColormapDialog(qt.QDialog):
     :param str title: The QDialog title
     """
 
+    visibleChanged = qt.Signal(bool)
+    """This event is sent when the dialog visibility change"""
+
     def __init__(self, parent=None, title="Colormap Dialog"):
         qt.QDialog.__init__(self, parent)
         self.setWindowTitle(title)
@@ -371,6 +374,14 @@ class ColormapDialog(qt.QDialog):
 
         vLayout.setSizeConstraint(qt.QLayout.SetMinimumSize)
         self.setFixedSize(self.sizeHint())
+
+    def showEvent(self, event):
+        self.visibleChanged.emit(True)
+        super(ColormapDialog, self).showEvent(event)
+
+    def hideEvent(self, event):
+        self.visibleChanged.emit(False)
+        super(ColormapDialog, self).hideEvent(event)
 
     def close(self):
         self.accept()

--- a/silx/gui/plot/actions/PlotAction.py
+++ b/silx/gui/plot/actions/PlotAction.py
@@ -32,10 +32,9 @@ from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "20/04/2017"
+__date__ = "03/01/2018"
 
 
-from collections import OrderedDict
 import weakref
 from silx.gui import icons
 from silx.gui import qt

--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -327,6 +327,7 @@ class ColormapAction(PlotAction):
             tooltip="Change colormap",
             triggered=self._actionTriggered,
             checkable=True, parent=parent)
+        self.plot.sigActiveImageChanged.connect(self._updateColormap)
 
     def setColorDialog(self, colorDialog):
         """Set a specific color dialog instead of using the default dialog."""
@@ -352,7 +353,6 @@ class ColormapAction(PlotAction):
         if self._dialog is None:
             self._dialog = self._createDialog(self.plot)
             self._dialog.visibleChanged.connect(self._dialogVisibleChanged)
-            self.plot.sigActiveImageChanged.connect(self._updateColormap)
 
         # Run the dialog listening to colormap change
         if checked is True:

--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -379,9 +379,7 @@ class ColormapAction(PlotAction):
             # Reset histogram and range if any
             self._dialog.setData(None)
 
-        # avoid setting multiple time the same colormap to be able to reset it
-        if colormap is not self._dialog.getColormap():
-            self._dialog.setColormap(colormap=colormap)
+        self._dialog.setColormap(colormap)
 
 
 class KeepAspectRatioAction(PlotAction):

--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -50,7 +50,7 @@ from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "05/01/2018"
+__date__ = "08/01/2018"
 
 from . import PlotAction
 import logging
@@ -365,6 +365,8 @@ class ColormapAction(PlotAction):
         self.setChecked(isVisible)
 
     def _updateColormap(self):
+        if self._dialog is None:
+            return
         image = self.plot.getActiveImage()
         if isinstance(image, items.ColormapMixIn):
             # Set dialog from active image

--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -328,14 +328,22 @@ class ColormapAction(PlotAction):
             triggered=self._actionTriggered,
             checkable=True, parent=parent)
 
-    def _createDialog(self, parent):
+    def setColorDialog(self, colorDialog):
+        """Set a specific color dialog instead of using the default dialog."""
+        assert(colorDialog is not None)
+        assert(self._dialog is None)
+        self._dialog = colorDialog
+        self._dialog.visibleChanged.connect(self._dialogVisibleChanged)
+        self.setChecked(self._dialog.isVisible())
+
+    @staticmethod
+    def _createDialog(parent):
         """Create the dialog if not already existing
 
         :parent QWidget parent: Parent of the new colormap
         :rtype: ColormapDialog
         """
         dialog = ColormapDialog(parent=parent)
-        dialog.finished.connect(self._setUnChecked)
         dialog.setModal(False)
         return dialog
 
@@ -343,17 +351,18 @@ class ColormapAction(PlotAction):
         """Create a cmap dialog and update active image and default cmap."""
         if self._dialog is None:
             self._dialog = self._createDialog(self.plot)
-            self._updateColormap()
+            self._dialog.visibleChanged.connect(self._dialogVisibleChanged)
             self.plot.sigActiveImageChanged.connect(self._updateColormap)
 
         # Run the dialog listening to colormap change
         if checked is True:
             self._dialog.show()
+            self._updateColormap()
         else:
             self._dialog.hide()
 
-    def _setUnChecked(self):
-        self.setChecked(False)
+    def _dialogVisibleChanged(self, isVisible):
+        self.setChecked(isVisible)
 
     def _updateColormap(self):
         image = self.plot.getActiveImage()

--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -328,13 +328,21 @@ class ColormapAction(PlotAction):
             triggered=self._actionTriggered,
             checkable=True, parent=parent)
 
+    def _createDialog(self, parent):
+        """Create the dialog if not already existing
+
+        :parent QWidget parent: Parent of the new colormap
+        :rtype: ColormapDialog
+        """
+        dialog = ColormapDialog(parent=parent)
+        dialog.finished.connect(self._setUnChecked)
+        dialog.setModal(False)
+        return dialog
+
     def _actionTriggered(self, checked=False):
         """Create a cmap dialog and update active image and default cmap."""
-        # Create the dialog if not already existing
         if self._dialog is None:
-            self._dialog = ColormapDialog(self.plot)
-            self._dialog.finished.connect(self._setUnChecked)
-            self._dialog.setModal(False)
+            self._dialog = self._createDialog(self.plot)
             self._updateColormap()
             self.plot.sigActiveImageChanged.connect(self._updateColormap)
 

--- a/silx/gui/plot/actions/fit.py
+++ b/silx/gui/plot/actions/fit.py
@@ -36,7 +36,7 @@ from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "28/06/2017"
+__date__ = "03/01/2018"
 
 from . import PlotAction
 import logging
@@ -111,7 +111,7 @@ class FitAction(PlotAction):
 
         if histo is None and curve is None:
             # ambiguous case, we need to ask which plot item to fit
-            isd = ItemsSelectionDialog(plot=self.plot)
+            isd = ItemsSelectionDialog(parent=self.plot, plot=self.plot)
             isd.setWindowTitle("Select item to be fitted")
             isd.setItemsSelectionMode(qt.QTableWidget.SingleSelection)
             isd.setAvailableKinds(["curve", "histogram"])

--- a/silx/gui/plot/actions/medfilt.py
+++ b/silx/gui/plot/actions/medfilt.py
@@ -39,7 +39,7 @@ from __future__ import division
 __authors__ = ["V.A. Sole", "T. Vincent", "P. Knobel"]
 __license__ = "MIT"
 
-__date__ = "24/05/2017"
+__date__ = "03/01/2018"
 
 from . import PlotAction
 from silx.gui.widgets.MedianFilterDialog import MedianFilterDialog
@@ -67,7 +67,7 @@ class MedianFilterAction(PlotAction):
         self._originalImage = None
         self._legend = None
         self._filteredImage = None
-        self._popup = MedianFilterDialog(parent=None)
+        self._popup = MedianFilterDialog(parent=plot)
         self._popup.sigFilterOptChanged.connect(self._updateFilter)
         self.plot.sigActiveImageChanged.connect(self._updateActiveImage)
         self._updateActiveImage()

--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -289,7 +289,7 @@ class TestColormapAction(TestCaseQt):
                                   normalization='log')
         self.defaultColormap = self.plot.getDefaultColormap()
 
-        self.plot.getColormapAction()._actionTriggered()
+        self.plot.getColormapAction()._actionTriggered(checked=True)
         self.colormapDialog = self.plot.getColormapAction()._dialog
         self.colormapDialog.setAttribute(qt.Qt.WA_DeleteOnClose)
 
@@ -326,10 +326,10 @@ class TestColormapAction(TestCaseQt):
         self.assertTrue(self.colormapDialog.getColormap() is self.defaultColormap)
 
     def testShowHideColormapDialog(self):
+        self.plot.getColormapAction()._actionTriggered(checked=False)
         self.assertFalse(self.plot.getColormapAction().isChecked())
-        self.plot.getColormapAction()._actionTriggered()
-        # _qapp.processEvents()
-        # self.assertTrue(self.plot.getColormapAction().isChecked())
+        self.plot.getColormapAction()._actionTriggered(checked=True)
+        self.assertTrue(self.plot.getColormapAction().isChecked())
         self.plot.addImage(data=numpy.random.rand(10, 10), legend='img1',
                            replace=False, origin=(0, 0),
                            colormap=self.colormap1)


### PR DESCRIPTION
Using the fact colormap object is now interactive (get/set/events) we can provide a convenient unique colormap for all the views. It avoid the user to custom everytime the same thing, with many popups.

This PR
- provides a unique default color maps from the `DefaultView` class
- Any view can use it
- Most of the views have been patched to use it (2d, stack, NX, complex)
- Colormap dialog supports no colormap

Close #1425
Close #1424
  
  