### PR TITLE
[convert] no extra root level

### DIFF
--- a/doc/source/applications/convert.rst
+++ b/doc/source/applications/convert.rst
@@ -26,12 +26,16 @@ Usage
 Options
 -------
 
+::
+
   input_files           Input files (EDF, TIFF, SPEC...). When specifying
                         multiple files, you cannot specify both fabio images
                         and SPEC files. Multiple SPEC files will simply be
                         concatenated, with one entry per scan. Multiple image
                         files will be merged into a single entry with a stack
                         of images.
+
+
   -h, --help            show this help message and exit
   --file-pattern FILE_PATTERN
                         File name pattern for loading a series of indexed

--- a/doc/source/applications/convert.rst
+++ b/doc/source/applications/convert.rst
@@ -14,7 +14,7 @@ Usage
 ::
 
     silx convert [-h] [--file-pattern FILE_PATTERN] [-o OUTPUT_URI]
-                    [-m MODE] [--begin BEGIN] [--end END] [--no-root-group]
+                    [-m MODE] [--begin BEGIN] [--end END] [--add-root-group]
                     [--overwrite-data] [--min-size MIN_SIZE]
                     [--chunks [CHUNKS]] [--compression [COMPRESSION]]
                     [--compression-opts COMPRESSION_OPTS] [--shuffle]
@@ -22,23 +22,30 @@ Usage
                     [input_files [input_files ...]]
 
 
+
 Options
 -------
 
+  input_files           Input files (EDF, TIFF, SPEC...). When specifying
+                        multiple files, you cannot specify both fabio images
+                        and SPEC files. Multiple SPEC files will simply be
+                        concatenated, with one entry per scan. Multiple image
+                        files will be merged into a single entry with a stack
+                        of images.
   -h, --help            show this help message and exit
   --file-pattern FILE_PATTERN
                         File name pattern for loading a series of indexed
-                        files (toto_%04d.edf). This argument is incompatible
-                        with argument input_files. If an output URI with a
-                        HDF5 path is provided, only the content of the
-                        NXdetector group will be copied there. If no HDF5
+                        image files (toto_%04d.edf). This argument is
+                        incompatible with argument input_files. If an output
+                        URI with a HDF5 path is provided, only the content of
+                        the NXdetector group will be copied there. If no HDF5
                         path, or just "/", is given, a complete NXdata
                         structure will be created.
   -o OUTPUT_URI, --output-uri OUTPUT_URI
                         Output file name (HDF5). An URI can be provided to
                         write the data into a specific group in the output
-                        file: /path/to/file::/path/to/group. By default, the
-                        filename uses the current date and time: YYYYmmdd-
+                        file: /path/to/file::/path/to/group. If not provided,
+                        the filename defaults to a timestamp: YYYYmmdd-
                         HHMMSS.h5
   -m MODE, --mode MODE  Write mode: "r+" (read/write, file must exist), "w"
                         (write, existing file is lost), "w-" (write, fail if
@@ -46,21 +53,20 @@ Options
                         otherwise)
   --begin BEGIN         First file index, or first file indices to be
                         considered. This argument only makes sense when used
-                        together with --file-pattern.
-                        Provide as many start indices as are indices
-                        in the file pattern, separated by commas. For
-                        instance: "--filepattern toto_%d.edf --begin 100", or
-                        "--filepattern toto_%d_%04d_%02d.edf --begin
-                        100,2000,5".
+                        together with --file-pattern. Provide as many start
+                        indices as there are indices in the file pattern, separated
+                        by commas. Examples: "--filepattern toto_%d.edf
+                        --begin 100", "--filepattern toto_%d_%04d_%02d.edf
+                        --begin 100,2000,5".
   --end END             Last file index, or last file indices to be
                         considered. The same rules as with argument --begin
                         apply. Example: "--filepattern toto_%d_%d.edf --end
                         199,1999"
