### PR TITLE
Forward compatibility with Python 10.0

### DIFF
--- a/silx/app/test/test_convert.py
+++ b/silx/app/test/test_convert.py
@@ -135,7 +135,7 @@ class TestConvertCommand(unittest.TestCase):
         # write a temporary SPEC file
         specname = os.path.join(tempdir, "input.dat")
         with io.open(specname, "wb") as fd:
-            if sys.version < '3.0':
+            if sys.version_info < (3, ):
                 fd.write(sftext)
             else:
                 fd.write(bytes(sftext, 'ascii'))
@@ -152,14 +152,14 @@ class TestConvertCommand(unittest.TestCase):
 
         with h5py.File(h5name, "r") as h5f:
             title12 = h5f["/1.2/title"][()]
-            if sys.version < '3.0':
+            if sys.version_info < (3, ):
                 title12 = title12.encode("utf-8")
             self.assertEqual(title12,
                              "aaaaaa")
 
             creator = h5f.attrs.get("creator")
             self.assertIsNotNone(creator, "No creator attribute in NXroot group")
-            if sys.version < '3.0':
+            if sys.version_info < (3, ):
                 creator = creator.encode("utf-8")
             self.assertIn("silx convert (v%s)" % silx.version, creator)
 

--- a/silx/gui/plot/backends/glutils/PlotImageFile.py
+++ b/silx/gui/plot/backends/glutils/PlotImageFile.py
@@ -93,7 +93,7 @@ def saveImageToFile(data, fileNameOrObj, fileFormat):
     assert fileFormat in ('png', 'ppm', 'svg', 'tiff')
 
     if not hasattr(fileNameOrObj, 'write'):
-        if sys.version < "3.0":
+        if sys.version_info < (3, ):
             fileObj = open(fileNameOrObj, "wb")
         else:
             if fileFormat in ('png', 'ppm', 'tiff'):

--- a/silx/gui/qt/_qt.py
+++ b/silx/gui/qt/_qt.py
@@ -104,7 +104,7 @@ else:  # Then try Qt bindings
 if BINDING == 'PyQt4':
     _logger.debug('Using PyQt4 bindings')
 
-    if sys.version < "3.0.0":
+    if sys.version_info < (3, ):
         try:
             import sip
 

--- a/silx/io/configdict.py
+++ b/silx/io/configdict.py
@@ -92,7 +92,7 @@ from collections import OrderedDict
 import numpy
 import re
 import sys
-if sys.version < '3.0':
+if sys.version_info < (3, ):
     import ConfigParser as configparser
 else:
     import configparser
@@ -475,7 +475,7 @@ class ConfigDict(OrderedDict):
         # Escape commas
         sstr = sstr.replace(",", "\,")
 
-        if sys.version > '3.0':
+        if sys.version_info >= (3, ):
             # Escape % characters except in "%%" and "%("
             sstr = re.sub(r'%([^%\(])', r'%%\1', sstr)
 

--- a/silx/io/specfile.pyx
+++ b/silx/io/specfile.pyx
@@ -614,7 +614,7 @@ class Scan(object):
 
 def _string_to_char_star(string_):
     """Convert a string to ASCII encoded bytes when using python3"""
-    if sys.version.startswith("3") and not isinstance(string_, bytes):
+    if sys.version_info[0] >= 3 and not isinstance(string_, bytes):
         return bytes(string_, "ascii")
     return string_
 

--- a/silx/io/test/test_specfile.py
+++ b/silx/io/test/test_specfile.py
@@ -136,14 +136,14 @@ class TestSpecFile(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         fd, cls.fname1 = tempfile.mkstemp(text=False)
-        if sys.version < '3.0':
+        if sys.version_info < (3, ):
             os.write(fd, sftext)
         else:
             os.write(fd, bytes(sftext, 'ascii'))
         os.close(fd)
 
         fd2, cls.fname2 = tempfile.mkstemp(text=False)
-        if sys.version < '3.0':
+        if sys.version_info < (3, ):
             os.write(fd2, sftext[370:923])
         else:
             os.write(fd2, bytes(sftext[370:923], 'ascii'))
@@ -151,7 +151,7 @@ class TestSpecFile(unittest.TestCase):
 
         fd3, cls.fname3 = tempfile.mkstemp(text=False)
         txt = sftext[371:923]
-        if sys.version < '3.0':
+        if sys.version_info < (3, ):
             os.write(fd3, txt)
         else:
             os.write(fd3, bytes(txt, 'ascii'))
@@ -382,7 +382,7 @@ class TestSFLocale(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         fd, cls.fname = tempfile.mkstemp(text=False)
-        if sys.version < '3.0':
+        if sys.version_info < (3, ):
             os.write(fd, sftext)
         else:
             os.write(fd, bytes(sftext, 'ascii'))

--- a/silx/io/test/test_specfilewrapper.py
+++ b/silx/io/test/test_specfilewrapper.py
@@ -113,7 +113,7 @@ class TestSpecfilewrapper(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         fd, cls.fname1 = tempfile.mkstemp(text=False)
-        if sys.version < '3.0':
+        if sys.version_info < (3, ):
             os.write(fd, sftext)
         else:
             os.write(fd, bytes(sftext, 'ascii'))

--- a/silx/io/test/test_spech5.py
+++ b/silx/io/test/test_spech5.py
@@ -215,7 +215,7 @@ class TestSpecH5(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         fd, cls.fname = tempfile.mkstemp()
-        if sys.version < '3.0':
+        if sys.version_info < (3, ):
             os.write(fd, sftext)
         else:
             os.write(fd, bytes(sftext, 'ascii'))
@@ -611,7 +611,7 @@ class TestSpecH5MultiMca(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         fd, cls.fname = tempfile.mkstemp(text=False)
-        if sys.version < '3.0':
+        if sys.version_info < (3, ):
             os.write(fd, sftext_multi_mca_headers)
         else:
             os.write(fd, bytes(sftext_multi_mca_headers, 'ascii'))
@@ -741,7 +741,7 @@ class TestSpecH5NoDataCols(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         fd, cls.fname = tempfile.mkstemp()
-        if sys.version < '3.0':
+        if sys.version_info < (3, ):
             os.write(fd, sftext_no_cols)
         else:
             os.write(fd, bytes(sftext_no_cols, 'ascii'))
@@ -812,7 +812,7 @@ class TestSpecH5SlashInLabels(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         fd, cls.fname = tempfile.mkstemp()
-        if sys.version < '3.0':
+        if sys.version_info < (3, ):
             os.write(fd, sf_text_slash)
         else:
             os.write(fd, bytes(sf_text_slash, 'ascii'))

--- a/silx/io/test/test_spectoh5.py
+++ b/silx/io/test/test_spectoh5.py
@@ -93,7 +93,7 @@ class TestConvertSpecHDF5(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         fd, cls.spec_fname = tempfile.mkstemp(text=False)
-        if sys.version < '3.0':
+        if sys.version_info < (3, ):
             os.write(fd, sftext)
         else:
             os.write(fd, bytes(sftext, 'ascii'))


### PR DESCRIPTION
I coded a lot of `sys.version < "3.0"`, so I fixed all of them in silx. 

I did not touch the *third_party* subpackage.