### PR TITLE
[CI] Use a different version of pyopencl depending on wheel availability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,7 +89,10 @@ before_script:
       fi
 
     # Install optional dependencies for running test
-    - pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ pyopencl==2015.1
+    - if [ "$TRAVIS_PYTHON_VERSION" != "3.6" ];
+      then
+          pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ pyopencl==2015.1;
+      fi
     # This installs PyQt and scipy if wheels are available
     - pip install --pre -r requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
           env:
               - BUILD_COMMAND=sdist
               - WITH_QT_TEST=False
+              - PYOPENCL_VERSION=2015.1
 
         - python: 3.4
           os: linux
@@ -20,24 +21,28 @@ matrix:
               - BUILD_COMMAND=sdist
               - WITH_QT_TEST=False
               - PIP_INSTALL_EXTRA_ARGS="--global-option build --global-option --debug"
+              - PYOPENCL_VERSION=2015.1
 
         - python: 3.5
           os: linux
           env:
               - BUILD_COMMAND=sdist
               - WITH_QT_TEST=True
+              - PYOPENCL_VERSION=2015.1
               
         - python: 3.6
           os: linux
           env:
               - BUILD_COMMAND=sdist
               - WITH_QT_TEST=True
+              - PYOPENCL_VERSION=2018.1
 
         - language: generic
           os: osx
           env:
               - BUILD_COMMAND=bdist_wheel
               - WITH_QT_TEST=True
+              - PYOPENCL_VERSION=2017.2
 
 cache:
     apt: true
@@ -89,10 +94,7 @@ before_script:
       fi
 
     # Install optional dependencies for running test
-    - if [ "$TRAVIS_PYTHON_VERSION" != "3.6" ];
-      then
-          pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ pyopencl==2015.1;
-      fi
+    - pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ pyopencl==$PYOPENCL_VERSION
     # This installs PyQt and scipy if wheels are available
     - pip install --pre -r requirements.txt
 


### PR DESCRIPTION
I made the wheel for pyopencl 2018.1 for python3.6, let's try to use it....