### PR TITLE
Group skipped tests by reasons in test results

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -32,7 +32,7 @@ Test coverage dependencies: coverage, lxml.
 """
 
 __authors__ = ["Jérôme Kieffer", "Thomas Vincent"]
-__date__ = "26/01/2018"
+__date__ = "29/01/2018"
 __license__ = "MIT"
 
 import distutils.util
@@ -42,6 +42,7 @@ import subprocess
 import sys
 import time
 import unittest
+import collections
 from argparse import ArgumentParser
 
 
@@ -144,7 +145,7 @@ class TextTestResultWithSkipList(unittest.TextTestResult):
         self.printGroupedList("SKIPPED", self.skipped)
 
     def printGroupedList(self, flavour, errors):
-        grouped = {}
+        grouped = collections.OrderedDict()
 
         for test, err in errors:
             if err in grouped:

--- a/run_tests.py
+++ b/run_tests.py
@@ -32,7 +32,7 @@ Test coverage dependencies: coverage, lxml.
 """
 
 __authors__ = ["Jérôme Kieffer", "Thomas Vincent"]
-__date__ = "15/01/2018"
+__date__ = "26/01/2018"
 __license__ = "MIT"
 
 import distutils.util
@@ -141,7 +141,23 @@ class TextTestResultWithSkipList(unittest.TextTestResult):
     def printErrors(self):
         unittest.TextTestResult.printErrors(self)
         # Print skipped tests at the end
-        self.printErrorList("SKIPPED", self.skipped)
+        self.printGroupedList("SKIPPED", self.skipped)
+
+    def printGroupedList(self, flavour, errors):
+        grouped = {}
+
+        for test, err in errors:
+            if err in grouped:
+                grouped[err] = grouped[err] + [test]
+            else:
+                grouped[err] = [test]
+
+        for err, tests in grouped.items():
+            self.stream.writeln(self.separator1)
+            for test in tests:
+                self.stream.writeln("%s: %s" % (flavour, self.getDescription(test)))
+            self.stream.writeln(self.separator2)
+            self.stream.writeln("%s" % err)
 
 
 class ProfileTextTestResult(unittest.TextTestRunner.resultclass):


### PR DESCRIPTION
Here is the result of a `./run_tests.py --no-opencl --no-gui`

