### PR TITLE
[plot] Fix ColormapDialog for complex images

### DIFF
--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -368,12 +368,29 @@ class ColormapAction(PlotAction):
         if self._dialog is None:
             return
         image = self.plot.getActiveImage()
-        if isinstance(image, items.ColormapMixIn):
+
+        if isinstance(image, items.ImageComplexData):
+            # Specific init for complex images
+            colormap = image.getColormap()
+
+            mode = image.getVisualizationMode()
+            if mode in (items.ImageComplexData.Mode.AMPLITUDE_PHASE,
+                        items.ImageComplexData.Mode.LOG10_AMPLITUDE_PHASE):
+                data = image.getData(
+                    copy=False, mode=items.ImageComplexData.Mode.PHASE)
+            else:
+                data = image.getData(copy=False)
+
+            # Set histogram and range if any
+            self._dialog.setData(data)
+
+        elif isinstance(image, items.ColormapMixIn):
             # Set dialog from active image
             colormap = image.getColormap()
             data = image.getData(copy=False)
             # Set histogram and range if any
             self._dialog.setData(data)
+
         else:
             # No active image or active image is RGBA,
             # set dialog from default info

--- a/silx/gui/plot/items/complex.py
+++ b/silx/gui/plot/items/complex.py
@@ -340,11 +340,13 @@ class ImageComplexData(ImageBase, ColormapMixIn):
             mode = self.getVisualizationMode()
 
         colormap = self.getColormap(mode=mode)
-        data = self.getData(copy=False, mode=mode)
         if mode is self.Mode.AMPLITUDE_PHASE:
+            data = self.getComplexData(copy=False)
             return _complex2rgbalin(colormap, data)
         elif mode is self.Mode.LOG10_AMPLITUDE_PHASE:
+            data = self.getComplexData(copy=False)
             max_, delta = self._getAmplitudeRangeInfo()
             return _complex2rgbalog(colormap, data, dlogs=delta, smax=max_)
         else:
+            data = self.getData(copy=False, mode=mode)
             return colormap.applyToData(data)


### PR DESCRIPTION
Merge #1496 first.

This PR adds a specific case to the plot ColormapAction for complex images: If the image is in a mode combining a colormap for the phase and transparency for the amplitude, the histogram is set from the phase in the ColormapDialog.

closes #1493