### PR TITLE
[plot3d] Update scene parameter tree

### DIFF
--- a/silx/gui/plot3d/_model/core.py
+++ b/silx/gui/plot3d/_model/core.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -56,6 +56,7 @@ class BaseRow(qt.QObject):
             row.setParent(self)
             self.__children.append(row)
         self.__flags = collections.defaultdict(lambda: qt.Qt.ItemIsEnabled)
+        self.__tooltip = None
 
     def model(self):
         """Return the model this node belongs to or None if not in a model.
@@ -166,7 +167,10 @@ class BaseRow(qt.QObject):
         :param int role: The role to get
         :return: Corresponding data (Default: None)
         """
-        return None
+        if role == qt.Qt.ToolTipRole and self.__tooltip is not None:
+            return self.__tooltip
+        else:
+            return None
 
     def setData(self, column, value, role):
         """Set data for given column and role
@@ -178,6 +182,15 @@ class BaseRow(qt.QObject):
         :rtype: bool
         """
         return False
+
+    def setToolTip(self, tooltip):
+        """Set the tooltip of the whole row.
+
+        If None there is no tooltip.
+
+        :param Union[str, None] tooltip:
+        """
+        self.__tooltip = tooltip
 
     def setFlags(self, flags, column=None):
         """Set the static flags to return.

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -44,7 +44,7 @@ from ..._utils import convertArrayToQImage
 from ...plot.Colormap import preferredColormaps
 from ... import qt, icons
 from .. import items
-from ..items.volume import Isosurface
+from ..items.volume import Isosurface, CutPlane
 
 
 from .core import AngleDegreeRow, BaseRow, ColorProxyRow, ProxyRow, StaticRow
@@ -1107,9 +1107,29 @@ def initScalarField3DNode(node, item):
     node.addRow(ScalarField3DIsoSurfacesRow(item))
 
 
+def initScalarField3DCutPlaneNode(node, item):
+    """Specific node init for ScalarField3D CutPlane
+
+    :param Item3DRow node: The model node to setup
+    :param CutPlane item: The CutPlane the node is representing
+    """
+    node.addRow(PlaneRow(item))
+
+    node.addRow(ColormapRow(item))
+
+    node.addRow(ProxyRow(
+        name='Values<=Min',
+        fget=item.getDisplayValuesBelowMin,
+        fset=item.setDisplayValuesBelowMin,
+        notify=item.sigItemChanged))
+
+    node.addRow(InterpolationRow(item))
+
+
 NODE_SPECIFIC_INIT = [  # class, init(node, item)
     (items.Scatter2D, initScatter2DNode),
     (items.ScalarField3D, initScalarField3DNode),
+    (CutPlane, initScalarField3DCutPlaneNode),
 ]
 """List of specific node init for different item class"""
 

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -554,13 +554,16 @@ class _ColormapBoundRow(_ColormapBaseRowMixIn, ProxyRow):
 
     def __init__(self, item, name, index):
         self._index = index
-        self._name = name
         _ColormapBaseRowMixIn.__init__(self, item)
         ProxyRow.__init__(
             self,
             name=name,
             fget=self._getBound,
             fset=self._setBound)
+
+        self.setToolTip('Colormap %s bound:\n'
+                        'Check to set bound manually, '
+                        'uncheck for autoscale' % name.lower())
 
     def _getRawBound(self):
         """Proxy to get raw colormap bound
@@ -620,12 +623,7 @@ class _ColormapBoundRow(_ColormapBaseRowMixIn, ProxyRow):
             return super(_ColormapBoundRow, self).flags(column)
 
     def data(self, column, role):
-        if role == qt.Qt.ToolTipRole:
-            return 'Colormap %s bound:\n' \
-                   'Check to set variable manually, ' \
-                   'uncheck for autoscale' % self._name.lower()
-
-        elif column == 0 and role == qt.Qt.CheckStateRole:
+        if column == 0 and role == qt.Qt.CheckStateRole:
             if self._getRawBound() is None:
                 return qt.Qt.Unchecked
             else:

--- a/silx/gui/plot3d/items/core.py
+++ b/silx/gui/plot3d/items/core.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -329,8 +329,8 @@ class DataItem3D(Item3D):
 
         if matrix is not None:
             matrix = numpy.array(matrix, dtype=numpy.float32)
-            assert matrix.shape in ((3, 3), (4, 4))
-            matrix4x4[:matrix.shape[0], :matrix.shape[1]] = matrix
+            assert matrix.shape == (3, 3)
+            matrix4x4[:3, :3] = matrix
 
         if not numpy.all(numpy.equal(matrix4x4, self._matrix.getMatrix())):
             self._matrix.setMatrix(matrix4x4)
@@ -339,9 +339,9 @@ class DataItem3D(Item3D):
     def getMatrix(self):
         """Returns the matrix set by :meth:`setMatrix`
 
-        :return: 4x4 matrix
+        :return: 3x3 matrix
         :rtype: numpy.ndarray"""
-        return self._matrix.getMatrix(copy=True)
+        return self._matrix.getMatrix(copy=True)[:3, :3]
 
 
 class GroupItem(DataItem3D):

--- a/silx/gui/plot3d/scene/cutplane.py
+++ b/silx/gui/plot3d/scene/cutplane.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,7 @@ from __future__ import absolute_import, division, unicode_literals
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "05/10/2016"
+__date__ = "11/01/2018"
 
 import string
 import numpy
@@ -279,6 +279,7 @@ class CutPlane(PlaneInGroup):
             self._interpolation = interpolation
             if self._mesh is not None:
                 self._mesh.interpolation = interpolation
+            self.notify()
 
     def prepareGL2(self, ctx):
         if self.isValid:
@@ -293,7 +294,7 @@ class CutPlane(PlaneInGroup):
                                             mode='fan',
                                             colormap=self.colormap)
                 self._mesh.alpha = self._alpha
-                self._interpolation = self.interpolation
+                self._mesh.interpolation = self.interpolation
                 self._children.insert(0, self._mesh)
 
             if self._mesh is not None:


### PR DESCRIPTION
This PR adds a few features and a fix to plot3d parameter tree:

- Enable/disable scatter2D symbol and line properties depending on visualization mode
- Add display/edit of 3x3 matrix transform of nodes
- Separate autoscale for colormap min and max in the model (and the tree view)
- Add cutplane clip values below min parameter
- Fix cut plane interpolation parameter that was not properly synchronized.

Related to #1311