### PR TITLE
Update DataUrl to support our specification

### DIFF
--- a/silx/io/test/test_utils.py
+++ b/silx/io/test/test_utils.py
@@ -49,7 +49,7 @@ except ImportError:
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "11/12/2017"
+__date__ = "29/01/2018"
 
 
 expected_spec1 = r"""#F .*
@@ -553,14 +553,14 @@ class TestGetData(unittest.TestCase):
     def test_hdf5_scalar(self):
         if h5py is None:
             self.skipTest("H5py is missing")
-        url = "silx:%s::/group/group/scalar" % self.h5_filename
+        url = "silx:%s?/group/group/scalar" % self.h5_filename
         data = utils.get_data(url=url)
         self.assertEqual(data, 50)
 
     def test_hdf5_array(self):
         if h5py is None:
             self.skipTest("H5py is missing")
-        url = "silx:%s::/group/group/array" % self.h5_filename
+        url = "silx:%s?/group/group/array" % self.h5_filename
         data = utils.get_data(url=url)
         self.assertEqual(data.shape, (5, ))
         self.assertEqual(data[0], 1)
@@ -568,7 +568,7 @@ class TestGetData(unittest.TestCase):
     def test_hdf5_array_slice(self):
         if h5py is None:
             self.skipTest("H5py is missing")
-        url = "silx:%s::/group/group/array2d[1]" % self.h5_filename
+        url = "silx:%s?path=/group/group/array2d&slice=1" % self.h5_filename
         data = utils.get_data(url=url)
         self.assertEqual(data.shape, (5, ))
         self.assertEqual(data[0], 6)
@@ -576,7 +576,7 @@ class TestGetData(unittest.TestCase):
     def test_hdf5_array_slice_out_of_range(self):
         if h5py is None:
             self.skipTest("H5py is missing")
-        url = "silx:%s::/group/group/array2d[5]" % self.h5_filename
+        url = "silx:%s?path=/group/group/array2d&slice=5" % self.h5_filename
         self.assertRaises(ValueError, utils.get_data, url)
 
     def test_edf_using_silx(self):
@@ -584,7 +584,7 @@ class TestGetData(unittest.TestCase):
             self.skipTest("H5py is missing")
         if fabio is None:
             self.skipTest("fabio is missing")
-        url = "silx:%s::/scan_0/instrument/detector_0/data" % self.edf_filename
+        url = "silx:%s?/scan_0/instrument/detector_0/data" % self.edf_filename
         data = utils.get_data(url=url)
         self.assertEqual(data.shape, (2, 2))
         self.assertEqual(data[0, 0], 10)
@@ -592,7 +592,7 @@ class TestGetData(unittest.TestCase):
     def test_fabio_frame(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        url = "fabio:%s::[1]" % self.edf_multiframe_filename
+        url = "fabio:%s?slice=1" % self.edf_multiframe_filename
         data = utils.get_data(url=url)
         self.assertEqual(data.shape, (2, 2))
         self.assertEqual(data[0, 0], 10)
@@ -600,7 +600,7 @@ class TestGetData(unittest.TestCase):
     def test_fabio_singleframe(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        url = "fabio:%s::[0]" % self.edf_filename
+        url = "fabio:%s?slice=0" % self.edf_filename
         data = utils.get_data(url=url)
         self.assertEqual(data.shape, (2, 2))
         self.assertEqual(data[0, 0], 10)
@@ -608,13 +608,13 @@ class TestGetData(unittest.TestCase):
     def test_fabio_too_much_frames(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        url = "fabio:%s::[...]" % self.edf_multiframe_filename
+        url = "fabio:%s?slice=..." % self.edf_multiframe_filename
         self.assertRaises(ValueError, utils.get_data, url)
 
     def test_fabio_no_frame(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        url = "fabio:%s::" % self.edf_filename
+        url = "fabio:%s?" % self.edf_filename
         self.assertRaises(ValueError, utils.get_data, url)
 
     def test_unsupported_scheme(self):
@@ -624,7 +624,7 @@ class TestGetData(unittest.TestCase):
     def test_no_scheme(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        url = "%s::/group/group/array2d[5]" % self.h5_filename
+        url = "%s?path=/group/group/array2d&slice=5" % self.h5_filename
         self.assertRaises((ValueError, IOError), utils.get_data, url)
 
     def test_file_not_exists(self):

--- a/silx/io/test/test_utils.py
+++ b/silx/io/test/test_utils.py
@@ -411,6 +411,30 @@ class TestOpen(unittest.TestCase):
         # load it
         self.assertRaises(IOError, utils.open, self.missing_filename)
 
+    def test_silx_scheme(self):
+        if h5py is None:
+            self.skipTest("H5py is missing")
+        url = silx.io.url.DataUrl(scheme="silx", file_path=self.h5_filename, data_path="/")
+        with utils.open(url.path()) as f:
+            self.assertIsNotNone(f)
+            self.assertTrue(silx.io.utils.is_file(f))
+
+    def test_fabio_scheme(self):
+        if h5py is None:
+            self.skipTest("H5py is missing")
+        if fabio is None:
+            self.skipTest("Fabio is missing")
+        url = silx.io.url.DataUrl(scheme="fabio", file_path=self.edf_filename)
+        self.assertRaises(IOError, utils.open, url.path())
+
+    def test_bad_url(self):
+        url = silx.io.url.DataUrl(scheme="sil", file_path=self.h5_filename)
+        self.assertRaises(IOError, utils.open, url.path())
+
+    def test_sliced_url(self):
+        url = silx.io.url.DataUrl(file_path=self.h5_filename, data_slice=(5,))
+        self.assertRaises(IOError, utils.open, url.path())
+
 
 class TestNodes(unittest.TestCase):
     """Test `silx.io.utils.is_` functions."""

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["P. Knobel", "V. Valls"]
 __license__ = "MIT"
-__date__ = "19/12/2017"
+__date__ = "29/01/2018"
 
 import numpy
 import os.path
@@ -432,7 +432,7 @@ def h5ls(h5group, lvl=0):
     return h5repr
 
 
-def _open(filename):
+def _open_local_file(filename):
     """
     Load a file as an `h5py.File`-like object.
 
