### PR TITLE
[opencl] CBF compression

### DIFF
--- a/doc/source/modules/opencl/codec_cbf.rst
+++ b/doc/source/modules/opencl/codec_cbf.rst
@@ -1,0 +1,9 @@
+
+.. currentmodule:: silx.opencl.codec
+
+:mod:`byte_offset`: Byte Offset compression/decompression
+---------------------------------------------------------
+
+.. automodule:: silx.opencl.codec.byte_offset
+   :members: ByteOffset
+   :show-inheritance:

--- a/doc/source/modules/opencl/index.rst
+++ b/doc/source/modules/opencl/index.rst
@@ -11,4 +11,5 @@
    sift/index.rst
    fbp.rst
    medfilt.rst
+   codec_cbf.rst
 

--- a/silx/opencl/codec/byte_offset.py
+++ b/silx/opencl/codec/byte_offset.py
@@ -297,7 +297,7 @@ class ByteOffset(OpenclProcessing):
         return knl
 
     def encode(self, data, out=None):
-        """This function compress provided data to CBF.
+        """Compresses data to CBF.
 
         :param numpy.ndarray data: The data as a numpy array of int32.
         :param pyopencl.array out: pyopencl array in which to place the result.
@@ -305,7 +305,6 @@ class ByteOffset(OpenclProcessing):
         :rtype: pyopencl.array
         """
         # TODO also support pyopencl array as input
-        # TODO as_bytes argument
         # TODO record a maximum number of events
         # TODO use semaphore
         # TODO reuse buffers? and use those of decompression
@@ -329,3 +328,13 @@ class ByteOffset(OpenclProcessing):
         pyopencl.enqueue_copy_buffer(
             self.queue, d_compressed.data, out.data, byte_count=byte_count)
         return out
+
+    def encode_to_bytes(self, data):
+        """Compresses data to CBF and returns compressed data as bytes.
+
+        :param numpy.ndarray data: The data as a numpy array of int32.
+        :return: The compressed data as bytes.
+        :rtype: bytes
+        """
+        compressed_array = self.encode(data)
+        return compressed_array.get().tostring()

--- a/silx/opencl/codec/byte_offset.py
+++ b/silx/opencl/codec/byte_offset.py
@@ -28,7 +28,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 """
-Contains classes CBF byte offset decompression
+This module provides a class for CBF byte offset compression/decompression.
 """
 
 from __future__ import division, print_function, with_statement
@@ -62,19 +62,19 @@ else:
 
 
 class ByteOffset(OpenclProcessing):
-    """Perform the byte offset decompression on the GPU"""
+    """Perform the byte offset compression/decompression on the GPU
+
+        See :class:`OpenclProcessing` for optional arguments description.
+
+        :param int raw_size:
+            Size of the raw stream, can be (slightly) larger than the array
+        :param int dec_size:
+            Size of the output array (mandatory)
+        """
 
     def __init__(self, raw_size, dec_size, ctx=None, devicetype="all",
                  platformid=None, deviceid=None,
                  block_size=None, profile=False):
-        """Constructor of the Byte Offset decompressor.
-
-        See :class:`OpenclProcessing` for optional arguments description.
-
-        :param raw_size: size of the raw stream, can be (slightly) larger than the array
-        :param dec_size: size of the output array (mandatory)
-        """
-
         OpenclProcessing.__init__(self, ctx=ctx, devicetype=devicetype,
                                   platformid=platformid, deviceid=deviceid,
                                   block_size=block_size, profile=profile)

--- a/silx/opencl/codec/byte_offset.py
+++ b/silx/opencl/codec/byte_offset.py
@@ -309,7 +309,6 @@ class ByteOffset(OpenclProcessing):
         """
         # TODO also support pyopencl array as input
         # TODO reuse buffers? and use those of decompression
-        # TODO write test + sample code
 
         data = numpy.ascontiguousarray(data, dtype=numpy.int32).ravel()
         size = data.size
