### PR TITLE
Move useful test functions into silx.utils.testutils

### DIFF
--- a/silx/app/test/test_convert.py
+++ b/silx/app/test/test_convert.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "12/09/2017"
+__date__ = "17/01/2018"
 
 
 import os
@@ -43,7 +43,7 @@ except ImportError:
 
 import silx
 from .. import convert
-from silx.test import utils
+from silx.utils import testutils
 
 
 
@@ -103,9 +103,9 @@ class TestConvertCommand(unittest.TestCase):
             result = e.args[0]
         self.assertEqual(result, 0)
 
-    @utils.test_logging(convert._logger.name, error=1)
+    @testutils.test_logging(convert._logger.name, error=1)
     def testH5pyNotInstalled(self):
-        with utils.EnsureImportError("h5py"):
+        with testutils.EnsureImportError("h5py"):
             result = convert.main(["convert", "foo.spec", "bar.edf"])
             # we explicitly return -1 if h5py is not imported
             self.assertNotEqual(result, 0)
@@ -121,7 +121,7 @@ class TestConvertCommand(unittest.TestCase):
         self.assertNotEqual(result, 0)
 
     @unittest.skipIf(h5py is None, "h5py is required to test convert")
-    @utils.test_logging(convert._logger.name, error=3)
+    @testutils.test_logging(convert._logger.name, error=3)
     # one error log per missing file + one "Aborted" error log
     def testWrongFiles(self):
         result = convert.main(["convert", "foo.spec", "bar.edf"])

--- a/silx/gui/plot/_utils/test/test_ticklayout.py
+++ b/silx/gui/plot/_utils/test/test_ticklayout.py
@@ -27,13 +27,13 @@ from __future__ import absolute_import, division, unicode_literals
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "18/10/2016"
+__date__ = "17/01/2018"
 
 
 import unittest
 import numpy
 
-from silx.test.utils import ParametricTestCase
+from silx.utils.testutils import ParametricTestCase
 
 from silx.gui.plot._utils import ticklayout
 

--- a/silx/gui/plot/test/testColormap.py
+++ b/silx/gui/plot/test/testColormap.py
@@ -29,11 +29,11 @@ from __future__ import absolute_import
 
 __authors__ = ["H.Payno"]
 __license__ = "MIT"
-__date__ = "05/12/2016"
+__date__ = "17/01/2018"
 
 import unittest
 import numpy
-from silx.test.utils import ParametricTestCase
+from silx.utils.testutils import ParametricTestCase
 from silx.gui.plot.Colormap import Colormap
 from silx.gui.plot.Colormap import preferredColormaps, setPreferredColormaps
 

--- a/silx/gui/plot/test/testColormapDialog.py
+++ b/silx/gui/plot/test/testColormapDialog.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "05/12/2016"
+__date__ = "17/01/2018"
 
 
 import doctest
@@ -37,7 +37,7 @@ from silx.gui import qt
 from silx.gui.plot import ColormapDialog
 from silx.gui.test.utils import TestCaseQt
 from silx.gui.plot.Colormap import Colormap, preferredColormaps
-from silx.test.utils import ParametricTestCase
+from silx.utils.testutils import ParametricTestCase
 from silx.gui.plot.PlotWindow import PlotWindow
 
 import numpy.random

--- a/silx/gui/plot/test/testColors.py
+++ b/silx/gui/plot/test/testColors.py
@@ -26,13 +26,13 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "05/12/2016"
+__date__ = "17/01/2018"
 
 
 import numpy
 
 import unittest
-from silx.test.utils import ParametricTestCase
+from silx.utils.testutils import ParametricTestCase
 
 from silx.gui.plot import Colors
 from silx.gui.plot.Colormap import Colormap

--- a/silx/gui/plot/test/testComplexImageView.py
+++ b/silx/gui/plot/test/testComplexImageView.py
@@ -26,14 +26,14 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "14/09/2017"
+__date__ = "17/01/2018"
 
 
 import unittest
 import logging
 import numpy
 
-from silx.test.utils import ParametricTestCase
+from silx.utils.testutils import ParametricTestCase
 from silx.gui.plot import ComplexImageView
 
 from .utils import PlotWidgetTestCase

--- a/silx/gui/plot/test/testMaskToolsWidget.py
+++ b/silx/gui/plot/test/testMaskToolsWidget.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "01/09/2017"
+__date__ = "17/01/2018"
 
 
 import logging
