### PR TITLE
[convert] fix bug with None @file_name

### DIFF
--- a/silx/app/test/test_convert.py
+++ b/silx/app/test/test_convert.py
@@ -155,7 +155,7 @@ class TestConvertCommand(unittest.TestCase):
             if sys.version < '3.0':
                 title12 = title12.encode("utf-8")
             self.assertEqual(title12,
-                             "1 aaaaaa")
+                             "aaaaaa")
 
             creator = h5f.attrs.get("creator")
             self.assertIsNotNone(creator, "No creator attribute in NXroot group")

--- a/silx/io/fabioh5.py
+++ b/silx/io/fabioh5.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -869,8 +869,9 @@ class File(commonh5.File):
 
         attrs = {"NX_class": "NXroot",
                  "file_time": datetime.datetime.now().isoformat(),
-                 "file_name": file_name,
                  "creator": "silx %s" % silx_version}
+        if file_name is not None:
+            attrs["file_name"] = file_name
         commonh5.File.__init__(self, name=file_name, attrs=attrs)
         scan = self.create_scan_group(self.__fabio_reader)
         self.add_node(scan)

--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -655,13 +655,12 @@ class InstrumentSpecfileGroup(commonh5.Group, SpecH5Group):
                                 attrs={"NX_class": to_h5py_utf8("NXcollection")})
         self.add_node(SpecH5NodeDataset(
                 name="file_header",
-                data=to_h5py_utf8(
-                        "\n".join(scan.file_header)),
+                data=to_h5py_utf8(scan.file_header),
                 parent=self,
                 attrs={}))
         self.add_node(SpecH5NodeDataset(
                 name="scan_header",
-                data=to_h5py_utf8("\n".join(scan.scan_header)),
+                data=to_h5py_utf8(scan.scan_header),
                 parent=self,
                 attrs={}))
 

--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -589,10 +589,12 @@ class ScanGroup(commonh5.Group, SpecH5Group):
         commonh5.Group.__init__(self, scan_key, parent=parent,
                                 attrs={"NX_class": to_h5py_utf8("NXentry")})
 
-        self.add_node(SpecH5NodeDataset(
-                name="title",
-                data=to_h5py_utf8(scan.scan_header_dict["S"]),
-                parent=self))
+        # take title in #S after stripping away scan number and spaces
+        s_hdr_line = scan.scan_header_dict["S"]
+        title = s_hdr_line.lstrip("0123456789").lstrip()
+        self.add_node(SpecH5NodeDataset(name="title",
+                                        data=to_h5py_utf8(title),
+                                        parent=self))
 
         if "D" in scan.scan_header_dict:
             try:

--- a/silx/io/test/test_spech5.py
+++ b/silx/io/test/test_spech5.py
@@ -354,19 +354,19 @@ class TestSpecH5(unittest.TestCase):
         scan_header = self.sfh5["/1.2/instrument/specfile/scan_header"]
 
         # File header has 10 lines
-        self.assertEqual(len(file_header.split("\n")), 10)
+        self.assertEqual(len(file_header), 10)
         # 1.2 has 9 scan & mca header lines
-        self.assertEqual(len(scan_header.split("\n")), 9)
+        self.assertEqual(len(scan_header), 9)
 
         # line 4 of file header
         self.assertEqual(
-                file_header.split("\n")[3],
+                file_header[3],
                 u"#C imaging  User = opid17")
         # line 4 of scan header
         scan_header = self.sfh5["25.1/instrument/specfile/scan_header"]
 
         self.assertEqual(
-                scan_header.split("\n")[3],
+                scan_header[3],
                 u"#P1 4.74255 6.197579 2.238283")
 
     def testLinks(self):

--- a/silx/io/test/test_spech5.py
+++ b/silx/io/test/test_spech5.py
@@ -479,7 +479,7 @@ class TestSpecH5(unittest.TestCase):
 
     def testTitle(self):
         self.assertEqual(self.sfh5["/25.1/title"],
-                         u"25  ascan  c3th 1.33245 1.52245  40 0.15")
+                         u"ascan  c3th 1.33245 1.52245  40 0.15")
 
     def testValues(self):
         group = self.sfh5["/25.1"]

--- a/silx/io/test/test_spectoh5.py
+++ b/silx/io/test/test_spectoh5.py
@@ -144,7 +144,7 @@ class TestConvertSpecHDF5(unittest.TestCase):
         """Test the value of a dataset"""
         title12 = self.h5f["/1.2/title"].value
         self.assertEqual(title12,
-                         u"1 aaaaaa")
+                         u"aaaaaa")
 
     def testAttrs(self):
         # Test root group (file) attributes


### PR DESCRIPTION
Closes #1537 

In a file series, don't fill the file_name attribute.

Also, add another layer of checking attribute types in `silx.io.convert`, to ensure they are encoded as utf-8 in the HDF5 output, so we can always read them back as unicode. This was not necessarily the case with `fabioh5` objects converted with python2.