### PR TITLE
[convert & spech5] Use utf-8 text

### DIFF
--- a/silx/app/convert.py
+++ b/silx/app/convert.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2017 European Synchrotron Radiation Facility
+# Copyright (C) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -34,6 +34,7 @@ import time
 
 import silx.io
 from silx.io.specfile import is_specfile
+from silx.third_party import six
 
 try:
     from silx.io import fabioh5
@@ -529,11 +530,16 @@ def main(argv):
 
     with h5py.File(output_name, mode="r+") as h5f:
         # append "silx convert" to the creator attribute, for NeXus files
-        previous_creator = h5f.attrs.get("creator", b"").decode()
+        previous_creator = h5f.attrs.get("creator", u"")
         creator = "silx convert (v%s)" % silx.version
         # only if it not already there
         if creator not in previous_creator:
-            h5f.attrs["creator"] = \
-                numpy.string_(previous_creator + "; " + creator)
+            if not previous_creator:
+                new_creator = creator
+            else:
+                new_creator = previous_creator + "; " + creator
+            h5f.attrs["creator"] = numpy.array(
+                    new_creator,
+                    dtype=h5py.special_dtype(vlen=six.text_type))
 
     return 0

--- a/silx/app/test/test_convert.py
+++ b/silx/app/test/test_convert.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -152,14 +152,15 @@ class TestConvertCommand(unittest.TestCase):
 
         with h5py.File(h5name, "r") as h5f:
             title12 = h5f["/1.2/title"][()]
-            if sys.version > '3.0':
-                title12 = title12.decode()
+            if sys.version < '3.0':
+                title12 = title12.encode("ascii")
             self.assertEqual(title12,
                              "1 aaaaaa")
 
             creator = h5f.attrs.get("creator")
             self.assertIsNotNone(creator, "No creator attribute in NXroot group")
-            creator = creator.decode()  # make sure we can compare creator with native string
+            if sys.version < '3.0':
+                creator = creator.encode("ascii")
             self.assertIn("silx convert (v%s)" % silx.version, creator)
 
         # delete input file

--- a/silx/app/test/test_convert.py
+++ b/silx/app/test/test_convert.py
@@ -153,14 +153,14 @@ class TestConvertCommand(unittest.TestCase):
         with h5py.File(h5name, "r") as h5f:
             title12 = h5f["/1.2/title"][()]
             if sys.version < '3.0':
-                title12 = title12.encode("ascii")
+                title12 = title12.encode("utf-8")
             self.assertEqual(title12,
                              "1 aaaaaa")
 
             creator = h5f.attrs.get("creator")
             self.assertIsNotNone(creator, "No creator attribute in NXroot group")
             if sys.version < '3.0':
-                creator = creator.encode("ascii")
+                creator = creator.encode("utf-8")
             self.assertIn("silx convert (v%s)" % silx.version, creator)
 
         # delete input file

--- a/silx/io/convert.py
+++ b/silx/io/convert.py
@@ -28,24 +28,23 @@ supported formats.
 Read the documentation of :mod:`silx.io.spech5` and :mod:`silx.io.fabioh5` for
 information on the structure of the output HDF5 files.
 
-Strings are written to the HDF5 datasets as fixed-length ASCII (NumPy *S* type).
-This is done in order to produce files that have maximum compatibility with
-other HDF5 libraries, as recommended in the
-`h5py documentation <http://docs.h5py.org/en/latest/strings.html#how-to-store-text-strings>`_.
+Text strings are written to the HDF5 datasets as variable-length utf-8.
 
-If you read the files back with *h5py* in Python 3, you will recover strings
-as bytes, which you should decode to transform them into python strings::
+.. warning::
 
-    >>> import h5py
-    >>> f = h5py.File("myfile.h5")
-    >>> f["/1.1/instrument/specfile/scan_header"][0]
-    b'#S 94  ascan  del -0.5 0.5  20 1'
-    >>> f["/1.1/instrument/specfile/scan_header"][0].decode()
-    '#S 94  ascan  del -0.5 0.5  20 1'
+    The output format for text strings changed in silx version 0.7.0.
+    Prior to that, text was output as fixed-length ASCII.
 
