### PR TITLE
[CI] Remove travis macos python2 test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,18 +29,9 @@ matrix:
 
         - language: generic
           os: osx
-          osx_image: xcode7.3
           env:
               - BUILD_COMMAND=bdist_wheel
               - WITH_QT_TEST=True
-              - PYTHON_VERSION=2
-
-        - language: generic
-          os: osx
-          env:
-              - BUILD_COMMAND=bdist_wheel
-              - WITH_QT_TEST=True
-              - PYTHON_VERSION=3
 
 cache:
     apt: true

--- a/ci/before_install-osx.sh
+++ b/ci/before_install-osx.sh
@@ -1,19 +1,15 @@
-# Script for travis-CI Mac OS X specific setup.
-# source this script with PYTHON_VERSION env variable set
+# Script for travis-CI Mac OS X python 3 specific setup.
 
 VENV_DIR=./venv
 
 # Use brew for python3
-if [ "$PYTHON_VERSION" == "3" ];
-then
-    brew install python3;
-    PYTHON_EXE=`brew list python3 | grep "bin/python3$" | head -n 1`;
-    # Create virtual env
-    $PYTHON_EXE -m venv $VENV_DIR
-    source $VENV_DIR/bin/activate
-fi
+brew install python3
+PYTHON_EXE=`brew list python3 | grep "bin/python3$" | head -n 1`
+# Create virtual env
+$PYTHON_EXE -m venv $VENV_DIR
+source $VENV_DIR/bin/activate
 
 # Alternative python installation using miniconda
-#curl -o miniconda_installer.sh "https://repo.continuum.io/miniconda/Miniconda$PYTHON_VERSION-latest-MacOSX-x86_64.sh"
+#curl -o miniconda_installer.sh "https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
 #bash miniconda_installer.sh -b -p miniconda
 #export PATH="`pwd`/miniconda/bin":$PATH


### PR DESCRIPTION
This PR proposes to remove Travis macos python2/pyqt4 test environment.
macos is still tested with python3/pyqt5.
macos CI tests are quite delayed on Travis and as time pass, python2/pyqt4 is becoming less and less the main target...

Unless someone has an opinion against that, I propose to merge that

closes #1480