### PR TITLE
[doc] Fix doc build warnings

### DIFF
--- a/doc/source/modules/gui/plot/plotwidget.rst
+++ b/doc/source/modules/gui/plot/plotwidget.rst
@@ -166,6 +166,11 @@ The :class:`PlotWidget` provides the following Qt signals:
 .. autoattribute:: PlotWidget.sigActiveScatterChanged
 .. autoattribute:: PlotWidget.sigInteractiveModeChanged
 
+.. toctree::
+   :hidden:
+
+   plotsignal.rst
+
 .. PlotWidget public API that is not documented:
    Could be added:
    - addItem

--- a/doc/source/modules/gui/plot3d/items.rst
+++ b/doc/source/modules/gui/plot3d/items.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: silx.gui.plot3d
 
 :mod:`items`: SceneWidget items
-=============================
+===============================
 
 The following classes are items that describes the content of a :class:`SceneWidget`:
 

--- a/doc/source/modules/gui/plot3d/scenewidget.rst
+++ b/doc/source/modules/gui/plot3d/scenewidget.rst
@@ -14,14 +14,14 @@ For sample code using :class:`SceneWidget`, see ``plot3dSceneWindow.py`` in :ref
 .. currentmodule:: silx.gui.plot3d.SceneWidget
 
 :class:`SceneWidget`
-------------------
+--------------------
 
 .. autoclass:: SceneWidget
    :show-inheritance:
    :members:
 
 :class:`SceneWidget` items
-------------------------
+--------------------------
 
 .. toctree::
    :maxdepth: 2

--- a/silx/gui/_glutils/Texture.py
+++ b/silx/gui/_glutils/Texture.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -49,7 +49,8 @@ class Texture(object):
     :type data: numpy.ndarray or None
     :param format_: Input data format if different from internalFormat
     :param shape: If data is None, shape of the texture
-    :type shape: 2 or 3-tuple of int (height, width) or (depth, height, width)
+                  (height, width) or (depth, height, width)
+    :type shape: List[int]
     :param int texUnit: The texture unit to use
     :param minFilter: OpenGL texture minimization filter (default: GL_NEAREST)
     :param magFilter: OpenGL texture magnification filter (default: GL_LINEAR)
@@ -258,7 +259,7 @@ class Texture(object):
         :param format_: The OpenGL format of the data
         :param data: The data to use to update the texture
         :param offset: The offset in the texture where to copy the data