-Arrays of strings, such as file and scan headers, are stored as fixed-length
-strings. The length of all strings in an array is equal to the length of the
-longest string. Shorter strings are right-padded with blank spaces.
+    To be on the safe side, when reading back a HDF5 file written with an
+    older version of silx, you can test for the presence of a *decode*
+    attribute. To ensure that you always work with unicode text::
+
+        >>> import h5py
+        >>> h5f = h5py.File("my_scans.h5", "r")
+        >>> title = h5f["/68.1/title"]
+        >>> if hasattr(title, "decode"):
+        ...     title = title.decode()
+
 
 .. note:: This module has a dependency on the `h5py <http://www.h5py.org/>`_
     library, which is not a mandatory dependency for `silx`. You might need

--- a/silx/io/convert.py
+++ b/silx/io/convert.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -52,7 +52,6 @@ longest string. Shorter strings are right-padded with blank spaces.
     to install it if you don't already have it.
 """
 
-import numpy
 import logging
 
 import silx.io
@@ -60,7 +59,7 @@ from silx.io import is_dataset, is_group, is_softlink
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "14/09/2017"
+__date__ = "29/01/2018"
 
 _logger = logging.getLogger(__name__)
 
@@ -168,7 +167,7 @@ class Hdf5Writer(object):
         for key in infile.attrs:
             if self.overwrite_data or key not in root_grp.attrs:
                 root_grp.attrs.create(key,
-                                      numpy.string_(infile.attrs[key]))
+                                      infile.attrs[key])
 
         # Handle links at the end, when their targets are created
         for link_name, target_name in self._links:
@@ -208,7 +207,7 @@ class Hdf5Writer(object):
             # add HDF5 attributes
             for key in obj.attrs:
                 if self.overwrite_data or key not in ds.attrs:
-                    ds.attrs.create(key, numpy.string_(obj.attrs[key]))
+                    ds.attrs.create(key, obj.attrs[key])
 
             if not self.overwrite_data and member_initially_exists:
                 _logger.warn("Not overwriting existing dataset: " + h5_name)
@@ -223,7 +222,7 @@ class Hdf5Writer(object):
             # add HDF5 attributes
             for key in obj.attrs:
                 if self.overwrite_data or key not in grp.attrs:
-                    grp.attrs.create(key, numpy.string_(obj.attrs[key]))
+                    grp.attrs.create(key, obj.attrs[key])
 
 
 def _is_commonh5_group(grp):

--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -206,7 +206,7 @@ logger1 = logging.getLogger(__name__)
 text_dtype = h5py.special_dtype(vlen=six.text_type)
 
 
-def str_to_h5py_utf8(str_list):
+def to_h5py_utf8(str_list):
     """Convert a string or a list of strings to a numpy array of
     unicode strings that can be written to HDF5 as utf-8.
 
@@ -473,7 +473,7 @@ class SpecH5NodeDataset(commonh5.Dataset, SpecH5Dataset):
         # attributes (dtype, shape, size)
         if isinstance(data, six.string_types):
             # use unicode (utf-8 when saved to HDF5 output)
-            value = str_to_h5py_utf8(data)
+            value = to_h5py_utf8(data)
         elif isinstance(data, float):
             # use 32 bits for float scalars
             value = numpy.float32(data)
@@ -561,11 +561,11 @@ class SpecH5(commonh5.File, SpecH5Group):
 
         self._sf = SpecFile(filename)
 
