### PR TITLE
[colormap action] fix #1427

### DIFF
--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -359,7 +359,9 @@ class ColormapAction(PlotAction):
             colormap = image.getColormap()
 
         self._dialog.setHistogram()
-        self._dialog.setColormap(colormap=colormap)
+        # avoid setting multiple time the same colormap to be able to reset it
+        if colormap is not self._dialog.getColormap():
+            self._dialog.setColormap(colormap=colormap)
 
 
 class KeepAspectRatioAction(PlotAction):


### PR DESCRIPTION
In the colormap action, set the colormap only if it is not the one already set.
Allow to reset the colormap from the first set from the colormap dialog