### PR TITLE
Improve colormap dialog

### DIFF
--- a/examples/colormapDialog.py
+++ b/examples/colormapDialog.py
@@ -1,0 +1,195 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This script shows the features of a colormap dialog.
+"""
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "04/01/2018"
+
+import functools
+
+from silx.gui import qt
+
+from silx.gui.plot.ColormapDialog import ColormapDialog
+from silx.gui.plot.Colormap import Colormap
+from silx.gui.plot.ColorBar import ColorBarWidget
+
+
+class ColormapDialogExample(qt.QMainWindow):
+    """PlotWidget with an ad hoc toolbar and a colorbar"""
+
+    def __init__(self, parent=None):
+        super(ColormapDialogExample, self).__init__(parent)
+        self.setWindowTitle("Colormap dialog example")
+
+        self.colormap1 = Colormap("viridis")
+        self.colormap2 = Colormap("gray")
+
+        self.colorBar = ColorBarWidget(self)
+
+        self.colorDialogs = []
+
+        options = qt.QWidget(self)
+        options.setLayout(qt.QVBoxLayout())
+        self.createOptions(options.layout())
+
+        mainWidget = qt.QWidget(self)
+        mainWidget.setLayout(qt.QHBoxLayout())
+        mainWidget.layout().addWidget(options)
+        mainWidget.layout().addWidget(self.colorBar)
+        self.mainWidget = mainWidget
+
+        self.setCentralWidget(mainWidget)
+        self.createColorDialog()
+
+    def createOptions(self, layout):
+        button = qt.QPushButton("Create a new dialog")
+        button.clicked.connect(self.createColorDialog)
+        layout.addWidget(button)
+
+        layout.addSpacing(10)
+
+        button = qt.QPushButton("Set colormap 1")
+        button.clicked.connect(self.setColormap1)
+        layout.addWidget(button)
+        button = qt.QPushButton("Set colormap 2")
+        button.clicked.connect(self.setColormap2)
+        layout.addWidget(button)
+        button = qt.QPushButton("Create new colormap")
+        button.clicked.connect(self.setNewColormap)
+        layout.addWidget(button)
+
+        layout.addSpacing(10)
+
+        button = qt.QPushButton("Set no histogram")
+        button.clicked.connect(self.setNoHistogram)
+        layout.addWidget(button)
+        button = qt.QPushButton("Set positive histogram")
+        button.clicked.connect(self.setPositiveHistogram)
+        layout.addWidget(button)
+        button = qt.QPushButton("Set neg-pos histogram")
+        button.clicked.connect(self.setNegPosHistogram)
+        layout.addWidget(button)
+        button = qt.QPushButton("Set negative histogram")
+        button.clicked.connect(self.setNegativeHistogram)
+        layout.addWidget(button)
+
+        layout.addSpacing(10)
+
+        button = qt.QPushButton("Set no range")
+        button.clicked.connect(self.setNoRange)
+        layout.addWidget(button)
+        button = qt.QPushButton("Set positive range")
+        button.clicked.connect(self.setPositiveRange)
+        layout.addWidget(button)
+        button = qt.QPushButton("Set neg-pos range")
+        button.clicked.connect(self.setNegPosRange)
+        layout.addWidget(button)
+        button = qt.QPushButton("Set negative range")
+        button.clicked.connect(self.setNegativeRange)
+        layout.addWidget(button)
+
+        layout.addStretch()
+
+    def createColorDialog(self):
+        newDialog = ColormapDialog(self)
+        newDialog.finished.connect(functools.partial(self.removeColorDialog, newDialog))
+        self.colorDialogs.append(newDialog)
+        self.mainWidget.layout().addWidget(newDialog)
+
+    def removeColorDialog(self, dialog):
+        self.colorDialogs.remove(dialog)
+
+    def setColormap1(self):
+        self.colorBar.setColormap(self.colormap1)
+        for dialog in self.colorDialogs:
+            dialog.setColormap(self.colormap1)
+
+    def setColormap2(self):
+        self.colorBar.setColormap(self.colormap2)
+        for dialog in self.colorDialogs:
+            dialog.setColormap(self.colormap2)
+
+    def setNewColormap(self):
+        self.colormap = Colormap("inferno")
+        self.colorBar.setColormap(self.colormap)
+        for dialog in self.colorDialogs:
+            dialog.setColormap(self.colormap)
+
+    def setNoHistogram(self):
+        for dialog in self.colorDialogs:
+            dialog.setHistogram()
+
+    def setPositiveHistogram(self):
+        histo = [5, 10, 50, 10, 5]
+        pos = 1
+        edges = list(range(pos, pos + len(histo)))
+        for dialog in self.colorDialogs:
+            dialog.setHistogram(histo, edges)
+
+    def setNegPosHistogram(self):
+        histo = [5, 10, 50, 10, 5]
+        pos = -2
+        edges = list(range(pos, pos + len(histo)))
+        for dialog in self.colorDialogs:
+            dialog.setHistogram(histo, edges)
+
+    def setNegativeHistogram(self):
+        histo = [5, 10, 50, 10, 5]
+        pos = -30
+        edges = list(range(pos, pos + len(histo)))
+        for dialog in self.colorDialogs:
+            dialog.setHistogram(histo, edges)
+
+    def setNoRange(self):
+        for dialog in self.colorDialogs:
+            dialog.setDataRange()
+
+    def setPositiveRange(self):
+        for dialog in self.colorDialogs:
+            dialog.setDataRange(1, 1, 10)
+
+    def setNegPosRange(self):
+        for dialog in self.colorDialogs:
+            dialog.setDataRange(-10, 1, 10)
+
+    def setNegativeRange(self):
+        for dialog in self.colorDialogs:
+            dialog.setDataRange(-10, float("nan"), -1)
+
+
+def main():
+    app = qt.QApplication([])
+
+    # Create the ad hoc plot widget and change its default colormap
+    example = ColormapDialogExample()
+    example.show()
+
+    app.exec_()
+
+
+if __name__ == '__main__':
+    main()

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -63,7 +63,7 @@ from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent", "H. Payno"]
 __license__ = "MIT"
-__date__ = "03/01/2018"
+__date__ = "04/01/2018"
 
 
 import logging
@@ -306,20 +306,33 @@ class ColormapDialog(qt.QDialog):
             self._plot.setVisible(True)
             self.setFixedSize(self.layout().minimumSize())
 
-        mindata, maxdata = self._minValue.getFiniteValue(), self._maxValue.getFiniteValue()
-        if mindata > maxdata:
+        minData, maxData = self._minValue.getFiniteValue(), self._maxValue.getFiniteValue()
+        if minData > maxData:
             # avoid a full collapse
-            mindata, maxdata = maxdata, mindata
-        minimum = mindata
-        maximum = maxdata
-        if self._initialRange is not None:
-            minimum = min(mindata, self._initialRange[0])
-            maximum = max(maxdata, self._initialRange[1])
-        if not updateMarkers:
-            self._initialRange = minimum, maximum
+            minData, maxData = maxData, minData
+        minimum = minData
+        maximum = maxData
+        if self._histogramData is not None:
+            minHisto = self._histogramData[1][0]
+            maxHisto = self._histogramData[1][-1]
+            minimum = min(minimum, minHisto)
+            maximum = max(maximum, maxHisto)
 
         marge = abs(maximum - minimum) / 6.0
-        x = [minimum - marge, mindata, maxdata, maximum + marge]
+        if marge < 0.0001:
+            # Smaller that the QLineEdit precision
+            marge = 0.0001
+
+        minView, maxView = minimum - marge, maximum + marge
+
+        if updateMarkers:
+            # Save the state in we are not moving the markers
+            self._initialRange = minView, maxView
+        elif self._initialRange is not None:
+            minView = min(minView, self._initialRange[0])
+            maxView = max(maxView, self._initialRange[1])
+
+        x = [minView, minData, maxData, maxView]
         y = [0, 0, 1, 1]
 
         self._plot.addCurve(x, y,

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -485,13 +485,11 @@ class ColormapDialog(qt.QDialog):
         """Update the min and max of the data according to the data range and
         the histogram preset."""
         colormap = self.getColormap()
-        if colormap is None:
-            return
 
         minimum = float("+inf")
         maximum = float("-inf")
 
-        if colormap.getNormalization() == colormap.LOGARITHM:
+        if colormap is not None and colormap.getNormalization() == colormap.LOGARITHM:
             # find a range in the positive part of the data
             if self._dataRange is not None:
                 minimum = min(minimum, self._dataRange[1])

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -416,22 +416,18 @@ class ColormapDialog(qt.QDialog):
         """
         if hist is None or bin_edges is None:
             self._histogramData = None