-        attrs = {"NX_class": u"NXroot",
-                 "file_time": str_to_h5py_utf8(
+        attrs = {"NX_class": to_h5py_utf8("NXroot"),
+                 "file_time": to_h5py_utf8(
                          datetime.datetime.now().isoformat()),
-                 "file_name": str_to_h5py_utf8(filename),
-                 "creator": u"silx spech5 %s" % silx_version}
+                 "file_name": to_h5py_utf8(filename),
+                 "creator": to_h5py_utf8("silx spech5 %s" % silx_version)}
         commonh5.File.__init__(self, filename, attrs=attrs)
 
         for scan_key in self._sf.keys():
@@ -587,11 +587,11 @@ class ScanGroup(commonh5.Group, SpecH5Group):
         :param scan: specfile.Scan object
         """
         commonh5.Group.__init__(self, scan_key, parent=parent,
-                                attrs={"NX_class": u"NXentry"})
+                                attrs={"NX_class": to_h5py_utf8("NXentry")})
 
         self.add_node(SpecH5NodeDataset(
                 name="title",
-                data=str_to_h5py_utf8(scan.scan_header_dict["S"]),
+                data=to_h5py_utf8(scan.scan_header_dict["S"]),
                 parent=self))
 
         if "D" in scan.scan_header_dict:
@@ -618,7 +618,7 @@ class ScanGroup(commonh5.Group, SpecH5Group):
                          scan_key)
             start_time_str = ""
         self.add_node(SpecH5NodeDataset(name="start_time",
-                                        data=str_to_h5py_utf8(start_time_str),
+                                        data=to_h5py_utf8(start_time_str),
                                         parent=self))
 
         self.add_node(InstrumentGroup(parent=self, scan=scan))
@@ -635,7 +635,7 @@ class InstrumentGroup(commonh5.Group, SpecH5Group):
         :param scan: specfile.Scan object
         """
         commonh5.Group.__init__(self, name="instrument", parent=parent,
-                                attrs={"NX_class": u"NXinstrument"})
+                                attrs={"NX_class": to_h5py_utf8("NXinstrument")})
 
         self.add_node(InstrumentSpecfileGroup(parent=self, scan=scan))
         self.add_node(PositionersGroup(parent=self, scan=scan))
@@ -650,16 +650,16 @@ class InstrumentGroup(commonh5.Group, SpecH5Group):
 class InstrumentSpecfileGroup(commonh5.Group, SpecH5Group):
     def __init__(self, parent, scan):
         commonh5.Group.__init__(self, name="specfile", parent=parent,
-                                attrs={"NX_class": u"NXcollection"})
+                                attrs={"NX_class": to_h5py_utf8("NXcollection")})
         self.add_node(SpecH5NodeDataset(
                 name="file_header",
-                data=str_to_h5py_utf8(
+                data=to_h5py_utf8(
                         "\n".join(scan.file_header)),
                 parent=self,
                 attrs={}))
         self.add_node(SpecH5NodeDataset(
                 name="scan_header",
-                data=str_to_h5py_utf8("\n".join(scan.scan_header)),
+                data=to_h5py_utf8("\n".join(scan.scan_header)),
                 parent=self,
                 attrs={}))
 
@@ -667,7 +667,7 @@ class InstrumentSpecfileGroup(commonh5.Group, SpecH5Group):
 class PositionersGroup(commonh5.Group, SpecH5Group):
     def __init__(self, parent, scan):
         commonh5.Group.__init__(self, name="positioners", parent=parent,
-                                attrs={"NX_class": u"NXcollection"})
+                                attrs={"NX_class": to_h5py_utf8("NXcollection")})
         for motor_name in scan.motor_names:
             safe_motor_name = motor_name.replace("/", "%")
             if motor_name in scan.labels and scan.data.shape[0] > 0:
