### PR TITLE
[plot3d] Add a widget to set properties globally in a SceneWidget

### DIFF
--- a/silx/gui/plot/ColormapDialog.py
+++ b/silx/gui/plot/ColormapDialog.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -402,6 +402,13 @@ class ColormapDialog(qt.QDialog):
         self._buttonsNonModal.setVisible(not modal)
         self._buttonsModal.setVisible(modal)
         qt.QDialog.setModal(self, modal)
+
+    def exec_(self):
+        wasModal = self.isModal()
+        self.setModal(True)
+        result = super(ColormapDialog, self).exec_()
+        self.setModal(wasModal)
+        return result
 
     def _plotInit(self):
         """Init the plot to display the range and the values"""

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -455,6 +455,14 @@ class SymbolMixIn(ItemMixInBase):
         """
         return tuple(cls._SUPPORTED_SYMBOLS.keys())
 
+    @classmethod
+    def getSupportedSymbolNames(cls):
+        """Returns the list of supported symbol human-readable names.
+
+        :rtype: tuple of str
+        """
+        return tuple(cls._SUPPORTED_SYMBOLS.values())
+
     def getSymbolName(self, symbol=None):
         """Returns human-readable name for a symbol.
 

--- a/silx/gui/plot3d/SceneWindow.py
+++ b/silx/gui/plot3d/SceneWindow.py
@@ -36,6 +36,7 @@ from silx.gui import qt
 
 from .SceneWidget import SceneWidget
 from .tools import OutputToolBar, InteractiveModeToolBar, ViewpointToolBar
+from silx.gui.plot3d.tools.GroupPropertiesWidget import GroupPropertiesWidget
 
 from .ParamTreeView import ParamTreeView
 
@@ -72,10 +73,22 @@ class SceneWindow(qt.QMainWindow):
         self._paramTreeView = ParamTreeView()
         self._paramTreeView.setModel(self._sceneWidget.model())
 