-            self._plot.remove(legend='Histogram', kind='curve')
+            self._plot.remove(legend='Histogram', kind='histogram')
         else:
             hist = numpy.array(hist, copy=True)
             bin_edges = numpy.array(bin_edges, copy=True)
             self._histogramData = hist, bin_edges
-
-            # For now, draw the histogram as a curve
-            # using bin centers and normalised counts
-            bins_center = 0.5 * (bin_edges[:-1] + bin_edges[1:])
             norm_hist = hist / max(hist)
-            self._plot.addCurve(bins_center, norm_hist,
-                                legend="Histogram",
-                                color='gray',
-                                symbol='',
-                                linestyle='-',
-                                fill=True)
+            self._plot.addHistogram(norm_hist,
+                                    bin_edges,
+                                    legend="Histogram",
+                                    color='gray',
+                                    align='center',
+                                    fill=True)
 
             # Update the data range
             colormap = self.getColormap()

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -314,6 +314,13 @@ class ColormapDialog(qt.QDialog):
             minData, maxData = maxData, minData
         minimum = minData
         maximum = maxData
+
+        if self._dataRange is not None:
+            minRange = self._dataRange[0]
+            maxRange = self._dataRange[2]
+            minimum = min(minimum, minRange)
+            maximum = max(maximum, maxRange)
+
         if self._histogramData is not None:
             minHisto = self._histogramData[1][0]
             maxHisto = self._histogramData[1][-1]
