### PR TITLE
[colormap action] fix #1423

### DIFF
--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -333,7 +333,7 @@ class ColormapAction(PlotAction):
         """Create a cmap dialog and update active image and default cmap."""
         # Create the dialog if not already existing
         if self._dialog is None:
-            self._dialog = ColormapDialog()
+            self._dialog = ColormapDialog(self.plot)
             self._dialog.finished.connect(self._setUnChecked)
             self._dialog.setModal(False)
             self._updateColormap()


### PR DESCRIPTION
add the plot as the colormap dialog parent. This way when the plot is deleted will delete the colormap dialog to.