-  --no-root-group       This option disables the default behavior of creating
-                        a root group (entry) for each file to be converted.
-                        When merging multiple input files, this can cause
-                        conflicts when datasets have the same name (see
-                        --overwrite-data). This option has no effect when
+  --add-root-group      This option causes each input file to be written to a
+                        specific root group with the same name as the file.
+                        When merging multiple input files, this can help
+                        preventing conflicts when datasets have the same name
+                        (see --overwrite-data). This option is ignored when
                         using --file-pattern.
   --overwrite-data      If the output path exists and an input dataset has the
                         same name as an existing output dataset, overwrite the
@@ -84,7 +90,7 @@ Options
                         Compression options. For "gzip", this may be an
                         integer from 0 to 9, with a default of 4. This is only
                         supported for GZIP.
-  --shuffle             Enables the byte shuffle filter, may improve the
+  --shuffle             Enables the byte shuffle filter. This may improve the
                         compression ratio for block oriented compressors like
                         GZIP or LZF.
   --fletcher32          Adds a checksum to each chunk to detect data
@@ -99,6 +105,10 @@ Examples of usage
 Simple single file conversion to new output file::
 
     silx convert 31oct98.dat -o 31oct98.h5
+
+Concatenation of all SPEC files in the current directory::
+
+    silx convert *.dat -o all_SPEC.h5
 
 Appending a file to an existing output file::
 

--- a/silx/app/convert.py
+++ b/silx/app/convert.py
@@ -153,7 +153,7 @@ def main(argv):
         help='Output file name (HDF5). An URI can be provided to write'
              ' the data into a specific group in the output file: '
              '/path/to/file::/path/to/group. '