@@ -686,7 +686,7 @@ class InstrumentMcaGroup(commonh5.Group, SpecH5Group):
     def __init__(self, parent, analyser_index, scan):
         name = "mca_%d" % analyser_index
         commonh5.Group.__init__(self, name=name, parent=parent,
-                                attrs={"NX_class": u"NXdetector"})
+                                attrs={"NX_class": to_h5py_utf8("NXdetector")})
 
         self.add_node(McaDataDataset(parent=self,
                                      analyser_index=analyser_index,
@@ -725,7 +725,7 @@ class McaDataDataset(SpecH5LazyNodeDataset):
     def __init__(self, parent, analyser_index, scan):
         commonh5.LazyLoadableDataset.__init__(
             self, name="data", parent=parent,
-            attrs={"interpretation": u"spectrum", })
+            attrs={"interpretation": to_h5py_utf8("spectrum"),})
         self._scan = scan
         self._analyser_index = analyser_index
         self._shape = None
@@ -788,7 +788,7 @@ class MeasurementGroup(commonh5.Group, SpecH5Group):
         :param scan: specfile.Scan object
         """
         commonh5.Group.__init__(self, name="measurement", parent=parent,
-                                attrs={"NX_class": u"NXcollection", })
+                                attrs={"NX_class": to_h5py_utf8("NXcollection"),})
         for label in scan.labels:
             safe_label = label.replace("/", "%")
             self.add_node(SpecH5NodeDataset(name=safe_label,
@@ -823,23 +823,23 @@ class SampleGroup(commonh5.Group, SpecH5Group):
         :param scan: specfile.Scan object
         """
         commonh5.Group.__init__(self, name="sample", parent=parent,
-                                attrs={"NX_class": u"NXsample", })
+                                attrs={"NX_class": to_h5py_utf8("NXsample"),})
 
         if _unit_cell_in_scan(scan):
             self.add_node(SpecH5NodeDataset(name="unit_cell",
                                             data=_parse_unit_cell(scan.scan_header_dict["G1"]),
                                             parent=self,
-                                            attrs={"interpretation": u"scalar"}))
+                                            attrs={"interpretation": to_h5py_utf8("scalar")}))
             self.add_node(SpecH5NodeDataset(name="unit_cell_abc",
                                             data=_parse_unit_cell(scan.scan_header_dict["G1"])[0, 0:3],
                                             parent=self,
-                                            attrs={"interpretation": u"scalar"}))
+                                            attrs={"interpretation": to_h5py_utf8("scalar")}))
             self.add_node(SpecH5NodeDataset(name="unit_cell_alphabetagamma",
                                             data=_parse_unit_cell(scan.scan_header_dict["G1"])[0, 3:6],
                                             parent=self,
-                                            attrs={"interpretation": u"scalar"}))
+                                            attrs={"interpretation": to_h5py_utf8("scalar")}))
         if _ub_matrix_in_scan(scan):
             self.add_node(SpecH5NodeDataset(name="ub_matrix",
                                             data=_parse_UB_matrix(scan.scan_header_dict["G3"]),
                                             parent=self,
-                                            attrs={"interpretation": u"scalar"}))
+                                            attrs={"interpretation": to_h5py_utf8("scalar")}))

--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -157,20 +157,30 @@ You can test for existence of data or groups::
     >>> "spam" in sfh5["1.1"]
     False
 
-Strings are stored encoded as ``numpy.string_``, as recommended by
-`the h5py documentation <http://docs.h5py.org/en/latest/strings.html>`_.
-This ensures maximum compatibility with third party software libraries,
-when saving a :class:`SpecH5` to a HDF5 file using :mod:`silx.io.spectoh5`.
+.. note::
 
-The type ``numpy.string_`` is a byte-string format. The consequence of this
-is that you should decode strings before using them in **Python 3**::
+    Text used to be stored with a dtype ``numpy.string_`` in silx versions
+    prior to *0.7.0*. The type ``numpy.string_`` is a byte-string format.
+    The consequence of this is that you had to decode strings before using
+    them in **Python 3**::
 
