### PR TITLE
[CI] Xorg rather than Xvfb on travis linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ before_script:
     - if [ "$TRAVIS_OS_NAME" == "linux" ];
       then
           export DISPLAY=:99.0;
-          Xorg -noreset +extension GLX +extension RANDR +extension RENDER -logfile ./99.log -config ./ci/travis-xorg.conf :99
+          Xorg -noreset +extension GLX +extension RANDR +extension RENDER -logfile ./99.log -config ./ci/travis-xorg.conf :99 &
           sleep 3;
       fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,12 +72,13 @@ install:
     - ls dist
 
 before_script:
-    # Start X Virtual Framebuffer useful for GUI testing
-    # Doc: https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
+    # Start X server with dummy video dirver
+    # Use this instead of Xvfb to have RANDR extension
+    # Otherwise there is a bug with Qt5.10.0
     - if [ "$TRAVIS_OS_NAME" == "linux" ];
       then
           export DISPLAY=:99.0;
-          sh -e /etc/init.d/xvfb start;
+          Xorg -noreset +extension GLX +extension RANDR +extension RENDER -logfile ./99.log -config ./ci/travis-xorg.conf :99
           sleep 3;
       fi
 

--- a/ci/travis-xorg.conf
+++ b/ci/travis-xorg.conf
@@ -1,0 +1,21 @@
+Section "Device"
+    Identifier  "Video Device"
+    Driver      "dummy"
+EndSection
+
+Section "Monitor"
+    Identifier  "Monitor"
+    HorizSync 31.5-48.5
+    VertRefresh 50-70
+EndSection
+
+Section "Screen"
+    Identifier  "Default Screen"
+    Monitor     "Monitor"
+    Device      "Video Device"
+    DefaultDepth 24
+    SubSection "Display"
+    Depth 24
+    Modes "1024x768"
+    EndSubSection
+EndSection


### PR DESCRIPTION
This workaround a seg fault in Qt most probably due to a bug in Qt 5.10.0 when RANDR extension is missing.

Closes #1521