@@ -36,7 +36,8 @@ import unittest
 import numpy
 
 from silx.gui import qt
-from silx.test.utils import temp_dir, ParametricTestCase
+from silx.test.utils import temp_dir
+from silx.utils.testutils import ParametricTestCase
 from silx.gui.test.utils import getQToolButtonFromAction
 from silx.gui.plot import PlotWindow, MaskToolsWidget
 from .utils import PlotWidgetTestCase

--- a/silx/gui/plot/test/testPlotTools.py
+++ b/silx/gui/plot/test/testPlotTools.py
@@ -26,13 +26,13 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "01/09/2017"
+__date__ = "17/01/2018"
 
 
 import numpy
 import unittest
 
-from silx.test.utils import ParametricTestCase, TestLogging
+from silx.utils.testutils import ParametricTestCase, TestLogging
 from silx.gui.test.utils import (
     qWaitForWindowExposedAndActivate, TestCaseQt, getQToolButtonFromAction)
 from silx.gui import qt

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -26,17 +26,17 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "01/09/2017"
+__date__ = "17/01/2018"
 
 
 import unittest
 import logging
 import numpy
 
-from silx.test.utils import ParametricTestCase
+from silx.utils.testutils import ParametricTestCase
 from silx.gui.test.utils import SignalListener
 from silx.gui.test.utils import TestCaseQt
-from silx.test import utils
+from silx.utils import testutils
 from silx.utils import deprecation
 
 from silx.gui import qt
@@ -723,7 +723,7 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
                 if getter is not None:
                     self.assertEqual(getter(), expected)
 
-    @utils.test_logging(deprecation.depreclog.name, warning=2)
+    @testutils.test_logging(deprecation.depreclog.name, warning=2)
     def testOldPlotAxis_Logarithmic(self):
         """Test silx API prior to silx 0.6"""
         x = self.plot.getXAxis()
@@ -762,7 +762,7 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         self.assertEqual(self.plot.isYAxisLogarithmic(), False)
         self.assertEqual(listener.arguments(callIndex=-1), ("y", False))
 
-    @utils.test_logging(deprecation.depreclog.name, warning=2)
+    @testutils.test_logging(deprecation.depreclog.name, warning=2)
     def testOldPlotAxis_AutoScale(self):
         """Test silx API prior to silx 0.6"""
         x = self.plot.getXAxis()
@@ -801,7 +801,7 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         self.assertEqual(self.plot.isYAxisAutoScale(), True)
         self.assertEqual(listener.arguments(callIndex=-1), ("y", True))
 
-    @utils.test_logging(deprecation.depreclog.name, warning=1)
+    @testutils.test_logging(deprecation.depreclog.name, warning=1)
     def testOldPlotAxis_Inverted(self):
         """Test silx API prior to silx 0.6"""
         x = self.plot.getXAxis()

--- a/silx/gui/plot/test/testPlotWidgetNoBackend.py
+++ b/silx/gui/plot/test/testPlotWidgetNoBackend.py
@@ -26,12 +26,12 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "27/06/2017"
+__date__ = "17/01/2018"
 
 
 import unittest
 from functools import reduce
-from silx.test.utils import ParametricTestCase
+from silx.utils.testutils import ParametricTestCase
 
 import numpy
 

--- a/silx/gui/plot/test/testProfile.py
+++ b/silx/gui/plot/test/testProfile.py
@@ -26,12 +26,12 @@
 
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "23/02/2017"
+__date__ = "17/01/2018"
 
 import numpy
 import unittest
 
-from silx.test.utils import ParametricTestCase
+from silx.utils.testutils import ParametricTestCase
 from silx.gui.test.utils import (
     TestCaseQt, getQToolButtonFromAction)
 from silx.gui import qt

--- a/silx/gui/plot/test/testScatterMaskToolsWidget.py
+++ b/silx/gui/plot/test/testScatterMaskToolsWidget.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "01/09/2017"
+__date__ = "17/01/2018"
 
 
 import logging
@@ -36,7 +36,8 @@ import unittest
 import numpy
 
 from silx.gui import qt
-from silx.test.utils import temp_dir, ParametricTestCase
+from silx.test.utils import temp_dir
+from silx.utils.testutils import ParametricTestCase
 from silx.gui.test.utils import getQToolButtonFromAction
 from silx.gui.plot import PlotWindow, ScatterMaskToolsWidget
 from .utils import PlotWidgetTestCase