-    >>> from silx.io.spech5 import SpecH5
-    >>> sfh5 = SpecH5("31oct98.dat")
-    >>> sfh5["/68.1/title"]
-    b'68  ascan  tx3 -28.5 -24.5  20 0.5'
-    >>> sfh5["/68.1/title"].decode()
-    '68  ascan  tx3 -28.5 -24.5  20 0.5'
+        >>> from silx.io.spech5 import SpecH5
+        >>> sfh5 = SpecH5("31oct98.dat")
+        >>> sfh5["/68.1/title"]
+        b'68  ascan  tx3 -28.5 -24.5  20 0.5'
+        >>> sfh5["/68.1/title"].decode()
+        '68  ascan  tx3 -28.5 -24.5  20 0.5'
+
+    From silx version *0.7.0* onwards, text is now stored as unicode. This
+    corresponds to the default text type in python 3, and to the *unicode*
+    type in Python 2.
+
+    To be on the safe side, you can test for the presence of a *decode*
+    attribute, to ensure that you always work with unicode text::
+
+        >>> title = sfh5["/68.1/title"]
+        >>> if hasattr(title, "decode"):
+        ...     title = title.decode()
 
 """
 
@@ -178,28 +188,32 @@ import datetime
 import logging
 import numpy
 import re
-import sys
 import io
+import h5py
 
 from silx import version as silx_version
 from .specfile import SpecFile
 from . import commonh5
+from silx.third_party import six
 
 __authors__ = ["P. Knobel", "D. Naudet"]
 __license__ = "MIT"
-__date__ = "23/08/2017"
+__date__ = "29/01/2018"
 
 logger1 = logging.getLogger(__name__)
 
-try:
-    import h5py
-except ImportError:
-    h5py = None
-    logger1.debug("Module h5py optional.", exc_info=True)
+
+text_dtype = h5py.special_dtype(vlen=six.text_type)
 
 
-string_types = (basestring,) if sys.version_info[0] == 2 else (str,)  # noqa
-integer_types = (int, long,) if sys.version_info[0] == 2 else (int,)  # noqa
+def str_to_h5py_utf8(str_list):
+    """Convert a string or a list of strings to a numpy array of
+    unicode strings that can be written to HDF5 as utf-8.
+
+    This ensures that the type will be consistent between python 2 and
+    python 3, if attributes or datasets are saved to an HDF5 file.
+    """
+    return numpy.array(str_list, dtype=text_dtype)
 
 
 def _get_number_of_mca_analysers(scan):
@@ -457,10 +471,9 @@ class SpecH5NodeDataset(commonh5.Dataset, SpecH5Dataset):
     def __init__(self, name, data, parent=None, attrs=None):
         # get proper value types, to inherit from numpy
         # attributes (dtype, shape, size)
-        if isinstance(data, string_types):
-            # use bytes for maximum compatibility
-            # (see http://docs.h5py.org/en/latest/strings.html)
-            value = numpy.string_(data)
+        if isinstance(data, six.string_types):
+            # use unicode (utf-8 when saved to HDF5 output)
+            value = str_to_h5py_utf8(data)
         elif isinstance(data, float):
             # use 32 bits for float scalars
             value = numpy.float32(data)
@@ -472,7 +485,8 @@ class SpecH5NodeDataset(commonh5.Dataset, SpecH5Dataset):
             data_kind = array.dtype.kind
 
             if data_kind in ["S", "U"]:
-                value = numpy.asarray(array, dtype=numpy.string_)
+                value = numpy.asarray(array,
+                                      dtype=text_dtype)
             elif data_kind in ["f"]:
                 value = numpy.asarray(array, dtype=numpy.float32)
             else:
@@ -547,12 +561,12 @@ class SpecH5(commonh5.File, SpecH5Group):
 
         self._sf = SpecFile(filename)
 
-        attrs = {"NX_class": "NXroot",
-                 "file_time": datetime.datetime.now().isoformat(),
-                 "file_name": filename,
-                 "creator": "silx spech5 %s" % silx_version}
+        attrs = {"NX_class": u"NXroot",
+                 "file_time": str_to_h5py_utf8(
+                         datetime.datetime.now().isoformat()),
+                 "file_name": str_to_h5py_utf8(filename),
+                 "creator": u"silx spech5 %s" % silx_version}
         commonh5.File.__init__(self, filename, attrs=attrs)
-        assert self.attrs["NX_class"] == "NXroot"
 
         for scan_key in self._sf.keys():
             scan = self._sf[scan_key]
@@ -573,11 +587,12 @@ class ScanGroup(commonh5.Group, SpecH5Group):
         :param scan: specfile.Scan object
         """
         commonh5.Group.__init__(self, scan_key, parent=parent,
-                                attrs={"NX_class": "NXentry"})
+                                attrs={"NX_class": u"NXentry"})
 
