### PR TITLE
[doc] Minimal bootstrap of silx.opencl doc

### DIFF
--- a/doc/source/modules/index.rst
+++ b/doc/source/modules/index.rst
@@ -8,6 +8,7 @@ API Reference
    io/index.rst
    image/index.rst
    math/index.rst
+   opencl/index.rst
    resources.rst
    utils/index.rst
    test/index.rst

--- a/doc/source/modules/opencl/fbp.rst
+++ b/doc/source/modules/opencl/fbp.rst
@@ -1,0 +1,10 @@
+
+.. currentmodule:: silx.opencl
+
+:mod:`backprojection`: (Filtered) Back-Projection
+--------------------------------------------------
+
+.. automodule:: silx.opencl.backprojection
+    :members: Backprojection
+    :show-inheritance:
+    :undoc-members:

--- a/doc/source/modules/opencl/index.rst
+++ b/doc/source/modules/opencl/index.rst
@@ -1,0 +1,14 @@
+
+.. py:module:: silx.opencl
+
+:mod:`silx.opencl`: OpenCL
+===========================
+
+
+.. toctree::
+   :maxdepth: 1
+
+   sift/index.rst
+   fbp.rst
+   medfilt.rst
+

--- a/doc/source/modules/opencl/index.rst
+++ b/doc/source/modules/opencl/index.rst
@@ -1,8 +1,8 @@
 
 .. py:module:: silx.opencl
 
-:mod:`silx.opencl`: OpenCL
-===========================
+:mod:`silx.opencl`: OpenCL-based features
+=========================================
 
 
 .. toctree::

--- a/doc/source/modules/opencl/medfilt.rst
+++ b/doc/source/modules/opencl/medfilt.rst
@@ -1,0 +1,7 @@
+.. currentmodule:: silx.opencl
+
+:mod:`medianfilter`: OpenCL median filter
+------------------------------------------
+
+.. automodule:: silx.opencl.medfilt
+    :members: MedianFilter2D, medfilt2d

--- a/doc/source/modules/opencl/sift/align.rst
+++ b/doc/source/modules/opencl/sift/align.rst
@@ -1,0 +1,7 @@
+.. currentmodule:: silx.opencl.sift
+
+:mod:`alignment`: SIFT Plan for linear alignment
+-------------------------------------------------
+
+.. automodule:: silx.opencl.sift.alignment
+    :members: LinearAlign

--- a/doc/source/modules/opencl/sift/index.rst
+++ b/doc/source/modules/opencl/sift/index.rst
@@ -1,0 +1,11 @@
+.. currentmodule:: silx.opencl.sift
+
+:mod:`sift`: SIFT image alignment
+==================================
+
+.. toctree::
+   :maxdepth: 1
+
+   plan.rst
+   match.rst
+   align.rst

--- a/doc/source/modules/opencl/sift/match.rst
+++ b/doc/source/modules/opencl/sift/match.rst
@@ -1,0 +1,7 @@
+.. currentmodule:: silx.opencl.sift
+
+:mod:`match`: SIFT Plan for keypoints matching
+------------------------------------------------------
+
+.. automodule:: silx.opencl.sift.match
+    :members: MatchPlan, match_py

--- a/doc/source/modules/opencl/sift/plan.rst
+++ b/doc/source/modules/opencl/sift/plan.rst
@@ -1,0 +1,7 @@
+.. currentmodule:: silx.opencl.sift
+
+:mod:`plan`: SIFT Plan
+-----------------------
+
+.. automodule:: silx.opencl.sift.plan
+    :members: SiftPlan


### PR DESCRIPTION
This PR adds a minimalistic silx.opencl doc.
It is not complete, but provides a placeholder.

It builds over PR #940