@@ -448,19 +448,6 @@ def _open(filename):
     :raises: IOError if the file can't be loaded as an h5py.File like object
     :rtype: h5py.File
     """
-    if "://" in filename:
-        uri = six.moves.urllib.parse.urlparse(filename)
-        if uri.netloc == '' or uri.scheme in ['', 'file']:
-            filename = uri.path
-        else:
-            if h5pyd is None:
-                raise IOError("URI '%s' unsupported. Try to install h5pyd." % filename)
-            path = uri.path
-            endpoint = "%s://%s" % (uri.scheme, uri.netloc)
-            if path.startswith("/"):
-                path = path[1:]
-            return h5pyd.File(path, 'r', endpoint=endpoint)
-
     if not os.path.isfile(filename):
         raise IOError("Filename '%s' must be a file path" % filename)
 
@@ -571,24 +558,40 @@ def open(filename):  # pylint:disable=redefined-builtin
     :raises: IOError if the file can't be loaded or path can't be found
     :rtype: h5py-like node
     """
-    if "::" in filename:
-        filename, h5_path = filename.split("::")
+    url = silx.io.url.DataUrl(filename)
+
+    if url.scheme() in [None, "file", "silx"]:
+        # That's a local file
+        if not url.is_valid():
+            raise IOError("URL '%s' is not valid" % filename)
+        h5_file = _open_local_file(url.file_path())
+    elif url.scheme() in ["fabio"]:
+        raise IOError("URL '%s' containing fabio scheme is not supported" % filename)
     else:
-        filename, h5_path = filename, "/"
+        # That's maybe an URL supported by h5pyd
+        uri = six.moves.urllib.parse.urlparse(filename)
+        if h5pyd is None:
+            raise IOError("URL '%s' unsupported. Try to install h5pyd." % filename)
+        path = uri.path
+        endpoint = "%s://%s" % (uri.scheme, uri.netloc)
+        if path.startswith("/"):
+            path = path[1:]
+        return h5pyd.File(path, 'r', endpoint=endpoint)
 
-    h5_file = _open(filename)
+    if url.data_slice():
+        raise IOError("URL '%s' containing slicing is not supported" % filename)
 
-    if h5_path in ["/", ""]:
-        # Short cut
+    if url.data_path() in [None, "/", ""]:
+        # The full file is requested
         return h5_file
-
-    if h5_path not in h5_file:
-        msg = "File '%s' do not contains path '%s'." % (filename, h5_path)
-        raise IOError(msg)
-
-    node = h5_file[h5_path]
-    proxy = _MainNode(node, h5_file)
-    return proxy
+    else:
+        # Only a children is requested
+        if url.data_path() not in h5_file:
+            msg = "File '%s' does not contain path '%s'." % (filename, url.data_path())
+            raise IOError(msg)
+        node = h5_file[url.data_path()]
+        proxy = _MainNode(node, h5_file)
+        return proxy
 
 
 @deprecated

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -594,26 +594,6 @@ def open(filename):  # pylint:disable=redefined-builtin
         return proxy
 
 
-@deprecated
-def load(filename):
-    """
-    Load a file as an `h5py.File`-like object.
-
-    Format supported:
-    - h5 files, if `h5py` module is installed
-    - Spec files if `SpecFile` module is installed
-
-    .. deprecated:: 0.4
-        Use :meth:`open`, or :meth:`silx.io.open`. Will be removed in
-        Silx 0.5.
-
-    :param str filename: A filename
-    :raises: IOError if the file can't be loaded as an h5py.File like object
-    :rtype: h5py.File
-    """
-    return open(filename)
-
-
 def _get_classes_type():
     """Returns a mapping between Python classes and HDF5 concepts.
 


### PR DESCRIPTION
- Use `?` or `::` as separator
- Use `path=` and `slice=` for data selection
- Implement `__str__, __repr__, __eq__, __ne__` for convenience
- Support `silx:` from `silx.io.open`
- Remove the old `silx.io.load` (which was an alias to `silx.io.open`)

Closes #1392