-        self.add_node(SpecH5NodeDataset(name="title",
-                                        data=scan.scan_header_dict["S"],
-                                        parent=self))
+        self.add_node(SpecH5NodeDataset(
+                name="title",
+                data=str_to_h5py_utf8(scan.scan_header_dict["S"]),
+                parent=self))
 
         if "D" in scan.scan_header_dict:
             try:
@@ -603,7 +618,7 @@ class ScanGroup(commonh5.Group, SpecH5Group):
                          scan_key)
             start_time_str = ""
         self.add_node(SpecH5NodeDataset(name="start_time",
-                                        data=start_time_str,
+                                        data=str_to_h5py_utf8(start_time_str),
                                         parent=self))
 
         self.add_node(InstrumentGroup(parent=self, scan=scan))
@@ -620,7 +635,7 @@ class InstrumentGroup(commonh5.Group, SpecH5Group):
         :param scan: specfile.Scan object
         """
         commonh5.Group.__init__(self, name="instrument", parent=parent,
-                                attrs={"NX_class": "NXinstrument"})
+                                attrs={"NX_class": u"NXinstrument"})
 
         self.add_node(InstrumentSpecfileGroup(parent=self, scan=scan))
         self.add_node(PositionersGroup(parent=self, scan=scan))
@@ -635,21 +650,24 @@ class InstrumentGroup(commonh5.Group, SpecH5Group):
 class InstrumentSpecfileGroup(commonh5.Group, SpecH5Group):
     def __init__(self, parent, scan):
         commonh5.Group.__init__(self, name="specfile", parent=parent,
-                                attrs={"NX_class": "NXcollection"})
-        self.add_node(SpecH5NodeDataset(name="file_header",
-                                        data="\n".join(scan.file_header),
-                                        parent=self,
-                                        attrs={}))
-        self.add_node(SpecH5NodeDataset(name="scan_header",
-                                        data="\n".join(scan.scan_header),
-                                        parent=self,
-                                        attrs={}))
+                                attrs={"NX_class": u"NXcollection"})
+        self.add_node(SpecH5NodeDataset(
+                name="file_header",
+                data=str_to_h5py_utf8(
+                        "\n".join(scan.file_header)),
+                parent=self,
+                attrs={}))
+        self.add_node(SpecH5NodeDataset(
+                name="scan_header",
+                data=str_to_h5py_utf8("\n".join(scan.scan_header)),
+                parent=self,
+                attrs={}))
 
 
 class PositionersGroup(commonh5.Group, SpecH5Group):
     def __init__(self, parent, scan):
         commonh5.Group.__init__(self, name="positioners", parent=parent,
-                                attrs={"NX_class": "NXcollection"})
+                                attrs={"NX_class": u"NXcollection"})
         for motor_name in scan.motor_names:
             safe_motor_name = motor_name.replace("/", "%")
             if motor_name in scan.labels and scan.data.shape[0] > 0:
@@ -668,7 +686,7 @@ class InstrumentMcaGroup(commonh5.Group, SpecH5Group):
     def __init__(self, parent, analyser_index, scan):
         name = "mca_%d" % analyser_index
         commonh5.Group.__init__(self, name=name, parent=parent,
-                                attrs={"NX_class": "NXdetector"})
+                                attrs={"NX_class": u"NXdetector"})
 
         self.add_node(McaDataDataset(parent=self,
                                      analyser_index=analyser_index,
@@ -707,7 +725,7 @@ class McaDataDataset(SpecH5LazyNodeDataset):
     def __init__(self, parent, analyser_index, scan):
         commonh5.LazyLoadableDataset.__init__(
             self, name="data", parent=parent,
-            attrs={"interpretation": "spectrum", })
+            attrs={"interpretation": u"spectrum", })
         self._scan = scan
         self._analyser_index = analyser_index
         self._shape = None
@@ -741,7 +759,7 @@ class McaDataDataset(SpecH5LazyNodeDataset):
     def __getitem__(self, item):
         # optimization for fetching a single spectrum if data not already loaded
         if not self._is_initialized:
-            if isinstance(item, integer_types):
+            if isinstance(item, six.integer_types):
                 if item < 0:
                     # negative indexing
                     item += len(self)
@@ -750,7 +768,7 @@ class McaDataDataset(SpecH5LazyNodeDataset):
             # accessing a slice or element of a single spectrum [i, j:k]
             try:
                 spectrum_idx, channel_idx_or_slice = item
-                assert isinstance(spectrum_idx, integer_types)
+                assert isinstance(spectrum_idx, six.integer_types)
             except (ValueError, TypeError, AssertionError):
                 pass
             else:
@@ -770,7 +788,7 @@ class MeasurementGroup(commonh5.Group, SpecH5Group):
         :param scan: specfile.Scan object
         """
         commonh5.Group.__init__(self, name="measurement", parent=parent,
-                                attrs={"NX_class": "NXcollection", })
+                                attrs={"NX_class": u"NXcollection", })
         for label in scan.labels:
             safe_label = label.replace("/", "%")
             self.add_node(SpecH5NodeDataset(name=safe_label,
@@ -805,23 +823,23 @@ class SampleGroup(commonh5.Group, SpecH5Group):
         :param scan: specfile.Scan object
         """
         commonh5.Group.__init__(self, name="sample", parent=parent,
-                                attrs={"NX_class": "NXsample", })
+                                attrs={"NX_class": u"NXsample", })
 
         if _unit_cell_in_scan(scan):
             self.add_node(SpecH5NodeDataset(name="unit_cell",
                                             data=_parse_unit_cell(scan.scan_header_dict["G1"]),
                                             parent=self,
-                                            attrs={"interpretation": "scalar"}))
+                                            attrs={"interpretation": u"scalar"}))
             self.add_node(SpecH5NodeDataset(name="unit_cell_abc",
                                             data=_parse_unit_cell(scan.scan_header_dict["G1"])[0, 0:3],
                                             parent=self,
-                                            attrs={"interpretation": "scalar"}))
+                                            attrs={"interpretation": u"scalar"}))
             self.add_node(SpecH5NodeDataset(name="unit_cell_alphabetagamma",
                                             data=_parse_unit_cell(scan.scan_header_dict["G1"])[0, 3:6],
                                             parent=self,
-                                            attrs={"interpretation": "scalar"}))
+                                            attrs={"interpretation": u"scalar"}))
         if _ub_matrix_in_scan(scan):
             self.add_node(SpecH5NodeDataset(name="ub_matrix",
                                             data=_parse_UB_matrix(scan.scan_header_dict["G3"]),
                                             parent=self,
-                                            attrs={"interpretation": "scalar"}))
+                                            attrs={"interpretation": u"scalar"}))

--- a/silx/io/test/test_spech5.py
+++ b/silx/io/test/test_spech5.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -45,7 +45,7 @@ except ImportError:
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "17/01/2018"
+__date__ = "29/01/2018"
 
 sftext = """#F /tmp/sf.dat
 #E 1455180875
@@ -272,9 +272,9 @@ class TestSpecH5(unittest.TestCase):
     def testDate(self):
         # start time is in Iso8601 format
         self.assertEqual(self.sfh5["/1.1/start_time"],
-                         b"2016-02-11T09:55:20")
+                         u"2016-02-11T09:55:20")
         self.assertEqual(self.sfh5["25.1/start_time"],
-                         b"2015-03-14T03:53:50")
+                         u"2015-03-14T03:53:50")
 
     def testDatasetInstanceAttr(self):
         """The SpecH5Dataset objects must implement some dummy attributes
@@ -296,7 +296,7 @@ class TestSpecH5(unittest.TestCase):
                          -3)
 
         self.assertEqual(self.sfh5.get("/1.1/start_time", default=-3),
-                         b"2016-02-11T09:55:20")
+                         u"2016-02-11T09:55:20")
 
     def testGetClass(self):
         """Test :meth:`SpecH5Group.get`"""
@@ -352,13 +352,6 @@ class TestSpecH5(unittest.TestCase):
     def testHeader(self):
         file_header = self.sfh5["/1.2/instrument/specfile/file_header"]
         scan_header = self.sfh5["/1.2/instrument/specfile/scan_header"]
-        # convert ndarray(dtype=numpy.string_) to str
-        if sys.version < '3.0':
-            file_header = str(file_header[()])
-            scan_header = str(scan_header[()])
-        else:
-            file_header = str(file_header.astype(str))
-            scan_header = str(scan_header.astype(str))
 
         # File header has 10 lines
         self.assertEqual(len(file_header.split("\n")), 10)
@@ -368,17 +361,13 @@ class TestSpecH5(unittest.TestCase):
         # line 4 of file header
         self.assertEqual(
                 file_header.split("\n")[3],
-                "#C imaging  User = opid17")
+                u"#C imaging  User = opid17")
         # line 4 of scan header
         scan_header = self.sfh5["25.1/instrument/specfile/scan_header"]
-        if sys.version < '3.0':
-            scan_header = str(scan_header[()])
-        else:
-            scan_header = str(scan_header[()].astype(str))
 
         self.assertEqual(
                 scan_header.split("\n")[3],
-                "#P1 4.74255 6.197579 2.238283")
+                u"#P1 4.74255 6.197579 2.238283")
 
     def testLinks(self):
         self.assertTrue(
@@ -490,7 +479,7 @@ class TestSpecH5(unittest.TestCase):
 
     def testTitle(self):
         self.assertEqual(self.sfh5["/25.1/title"],
-                         b"25  ascan  c3th 1.33245 1.52245  40 0.15")
+                         u"25  ascan  c3th 1.33245 1.52245  40 0.15")
 
     def testValues(self):
         group = self.sfh5["/25.1"]

--- a/silx/io/test/test_spectoh5.py
+++ b/silx/io/test/test_spectoh5.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,7 @@
 """Tests for SpecFile to HDF5 converter"""
 
 import gc
-from numpy import array_equal, string_
+from numpy import array_equal
 import os
 import sys
 import tempfile
@@ -41,7 +41,7 @@ else:
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "02/06/2017"
+__date__ = "29/01/2018"
 
 
 sftext = """#F /tmp/sf.dat
