### PR TITLE
 Fix transitional inconsistency on NumpyAxesSelectior

### DIFF
--- a/silx/gui/data/NumpyAxesSelector.py
+++ b/silx/gui/data/NumpyAxesSelector.py
@@ -29,7 +29,7 @@ from __future__ import division
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "16/01/2017"
+__date__ = "29/01/2018"
 
 import numpy
 import functools
@@ -423,6 +423,14 @@ class NumpyAxesSelector(qt.QWidget):
         # with a h5py dataset, it create a copy
         # TODO we can reuse the same memory in case of a copy
         view = self.__data[self.__selection]
+
+        if set(self.__axisNames) - set(axisNames) != set([]):
+            # Not all the expected axis are there
+            if self.__selectedData is not None:
+                self.__selectedData = None
+                self.__selection = tuple()
+                self.selectionChanged.emit()
+            return
 
         # order axis as expected
         source = []

--- a/silx/gui/data/test/test_numpyaxesselector.py
+++ b/silx/gui/data/test/test_numpyaxesselector.py
@@ -24,7 +24,7 @@
 # ###########################################################################*/
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "15/12/2016"
+__date__ = "29/01/2018"
 
 import os
 import tempfile
@@ -66,6 +66,20 @@ class TestNumpyAxesSelector(TestCaseQt):
 
         widget = NumpyAxesSelector()
         widget.setAxisNames(["x", "y", "z"])
+        widget.setData(data)
+        result = widget.selectedData()
+        self.assertTrue(numpy.array_equal(result, expectedResult))
+
+    def test_output_moredim(self):
+        data = numpy.arange(3 * 3 * 3 * 3)
+        data.shape = 3, 3, 3, 3
+        expectedResult = data
+
+        widget = NumpyAxesSelector()
+        widget.setAxisNames(["x", "y", "z", "boum"])
+        widget.setData(data[0])
+        result = widget.selectedData()
+        self.assertEqual(result, None)
         widget.setData(data)
         result = widget.selectedData()
         self.assertTrue(numpy.array_equal(result, expectedResult))


### PR DESCRIPTION
This occur when are more requested axes  than the available axes.

This PR detect the inconsistency and cancel the selection.