@@ -455,14 +462,26 @@ class ColormapDialog(qt.QDialog):
             self._ignoreColormapChange = False
             self._applyColormap()
 
-    def setDataRange(self, minimum, positiveMin, maximum):
+    def setDataRange(self, minimum=None, positiveMin=None, maximum=None):
         """Set the range of data to use for the range of the histogram area.
 
         :param float minimum: The minimum of the data
         :param float positiveMin: The positive minimum of the data
         :param float maximum: The maximum of the data
         """
-        self._dataRange = minimum, positiveMin, maximum
+        if minimum is None or positiveMin is None or maximum is None:
+            self._dataRange = None
+            self._plot.remove(legend='Range', kind='histogram')
+        else:
+            hist = numpy.array([1])
+            bin_edges = numpy.array([minimum, maximum])
+            self._plot.addHistogram(hist,
+                                    bin_edges,
+                                    legend="Range",
+                                    color='gray',
+                                    align='center',
+                                    fill=True)
+            self._dataRange = minimum, positiveMin, maximum
         # FIXME Take care of the log
         self._minValue.setDataValue(minimum)
         self._maxValue.setDataValue(maximum)

--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -171,6 +171,8 @@ class ColormapDialog(qt.QDialog):
         qt.QDialog.__init__(self, parent)
         self.setWindowTitle(title)
 
+        self._colormap = None
+
         self._ignoreColormapChange = False
         """Used as a semaphore to avoid editing the colormap object when we are
         only attempt to display it.
@@ -425,7 +427,8 @@ class ColormapDialog(qt.QDialog):
                                 fill=True)
 
             # Update the data range
-            if hasattr(self, '_colormap') and self._colormap():
+            colormap = self.getColormap()
+            if colormap is not None:
                 self._ignoreColormapChange = True
                 self._colormap().setVRange(bin_edges[0], bin_edges[-1])
                 self._ignoreColormapChange = False
@@ -434,7 +437,7 @@ class ColormapDialog(qt.QDialog):
         """Return the colormap description as a :class:`.Colormap`.
 
         """
-        if not hasattr(self, "_colormap"):
+        if self._colormap is None:
             return None
         return self._colormap()
 
@@ -445,9 +448,10 @@ class ColormapDialog(qt.QDialog):
         ..note :: the colormap reference state is the state when set or the
                   state when validated
         """
-        if self._colormap():
+        colormap = self.getColormap()
+        if colormap is not None:
             self._ignoreColormapChange = True
-            self._colormap()._setFromDict(self._colormapStoredState)
+            colormap._setFromDict(self._colormapStoredState)
             self._ignoreColormapChange = False
             self._applyColormap()
 
@@ -489,8 +493,9 @@ class ColormapDialog(qt.QDialog):
         if self._ignoreColormapChange is True:
             return
 
-        if hasattr(self, '_colormap') and self._colormap():
-            self._colormap().sigChanged.disconnect(self._applyColormap)
+        oldColormap = self.getColormap()
+        if oldColormap is not None:
+            oldColormap.sigChanged.disconnect(self._applyColormap)
         self._colormap = weakref.ref(colormap)
         self._colormap().sigChanged.connect(self._applyColormap)
         self.storeCurrentState()

--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -359,7 +359,7 @@ class ColormapAction(PlotAction):
 
             data = image.getData(copy=False)
             if data is None or len(data) == 0:
