### PR TITLE
[DataViewer] view NXentry like a NXdata

### DIFF
--- a/silx/io/nxdata.py
+++ b/silx/io/nxdata.py
@@ -125,7 +125,7 @@ def is_valid_nxdata(group):   # noqa
 
     if "axes" in group.attrs:
         axes_names = get_attr_as_string(group, "axes")
-        if isinstance(axes_names, str):
+        if isinstance(axes_names, (six.text_type, six.binary_type)):
             axes_names = [axes_names]
 
         if 1 < ndim < len(axes_names):
@@ -177,6 +177,7 @@ def is_valid_nxdata(group):   # noqa
             signal_size *= dim
         polynomial_axes_names = []
         for i, axis_name in enumerate(axes_names):
+
             if axis_name == ".":
                 continue
             if axis_name not in group or not is_dataset(group[axis_name]):
@@ -500,7 +501,7 @@ class NXdata(object):
             else:
                 return [None] * ndims
 
-        if isinstance(axes_dataset_names, str):
+        if isinstance(axes_dataset_names, (six.text_type, six.binary_type)):
             axes_dataset_names = [axes_dataset_names]
 
         for i, axis_name in enumerate(axes_dataset_names):

--- a/silx/io/nxdata.py
+++ b/silx/io/nxdata.py
@@ -631,3 +631,54 @@ class NXdata(object):
     def is_unsupported_scatter(self):
         """True if this is a scatter with a signal and more than 2 axes."""
         return self.is_scatter and len(self.axes) > 2
+
+
+def is_NXentry_with_default_NXdata(group):
+    """Return True if group is a valid NXentry defining a valid default
+    NXdata."""
+    if not is_group(group):
+        return False
+
+    nx_class = group.attrs.get("NX_class")
+    if nx_class != "NXentry":
+        return False
+
+    default_nxdata_name = group.attrs.get("default")
+    if default_nxdata_name is None or default_nxdata_name not in group:
+        return False
+
+    default_nxdata_group = group.get(default_nxdata_name)
+
+    if not is_group(default_nxdata_group):
+        return False
+
+    if not is_valid_nxdata(default_nxdata_group):
+        return False
+
+    return True
+
+
+def get_NXdata_in_group(group):
+    """Return a :class:`NXdata` corresponding to the default NXdata group in a
+    group.
+
+    This function can find the NXdata if group is already a NXdata or
+    if it is an NXentry defining a default NXdata.
+
+    Return None if group is not a NXdata and is also not an NXentry defining
+    a NXdata.
+
+    :param group: NXdata group or NXentry group defining an @default NXdata
+        group. Or None.
+    :return: :class:`NXdata` or None
+    :raise TypeError if group is not a h5py-like group
+    """
+    if not is_group(group):
+        raise TypeError("Provided parameter is not a h5py-like group")
+
+    if is_NXentry_with_default_NXdata(group):
+        return NXdata(group[group.attrs["default"]])
+    if is_valid_nxdata(group):
+        return NXdata(group)
+
+    return None

--- a/silx/io/nxdata.py
+++ b/silx/io/nxdata.py
@@ -30,7 +30,7 @@ See http://download.nexusformat.org/sphinx/classes/base_classes/NXdata.html
 """
 import logging
 import numpy
-from .utils import is_dataset, is_group
+from .utils import is_dataset, is_group, is_file
 from silx.third_party import six
 
 _logger = logging.getLogger(__name__)
@@ -661,7 +661,11 @@ def is_NXroot_with_default_NXdata(group):
     if not is_group(group):
         return False
 
-    if group.attrs.get("NX_class") != "NXroot":
+    # A NXroot is supposed to be at the root of a data file, and @NX_class
+    # is therefore optional. We accept groups that are not located at the root
+    # if they have @NX_class=NXroot (use case: several nexus files archived
+    # in a single HDF5 file)
+    if group.attrs.get("NX_class") != "NXroot" and not is_file(group):
         return False
 
     default_nxentry_name = group.attrs.get("default")


### PR DESCRIPTION
Closes #1471.
If a NXentry provides a @default pointing to a valid NXdata group, we can open it with an appropriate NXdata viewer.