-        dock = qt.QDockWidget()
-        dock.setWindowTitle('Parameters')
-        dock.setWidget(self._paramTreeView)
-        self.addDockWidget(qt.Qt.RightDockWidgetArea, dock)
+        paramDock = qt.QDockWidget()
+        paramDock.setWindowTitle('Object parameters')
+        paramDock.setWidget(self._paramTreeView)
+        self.addDockWidget(qt.Qt.RightDockWidgetArea, paramDock)
+
+        self._sceneGroupResetWidget = GroupPropertiesWidget()
+        self._sceneGroupResetWidget.setGroup(
+            self._sceneWidget.getSceneGroup())
+
+        resetDock = qt.QDockWidget()
+        resetDock.setWindowTitle('Global parameters')
+        resetDock.setWidget(self._sceneGroupResetWidget)
+        self.addDockWidget(qt.Qt.RightDockWidgetArea, resetDock)
+        self.tabifyDockWidget(paramDock, resetDock)
+
+        paramDock.raise_()
 
     def getSceneWidget(self):
         """Returns the SceneWidget of this window.

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -714,7 +714,7 @@ class SymbolSizeRow(ProxyRow):
             fget=item.getSymbolSize,
             fset=item.setSymbolSize,
             notify=item.sigItemChanged,
-            editorHint=(1, 50))  # TODO link with OpenGL max point size
+            editorHint=(1, 20))  # TODO link with OpenGL max point size
 
 
 class PlaneRow(ProxyRow):

--- a/silx/gui/plot3d/items/core.py
+++ b/silx/gui/plot3d/items/core.py
@@ -417,3 +417,14 @@ class GroupItem(DataItem3D):
         """Remove all item from the group."""
         for item in self.getItems():
             self.removeItem(item)
+
+    def visit(self):
+        """Generator visiting the group content.
+
+        It traverses the group sub-tree in a top-down left-to-right way.
+        """
+        for child in self.getItems():
+            yield child
+            if hasattr(child, 'visit'):
+                for item in child.visit():
+                    yield item

--- a/silx/gui/plot3d/items/volume.py
+++ b/silx/gui/plot3d/items/volume.py
@@ -442,3 +442,13 @@ class ScalarField3D(DataItem3D):
         sortedIso = sorted(self.getIsosurfaces(),
                            key=lambda isosurface: - isosurface.getLevel())
         self._isogroup.children = [iso._getScenePrimitive() for iso in sortedIso]
+
+    def visit(self):
+        """Generator visiting the ScalarField3D content.
+
+        It first access cut planes and then isosurface
+        """
+        for cutPlane in self.getCutPlanes():
+            yield cutPlane
+        for isosurface in self.getIsosurfaces():
+            yield isosurface

--- a/silx/gui/plot3d/tools/GroupPropertiesWidget.py
+++ b/silx/gui/plot3d/tools/GroupPropertiesWidget.py
@@ -1,0 +1,197 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+""":class:`GroupPropertiesWidget` allows to reset properties in a GroupItem."""
+
+from __future__ import absolute_import
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "11/01/2018"
+
+from silx.gui import qt
+from silx.gui.plot.ColormapDialog import ColormapDialog
+
+from silx.gui.plot3d.items import SymbolMixIn, ColormapMixIn
+
+
+class GroupPropertiesWidget(qt.QWidget):
+    """Set properties of all items in a :class:`GroupItem`
+
+    :param QWidget parent:
+    """
+
+    MAX_MARKER_SIZE = 20
+    """Maximum value for marker size"""
+
+    MAX_LINE_WIDTH = 10
+    """Maximum value for line width"""
+
+    def __init__(self, parent=None):
+        super(GroupPropertiesWidget, self).__init__(parent)
+        self._group = None
+        self.setEnabled(False)
+
+        # Set widgets
+        layout = qt.QFormLayout(self)
+        self.setLayout(layout)
+
+        # Colormap
+        colormapButton = qt.QPushButton('Set...')
+        colormapButton.setToolTip("Set colormap for all items")
+        colormapButton.clicked.connect(self._colormapButtonClicked)
+        layout.addRow('Colormap', colormapButton)
+
+        self._markerComboBox = qt.QComboBox(self)
+        self._markerComboBox.addItems(SymbolMixIn.getSupportedSymbolNames())
+
+        # Marker
+        markerButton = qt.QPushButton('Set')
+        markerButton.setToolTip("Set marker for all items")
+        markerButton.clicked.connect(self._markerButtonClicked)
+
+        markerLayout = qt.QHBoxLayout()
+        markerLayout.setContentsMargins(0, 0, 0, 0)
+        markerLayout.addWidget(self._markerComboBox, 1)
+        markerLayout.addWidget(markerButton, 0)
+
+        layout.addRow('Marker', markerLayout)
+
+        # Marker size
+        self._markerSizeSlider = qt.QSlider()
+        self._markerSizeSlider.setOrientation(qt.Qt.Horizontal)
+        self._markerSizeSlider.setSingleStep(1)
+        self._markerSizeSlider.setRange(1, self.MAX_MARKER_SIZE)
+        self._markerSizeSlider.setValue(1)
+
+        markerSizeButton = qt.QPushButton('Set')
+        markerSizeButton.setToolTip("Set marker size for all items")
+        markerSizeButton.clicked.connect(self._markerSizeButtonClicked)
+
+        markerSizeLayout = qt.QHBoxLayout()
+        markerSizeLayout.setContentsMargins(0, 0, 0, 0)
+        markerSizeLayout.addWidget(qt.QLabel('1'))
+        markerSizeLayout.addWidget(self._markerSizeSlider, 1)
+        markerSizeLayout.addWidget(qt.QLabel(str(self.MAX_MARKER_SIZE)))
+        markerSizeLayout.addWidget(markerSizeButton, 0)
+
+        layout.addRow('Marker Size', markerSizeLayout)
+
+        # Line width
+        self._lineWidthSlider = qt.QSlider()
+        self._lineWidthSlider.setOrientation(qt.Qt.Horizontal)
+        self._lineWidthSlider.setSingleStep(1)
+        self._lineWidthSlider.setRange(1, self.MAX_LINE_WIDTH)
+        self._lineWidthSlider.setValue(1)
+
+        lineWidthButton = qt.QPushButton('Set')
+        lineWidthButton.setToolTip("Set line width for all items")
+        lineWidthButton.clicked.connect(self._lineWidthButtonClicked)
+
+        lineWidthLayout = qt.QHBoxLayout()
+        lineWidthLayout.setContentsMargins(0, 0, 0, 0)
+        lineWidthLayout.addWidget(qt.QLabel('1'))
+        lineWidthLayout.addWidget(self._lineWidthSlider, 1)
+        lineWidthLayout.addWidget(qt.QLabel(str(self.MAX_LINE_WIDTH)))
+        lineWidthLayout.addWidget(lineWidthButton, 0)
+
+        layout.addRow('Line Width', lineWidthLayout)
+
+        self._colormapDialog = None  # To store dialog
+
+    def getGroup(self):
+        """Returns the :class:`GroupItem` this widget is attached to.
+
+        :rtype: Union[GroupItem, None]
+        """
+        return self._group
+
+    def setGroup(self, group):
+        """Set the :class:`GroupItem` this widget is attached to.
+
+        :param GroupItem group: GroupItem to control (or None)
+        """
+        self._group = group
+        if group is not None:
+            self.setEnabled(True)
+
+    def _colormapButtonClicked(self, checked=False):
+        """Handle colormap button clicked"""
+        group = self.getGroup()
+        if group is None:
+            return
+
+        if self._colormapDialog is None:
+            self._colormapDialog = ColormapDialog(self)
+
+        previousColormap = self._colormapDialog.getColormap()
+        if self._colormapDialog.exec_():
+            colormap = self._colormapDialog.getColormap()
+
+            for item in group.visit():
+                if isinstance(item, ColormapMixIn):
+                    itemCmap = item.getColormap()
+                    cmapName = colormap.getName()
+                    if cmapName is not None:
+                        itemCmap.setName(colormap.getName())
+                    else:
+                        itemCmap.setColormapLUT(colormap.getColormapLUT())
+                    itemCmap.setNormalization(colormap.getNormalization())
+                    itemCmap.setVRange(colormap.getVMin(), colormap.getVMax())
+        else:
+            # Reset colormap
+            self._colormapDialog.setColormap(**previousColormap._toDict())
+
+    def _markerButtonClicked(self, checked=False):
+        """Handle marker set button clicked"""
+        group = self.getGroup()
+        if group is None:
+            return
+
+        marker = self._markerComboBox.currentText()
+        for item in group.visit():
+            if isinstance(item, SymbolMixIn):
+                item.setSymbol(marker)
+
+    def _markerSizeButtonClicked(self, checked=False):
+        """Handle marker size set button clicked"""
+        group = self.getGroup()
+        if group is None:
+            return
+
+        markerSize = self._markerSizeSlider.value()
+        for item in group.visit():
+            if isinstance(item, SymbolMixIn):
+                item.setSymbolSize(markerSize)
+
+    def _lineWidthButtonClicked(self, checked=False):
+        """Handle line width set button clicked"""
+        group = self.getGroup()
+        if group is None:
+            return
+
+        lineWidth = self._lineWidthSlider.value()
+        for item in group.visit():
+            if hasattr(item, 'setLineWidth'):
+                item.setLineWidth(lineWidth)

--- a/silx/gui/plot3d/tools/GroupPropertiesWidget.py
+++ b/silx/gui/plot3d/tools/GroupPropertiesWidget.py
@@ -30,10 +30,11 @@ __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "11/01/2018"
 
-from silx.gui import qt
-from silx.gui.plot.ColormapDialog import ColormapDialog
+from ....gui import qt
+from ....gui.plot.Colormap import Colormap
+from ....gui.plot.ColormapDialog import ColormapDialog
 
-from silx.gui.plot3d.items import SymbolMixIn, ColormapMixIn
+from ..items import SymbolMixIn, ColormapMixIn
 
 
 class GroupPropertiesWidget(qt.QWidget):
@@ -119,6 +120,7 @@ class GroupPropertiesWidget(qt.QWidget):
         layout.addRow('Line Width', lineWidthLayout)
 
         self._colormapDialog = None  # To store dialog
+        self._colormap = Colormap()
 
     def getGroup(self):
         """Returns the :class:`GroupItem` this widget is attached to.
@@ -144,6 +146,7 @@ class GroupPropertiesWidget(qt.QWidget):
 
         if self._colormapDialog is None:
             self._colormapDialog = ColormapDialog(self)
+            self._colormapDialog.setColormap(self._colormap)
 
         previousColormap = self._colormapDialog.getColormap()
         if self._colormapDialog.exec_():
@@ -161,7 +164,7 @@ class GroupPropertiesWidget(qt.QWidget):
                     itemCmap.setVRange(colormap.getVMin(), colormap.getVMax())
         else:
             # Reset colormap
-            self._colormapDialog.setColormap(**previousColormap._toDict())
+            self._colormapDialog.setColormap(previousColormap)
 
     def _markerButtonClicked(self, checked=False):
         """Handle marker set button clicked"""


### PR DESCRIPTION
#1463 should be merged first

This PR adds a widget to set the colormap, marker and line width for all items of a SceneWidget.
It is available in SceneWindow as a tabbed dock widget.

Related to #1311

![screenshotglobalsettings](https://user-images.githubusercontent.com/9449698/34833650-3cdf8efc-f6f0-11e7-8866-68017a561da1.png)