-             'By default, the filename uses the current date and time:'
+             'If not provided, the filename defaults to a timestamp:'
              ' YYYYmmdd-HHMMSS.h5')
     parser.add_argument(
         '-m', '--mode',
@@ -176,13 +176,13 @@ def main(argv):
              'The same rules as with argument --begin apply. '
              'Example: "--filepattern toto_%%d_%%d.edf --end 199,1999"')
     parser.add_argument(
-        '--no-root-group',
+        '--add-root-group',
         action="store_true",
-        help='This option disables the default behavior of creating a '
-             'root group (entry) for each file to be converted. When '
-             'merging multiple input files, this can cause conflicts '
-             'when datasets have the same name (see --overwrite-data). '
-             'This option has no effect when using --file-pattern.')
+        help='This option causes each input file to be written to a '
+             'specific root group with the same name as the file. When '
+             'merging multiple input files, this can help preventing conflicts'
+             ' when datasets have the same name (see --overwrite-data). '
+             'This option is ignored when using --file-pattern.')
     parser.add_argument(
         '--overwrite-data',
         action="store_true",
@@ -229,7 +229,7 @@ def main(argv):
     parser.add_argument(
         '--shuffle',
         action="store_true",
-        help='Enables the byte shuffle filter, may improve the compression '
+        help='Enables the byte shuffle filter. This may improve the compression '
              'ratio for block oriented compressors like GZIP or LZF.')
     parser.add_argument(
         '--fletcher32',
@@ -438,7 +438,7 @@ def main(argv):
         h5paths_and_groups = []
         for input_name in options.input_files:
             hdf5_path_for_file = hdf5_path
-            if not options.no_root_group:
+            if options.add_root_group:
                 hdf5_path_for_file = hdf5_path.rstrip("/") + "/" + os.path.basename(input_name)
             try:
                 h5paths_and_groups.append((hdf5_path_for_file,
@@ -446,7 +446,8 @@ def main(argv):
             except IOError:
                 _logger.error("Cannot read file %s. If this is a file format "
                               "supported by the fabio library, you can try to"
-                              "install fabio (`pip install fabio`).",
+                              " install fabio (`pip install fabio`)."
+                              " Aborting conversion.",
                               input_name)
                 return -1
 

--- a/silx/app/convert.py
+++ b/silx/app/convert.py
@@ -191,9 +191,9 @@ def main(argv):
         '--begin',
         help='First file index, or first file indices to be considered. '
              'This argument only makes sense when used together with '
-             '--file-pattern. Provide as many start indices as '
-             'are indices in the file pattern, separated by commas. For '
-             'instance: "--filepattern toto_%%d.edf --begin 100", or '
+             '--file-pattern. Provide as many start indices as there '
+             'are indices in the file pattern, separated by commas. '
+             'Examples: "--filepattern toto_%%d.edf --begin 100", '
              ' "--filepattern toto_%%d_%%04d_%%02d.edf --begin 100,2000,5".')
     parser.add_argument(
         '--end',
@@ -434,8 +434,8 @@ def main(argv):
         create_dataset_args["fletcher32"] = True
 
     if (len(options.input_files) > 1 and
-            not contains_specfile(options.input_files)) or\
-            options.file_pattern is not None:
+            not contains_specfile(options.input_files) and
+            not options.add_root_group) or options.file_pattern is not None:
         # File series -> stack of images
         if fabioh5 is None:
             # return a helpful error message if fabio is missing
@@ -460,7 +460,9 @@ def main(argv):
                         create_dataset_args=create_dataset_args,
                         min_size=options.min_size)
 
-    elif len(options.input_files) == 1 or are_all_specfile(options.input_files):
+    elif len(options.input_files) == 1 or \
+            are_all_specfile(options.input_files) or\
+            options.add_root_group:
         # single file, or spec files
         h5paths_and_groups = []
         for input_name in options.input_files:

--- a/silx/app/convert.py
+++ b/silx/app/convert.py
@@ -66,7 +66,6 @@ def c_format_string_to_re(pattern_string):
 
     # %0nd
     for sub_pattern in re.findall("%0\d+d", pattern_string):
-        print(sub_pattern)
         n = int(re.search("%0(\d+)d", sub_pattern).group(1))
         if n == 1:
             re_sub_pattern = "([+-]?\d)"
@@ -384,7 +383,6 @@ def main(argv):
         if not options.input_files:
             _logger.error("No file matching --file-pattern found.")
             return -1
-
 
     # Test that the output path is writeable
     if "::" in options.output_uri:

--- a/silx/app/test/test_convert.py
+++ b/silx/app/test/test_convert.py
@@ -144,7 +144,7 @@ class TestConvertCommand(unittest.TestCase):
         h5name = os.path.join(tempdir, "output.h5")
         assert not os.path.isfile(h5name)
         command_list = ["convert", "-m", "w",
-                        "--no-root-group", specname, "-o", h5name]
+                        specname, "-o", h5name]
         result = convert.main(command_list)
 
         self.assertEqual(result, 0)

--- a/silx/io/convert.py
+++ b/silx/io/convert.py
@@ -92,7 +92,7 @@ def _create_link(h5f, link_name, target_name,
                      target_name)
         del h5f[link_name]
     else:
-        _logger.warn(link_name + " already exist. Can't create link to " +
+        _logger.warn(link_name + " already exist. Cannot create link to " +
                      target_name)
         return None
 
@@ -211,7 +211,7 @@ class Hdf5Writer(object):
                     ds.attrs.create(key, numpy.string_(obj.attrs[key]))
 
             if not self.overwrite_data and member_initially_exists:
-                _logger.warn("Ignoring existing dataset: " + h5_name)
+                _logger.warn("Not overwriting existing dataset: " + h5_name)
 
         elif is_group(obj):
             if h5_name not in self._h5f:


### PR DESCRIPTION
Closes #1498.

Change default behavior : don't add an extra group at the root, unless explicitly requested. 
Remove `--no-root-group` option, add `--add-root-group` option.

After this PR, users should ensure that they are not merging scans with the same scan number.

At the moment the only proper way to merge EDF files is for file series, with the `--file-pattern` option. `silx convert *edf` should only be used with option `--add-root-group`. The same goes for appending EDF files to an existing file. This is because `fabioh5` currently assigns the name `scan_0` to all entries.