### PR TITLE
Take screenshot on MPL fail

### DIFF
--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "17/01/2018"
+__date__ = "26/01/2018"
 
 
 import unittest
@@ -77,9 +77,9 @@ class TestPlotWidget(PlotWidgetTestCase, ParametricTestCase):
         self.assertEqual(self.plot.getYAxis().getLabel(), ylabel)
 
     def _checkLimits(self,
-                    expectedXLim=None,
-                    expectedYLim=None,
-                    expectedRatio=None):
+                     expectedXLim=None,
+                     expectedYLim=None,
+                     expectedRatio=None):
         """Assert that limits are as expected"""
         xlim = self.plot.getXAxis().getLimits()
         ylim = self.plot.getYAxis().getLimits()

--- a/silx/gui/plot/test/utils.py
+++ b/silx/gui/plot/test/utils.py
@@ -46,6 +46,8 @@ class PlotWidgetTestCase(TestCaseQt):
     plot attribute is the PlotWidget created for the test.
     """
 
+    __screenshot_already_taken = False
+
     def __init__(self, methodName='runTest'):
         TestCaseQt.__init__(self, methodName=methodName)
 
@@ -76,6 +78,16 @@ class PlotWidgetTestCase(TestCaseQt):
             logger.error("Plot is still alive")
 
     def tearDown(self):
+        if not self._currentTestSucceeded():
+            # MPL is the only widget which uses the real system mouse.
+            # In case of a the windows is outside of the screen, minimzed,
+            # overlapped by a system popup, the MPL widget will not receive the
+            # mouse event.
+            # Taking a screenshot help debuging this cases in the continuous
+            # integration environement.
+            if not PlotWidgetTestCase.__screenshot_already_taken:
+                PlotWidgetTestCase.__screenshot_already_taken = True
+                self.logScreenShot()
         self.qapp.processEvents()
         self._waitForPlotClosed()
         super(PlotWidgetTestCase, self).tearDown()

--- a/silx/gui/plot/test/utils.py
+++ b/silx/gui/plot/test/utils.py
@@ -26,17 +26,15 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "01/09/2017"
+__date__ = "26/01/2018"
 
 
 import logging
-import contextlib
 
 from silx.gui.test.utils import TestCaseQt
 
 from silx.gui import qt
 from silx.gui.plot import PlotWidget
-from silx.gui.plot.backends.BackendMatplotlib import BackendMatplotlibQt
 
 
 logger = logging.getLogger(__name__)
@@ -81,4 +79,3 @@ class PlotWidgetTestCase(TestCaseQt):
         self.qapp.processEvents()
         self._waitForPlotClosed()
         super(PlotWidgetTestCase, self).tearDown()
-


### PR DESCRIPTION
This can help us to debug CI environment, which is usually a very boring thing.

```
testFoo (silx.gui.plot.test.testPlotWidget.TestPlotWidget) ... FAIL
ERROR:silx.gui.test.utils:Screenshot saved at /workspace/valls/silx.git/build/test-debug/Screenshot_silx.gui.plot.test.testPlotWidget.TestPlotWidget.testFoo.png
ERROR:silx.gui.plot.test.utils:Plot is still alive
```