-                dataRange = None
+                self._dialog.setDataRange()
             else:
                 dataRange = min_max(data, min_positive=True, finite=True)
                 if dataRange.minimum is None:
@@ -372,14 +372,14 @@ class ColormapAction(PlotAction):
                         min_positive = float('nan')
                     dataRange = dataRange.minimum, min_positive, dataRange.maximum
 
-            if dataRange is None or len(dataRange) != 3:
-                qt.QMessageBox.warning(
-                    None, "No Data",
-                    "Image data does not contain any real value")
-                minimum, posMin, maximum = 1., 1., 10.
-            else:
-                minimum, posMin, maximum = dataRange
-            self._dialog.setDataRange(minimum, posMin, maximum)
+                if dataRange is None or len(dataRange) != 3:
+                    qt.QMessageBox.warning(
+                        None, "No Data",
+                        "Image data does not contain any real value")
+                    minimum, posMin, maximum = 1., 1., 10.
+                else:
+                    minimum, posMin, maximum = dataRange
+                self._dialog.setDataRange(minimum, posMin, maximum)
             # The histogram should be done in a worker thread
             # hist, bin_edges = numpy.histogram(data, bins=256)
             # self._dialog.setHistogram(hist, bin_edges)

--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -50,7 +50,7 @@ from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "27/06/2017"
+__date__ = "04/01/2018"
 
 from . import PlotAction
 import logging
@@ -60,6 +60,7 @@ from silx.gui.plot.ColormapDialog import ColormapDialog
 from silx.gui.plot._utils import applyZoomToPlot as _applyZoomToPlot
 from silx.gui import qt
 from silx.gui import icons
+from silx.math.combo import min_max
 
 _logger = logging.getLogger(__name__)
 
@@ -350,15 +351,46 @@ class ColormapAction(PlotAction):
 
     def _updateColormap(self):
         image = self.plot.getActiveImage()
-        if not isinstance(image, items.ColormapMixIn):
+        if isinstance(image, items.ColormapMixIn):
+            # Set dialog from active image
+            colormap = image.getColormap()
+            # Reset histogram and range if any
+            self._dialog.setHistogram()
+
+            data = image.getData(copy=False)
+            if data is None or len(data) == 0:
+                dataRange = None
+            else:
+                dataRange = min_max(data, min_positive=True, finite=True)
+                if dataRange.minimum is None:
+                    # Only non-finite data
+                    dataRange = None
+
+                if dataRange is not None:
+                    min_positive = dataRange.min_positive
+                    if min_positive is None:
+                        min_positive = float('nan')
+                    dataRange = dataRange.minimum, min_positive, dataRange.maximum
+
+            if dataRange is None or len(dataRange) != 3:
+                qt.QMessageBox.warning(
+                    None, "No Data",
+                    "Image data does not contain any real value")
+                minimum, posMin, maximum = 1., 1., 10.
+            else:
+                minimum, posMin, maximum = dataRange
+            self._dialog.setDataRange(minimum, posMin, maximum)
+            # The histogram should be done in a worker thread
+            # hist, bin_edges = numpy.histogram(data, bins=256)
+            # self._dialog.setHistogram(hist, bin_edges)
+
+        else:
             # No active image or active image is RGBA,
             # set dialog from default info
             colormap = self.plot.getDefaultColormap()
-        else:
-            # Set dialog from active image
-            colormap = image.getColormap()
+            # Reset histogram and range if any
+            self._dialog.setHistogram()
 
-        self._dialog.setHistogram()
         # avoid setting multiple time the same colormap to be able to reset it
         if colormap is not self._dialog.getColormap():
             self._dialog.setColormap(colormap=colormap)

--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -389,6 +389,7 @@ class ColormapAction(PlotAction):
             # set dialog from default info
             colormap = self.plot.getDefaultColormap()
             # Reset histogram and range if any
+            self._dialog.setDataRange()
             self._dialog.setHistogram()
 
         # avoid setting multiple time the same colormap to be able to reset it


### PR DESCRIPTION
Few improvements on the colormap dialog before reworking the viewer.

- Reuse the concept of `setDataRange`
- Use the `setHistogram` API instead of curves
- Display the data range in the plot
- Provide an example to be able to test the dialog
- Provide feature to auto set convenient min/max values
- Rework the plot interaction

![colormap dialog example](https://user-images.githubusercontent.com/7579321/34574963-e808893a-f170-11e7-8c59-e0342848ef04.png)