### PR TITLE
[NXdataView] support old API for setting a curve

### DIFF
--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -1105,6 +1105,18 @@ class _NXdataCurveView(DataView):
         else:
             x_errors = None
 
+        # this fix is necessary until the next release of PyMca (5.2.3 or 5.3.0)
+        # see https://github.com/vasole/pymca/issues/144 and https://github.com/vasole/pymca/pull/145
+        if not hasattr(self.getWidget(), "setCurvesData") and \
+                hasattr(self.getWidget(), "setCurveData"):
+            _logger.warning("Using deprecated ArrayCurvePlot API, "
+                            "without support of auxiliary signals")
+            self.getWidget().setCurveData(nxd.signal, nxd.axes[-1],
+                                          yerror=nxd.errors, xerror=x_errors,
+                                          ylabel=nxd.signal_name, xlabel=nxd.axes_names[-1],
+                                          title=nxd.title or nxd.signal_name)
+            return
+
         self.getWidget().setCurvesData([nxd.signal] + nxd.auxiliary_signals, nxd.axes[-1],
                                        yerror=nxd.errors, xerror=x_errors,
                                        ylabels=signals_names, xlabel=nxd.axes_names[-1],


### PR DESCRIPTION
My last PR (#1516)  broke PyMca because a widget was reimplemented completely in PyMca, in order to add features to the viewer.

It should be fixed in the next PyMca release. But silx will probably be released prior to PyMca, so this fix will be needed during at least one release cycle, to ensure a smooth transition..