@@ -143,24 +143,22 @@ class TestConvertSpecHDF5(unittest.TestCase):
     def testTitle(self):
         """Test the value of a dataset"""
         title12 = self.h5f["/1.2/title"].value
-        if sys.version > '3.0':
-            title12 = title12.decode()
         self.assertEqual(title12,
-                         "1 aaaaaa")
+                         u"1 aaaaaa")
 
     def testAttrs(self):
         # Test root group (file) attributes
         self.assertEqual(self.h5f.attrs["NX_class"],
-                         string_("NXroot"))
+                         u"NXroot")
         # Test dataset attributes
         ds = self.h5f["/1.2/instrument/mca_1/data"]
         self.assertTrue("interpretation" in ds.attrs)
         self.assertEqual(list(ds.attrs.values()),
-                         [string_("spectrum")])
+                         [u"spectrum"])
         # Test group attributes
         grp = self.h5f["1.1"]
         self.assertEqual(grp.attrs["NX_class"],
-                         string_("NXentry"))
+                         u"NXentry")
         self.assertEqual(len(list(grp.attrs.keys())),
                          1)
 


### PR DESCRIPTION
This PR introduces a change in the way `spech5` exposes strings (bytes -> unicode) and in the way `convert` writes them to HDF5 (ASCII -> utf-8). 