```
ss...............................................................................................................................................................................................s..................................................................................................................s..................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................................s..........sssssssssssssssssssssssssssssssssssssssssssssssssss.....
======================================================================
SKIPPED: test_gradient (silx.opencl.sift.test.test_image.TestImage)
SKIPPED: test_local_maxmin (silx.opencl.sift.test.test_image.TestImage)
SKIPPED: test_interpolation (silx.opencl.sift.test.test_image.TestImage)
----------------------------------------------------------------------
OpenCL missing
======================================================================
SKIPPED: test_uint8 (silx.opencl.sift.test.test_preproc.TestPreproc)
SKIPPED: test_uint16 (silx.opencl.sift.test.test_preproc.TestPreproc)
SKIPPED: test_uint32 (silx.opencl.sift.test.test_preproc.TestPreproc)
SKIPPED: test_uint64 (silx.opencl.sift.test.test_preproc.TestPreproc)
SKIPPED: test_int32 (silx.opencl.sift.test.test_preproc.TestPreproc)
SKIPPED: test_int64 (silx.opencl.sift.test.test_preproc.TestPreproc)
SKIPPED: test_rgb (silx.opencl.sift.test.test_preproc.TestPreproc)
SKIPPED: test_shrink (silx.opencl.sift.test.test_preproc.TestPreproc)
SKIPPED: test_bin (silx.opencl.sift.test.test_preproc.TestPreproc)
SKIPPED: test_matching (silx.opencl.sift.test.test_matching.TestMatching)
----------------------------------------------------------------------
no scipy or ocl
======================================================================
SKIPPED: test_decompress (silx.opencl.codec.test.test_byte_offset.TestByteOffset)
SKIPPED: test_many_decompress (silx.opencl.codec.test.test_byte_offset.TestByteOffset)
SKIPPED: test_encode (silx.opencl.codec.test.test_byte_offset.TestByteOffset)
Test byte offset compression
SKIPPED: test_encode_to_array (silx.opencl.codec.test.test_byte_offset.TestByteOffset)
Test byte offset compression while providing an out array
SKIPPED: test_encode_to_bytes (silx.opencl.codec.test.test_byte_offset.TestByteOffset)
Test byte offset compression to bytes
SKIPPED: test_encode_to_bytes_from_array (silx.opencl.codec.test.test_byte_offset.TestByteOffset)
Test byte offset compression to bytes from a pyopencl array.
SKIPPED: test_many_encode (silx.opencl.codec.test.test_byte_offset.TestByteOffset)
Test byte offset compression with many image
----------------------------------------------------------------------
PyOpenCl or fabio is missing
======================================================================
SKIPPED: test_descriptor (silx.opencl.sift.test.test_keypoints.TestKeypoints)
SKIPPED: test_orientation (silx.opencl.sift.test.test_keypoints.TestKeypoints)
SKIPPED: test_descriptor (silx.opencl.sift.test.test_keypoints.TestKeypoints)
SKIPPED: test_orientation (silx.opencl.sift.test.test_keypoints.TestKeypoints)
SKIPPED: test_descriptor (silx.opencl.sift.test.test_keypoints.TestKeypoints)
SKIPPED: test_orientation (silx.opencl.sift.test.test_keypoints.TestKeypoints)
----------------------------------------------------------------------
opencl or scipy missing
======================================================================
SKIPPED: test_align (silx.opencl.sift.test.test_align.TestLinalign)
----------------------------------------------------------------------
scipy or pyopencl are missing
======================================================================
SKIPPED: test_transform (silx.opencl.sift.test.test_transform.TestTransform)
----------------------------------------------------------------------
scipy or ocl missing
======================================================================
SKIPPED: test_convol (silx.opencl.sift.test.test_convol.TestConvol)
SKIPPED: test_convol_hor (silx.opencl.sift.test.test_convol.TestConvol)
SKIPPED: test_convol_vert (silx.opencl.sift.test.test_convol.TestConvol)
----------------------------------------------------------------------
scipy or opencl not available
======================================================================
SKIPPED: test_unicode_header (silx.io.test.test_fabioh5.TestFabioH5)
Test that it does not fail
----------------------------------------------------------------------
fabio do not allow to create the resource
======================================================================
SKIPPED: test_v1_odd (silx.opencl.sift.test.test_gaussian.TestGaussian)
SKIPPED: test_v1_even (silx.opencl.sift.test.test_gaussian.TestGaussian)
SKIPPED: test_v2_odd (silx.opencl.sift.test.test_gaussian.TestGaussian)
SKIPPED: test_v2_even (silx.opencl.sift.test.test_gaussian.TestGaussian)
----------------------------------------------------------------------
ocl or scipy is missing
======================================================================
SKIPPED: runTest (silx.test.test_sx.SkipSXTest)
SKIPPED: runTest (silx.gui.test.SkipGUITest)
SKIPPED: testConstruct (silx.app.test.test_view.TestViewer)
SKIPPED: testFile (silx.app.test.test_view.TestLauncher)
SKIPPED: testHelp (silx.app.test.test_view.TestLauncher)
SKIPPED: testWrongFile (silx.app.test.test_view.TestLauncher)
SKIPPED: testWrongOption (silx.app.test.test_view.TestLauncher)
----------------------------------------------------------------------
Skipped by command line
======================================================================
SKIPPED: testOpenCLMedFilt2d (silx.image.test.test_medianfilter.TestMedianFilterEngines)
test cpp engine for medfilt2d
SKIPPED: test_add (silx.opencl.test.test_addition.TestAddition)
SKIPPED: test_measurement (silx.opencl.test.test_addition.TestAddition)
SKIPPED: test_medfilt (silx.opencl.test.test_medfilt.TestMedianFilter)
SKIPPED: test_fbp (silx.opencl.test.test_backprojection.TestFBP)
SKIPPED: test_proj (silx.opencl.test.test_projection.TestProj)
SKIPPED: test_gradient (silx.opencl.test.test_linalg.TestLinAlg)
SKIPPED: test_divergence (silx.opencl.test.test_linalg.TestLinAlg)
SKIPPED: test_laplacian (silx.opencl.test.test_linalg.TestLinAlg)
SKIPPED: test_cpy2d (silx.opencl.test.test_array_utils.TestCpy2d)
SKIPPED: test_combine (silx.opencl.sift.test.test_algebra.TestAlgebra)
SKIPPED: test_compact (silx.opencl.sift.test.test_algebra.TestAlgebra)
----------------------------------------------------------------------
PyOpenCl is missing
======================================================================
SKIPPED: test_locale_de_DE (silx.io.test.test_specfile.TestSFLocale)
----------------------------------------------------------------------
de_DE.utf8 locale not installed
----------------------------------------------------------------------
Ran 906 tests in 13.608s

OK (skipped=56)
```