--- a/silx/gui/plot3d/scene/test/test_utils.py
+++ b/silx/gui/plot3d/scene/test/test_utils.py
@@ -27,11 +27,11 @@ from __future__ import absolute_import, division, unicode_literals
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "25/07/2016"
+__date__ = "17/01/2018"
 
 
 import unittest
-from silx.test.utils import ParametricTestCase
+from silx.utils.testutils import ParametricTestCase
 
 import numpy
 

--- a/silx/gui/plot3d/test/testScalarFieldView.py
+++ b/silx/gui/plot3d/test/testScalarFieldView.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "11/07/2017"
+__date__ = "17/01/2018"
 
 
 import logging
@@ -33,7 +33,7 @@ import unittest
 
 import numpy
 
-from silx.test.utils import ParametricTestCase
+from silx.utils.testutils import ParametricTestCase
 from silx.gui.test.utils import TestCaseQt
 from silx.gui import qt
 

--- a/silx/gui/widgets/test/test_threadpoolpushbutton.py
+++ b/silx/gui/widgets/test/test_threadpoolpushbutton.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "15/12/2016"
+__date__ = "17/01/2018"
 
 
 import unittest
@@ -35,7 +35,7 @@ from silx.gui import qt
 from silx.gui.test.utils import TestCaseQt
 from silx.gui.test.utils import SignalListener
 from silx.gui.widgets.ThreadPoolPushButton import ThreadPoolPushButton
-from silx.test.utils import TestLogging
+from silx.utils.testutils import TestLogging
 
 
 class TestThreadPoolPushButton(TestCaseQt):

--- a/silx/image/test/test_shapes.py
+++ b/silx/image/test/test_shapes.py
@@ -27,14 +27,14 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "15/05/2017"
+__date__ = "17/01/2018"
 
 
 import logging
 import unittest
 import numpy
 
-from silx.test.utils import ParametricTestCase
+from silx.utils.testutils import ParametricTestCase
 from silx.image import shapes
 
 _logger = logging.getLogger(__name__)

--- a/silx/io/test/test_dictdump.py
+++ b/silx/io/test/test_dictdump.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "10/02/2017"
+__date__ = "17/01/2018"
 
 from collections import OrderedDict
 import numpy
@@ -41,7 +41,7 @@ except ImportError:
 
 from collections import defaultdict
 
-from silx.test.utils import TestLogging
+from silx.utils.testutils import TestLogging
 
 from ..configdict import ConfigDict
 from ..dictdump import dicttoh5, dicttojson, dump

--- a/silx/io/test/test_specfile.py
+++ b/silx/io/test/test_specfile.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["P. Knobel", "V.A. Sole"]
 __license__ = "MIT"
-__date__ = "03/08/2017"
+__date__ = "17/01/2018"
 
 
 import locale
@@ -36,7 +36,7 @@ import sys
 import tempfile
 import unittest
 
-from silx.test import utils
+from silx.utils import testutils
 
 from ..specfile import SpecFile, Scan
 from .. import specfile
@@ -369,7 +369,7 @@ class TestSpecFile(unittest.TestCase):
         self.assertEqual(self.scan25.mca.channels,
                          [])
 