-        :type offset: 2 or 3-tuple of int
+        :type offset: List[int]
         :param int texUnit:
             The texture unit to use (default: the one provided at init)
         """

--- a/silx/gui/data/DataViewer.py
+++ b/silx/gui/data/DataViewer.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -137,7 +137,7 @@ class DataViewer(qt.QFrame):
         overwriten to provide a different set of viewers.
 
         :param QWidget parent: QWidget parent of the views
-        :rtype: list[silx.gui.data.DataViews.DataView]
+        :rtype: List[silx.gui.data.DataViews.DataView]
         """
         viewClasses = [
             DataViews._EmptyView,
@@ -377,7 +377,7 @@ class DataViewer(qt.QFrame):
         on rendering.
 
         :param object data: data which will be displayed
-        :param list[view] available: List of available views, from highest
+        :param List[view] available: List of available views, from highest
             priority to lowest.
         :rtype: DataView
         """
@@ -391,7 +391,7 @@ class DataViewer(qt.QFrame):
         views.
 
         :param object data: data which will be displayed
-        :param list[view] available: List of available views, from highest
+        :param List[view] available: List of available views, from highest
             priority to lowest.
         :rtype: DataView
         """

--- a/silx/gui/data/DataViewerFrame.py
+++ b/silx/gui/data/DataViewerFrame.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -133,7 +133,7 @@ class DataViewerFrame(qt.QWidget):
         overwriten to provide a different set of viewers.
 
         :param QWidget parent: QWidget parent of the views
-        :rtype: list[silx.gui.data.DataViews.DataView]
+        :rtype: List[silx.gui.data.DataViews.DataView]
         """
         return self.__dataViewer._createDefaultViews(parent)
 

--- a/silx/gui/data/NumpyAxesSelector.py
+++ b/silx/gui/data/NumpyAxesSelector.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -133,7 +133,7 @@ class _Axis(qt.QWidget):
     def setAxisNames(self, axesNames):
         """Set the available list of names for the axis.
 
-        :param list[str] axesNames: List of available names
+        :param List[str] axesNames: List of available names
         """
         self.__axes.clear()
         previous = self.__axes.blockSignals(True)
@@ -146,7 +146,7 @@ class _Axis(qt.QWidget):
     def setCustomAxis(self, axesNames):
         """Set the available list of named axis which can be set to a value.
 
-        :param list[str] axesNames: List of customable axis names
+        :param List[str] axesNames: List of customable axis names
         """
         self.__customAxisNames = set(axesNames)
         self.__updateSliderVisibility()
@@ -258,7 +258,7 @@ class NumpyAxesSelector(qt.QWidget):
         The size of the list will constrain the dimension of the resulting
         array.
 
-        :param list[str] axesNames: List of distinct strings identifying axis names
+        :param List[str] axesNames: List of distinct strings identifying axis names
         """
         self.__axisNames = list(axesNames)
         assert len(set(self.__axisNames)) == len(self.__axisNames),\
@@ -280,7 +280,7 @@ class NumpyAxesSelector(qt.QWidget):
     def setCustomAxis(self, axesNames):
         """Set the available list of named axis which can be set to a value.
 
-        :param list[str] axesNames: List of customable axis names
+        :param List[str] axesNames: List of customable axis names
         """
         self.__customAxisNames = set(axesNames)
         for axis in self.__axis:

--- a/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/silx/gui/hdf5/Hdf5TreeModel.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -325,7 +325,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         Returns an object that contains serialized items of data corresponding
         to the list of indexes specified.
 
-        :param list(qt.QModelIndex) indexes: List of indexes
+        :param List[qt.QModelIndex] indexes: List of indexes
         :rtype: qt.QMimeData
         """
         if not self.__fileMoveEnabled or len(indexes) == 0:

--- a/silx/gui/hdf5/NexusSortFilterProxyModel.py
+++ b/silx/gui/hdf5/NexusSortFilterProxyModel.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -94,7 +94,7 @@ class NexusSortFilterProxyModel(qt.QSortFilterProxyModel):
         `["aaa", 10, "bbb", 50, ".", 30]`.
 
         :param str name: A name
-        :rtype: list
+        :rtype: List
         """
         words = self.__split.findall(name)
         result = []

--- a/silx/gui/plot/Colormap.py
+++ b/silx/gui/plot/Colormap.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -393,7 +393,7 @@ class Colormap(qt.QObject):
     def copy(self):
         """Return a copy of the Colormap.
 
-        :rtype: Colormap
+        :rtype: silx.gui.plot.Colormap.Colormap
         """
         return Colormap(name=self._name,
                         colors=copy_mdl.copy(self._colors),

--- a/silx/gui/plot/ComplexImageView.py
+++ b/silx/gui/plot/ComplexImageView.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -589,14 +589,14 @@ class ComplexImageView(qt.QWidget):
         WARNING: This colormap is not used when displaying both
         amplitude and phase.
 
-        :param Colormap colormap: The colormap
+        :param silx.gui.plot.Colormap.Colormap colormap: The colormap
         """
         self._plotImage.setColormap(colormap)
 
     def getColormap(self):
         """Returns the colormap used to display the data.
 
-        :rtype: Colormap
+        :rtype: silx.gui.plot.Colormap.Colormap
         """
         # Returns internal colormap and bypass forcing colormap
         return items.ImageData.getColormap(self._plotImage)

--- a/silx/gui/plot/PlotTools.py
+++ b/silx/gui/plot/PlotTools.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -83,10 +83,10 @@ class PositionInfo(qt.QWidget):
     >>> plot.show()  # To display the PlotWindow with the position widget
 
     :param plot: The PlotWidget this widget is displaying data coords from.
-    :param converters: List of name to display and conversion function from
-                       (x, y) in data coords to displayed value.
-                       If None, the default, it displays X and Y.
-    :type converters: Iterable of 2-tuple (str, function)
+    :param converters:
+        List of 2-tuple: name to display and conversion function from (x, y)
+        in data coords to displayed value.
+        If None, the default, it displays X and Y.
     :param parent: Parent widget
     """
 

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -821,7 +821,7 @@ class PlotWidget(qt.QMainWindow):
         :param colormap: Description of the :class:`.Colormap` to use
                                   (or None).
                                   This is ignored if data is a RGB(A) image.
-        :type colormap: Colormap or dict (old API )
+        :type colormap: Union[silx.gui.plot.Colormap.Colormap, dict]
         :param pixmap: Pixmap representation of the data (if any)
         :type pixmap: (nrows, ncolumns, RGBA) ubyte array or None (default)
         :param str xlabel: X axis label to show when this curve is active,
@@ -964,8 +964,8 @@ class PlotWidget(qt.QMainWindow):
         :param numpy.ndarray y: The data corresponding to the y coordinates
         :param numpy.ndarray value: The data value associated with each point
         :param str legend: The legend to be associated to the scatter (or None)
-        :param Colormap colormap: The :class:`.Colormap`. to be used for the
-                                  scatter (or None)
+        :param silx.gui.plot.Colormap.Colormap colormap:
+            The :class:`.Colormap`. to be used for the scatter (or None)
         :param info: User-defined information associated to the curve
         :param str symbol: Symbol to be drawn at each (x, y) position::
 
@@ -2264,9 +2264,10 @@ class PlotWidget(qt.QMainWindow):
         It only affects future calls to :meth:`addImage` without the colormap
         parameter.
 
-        :param Colormap colormap: The description of the default colormap, or
-                            None to set the :class:`.Colormap` to a linear
-                            autoscale gray colormap.
+        :param silx.gui.plot.Colormap.Colormap colormap:
+            The description of the default colormap, or
+            None to set the :class:`.Colormap` to a linear
+            autoscale gray colormap.
         """
         if colormap is None:
             colormap = Colormap(name='gray',

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -652,7 +652,7 @@ class StackView(qt.QMainWindow):
         when the volume is rotated (when different axes are selected as the
         X and Y axes).
 
-        :param list(str) labels: 3 labels corresponding to the 3 dimensions
+        :param List[str] labels: 3 labels corresponding to the 3 dimensions
              of the data volumes.
         """
 

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -406,7 +406,7 @@ class ColormapMixIn(ItemMixInBase):
     def setColormap(self, colormap):
         """Set the colormap of this image
 
-        :param Colormap colormap: colormap description
+        :param silx.gui.plot.Colormap.Colormap colormap: colormap description
         """
         if isinstance(colormap, dict):
             colormap = Colormap._fromDict(colormap)

--- a/silx/gui/plot3d/ScalarFieldView.py
+++ b/silx/gui/plot3d/ScalarFieldView.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -294,7 +294,8 @@ class SelectedRegion(object):
 class CutPlane(qt.QObject):
     """Class representing a cutting plane
 
-    :param ScalarFieldView sfView: Widget in which the cut plane is applied.
+    :param ~silx.gui.plot3d.ScalarFieldView.ScalarFieldView sfView:
+        Widget in which the cut plane is applied.
     """
 
     sigVisibilityChanged = qt.Signal(bool)
@@ -513,7 +514,7 @@ class CutPlane(qt.QObject):
         """Returns the colormap set by :meth:`setColormap`.
 
         :return: The colormap
-        :rtype: Colormap
+        :rtype: ~silx.gui.plot.Colormap.Colormap
         """
         return self._colormap
 
@@ -530,7 +531,7 @@ class CutPlane(qt.QObject):
         :param name: Name of the colormap in
             'gray', 'reversed gray', 'temperature', 'red', 'green', 'blue'.
             Or Colormap object.
-        :type name: str or Colormap
+        :type name: str or ~silx.gui.plot.Colormap.Colormap
         :param str norm: Colormap mapping: 'linear' or 'log'.
         :param float vmin: The minimum value of the range or None for autoscale
         :param float vmax: The maximum value of the range or None for autoscale

--- a/silx/gui/plot3d/SceneWindow.py
+++ b/silx/gui/plot3d/SceneWindow.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -68,9 +68,9 @@ class SceneWindow(qt.QMainWindow):
             self.addActions(toolbar.actions())
 
     def getSceneWidget(self):
-        """Returns the :class:`SceneWidget` of this window.
+        """Returns the SceneWidget of this window.
 
-        :rtype: SceneWidget
+        :rtype: ~silx.gui.plot3d.SceneWidget.SceneWidget
         """
         return self._sceneWidget
 

--- a/silx/gui/plot3d/actions/Plot3DAction.py
+++ b/silx/gui/plot3d/actions/Plot3DAction.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -44,7 +44,8 @@ class Plot3DAction(qt.QAction):
     """QAction associated to a Plot3DWidget
 
     :param parent: See :class:`QAction`
-    :param Plot3DWidget plot3d: Plot3DWidget the action is associated with
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
     """
 
     def __init__(self, parent, plot3d=None):
@@ -55,7 +56,8 @@ class Plot3DAction(qt.QAction):
     def setPlot3DWidget(self, widget):
         """Set the Plot3DWidget this action is associated with
 
-        :param Plot3DWidget widget: The Plot3DWidget to use
+        :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget widget:
+            The Plot3DWidget to use
         """
         self._plot3d = None if widget is None else weakref.ref(widget)
 
@@ -64,6 +66,6 @@ class Plot3DAction(qt.QAction):
 
         If no widget is associated, it returns None.
 
-        :rtype: qt.QWidget
+        :rtype: QWidget
         """
         return None if self._plot3d is None else self._plot3d()

--- a/silx/gui/plot3d/actions/io.py
+++ b/silx/gui/plot3d/actions/io.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -54,7 +54,8 @@ class CopyAction(Plot3DAction):
     """QAction to provide copy of a Plot3DWidget
 
     :param parent: See :class:`QAction`
-    :param Plot3DWidget plot3d: Plot3DWidget the action is associated with
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
     """
 
     def __init__(self, parent, plot3d=None):
@@ -81,7 +82,8 @@ class SaveAction(Plot3DAction):
     """QAction to provide save snapshot of a Plot3DWidget
 
     :param parent: See :class:`QAction`
-    :param Plot3DWidget plot3d: Plot3DWidget the action is associated with
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
     """
 
     def __init__(self, parent, plot3d=None):
@@ -135,7 +137,8 @@ class PrintAction(Plot3DAction):
     """QAction to provide printing of a Plot3DWidget
 
     :param parent: See :class:`QAction`
-    :param Plot3DWidget plot3d: Plot3DWidget the action is associated with
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
     """
 
     def __init__(self, parent, plot3d=None):
@@ -152,7 +155,7 @@ class PrintAction(Plot3DAction):
     def getPrinter(self):
         """Return the QPrinter instance used for printing.
 
-        :rtype: qt.QPrinter
+        :rtype: QPrinter
         """
         # TODO This is a hack to sync with silx plot PrintAction
         # This needs to be centralized
@@ -201,6 +204,8 @@ class VideoAction(Plot3DAction):
     The scene is rotated 360 degrees around a vertical axis.
 
     :param parent: Action parent see :class:`QAction`.
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
     """
 
     PNG_SERIE_FILTER = 'Serie of PNG files (*.png)'

--- a/silx/gui/plot3d/actions/mode.py
+++ b/silx/gui/plot3d/actions/mode.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -48,7 +48,8 @@ class InteractiveModeAction(Plot3DAction):
 
     :param parent: See :class:`QAction`
     :param str interaction: The interactive mode this action controls
-    :param Plot3DWidget plot3d: Plot3DWidget the action is associated with
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
     """
 
     def __init__(self, parent, interaction, plot3d=None):
@@ -100,7 +101,8 @@ class RotateArcballAction(InteractiveModeAction):
     """QAction to set arcball rotation interaction on a Plot3DWidget
 
     :param parent: See :class:`QAction`
-    :param Plot3DWidget plot3d: Plot3DWidget the action is associated with
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
     """
 
     def __init__(self, parent, plot3d=None):
@@ -115,7 +117,8 @@ class PanAction(InteractiveModeAction):
     """QAction to set pan interaction on a Plot3DWidget
 
     :param parent: See :class:`QAction`
-    :param Plot3DWidget plot3d: Plot3DWidget the action is associated with
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
     """
 
     def __init__(self, parent, plot3d=None):

--- a/silx/gui/plot3d/actions/viewpoint.py
+++ b/silx/gui/plot3d/actions/viewpoint.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -50,7 +50,8 @@ class _SetViewpointAction(Plot3DAction):
 
     :param parent: See :class:`QAction`
     :param str face: The name of the predefined viewpoint
-    :param Plot3DWidget plot3d: Plot3DWidget the action is associated with
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
     """
     def __init__(self, parent, face, plot3d=None):
         super(_SetViewpointAction, self).__init__(parent, plot3d)
@@ -75,7 +76,8 @@ class FrontViewpointAction(_SetViewpointAction):
     """QAction to set Plot3DWidget viewpoint to look from the front
 
     :param parent: See :class:`QAction`
-    :param Plot3DWidget plot3d: Plot3DWidget the action is associated with
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
     """
     def __init__(self, parent, plot3d=None):
         super(FrontViewpointAction, self).__init__(parent, 'front', plot3d)
@@ -89,7 +91,8 @@ class BackViewpointAction(_SetViewpointAction):
     """QAction to set Plot3DWidget viewpoint to look from the back
 
     :param parent: See :class:`QAction`
-    :param Plot3DWidget plot3d: Plot3DWidget the action is associated with
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
     """
     def __init__(self, parent, plot3d=None):
         super(BackViewpointAction, self).__init__(parent, 'back', plot3d)
@@ -103,7 +106,8 @@ class LeftViewpointAction(_SetViewpointAction):
     """QAction to set Plot3DWidget viewpoint to look from the left
 
     :param parent: See :class:`QAction`
-    :param Plot3DWidget plot3d: Plot3DWidget the action is associated with
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
     """
     def __init__(self, parent, plot3d=None):
         super(LeftViewpointAction, self).__init__(parent, 'left', plot3d)
@@ -117,7 +121,8 @@ class RightViewpointAction(_SetViewpointAction):
     """QAction to set Plot3DWidget viewpoint to look from the right
 
     :param parent: See :class:`QAction`
-    :param Plot3DWidget plot3d: Plot3DWidget the action is associated with
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
     """
     def __init__(self, parent, plot3d=None):
         super(RightViewpointAction, self).__init__(parent, 'right', plot3d)
@@ -131,7 +136,8 @@ class TopViewpointAction(_SetViewpointAction):
     """QAction to set Plot3DWidget viewpoint to look from the top
 
     :param parent: See :class:`QAction`
-    :param Plot3DWidget plot3d: Plot3DWidget the action is associated with
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
     """
     def __init__(self, parent, plot3d=None):
         super(TopViewpointAction, self).__init__(parent, 'top', plot3d)
@@ -145,7 +151,8 @@ class BottomViewpointAction(_SetViewpointAction):
     """QAction to set Plot3DWidget viewpoint to look from the bottom
 
     :param parent: See :class:`QAction`
-    :param Plot3DWidget plot3d: Plot3DWidget the action is associated with
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
     """
     def __init__(self, parent, plot3d=None):
         super(BottomViewpointAction, self).__init__(parent, 'bottom', plot3d)
@@ -159,7 +166,8 @@ class SideViewpointAction(_SetViewpointAction):
     """QAction to set Plot3DWidget viewpoint to look from the side
 
     :param parent: See :class:`QAction`
-    :param Plot3DWidget plot3d: Plot3DWidget the action is associated with
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
     """
     def __init__(self, parent, plot3d=None):
         super(SideViewpointAction, self).__init__(parent, 'side', plot3d)
@@ -173,7 +181,8 @@ class RotateViewpoint(Plot3DAction):
     """QAction to rotate the scene of a Plot3DWidget
 
     :param parent: See :class:`QAction`
-    :param Plot3DWidget plot3d: Plot3DWidget the action is associated with
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
     """
 
     _TIMEOUT_MS = 50

--- a/silx/gui/plot3d/items/volume.py
+++ b/silx/gui/plot3d/items/volume.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -368,7 +368,7 @@ class ScalarField3D(DataItem3D):
     """
 
     def addIsosurface(self, level, color):
-        """Add an :class:`Isosurface` to this item.
+        """Add an isosurface to this item.
 
         :param level:
             The value at which to build the iso-surface or a callable
@@ -378,8 +378,8 @@ class ScalarField3D(DataItem3D):
         :type level: float or callable
         :param color: RGBA color of the isosurface
         :type color: str or array-like of 4 float in [0., 1.]
-        :return: Isosurface object describing this isosurface
-        :rtype: Isosurface
+        :return: isosurface object
+        :rtype: ~silx.gui.plot3d.items.volume.Isosurface
         """
         isosurface = Isosurface(parent=self)
         isosurface.setColor(color)
@@ -398,13 +398,15 @@ class ScalarField3D(DataItem3D):
         return isosurface
 
     def getIsosurfaces(self):
-        """Return an iterable of all :class:`Isosurface` instance of this item"""
+        """Return an iterable of all :class:`.Isosurface` instance of this item"""
         return tuple(self._isosurfaces)
 
     def removeIsosurface(self, isosurface):
         """Remove an iso-surface from this item.
 
-        :param Isosurface isosurface: The isosurface object to remove"""
+        :param ~silx.gui.plot3d.Plot3DWidget.Isosurface isosurface:
+            The isosurface object to remove
+        """
         if isosurface not in self.getIsosurfaces():
             _logger.warning(
                 "Try to remove isosurface that is not in the list: %s",
@@ -416,7 +418,7 @@ class ScalarField3D(DataItem3D):
             self.sigIsosurfaceRemoved.emit(isosurface)
 
     def clearIsosurfaces(self):
-        """Remove all :class:`Isosurface` instances from this item."""
+        """Remove all :class:`.Isosurface` instances from this item."""
         for isosurface in self.getIsosurfaces():
             self.removeIsosurface(isosurface)
 

--- a/silx/gui/plot3d/scene/camera.py
+++ b/silx/gui/plot3d/scene/camera.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -252,8 +252,9 @@ class Camera(transform.Transform):
     :param float fovy: Vertical field-of-view in degrees.
     :param float near: The near clipping plane Z coord (strictly positive).
     :param float far: The far clipping plane Z coord (> near).
-    :param size: Viewport's size used to compute the aspect ratio.
-    :type size: 2-tuple of float (width, height).
+    :param size:
+        Viewport's size used to compute the aspect ratio (width, height).
+    :type size: 2-tuple of float
     :param position: Coordinates of the point of view.
     :type position: numpy.ndarray-like of 3 float32.
     :param direction: Sight direction vector.

--- a/silx/gui/plot3d/scene/primitives.py
+++ b/silx/gui/plot3d/scene/primitives.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -331,8 +331,8 @@ class Geometry(core.Elem):
         Attributes name are taken in the given order to compute the
         (x, y, z) the bounding box, e.g.::
 
-        geometry.boundsAttributeNames = 'position'
-        geometry.boundsAttributeNames = 'x', 'y', 'z'
+          geometry.boundsAttributeNames = 'position'
+          geometry.boundsAttributeNames = 'x', 'y', 'z'
         """
         return self.__boundsAttributeNames
 

--- a/silx/gui/plot3d/scene/transform.py
+++ b/silx/gui/plot3d/scene/transform.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -757,8 +757,9 @@ class _Projection(Transform):
     :param float near: Distance to the near plane.
     :param float far: Distance to the far plane.
     :param bool checkDepthExtent: Toggle checks near > 0 and far > near.
-    :param size: Viewport's size used to compute the aspect ratio.
-    :type size: 2-tuple of float (width, height).
+    :param size:
+        Viewport's size used to compute the aspect ratio (width, height).
+    :type size: 2-tuple of float
     """
 
     def __init__(self, near, far, checkDepthExtent=False, size=(1., 1.)):
@@ -833,8 +834,9 @@ class Orthographic(_Projection):
     :param float top: Coord of the top clipping plane.
     :param float near: Distance to the near plane.
     :param float far: Distance to the far plane.
-    :param size: Viewport's size used to compute the aspect ratio.
-    :type size: 2-tuple of float (width, height).
+    :param size:
+        Viewport's size used to compute the aspect ratio (width, height).
+    :type size: 2-tuple of float
     """
 
     def __init__(self, left=0., right=1., bottom=1., top=0., near=-1., far=1.,
@@ -923,8 +925,9 @@ class Ortho2DWidget(_Projection):
 
     :param float near: Z coordinate of the near clipping plane.
     :param float far: Z coordinante of the far clipping plane.
-    :param size: Viewport's size used to compute the aspect ratio.
-    :type size: 2-tuple of float (width, height).
+    :param size:
+        Viewport's size used to compute the aspect ratio (width, height).
+    :type size: 2-tuple of float
     """
 
     def __init__(self, near=-1., far=1., size=(1., 1.)):
@@ -942,8 +945,9 @@ class Perspective(_Projection):
     :param float fovy: Vertical field-of-view in degrees.
     :param float near: The near clipping plane Z coord (stricly positive).
     :param float far: The far clipping plane Z coord (> near).
-    :param size: Viewport's size used to compute the aspect ratio.
-    :type size: 2-tuple of float (width, height).
+    :param size:
+        Viewport's size used to compute the aspect ratio (width, height).
+    :type size: 2-tuple of float
     """
 
     def __init__(self, fovy=90., near=0.1, far=1., size=(1., 1.)):

--- a/silx/gui/plot3d/scene/window.py
+++ b/silx/gui/plot3d/scene/window.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -326,7 +326,8 @@ class Window(event.Notifier):
         """Returns the raster of the scene as an RGB numpy array
 
         :returns: OpenGL scene RGB bitmap
-        :rtype: numpy.ndarray of uint8 of dimension (height, width, 3)
+                  as an array of dimension (height, width, 3)
+        :rtype: numpy.ndarray of uint8
         """
         height, width = self.shape
         image = numpy.empty((height, width, 3), dtype=numpy.uint8)

--- a/silx/gui/plot3d/tools/ViewpointTools.py
+++ b/silx/gui/plot3d/tools/ViewpointTools.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -42,7 +42,6 @@ class ViewpointToolButton(qt.QToolButton):
     """A toolbutton with a drop-down list of ways to reset the viewpoint.
 
     :param parent: See :class:`QToolButton`
-    :param Plot3DWiddget plot3D: The widget to control
     """
 
     def __init__(self, parent=None):
@@ -67,7 +66,8 @@ class ViewpointToolButton(qt.QToolButton):
     def setPlot3DWidget(self, widget):
         """Set the Plot3DWidget this toolbar is associated with
 
-        :param Plot3DWidget widget: The widget to control
+        :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget widget:
+            The widget to control
         """
         self._plot3DRef = None if widget is None else weakref.ref(widget)
 
@@ -79,6 +79,6 @@ class ViewpointToolButton(qt.QToolButton):
 
         If no widget is associated, it returns None.
 
-        :rtype: qt.QWidget
+        :rtype: ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget or None
         """
         return None if self._plot3DRef is None else self._plot3DRef()

--- a/silx/gui/widgets/PeriodicTable.py
+++ b/silx/gui/widgets/PeriodicTable.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -634,7 +634,7 @@ class PeriodicTable(qt.QWidget):
         objects.
 
         :return: Selected items
-        :rtype: list(PeriodicTableItem)
+        :rtype: List[PeriodicTableItem]
         """
         return [b.item for b in self._eltButtons.values() if b.isSelected()]
 
@@ -644,7 +644,7 @@ class PeriodicTable(qt.QWidget):
         This causes the sigSelectionChanged signal
         to be emitted, even if the selection didn't actually change.
 
-        :param list(str) symbols: List of symbols of elements to be selected
+        :param List[str] symbols: List of symbols of elements to be selected
             (e.g. *["Fe", "Hg", "Li"]*)
         """
         # accept list of PeriodicTableItems as input, because getSelection
@@ -813,7 +813,7 @@ class PeriodicList(qt.QTreeWidget):
         objects.
 
         :return: Selected elements
-        :rtype: list(PeriodicTableItem)"""
+        :rtype: List[PeriodicTableItem]"""
         return [_defaultTableItems[idx] for idx in range(len(self.tree_items))
                 if self.tree_items[idx].isSelected()]
 

--- a/silx/gui/widgets/ThreadPoolPushButton.py
+++ b/silx/gui/widgets/ThreadPoolPushButton.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -214,7 +214,7 @@ class ThreadPoolPushButton(WaitingPushButton):
         """Create a QRunnable from a callable object.
 
         :param callable function: A callable Python object.
-        :param list args: List of arguments to call the function.
+        :param List args: List of arguments to call the function.
         :param dict kwargs: Dictionary of arguments used to call the function.
         :rtpye: qt.QRunnable
         """
@@ -230,7 +230,7 @@ class ThreadPoolPushButton(WaitingPushButton):
         WARNING: The callable will be called in a separate thread.
 
         :param callable function: A callable Python object
-        :param list args: List of arguments to call the function.
+        :param List args: List of arguments to call the function.
         :param dict kwargs: Dictionary of arguments used to call the function.
         """
         self.__callable = function

--- a/silx/io/commonh5.py
+++ b/silx/io/commonh5.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -720,7 +720,7 @@ class Group(Node):
     def __getitem__(self, name):
         """Return a child from his name.
 
-        :param name str: name of a member or a path throug members using '/'
+        :param str name: name of a member or a path throug members using '/'
             separator. A '/' as a prefix access to the root item of the tree.
         :rtype: Node
         """
@@ -817,7 +817,7 @@ class Group(Node):
         See the documentation for `h5py.Group.visit` for more help.
 
         :param func: Callable (function, method or callable object)
-        :type func: function
+        :type func: callable
         """
         origin_name = self.name
         return self._visit(func, origin_name, visit_links)
@@ -827,7 +827,7 @@ class Group(Node):
         See the documentation for `h5py.Group.visititems` for more help.
 
         :param func: Callable (function, method or callable object)
-        :type func: function
+        :type func: callable
         :param bool visit_links: If *False*, ignore links. If *True*,
             call `func(name)` for links and recurse into target groups.
         """

--- a/silx/io/configdict.py
+++ b/silx/io/configdict.py
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2004-2016 European Synchrotron Radiation Facility
+# Copyright (C) 2004-2018 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -382,7 +382,7 @@ class ConfigDict(OrderedDict):
             dictionary
         :param sections: If not ``None``, add only the content of the
             specified sections
-        :type sections: list
+        :type sections: List
         """
         filelist = self.__tolist(filelist)
         sections = self.__tolist(sections)

--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -306,7 +306,7 @@ def h5todict(h5file, path="/", exclude_names=None):
         fabioh5 file.
     :param str path: Name of HDF5 group to use as dictionary root level,
         to read only a sub-group in the file
-    :param list[str] exclude_names: Groups and datasets whose name contains
+    :param List[str] exclude_names: Groups and datasets whose name contains
         a string in this list will be ignored. Default is None (ignore nothing)
     :return: Nested dictionary
     """

--- a/silx/io/nxdata.py
+++ b/silx/io/nxdata.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -425,7 +425,7 @@ class NXdata(object):
             the output will be a numpy array resulting from slicing that
             axis (*axis[first_good:last_good + 1]*).
 
-        :rtype: list[Dataset or 1D array or None]
+        :rtype: List[Dataset or 1D array or None]
         """
         if self._axes is not None:
             # use cache

--- a/silx/io/specfilewrapper.py
+++ b/silx/io/specfilewrapper.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*#########################################################################
-# Copyright (C) 2016 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -332,7 +332,7 @@ class scandata(Scan):  # noqa
             lines.
             If ``key`` does not match any header line, return empty list.
         :return: List of scan header lines
-        :rtype: list[str]
+        :rtype: List[str]
         """
         if key.strip() == "":
             return self.scan_header

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -81,8 +81,8 @@ def supported_extensions(flat_formats=True):
 
     :param bool flat_formats: If true, also include flat formats like npy or
         edf (while the expected module is available)
-    :returns: A dictionary indexed by file description and containg a set of
-        extensions (an extension is a string like "*.ext").
+    :returns: A dictionary indexed by file description and containing a set of
+        extensions (an extension is a string like "\*.ext").
     :rtype: Dict[str, Set[str]]
     """
     formats = {}

--- a/silx/math/fit/fitmanager.py
+++ b/silx/math/fit/fitmanager.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*#########################################################################
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -240,15 +240,15 @@ class FitManager(object):
             If this parameter is provided, all other parameters, except for
             ``name``, are ignored.
         :type theory: :class:`silx.math.fit.fittheory.FitTheory`
-        :param function function: Mandatory argument if ``theory`` is not provided.
+        :param callable function: Mandatory argument if ``theory`` is not provided.
             See documentation for :attr:`silx.math.fit.fittheory.FitTheory.function`.
-        :param list[str] parameters: Mandatory argument if ``theory`` is not provided.
+        :param List[str] parameters: Mandatory argument if ``theory`` is not provided.
             See documentation for :attr:`silx.math.fit.fittheory.FitTheory.parameters`.
-        :param function estimate: See documentation for
+        :param callable estimate: See documentation for
             :attr:`silx.math.fit.fittheory.FitTheory.estimate`
-        :param function configure: See documentation for
+        :param callable configure: See documentation for
             :attr:`silx.math.fit.fittheory.FitTheory.configure`
-        :param function derivative: See documentation for
+        :param callable derivative: See documentation for
             :attr:`silx.math.fit.fittheory.FitTheory.derivative`
         :param str description: See documentation for
             :attr:`silx.math.fit.fittheory.FitTheory.description`

--- a/silx/resources/__init__.py
+++ b/silx/resources/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -162,7 +162,7 @@ def list_dir(resource):
 
     :param str resource: Name of the resource directory to list
     :return: list of name contained in the directory
-    :rtype: list
+    :rtype: List
     """
     resource_directory, resource_name = _get_package_and_resource(resource)
 

--- a/silx/utils/array_like.py
+++ b/silx/utils/array_like.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -300,7 +300,7 @@ class ListOfImages(object):
         The returned object refers to
         the same images but with a different :attr:`transposition`.
 
-        :param list[int] transposition: List/tuple of dimension numbers in the
+        :param List[int] transposition: List/tuple of dimension numbers in the
             wanted order.
             If ``None`` (default), reverse the dimensions.
         :return: new :class:`ListOfImages` object
@@ -568,7 +568,7 @@ class DatasetView(object):
         The returned object refers to
         the same dataset but with a different :attr:`transposition`.
 
-        :param list[int] transposition: List of dimension numbers in the wanted order.
+        :param List[int] transposition: List of dimension numbers in the wanted order.
             If ``None`` (default), reverse the dimensions.
         :return: Transposed DatasetView
         """


### PR DESCRIPTION
This PR fixes sphinx documentation build warnings (tested with Sphinx 1.2.3 and 1.6.5).

Most warnings were due to reference leading to 2 targets and a few typos.
In particular, with Sphinx 1.6.5:
- Using `list` for argument/returned values type had 2 targets in silx and linked to `specfilewrapper.list`.. I use `List` (and `List[..]`) instead as in Python3.5 type hinting.
- Using `function` instead of `callable` had the same issue.