@@ -341,6 +340,19 @@ class ByteOffset(OpenclProcessing):
 
     def encode_to_bytes(self, data):
         """Compresses data to CBF and returns compressed data as bytes.
+
+        Usage:
+
+        Provided an image (`image`) stored as a numpy array of int32,
+        first, create a byte offset compression/decompression object:
+
+        >>> from silx.opencl.codec.byte_offset import ByteOffset
+        >>> byte_offset_codec = ByteOffset(
+        ...     raw_size=image.size//3, dec_size=image.size)
+
+        Then, compress an image into bytes:
+
+        >>> compressed = byte_offset_codec.encode_to_bytes(image)
 
         :param numpy.ndarray data: The data as a numpy array of int32.
         :return: The compressed data as bytes.

--- a/silx/opencl/codec/byte_offset.py
+++ b/silx/opencl/codec/byte_offset.py
@@ -44,8 +44,10 @@ import os
 import numpy
 from ..common import ocl, pyopencl
 from ..processing import BufferDescription, EventDescription, OpenclProcessing
+
 import logging
 logger = logging.getLogger(__name__)
+
 if pyopencl:
     import pyopencl.version
     if pyopencl.version.VERSION < (2016, 0):
@@ -58,7 +60,8 @@ else:
 
 
 class ByteOffset(OpenclProcessing):
-    "Perform the byte offset decompression on the GPU"
+    """Perform the byte offset decompression on the GPU"""
+
     def __init__(self, raw_size, dec_size, ctx=None, devicetype="all",
                  platformid=None, deviceid=None,
                  block_size=None, profile=False):
@@ -95,7 +98,7 @@ class ByteOffset(OpenclProcessing):
                                  self._init_compression_scan())
 
     def _init_double_scan(self):
-        "generates a double scan on indexes and values in one operation"
+        """"generates a double scan on indexes and values in one operation"""
         arguments = "__global int *value", "__global int *index"
         int2 = pyopencl.tools.get_or_register_dtype("int2")
         input_expr = "index[i]>0 ? (int2)(0, 0) : (int2)(value[i], 1)"

--- a/silx/opencl/codec/byte_offset.py
+++ b/silx/opencl/codec/byte_offset.py
@@ -4,7 +4,7 @@
 #    Project: Sift implementation in Python + OpenCL
 #             https://github.com/silx-kit/silx
 #
-#    Copyright (C) 2013-2017  European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2013-2018  European Synchrotron Radiation Facility, Grenoble, France
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -331,6 +331,10 @@ class ByteOffset(OpenclProcessing):
             if out is None:
                 out = pyopencl.array.empty(
                     self.queue, shape=(byte_count,), dtype=numpy.int8)
+            elif out.size < byte_count:
+                raise ValueError(
+                    "Provided output buffer is not large enough: "
+                    "requires %d bytes, got %d" % (byte_count, out.size))
 
             evt = pyopencl.enqueue_copy_buffer(
                 self.queue, d_compressed.data, out.data, byte_count=byte_count)

--- a/silx/opencl/codec/byte_offset.py
+++ b/silx/opencl/codec/byte_offset.py
@@ -91,6 +91,8 @@ class ByteOffset(OpenclProcessing):
         self.allocate_buffers(buffers, use_array=True)
         self.compile_kernels([os.path.join("codec", "byte_offset")])
         self.kernels.__setattr__("scan", self._init_double_scan())
+        self.kernels.__setattr__("compression_scan",
+                                 self._init_compression_scan())
 
     def _init_double_scan(self):
         "generates a double scan on indexes and values in one operation"
@@ -221,3 +223,109 @@ class ByteOffset(OpenclProcessing):
         return out
 
     __call__ = decode
