### PR TITLE
Remove ci_popups when it is not needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,8 +109,11 @@ before_script:
           ldd $(python -c "import h5py;print(h5py.h5d.__file__)");
       fi
 
-    - "pip install --upgrade pynput"
-    - "python ci/close_popup.py"
+    - if [ "$TRAVIS_OS_NAME" == "osx" ];
+      then
+          pip install --upgrade pynput;
+          python ci/close_popup.py;
+      fi
 
 script:
     - echo "WITH_QT_TEST="$WITH_QT_TEST

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -97,8 +97,8 @@ before_test:
     - "pip list --format=columns"
 
     # Try to close popups
-    - "pip install --upgrade pynput"
-    - "python ./ci/close_popup.py"
+    #- "pip install --upgrade pynput"
+    #- "python ./ci/close_popup.py"
 
 test_script:
     # Run tests with selected Qt binding and without OpenCL


### PR DESCRIPTION
The script looks to segfault (an update of Qt5 ?) on some env, and is fortunatly not needed now. This PR remove it everywhere but on Mac OS X.