-    @utils.test_logging(specfile._logger.name, warning=1)
+    @testutils.test_logging(specfile._logger.name, warning=1)
     def test_empty_scan(self):
         """Test reading a scan with no data points"""
         self.assertEqual(len(self.empty_scan.labels),

--- a/silx/io/test/test_spech5.py
+++ b/silx/io/test/test_spech5.py
@@ -31,7 +31,7 @@ import unittest
 import datetime
 from functools import partial
 
-from silx.test import utils
+from silx.utils import testutils
 
 from .. import spech5
 from ..spech5 import (SpecH5, SpecH5Group,
@@ -45,7 +45,7 @@ except ImportError:
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "26/07/2017"
+__date__ = "17/01/2018"
 
 sftext = """#F /tmp/sf.dat
 #E 1455180875
@@ -581,7 +581,7 @@ class TestSpecH5(unittest.TestCase):
         with self.assertRaises(KeyError):
             uc = self.sfh5["/1001.1/sample/unit_cell"]
 
-    @utils.test_logging(spech5.logger1.name, warning=2)
+    @testutils.test_logging(spech5.logger1.name, warning=2)
     def testOpenFileDescriptor(self):
         """Open a SpecH5 file from a file descriptor"""
         with io.open(self.sfh5.filename) as f:

--- a/silx/math/fit/test/test_fit.py
+++ b/silx/math/fit/test/test_fit.py
@@ -30,7 +30,7 @@ import unittest
 import numpy
 import sys
 
-from silx.test import utils
+from silx.utils import testutils
 from silx.math.fit.leastsq import _logger as fitlogger
 
 
@@ -241,7 +241,7 @@ class Test_leastsq(unittest.TestCase):
                                                       fittedpar[i])
             self.assertTrue(test_condition, msg)
 
-    @utils.test_logging(fitlogger.name, warning=2)
+    @testutils.test_logging(fitlogger.name, warning=2)
     def testBadlyShapedData(self):
         parameters_actual = [10.5, 2, 1000.0, 20., 15]
         x = numpy.arange(10000.).reshape(1000, 10)
@@ -263,7 +263,7 @@ class Test_leastsq(unittest.TestCase):
                                                           fittedpar[i])
                 self.assertTrue(test_condition, msg)
 
-    @utils.test_logging(fitlogger.name, warning=3)
+    @testutils.test_logging(fitlogger.name, warning=3)
     def testDataWithNaN(self):
         parameters_actual = [10.5, 2, 1000.0, 20., 15]
         x = numpy.arange(10000.).reshape(1000, 10)

--- a/silx/math/medianfilter/test/test_medianfilter.py
+++ b/silx/math/medianfilter/test/test_medianfilter.py
@@ -25,14 +25,14 @@
 
 __authors__ = ["H. Payno"]
 __license__ = "MIT"
-__date__ = "02/05/2017"
+__date__ = "17/01/2018"
 
 import unittest
 import numpy
 from silx.math.medianfilter import medfilt2d
 from silx.math.medianfilter.medianfilter import reflect, mirror
 from silx.math.medianfilter.medianfilter import MODES as silx_mf_modes
-from silx.test.utils import ParametricTestCase
+from silx.utils.testutils import ParametricTestCase
 try:
     import scipy
     import scipy.misc

--- a/silx/math/test/benchmark_combo.py
+++ b/silx/math/test/benchmark_combo.py
@@ -27,7 +27,7 @@ from __future__ import division
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "15/05/2017"
+__date__ = "17/01/2018"
 
 
 import logging
@@ -37,7 +37,8 @@ import unittest
 
 import numpy
 
-from silx.test.utils import ParametricTestCase, temp_dir
+from silx.test.utils import temp_dir
+from silx.utils.testutils import ParametricTestCase
 
 from silx.math import combo
 

--- a/silx/math/test/test_combo.py
+++ b/silx/math/test/test_combo.py
@@ -27,14 +27,14 @@ from __future__ import division
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "19/10/2017"
+__date__ = "17/01/2018"
 
 
 import unittest
 
 import numpy
 
-from silx.test.utils import ParametricTestCase
+from silx.utils.testutils import ParametricTestCase
 
 from silx.math.combo import min_max
 

--- a/silx/math/test/test_marchingcubes.py
+++ b/silx/math/test/test_marchingcubes.py
@@ -27,13 +27,13 @@ from __future__ import division
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "05/12/2016"
+__date__ = "17/01/2018"
 
 import unittest
 
 import numpy
 
-from silx.test.utils import ParametricTestCase
+from silx.utils.testutils import ParametricTestCase
 
 from silx.math import marchingcubes
 

--- a/silx/test/utils.py
+++ b/silx/test/utils.py
@@ -24,31 +24,21 @@
 # ###########################################################################*/
 """Utilities for writing tests.
 
-- :class:`ParametricTestCase` provides a :meth:`TestCase.subTest` replacement
-  for Python < 3.4
-- :class:`TestLogging` with context or the :func:`test_logging` decorator
-  enables testing the number of logging messages of different levels.
 - :func:`temp_dir` provides a with context to create/delete a temporary
   directory.
 """
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "03/08/2017"
+__date__ = "17/01/2018"
 
 
-import os
 import contextlib
-import functools
-import logging
 import numpy
 import shutil
-import sys
 import tempfile
-import unittest
 from ..resources import ExternalResources
 
-_logger = logging.getLogger(__name__)
 
 utilstest = ExternalResources(project="silx",
                               url_base="http://www.silx.org/pub/silx/",
@@ -56,173 +46,8 @@ utilstest = ExternalResources(project="silx",
                               timeout=60)
 "This is the instance to be used. Singleton-like feature provided by module"
 
-# Parametric Test Base Class ##################################################
-
-if sys.hexversion >= 0x030400F0:  # Python >= 3.4
-    class ParametricTestCase(unittest.TestCase):
-        pass
-
-else:
-    class ParametricTestCase(unittest.TestCase):
-        """TestCase with subTest support for Python < 3.4.
-
-        Add subTest method to support parametric tests.
-        API is the same, but behavior differs:
-        If a subTest fails, the following ones are not run.
-        """
-
-        _subtest_msg = None  # Class attribute to provide a default value
-
-        @contextlib.contextmanager
-        def subTest(self, msg=None, **params):
-            """Use as unittest.TestCase.subTest method in Python >= 3.4."""
-            # Format arguments as: '[msg] (key=value, ...)'
-            param_str = ', '.join(['%s=%s' % (k, v) for k, v in params.items()])
-            self._subtest_msg = '[%s] (%s)' % (msg or '', param_str)
-            yield
-            self._subtest_msg = None
-
-        def shortDescription(self):
-            short_desc = super(ParametricTestCase, self).shortDescription()
-            if self._subtest_msg is not None:
-                # Append subTest message to shortDescription
-                short_desc = ' '.join(
-                    [msg for msg in (short_desc, self._subtest_msg) if msg])
-
-            return short_desc if short_desc else None
-
-
-# Test logging messages #######################################################
-
-class TestLogging(logging.Handler):
-    """Context checking the number of logging messages from a specified Logger.
-
-    It disables propagation of logging message while running.
-
-    This is meant to be used as a with statement, for example:
-
-    >>> with TestLogging(logger, error=2, warning=0):
-    >>>     pass  # Run tests here expecting 2 ERROR and no WARNING from logger
-    ...
-
-    :param logger: Name or instance of the logger to test.
-                   (Default: root logger)
-    :type logger: str or :class:`logging.Logger`
-    :param int critical: Expected number of CRITICAL messages.
-                         Default: Do not check.
-    :param int error: Expected number of ERROR messages.
-                      Default: Do not check.
-    :param int warning: Expected number of WARNING messages.
-                        Default: Do not check.
-    :param int info: Expected number of INFO messages.
-                     Default: Do not check.
-    :param int debug: Expected number of DEBUG messages.
-                      Default: Do not check.
-    :param int notset: Expected number of NOTSET messages.
-                       Default: Do not check.
-    :raises RuntimeError: If the message counts are the expected ones.
-    """
-
-    def __init__(self, logger=None, critical=None, error=None,
-                 warning=None, info=None, debug=None, notset=None):
-        if logger is None:
-            logger = logging.getLogger()
-        elif not isinstance(logger, logging.Logger):
-            logger = logging.getLogger(logger)
-        self.logger = logger
-
-        self.records = []
-
-        self.count_by_level = {
-            logging.CRITICAL: critical,
-            logging.ERROR: error,
-            logging.WARNING: warning,
-            logging.INFO: info,
-            logging.DEBUG: debug,
-            logging.NOTSET: notset
-        }
-
-        super(TestLogging, self).__init__()
-
-    def __enter__(self):
-        """Context (i.e., with) support"""
-        self.records = []  # Reset recorded LogRecords
-        self.logger.addHandler(self)
-        self.logger.propagate = False
-        # ensure no log message is ignored
-        self.entry_level = self.logger.level * 1
-        self.logger.setLevel(logging.DEBUG)
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        """Context (i.e., with) support"""
-        self.logger.removeHandler(self)
-        self.logger.propagate = True
-        self.logger.setLevel(self.entry_level)
-
-        for level, expected_count in self.count_by_level.items():
-            if expected_count is None:
-                continue
-
-            # Number of records for the specified level_str
-            count = len([r for r in self.records if r.levelno == level])
-            if count != expected_count:  # That's an error
-                # Resend record logs through logger as they where masked
-                # to help debug
-                for record in self.records:
-                    self.logger.handle(record)
-                raise RuntimeError(
-                    'Expected %d %s logging messages, got %d' % (
-                        expected_count, logging.getLevelName(level), count))
-
-    def emit(self, record):
-        """Override :meth:`logging.Handler.emit`"""
-        self.records.append(record)
-
-
-def test_logging(logger=None, critical=None, error=None,
-                 warning=None, info=None, debug=None, notset=None):
-    """Decorator checking number of logging messages.
-
-    Propagation of logging messages is disabled by this decorator.
-
-    In case the expected number of logging messages is not found, it raises
-    a RuntimeError.
-
-    >>> class Test(unittest.TestCase):
-    ...     @test_logging('module_logger_name', error=2, warning=0)
-    ...     def test(self):
-    ...         pass  # Test expecting 2 ERROR and 0 WARNING messages
-
-    :param logger: Name or instance of the logger to test.
-                   (Default: root logger)
-    :type logger: str or :class:`logging.Logger`
-    :param int critical: Expected number of CRITICAL messages.
-                         Default: Do not check.
-    :param int error: Expected number of ERROR messages.
-                      Default: Do not check.
-    :param int warning: Expected number of WARNING messages.
-                        Default: Do not check.
-    :param int info: Expected number of INFO messages.
-                     Default: Do not check.
-    :param int debug: Expected number of DEBUG messages.
-                      Default: Do not check.
-    :param int notset: Expected number of NOTSET messages.
-                       Default: Do not check.
-    """
-    def decorator(func):
-        test_context = TestLogging(logger, critical, error,
-                                   warning, info, debug, notset)
-
-        @functools.wraps(func)
-        def wrapper(*args, **kwargs):
-            with test_context:
-                result = func(*args, **kwargs)
-            return result
-        return wrapper
-    return decorator
-
-
 # Temporary directory context #################################################
+
 
 @contextlib.contextmanager
 def temp_dir():
@@ -237,57 +62,6 @@ def temp_dir():
         yield tmp_dir
     finally:
         shutil.rmtree(tmp_dir)
-
-
-# Simulate missing library context
-class EnsureImportError(object):
-    """This context manager allows to simulate the unavailability
-    of a library, even if it is actually available. It ensures that
-    an ImportError is raised if the code inside the context tries to
-    import the module.
-
-    It can be used to test that a correct fallback library is used,
-    or that the expected error code is returned.
-
-    Trivial example::
-
-        from silx.test.utils import EnsureImportError
-
-        with EnsureImportError("h5py"):
-            try:
-                import h5py
-            except ImportError:
-                print("Good")
-
-    .. note::
-
-        This context manager does not remove the library from the namespace,
-        if it is already imported. It only ensures that any attempt to import
-        it again will cause an ImportError to be raised.
-    """
-    def __init__(self, name):
-        """
-
-        :param str name: Name of module to be hidden (e.g. "h5py")
-        """
-        self.module_name = name
-
-    def __enter__(self):
-        """Simulate failed import by setting sys.modules[name]=None"""
-        if self.module_name not in sys.modules:
-            self._delete_on_exit = True
-            self._backup = None
-        else:
-            self._delete_on_exit = False
-            self._backup = sys.modules[self.module_name]
-        sys.modules[self.module_name] = None
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        """Restore previous state"""
-        if self._delete_on_exit:
-            del sys.modules[self.module_name]
-        else:
-            sys.modules[self.module_name] = self._backup
 
 
 # Synthetic data and random noise #############################################

--- a/silx/utils/test/test_deprecation.py
+++ b/silx/utils/test/test_deprecation.py
@@ -26,12 +26,12 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "11/09/2017"
+__date__ = "17/01/2018"
 
 
 import unittest
 from .. import deprecation
-from silx.test import utils
+from silx.utils import testutils
 
 
 class TestDeprecation(unittest.TestCase):
@@ -53,22 +53,22 @@ class TestDeprecation(unittest.TestCase):
     def deprecatedEveryTime(self):
         pass
 
-    @utils.test_logging(deprecation.depreclog.name, warning=1)
+    @testutils.test_logging(deprecation.depreclog.name, warning=1)
     def testAnnotationWithoutParam(self):
         self.deprecatedWithoutParam()
 
-    @utils.test_logging(deprecation.depreclog.name, warning=1)
+    @testutils.test_logging(deprecation.depreclog.name, warning=1)
     def testAnnotationWithParams(self):
         self.deprecatedWithParams()
 
-    @utils.test_logging(deprecation.depreclog.name, warning=3)
+    @testutils.test_logging(deprecation.depreclog.name, warning=3)
     def testLoggedEveryTime(self):
         """Logged everytime cause it is 3 different locations"""
         self.deprecatedOnlyOnce()
         self.deprecatedOnlyOnce()
         self.deprecatedOnlyOnce()
 
-    @utils.test_logging(deprecation.depreclog.name, warning=1)
+    @testutils.test_logging(deprecation.depreclog.name, warning=1)
     def testLoggedSingleTime(self):
         def log():
             self.deprecatedOnlyOnce()
@@ -76,18 +76,18 @@ class TestDeprecation(unittest.TestCase):
         log()
         log()
 
-    @utils.test_logging(deprecation.depreclog.name, warning=3)
+    @testutils.test_logging(deprecation.depreclog.name, warning=3)
     def testLoggedEveryTime2(self):
         self.deprecatedEveryTime()
         self.deprecatedEveryTime()
         self.deprecatedEveryTime()
 
-    @utils.test_logging(deprecation.depreclog.name, warning=1)
+    @testutils.test_logging(deprecation.depreclog.name, warning=1)
     def testWarning(self):
         deprecation.deprecated_warning(type_="t", name="n")
 
     def testBacktrace(self):
-        testLogging = utils.TestLogging(deprecation.depreclog.name)
+        testLogging = testutils.TestLogging(deprecation.depreclog.name)
         with testLogging:
             self.deprecatedEveryTime()
         message = testLogging.records[0].getMessage()

--- a/silx/utils/test/test_launcher.py
+++ b/silx/utils/test/test_launcher.py
@@ -26,12 +26,12 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "03/04/2017"
+__date__ = "17/01/2018"
 
 
 import sys
 import unittest
-from silx.test.utils import ParametricTestCase
+from silx.utils.testutils import ParametricTestCase
 from .. import launcher
 
 

--- a/silx/utils/testutils.py
+++ b/silx/utils/testutils.py
@@ -1,0 +1,256 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Utilities for writing tests.
+
+- :class:`ParametricTestCase` provides a :meth:`TestCase.subTest` replacement
+  for Python < 3.4
+- :class:`TestLogging` with context or the :func:`test_logging` decorator
+  enables testing the number of logging messages of different levels.
+"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "17/01/2018"
+
+
+import contextlib
+import functools
+import logging
+import sys
+import unittest
+
+_logger = logging.getLogger(__name__)
+
+
+if sys.hexversion >= 0x030400F0:  # Python >= 3.4
+    class ParametricTestCase(unittest.TestCase):
+        pass
+else:
+    class ParametricTestCase(unittest.TestCase):
+        """TestCase with subTest support for Python < 3.4.
+
+        Add subTest method to support parametric tests.
+        API is the same, but behavior differs:
+        If a subTest fails, the following ones are not run.
+        """
+
+        _subtest_msg = None  # Class attribute to provide a default value
+
+        @contextlib.contextmanager
+        def subTest(self, msg=None, **params):
+            """Use as unittest.TestCase.subTest method in Python >= 3.4."""
+            # Format arguments as: '[msg] (key=value, ...)'
+            param_str = ', '.join(['%s=%s' % (k, v) for k, v in params.items()])
+            self._subtest_msg = '[%s] (%s)' % (msg or '', param_str)
+            yield
+            self._subtest_msg = None
+
+        def shortDescription(self):
+            short_desc = super(ParametricTestCase, self).shortDescription()
+            if self._subtest_msg is not None:
+                # Append subTest message to shortDescription
+                short_desc = ' '.join(
+                    [msg for msg in (short_desc, self._subtest_msg) if msg])
+
+            return short_desc if short_desc else None
+
+
+class TestLogging(logging.Handler):
+    """Context checking the number of logging messages from a specified Logger.
+
+    It disables propagation of logging message while running.
+
+    This is meant to be used as a with statement, for example:
+
+    >>> with TestLogging(logger, error=2, warning=0):
+    >>>     pass  # Run tests here expecting 2 ERROR and no WARNING from logger
+    ...
+
+    :param logger: Name or instance of the logger to test.
+                   (Default: root logger)
+    :type logger: str or :class:`logging.Logger`
+    :param int critical: Expected number of CRITICAL messages.
+                         Default: Do not check.
+    :param int error: Expected number of ERROR messages.
+                      Default: Do not check.
+    :param int warning: Expected number of WARNING messages.
+                        Default: Do not check.
+    :param int info: Expected number of INFO messages.
+                     Default: Do not check.
+    :param int debug: Expected number of DEBUG messages.
+                      Default: Do not check.
+    :param int notset: Expected number of NOTSET messages.
+                       Default: Do not check.
+    :raises RuntimeError: If the message counts are the expected ones.
+    """
+
+    def __init__(self, logger=None, critical=None, error=None,
+                 warning=None, info=None, debug=None, notset=None):
+        if logger is None:
+            logger = logging.getLogger()
+        elif not isinstance(logger, logging.Logger):
+            logger = logging.getLogger(logger)
+        self.logger = logger
+
+        self.records = []
+
+        self.count_by_level = {
+            logging.CRITICAL: critical,
+            logging.ERROR: error,
+            logging.WARNING: warning,
+            logging.INFO: info,
+            logging.DEBUG: debug,
+            logging.NOTSET: notset
+        }
+
+        super(TestLogging, self).__init__()
+
+    def __enter__(self):
+        """Context (i.e., with) support"""
+        self.records = []  # Reset recorded LogRecords
+        self.logger.addHandler(self)
+        self.logger.propagate = False
+        # ensure no log message is ignored
+        self.entry_level = self.logger.level * 1
+        self.logger.setLevel(logging.DEBUG)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Context (i.e., with) support"""
+        self.logger.removeHandler(self)
+        self.logger.propagate = True
+        self.logger.setLevel(self.entry_level)
+
+        for level, expected_count in self.count_by_level.items():
+            if expected_count is None:
+                continue
+
+            # Number of records for the specified level_str
+            count = len([r for r in self.records if r.levelno == level])
+            if count != expected_count:  # That's an error
+                # Resend record logs through logger as they where masked
+                # to help debug
+                for record in self.records:
+                    self.logger.handle(record)
+                raise RuntimeError(
+                    'Expected %d %s logging messages, got %d' % (
+                        expected_count, logging.getLevelName(level), count))
+
+    def emit(self, record):
+        """Override :meth:`logging.Handler.emit`"""
+        self.records.append(record)
+
+
+def test_logging(logger=None, critical=None, error=None,
+                 warning=None, info=None, debug=None, notset=None):
+    """Decorator checking number of logging messages.
+
+    Propagation of logging messages is disabled by this decorator.
+
+    In case the expected number of logging messages is not found, it raises
+    a RuntimeError.
+
+    >>> class Test(unittest.TestCase):
+    ...     @test_logging('module_logger_name', error=2, warning=0)
+    ...     def test(self):
+    ...         pass  # Test expecting 2 ERROR and 0 WARNING messages
+
+    :param logger: Name or instance of the logger to test.
+                   (Default: root logger)
+    :type logger: str or :class:`logging.Logger`
+    :param int critical: Expected number of CRITICAL messages.
+                         Default: Do not check.
+    :param int error: Expected number of ERROR messages.
+                      Default: Do not check.
+    :param int warning: Expected number of WARNING messages.
+                        Default: Do not check.
+    :param int info: Expected number of INFO messages.
+                     Default: Do not check.
+    :param int debug: Expected number of DEBUG messages.
+                      Default: Do not check.
+    :param int notset: Expected number of NOTSET messages.
+                       Default: Do not check.
+    """
+    def decorator(func):
+        test_context = TestLogging(logger, critical, error,
+                                   warning, info, debug, notset)
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            with test_context:
+                result = func(*args, **kwargs)
+            return result
+        return wrapper
+    return decorator
+
+
+# Simulate missing library context
+class EnsureImportError(object):
+    """This context manager allows to simulate the unavailability
+    of a library, even if it is actually available. It ensures that
+    an ImportError is raised if the code inside the context tries to
+    import the module.
+
+    It can be used to test that a correct fallback library is used,
+    or that the expected error code is returned.
+
+    Trivial example::
+
+        from silx.utils.testutils import EnsureImportError
+
+        with EnsureImportError("h5py"):
+            try:
+                import h5py
+            except ImportError:
+                print("Good")
+
+    .. note::
+
+        This context manager does not remove the library from the namespace,
+        if it is already imported. It only ensures that any attempt to import
+        it again will cause an ImportError to be raised.
+    """
+    def __init__(self, name):
+        """
+
+        :param str name: Name of module to be hidden (e.g. "h5py")
+        """
+        self.module_name = name
+
+    def __enter__(self):
+        """Simulate failed import by setting sys.modules[name]=None"""
+        if self.module_name not in sys.modules:
+            self._delete_on_exit = True
+            self._backup = None
+        else:
+            self._delete_on_exit = False
+            self._backup = sys.modules[self.module_name]
+        sys.modules[self.module_name] = None
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        """Restore previous state"""
+        if self._delete_on_exit:
+            del sys.modules[self.module_name]
+        else:
+            sys.modules[self.module_name] = self._backup


### PR DESCRIPTION
This function are generic and can be reused by other projects. Moving it to `silx.utils` freeze the API.

Close #1469 