+
+    def _init_compression_scan(self):
+        """Initialize CBF compression scan kernels"""
+        preamble = """
+        int compressed_size(int diff) {
+            int abs_diff = abs(diff);
+
+            if (abs_diff < 128) {
+                return 1;
+            }
+            else if (abs_diff < 32768) {
+                return 3;
+            }
+            else {
+                return 7;
+            }
+        }
+
+        void write(const int index,
+                   const int diff,
+                   global char *output) {
+            int abs_diff = abs(diff);
+
+            if (abs_diff < 128) {
+                output[index] = (char) diff;
+            }
+            else if (abs_diff < 32768) {
+                output[index] = -128;
+                output[index + 1] = (char) (diff >> 0);
+                output[index + 2] = (char) (diff >> 8);
+            }
+            else {
+                output[index] = -128;
+                output[index + 1] = 0;
+                output[index + 2] = -128;
+                output[index + 3] = (char) (diff >> 0);
+                output[index + 4] = (char) (diff >> 8);
+                output[index + 5] = (char) (diff >> 16);
+                output[index + 6] = (char) (diff >> 24);
+            }
+        }
+        """
+        arguments = "__global const int *data, __global char *compressed, __global int *size"
+        input_expr = "compressed_size((i == 0) ? data[0] : (data[i] - data[i - 1]))"
+        scan_expr = "a+b"
+        neutral = "0"
+        output_statement = """
+        if (prev_item == 0) { // 1st thread store compressed data size
+            size[0] = last_item;
+        }
+        write(prev_item, (i == 0) ? data[0] : (data[i] - data[i - 1]), compressed);
+        """
+
+        if self.block_size >= 64:
+            knl = GenericScanKernel(self.ctx,
+                                    dtype=numpy.int32,
+                                    preamble=preamble,
+                                    arguments=arguments,
+                                    input_expr=input_expr,
+                                    scan_expr=scan_expr,
+                                    neutral=neutral,
+                                    output_statement=output_statement)
+        else:  # MacOS on CPU
+            knl = GenericDebugScanKernel(self.ctx,
+                                         dtype=numpy.int32,
+                                         preamble=preamble,
+                                         arguments=arguments,
+                                         input_expr=input_expr,
+                                         scan_expr=scan_expr,
+                                         neutral=neutral,
+                                         output_statement=output_statement)
+        return knl
+
+    def encode(self, data, out=None):
+        """This function compress provided data to CBF.
+
+        :param numpy.ndarray data: The data as a numpy array of int32.
+        :param pyopencl.array out: pyopencl array in which to place the result.
+        :return: The compressed data as a pyopencl array.
+        :rtype: pyopencl.array
+        """
+        # TODO also support pyopencl array as input
+        # TODO as_bytes argument
+        # TODO record a maximum number of events
+        # TODO use semaphore
+        # TODO reuse buffers? and use those of decompression
+        # TODO write test + sample code
+
+        data = numpy.ascontiguousarray(data, dtype=numpy.int32).ravel()
+        size = data.size
+
+        d_data = pyopencl.array.to_device(self.queue, data)
+        d_compressed = pyopencl.array.empty(
+            self.queue, shape=(size * 7,), dtype=numpy.int8)
+        d_size = pyopencl.array.zeros(self.queue, (1,), dtype=numpy.int32)
+
+        self.kernels.compression_scan(d_data, d_compressed, d_size)
+        byte_count = d_size.get()[0]
+
+        if out is None:
+            out = pyopencl.array.empty(
+                self.queue, shape=(byte_count,), dtype=numpy.int8)
+
+        pyopencl.enqueue_copy_buffer(
+            self.queue, d_compressed.data, out.data, byte_count=byte_count)
+        return out

--- a/silx/opencl/codec/byte_offset.py
+++ b/silx/opencl/codec/byte_offset.py
@@ -71,7 +71,7 @@ class ByteOffset(OpenclProcessing):
             It can be (slightly) larger than the array.
         :param int dec_size:
             Size of the decompression output array
