### PR TITLE
make a simpler @creator, to avoid file leaks

### DIFF
--- a/silx/app/convert.py
+++ b/silx/app/convert.py
@@ -458,11 +458,12 @@ def main(argv):
                             min_size=options.min_size)
 
     with h5py.File(output_name, mode="r+") as h5f:
-        # append the convert command to the creator attribute, for NeXus files
-        creator = h5f.attrs.get("creator", b"").decode()
-        convert_command = " ".join(argv)
-        if convert_command not in creator:
+        # append "silx convert" to the creator attribute, for NeXus files
+        previous_creator = h5f.attrs.get("creator", b"").decode()
+        creator = "silx convert (v%s)" % silx.version
+        # only if it not already there
+        if creator not in previous_creator:
             h5f.attrs["creator"] = \
-                numpy.string_(creator + "; convert command: %s" % " ".join(argv))
+                numpy.string_(previous_creator + "; " + creator)
 
     return 0

--- a/silx/app/test/test_convert.py
+++ b/silx/app/test/test_convert.py
@@ -163,6 +163,7 @@ class TestConvertCommand(unittest.TestCase):
             self.assertIn("silx convert (v%s)" % silx.version, creator)
 
         # delete input file
+        gc.collect()  # necessary to free spec file on Windows
         os.unlink(specname)
         os.unlink(h5name)
         os.rmdir(tempdir)

--- a/silx/app/test/test_convert.py
+++ b/silx/app/test/test_convert.py
@@ -142,6 +142,7 @@ class TestConvertCommand(unittest.TestCase):
 
         # convert it
         h5name = os.path.join(tempdir, "output.h5")
+        assert not os.path.isfile(h5name)
         command_list = ["convert", "-m", "w",
                         "--no-root-group", specname, "-o", h5name]
         result = convert.main(command_list)
@@ -159,12 +160,9 @@ class TestConvertCommand(unittest.TestCase):
             creator = h5f.attrs.get("creator")
             self.assertIsNotNone(creator, "No creator attribute in NXroot group")
             creator = creator.decode()  # make sure we can compare creator with native string
-            self.assertTrue(creator.startswith("silx %s" % silx.version))
-            command = " ".join(command_list)
-            self.assertTrue(creator.endswith(command))
+            self.assertIn("silx convert (v%s)" % silx.version, creator)
 
         # delete input file
-        gc.collect()  # necessary to free spec file on Windows
         os.unlink(specname)
         os.unlink(h5name)
         os.rmdir(tempdir)

--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -550,7 +550,7 @@ class SpecH5(commonh5.File, SpecH5Group):
         attrs = {"NX_class": "NXroot",
                  "file_time": datetime.datetime.now().isoformat(),
                  "file_name": filename,
-                 "creator": "silx %s" % silx_version}
+                 "creator": "silx spech5 %s" % silx_version}
         commonh5.File.__init__(self, filename, attrs=attrs)
         assert self.attrs["NX_class"] == "NXroot"
 


### PR DESCRIPTION
Appending the complete command to the @creator attr can cause important file leaks when the output file is used to incrementally save a long series of scans.

This PR simplifies the creator to *"silx convert (v0.7.0-dev0)"*. In case multiple versions of silx are used to append to the same file (probably not a good idea), the creator can still be modified, but this will not happen often :  *"silx convert (v0.7.0-dev0); silx convert (v0.7.0)"*