### PR TITLE
[CI] Fix Travis-Linux build

### DIFF
--- a/ci/amd_sdk.sh
+++ b/ci/amd_sdk.sh
@@ -4,7 +4,7 @@
 
 # Location from which get nonce and file name from
 URL="http://developer.amd.com/amd-accelerated-parallel-processing-app-sdk/"
-URLDOWN="https://developer.amd.com/amd-license-agreement-appsdk/"
+URLDOWN="http://developer.amd.com/amd-license-agreement-appsdk/"
 
 NONCE1_STRING='name="amd_developer_central_downloads_page_nonce"'
 FILE_STRING='name="f"'


### PR DESCRIPTION
Workaround issue:
```
ERROR: cannot verify developer.amd.com's certificate, issued by ‘/C=US/O=GeoTrust Inc./CN=GeoTrust SSL CA - G3’:
  Issued certificate has expired.
```
  