-           (mandatory for decompression)
+            (mandatory for decompression)
         """
 
     def __init__(self, raw_size=None, dec_size=None,

--- a/silx/opencl/codec/byte_offset.py
+++ b/silx/opencl/codec/byte_offset.py
@@ -320,7 +320,7 @@ class ByteOffset(OpenclProcessing):
         d_size = pyopencl.array.zeros(self.queue, (1,), dtype=numpy.int32)
 
         self.kernels.compression_scan(d_data, d_compressed, d_size)
-        byte_count = d_size.get()[0]
+        byte_count = int(d_size.get()[0])
 
         if out is None:
             out = pyopencl.array.empty(

--- a/silx/opencl/codec/test/test_byte_offset.py
+++ b/silx/opencl/codec/test/test_byte_offset.py
@@ -49,11 +49,16 @@ try:
     import fabio
 except:
     fabio = None
+try:
+    import pyopencl
+except ImportError:
+    pyopencl = None
 import unittest
 logger = logging.getLogger(__name__)
 
 
-@unittest.skipUnless(ocl and fabio, "PyOpenCl or fabio is missing")
+@unittest.skipUnless(ocl and fabio and pyopencl,
+                     "PyOpenCl or fabio is missing")
 class TestByteOffset(unittest.TestCase):
 
     def _create_test_data(self, shape, nexcept, lam=200):
@@ -78,8 +83,6 @@ class TestByteOffset(unittest.TestCase):
         """
         tests the byte offset decompression on GPU
         """
-        import pyopencl
-
         ref, raw = self._create_test_data(shape=(2713, 2719), nexcept=2729)
         size = numpy.prod(ref.shape)
 
@@ -112,8 +115,6 @@ class TestByteOffset(unittest.TestCase):
         tests the byte offset decompression on GPU, many images to ensure there 
         is not leaking in memory 
         """
-        import pyopencl
-
         shape = (991, 997)
         size = numpy.prod(shape)
         ref, raw = self._create_test_data(shape=shape, nexcept=0, lam=100)
@@ -158,8 +159,6 @@ class TestByteOffset(unittest.TestCase):
 
     def test_compress(self):
         """Test byte offset compression"""
-        import pyopencl
-
         ref, raw = self._create_test_data(shape=(2713, 2719), nexcept=2729)
         size = numpy.prod(ref.shape)
 

--- a/silx/opencl/codec/test/test_byte_offset.py
+++ b/silx/opencl/codec/test/test_byte_offset.py
@@ -47,7 +47,7 @@ from silx.opencl import ocl
 from silx.opencl.codec import byte_offset
 try:
     import fabio
-except:
+except ImportError:
     fabio = None
 try:
     import pyopencl
@@ -61,7 +61,8 @@ logger = logging.getLogger(__name__)
                      "PyOpenCl or fabio is missing")
 class TestByteOffset(unittest.TestCase):
 
-    def _create_test_data(self, shape, nexcept, lam=200):
+    @staticmethod
+    def _create_test_data(shape, nexcept, lam=200):
         """Create test (image, compressed stream) pair.
 
         :param shape: Shape of test image
@@ -172,7 +173,6 @@ class TestByteOffset(unittest.TestCase):
         compressed_stream = compressed_array.get().tostring()
         self.assertEqual(raw, compressed_stream)
 
-
     def test_encode_to_bytes(self):
         """Test byte offset compression to bytes"""
         ref, raw = self._create_test_data(shape=(2713, 2719), nexcept=2729)
@@ -189,9 +189,9 @@ class TestByteOffset(unittest.TestCase):
 
 
 def suite():
-    testSuite = unittest.TestSuite()
-    testSuite.addTest(TestByteOffset("test_decompress"))
-    testSuite.addTest(TestByteOffset("test_many_decompress"))
-    testSuite.addTest(TestByteOffset("test_encode"))
-    testSuite.addTest(TestByteOffset("test_encode_to_bytes"))
-    return testSuite
+    test_suite = unittest.TestSuite()
+    test_suite.addTest(TestByteOffset("test_decompress"))
+    test_suite.addTest(TestByteOffset("test_many_decompress"))
+    test_suite.addTest(TestByteOffset("test_encode"))
+    test_suite.addTest(TestByteOffset("test_encode_to_bytes"))
+    return test_suite

--- a/silx/opencl/codec/test/test_byte_offset.py
+++ b/silx/opencl/codec/test/test_byte_offset.py
@@ -157,7 +157,7 @@ class TestByteOffset(unittest.TestCase):
                          1000.0 * (t1 - t0),
                          1000.0 * (t2 - t1))
 
-    def test_compress(self):
+    def test_encode(self):
         """Test byte offset compression"""
         ref, raw = self._create_test_data(shape=(2713, 2719), nexcept=2729)
         size = numpy.prod(ref.shape)
@@ -166,13 +166,25 @@ class TestByteOffset(unittest.TestCase):
             bo = byte_offset.ByteOffset(len(raw), size, profile=True)
         except (RuntimeError, pyopencl.RuntimeError) as err:
             logger.warning(err)
-            if sys.platform == "darwin":
-                raise unittest.SkipTest("Byte-offset decompression is known to be buggy on MacOS-CPU")
-            else:
-                raise err
+            raise err
 
         compressed_array = bo.encode(ref)
         compressed_stream = compressed_array.get().tostring()
+        self.assertEqual(raw, compressed_stream)
+
+
+    def test_encode_to_bytes(self):
+        """Test byte offset compression to bytes"""
+        ref, raw = self._create_test_data(shape=(2713, 2719), nexcept=2729)
+        size = numpy.prod(ref.shape)
+
+        try:
+            bo = byte_offset.ByteOffset(len(raw), size, profile=True)
+        except (RuntimeError, pyopencl.RuntimeError) as err:
+            logger.warning(err)
+            raise err
+
+        compressed_stream = bo.encode_to_bytes(ref)
         self.assertEqual(raw, compressed_stream)
 
 
@@ -180,5 +192,6 @@ def suite():
     testSuite = unittest.TestSuite()
     testSuite.addTest(TestByteOffset("test_decompress"))
     testSuite.addTest(TestByteOffset("test_many_decompress"))
-    testSuite.addTest(TestByteOffset("test_compress"))
+    testSuite.addTest(TestByteOffset("test_encode"))
+    testSuite.addTest(TestByteOffset("test_encode_to_bytes"))
     return testSuite

--- a/silx/opencl/codec/test/test_byte_offset.py
+++ b/silx/opencl/codec/test/test_byte_offset.py
@@ -88,7 +88,7 @@ class TestByteOffset(unittest.TestCase):
         size = numpy.prod(ref.shape)
 
         try:
-            bo = byte_offset.ByteOffset(len(raw), size, profile=True)
+            bo = byte_offset.ByteOffset(dec_size=size, profile=True)
         except (RuntimeError, pyopencl.RuntimeError) as err:
             logger.warning(err)
             if sys.platform == "darwin":
@@ -185,7 +185,7 @@ class TestByteOffset(unittest.TestCase):
         ref, raw = self._create_test_data(shape=(2713, 2719), nexcept=2729)
 
         try:
-            bo = byte_offset.ByteOffset(len(raw), ref.size, profile=True)
+            bo = byte_offset.ByteOffset(profile=True)
         except (RuntimeError, pyopencl.RuntimeError) as err:
             logger.warning(err)
             raise err
@@ -214,7 +214,7 @@ class TestByteOffset(unittest.TestCase):
         ref, raw = self._create_test_data(shape=(2713, 2719), nexcept=2729)
 
         try:
-            bo = byte_offset.ByteOffset(len(raw), ref.size, profile=True)
+            bo = byte_offset.ByteOffset(profile=True)
         except (RuntimeError, pyopencl.RuntimeError) as err:
             logger.warning(err)
             raise err
@@ -238,7 +238,7 @@ class TestByteOffset(unittest.TestCase):
         ref, raw = self._create_test_data(shape=(2713, 2719), nexcept=2729)
 
         try:
-            bo = byte_offset.ByteOffset(len(raw), ref.size, profile=True)
+            bo = byte_offset.ByteOffset(profile=True)
         except (RuntimeError, pyopencl.RuntimeError) as err:
             logger.warning(err)
             raise err
@@ -265,7 +265,7 @@ class TestByteOffset(unittest.TestCase):
         ref, raw = self._create_test_data(shape=shape, nexcept=0, lam=100)
 
         try:
-            bo = byte_offset.ByteOffset(len(raw), ref.size, profile=False)
+            bo = byte_offset.ByteOffset(profile=False)
         except (RuntimeError, pyopencl.RuntimeError) as err:
             logger.warning(err)
             raise err


### PR DESCRIPTION
This PR adds OpenCL compression to the `ByteOffset` class through an `encode` method with some tests.

There is still some TODOs (see in source file) for the API, reusing buffers, etc.. and a sample code.
Code in the test class can be reused across different tests.