### PR TITLE
[plot3d] Add bounding boxes to SceneWindow items

### DIFF
--- a/doc/source/modules/gui/plot3d/items.rst
+++ b/doc/source/modules/gui/plot3d/items.rst
@@ -110,7 +110,6 @@ The following classes allows to configure :class:`ScalarField3D` visualization:
              getNormal, setNormal,
              getPoint, setPoint,
              getParameters,
-             getStrokeColor, setStrokeColor
 
 Clipping plane
 --------------

--- a/examples/plot3dSceneWindow.py
+++ b/examples/plot3dSceneWindow.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -61,7 +61,8 @@ window = SceneWindow()
 # Get the SceneWidget contained in the window and set its colors
 sceneWidget = window.getSceneWidget()
 sceneWidget.setBackgroundColor((0.8, 0.8, 0.8, 1.))
-sceneWidget.setForegroundColor((0.1, 0.1, 0.1, 1.))
+sceneWidget.setForegroundColor((1., 1., 1., 1.))
+sceneWidget.setTextColor((0.1, 0.1, 0.1, 1.))
 
 
 # 2D Image ###

--- a/examples/plot3dSceneWindow.py
+++ b/examples/plot3dSceneWindow.py
@@ -122,7 +122,6 @@ for row, heightMap in enumerate((False, True)):
 # The group children share the group transform
 group = items.GroupItem()  # Create a new group item
 group.setTranslation(SIZE * 4, 0., 0.)  # Translate the group
-sceneWidget.addItem(group)  # Add the group as an item of the scene
 
 
 # Clipping plane ###
@@ -188,6 +187,8 @@ cutPlane.setVisible(True)  # Set it to be visible
 cutPlane.getColormap().setName('jet')  # Set cut plane's colormap
 cutPlane.setNormal((0., 0., 1.))  # Set cut plane's normal
 cutPlane.moveToCenter()  # Place the cut plane at the center of the volume
+
+sceneWidget.addItem(group)  # Add the group as an item of the scene
 
 # Show the SceneWidget widget
 window.show()

--- a/silx/gui/plot3d/SceneWidget.py
+++ b/silx/gui/plot3d/SceneWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -52,6 +52,7 @@ class SceneWidget(Plot3DWidget):
         self._model = None
         self._items = []
 
+        self._textColor = 1., 1., 1., 1.
         self._foregroundColor = 1., 1., 1., 1.
         self._highlightColor = 0.7, 0.7, 0., 1.
 
@@ -272,11 +273,32 @@ class SceneWidget(Plot3DWidget):
 
     def _updateColors(self):
         """Update item depending on foreground/highlight color"""
-        self._bbox.tickColor = self._foregroundColor
-        self._bbox.color = self._highlightColor
+        self._bbox.tickColor = self._textColor
+        self._bbox.color = self._foregroundColor
+
+    def getTextColor(self):
+        """Return color used for text
+
+        :rtype: QColor"""
+        return qt.QColor.fromRgbF(*self._textColor)
+
+    def setTextColor(self, color):
+        """Set the text color.
+
+        :param color: RGB color: name, #RRGGBB or RGB values
+        :type color:
+            QColor, str or array-like of 3 or 4 float in [0., 1.] or uint8
+        """
+        color = rgba(color)
+        if color != self._textColor:
+            self._textColor = color
+            self._updateColors()
 
     def getForegroundColor(self):
-        """Return color used for text and bounding box (QColor)"""
+        """Return color used for bounding box
+
+        :rtype: QColor
+        """
         return qt.QColor.fromRgbF(*self._foregroundColor)
 
     def setForegroundColor(self, color):
@@ -292,7 +314,10 @@ class SceneWidget(Plot3DWidget):
             self._updateColors()
 
     def getHighlightColor(self):
-        """Return color used for highlighted item bounding box (QColor)"""
+        """Return color used for highlighted item bounding box
+
+        :rtype: QColor
+        """
         return qt.QColor.fromRgbF(*self._highlightColor)
 
     def setHighlightColor(self, color):

--- a/silx/gui/plot3d/SceneWidget.py
+++ b/silx/gui/plot3d/SceneWidget.py
@@ -313,6 +313,11 @@ class SceneWidget(Plot3DWidget):
             self._foregroundColor = color
             self._updateColors()
 
+            # Update scene items
+            for item in self.getSceneGroup().visit():
+                if isinstance(item, items.DataItem3D):
+                    item._setBoundingBoxColor(color)
+
     def getHighlightColor(self):
         """Return color used for highlighted item bounding box
 

--- a/silx/gui/plot3d/SceneWidget.py
+++ b/silx/gui/plot3d/SceneWidget.py
@@ -198,63 +198,6 @@ class SceneWidget(Plot3DWidget):
         """Remove all item from :class:`SceneWidget`."""
         return self.getSceneGroup().clear()
 
-    # Axes labels
-
-    def setAxesLabels(self, xlabel=None, ylabel=None, zlabel=None):
-        """Set the text labels of the axes.
-
-        :param str xlabel: Label of the X axis, None to leave unchanged.
-        :param str ylabel: Label of the Y axis, None to leave unchanged.
-        :param str zlabel: Label of the Z axis, None to leave unchanged.
-        """
-        bbox = self._sceneGroup._getScenePrimitive()  # TODO move in group
-        if xlabel is not None:
-            bbox.xlabel = xlabel
-
-        if ylabel is not None:
-            bbox.ylabel = ylabel
-
-        if zlabel is not None:
-            bbox.zlabel = zlabel
-
-    class _Labels(tuple):
-        """Return type of :meth:`getAxesLabels`"""
-
-        def getXLabel(self):
-            """Label of the X axis (str)"""
-            return self[0]
-
-        def getYLabel(self):
-            """Label of the Y axis (str)"""
-            return self[1]
-
-        def getZLabel(self):
-            """Label of the Z axis (str)"""
-            return self[2]
-
-    def getAxesLabels(self):
-        """Returns the text labels of the axes
-
-        >>> widget = SceneWidget()
-        >>> widget.setAxesLabels(xlabel='X')
-
-        You can get the labels either as a 3-tuple:
-
-        >>> xlabel, ylabel, zlabel = widget.getAxesLabels()
-
-        Or as an object with methods getXLabel, getYLabel and getZLabel:
-
-        >>> labels = widget.getAxesLabels()
-        >>> labels.getXLabel()
-        ... 'X'
-
-        :return: object describing the labels
-        """
-        bbox = self._sceneGroup._getScenePrimitive()  # TODO move in group
-        return self._Labels((bbox.xlabel,
-                             bbox.ylabel,
-                             bbox.zlabel))
-
     # Colors
 
     def _updateColors(self):

--- a/silx/gui/plot3d/SceneWidget.py
+++ b/silx/gui/plot3d/SceneWidget.py
@@ -56,12 +56,10 @@ class SceneWidget(Plot3DWidget):
         self._foregroundColor = 1., 1., 1., 1.
         self._highlightColor = 0.7, 0.7, 0., 1.
 
-        self._sceneGroup = items.GroupItem(parent=self)
+        self._sceneGroup = items.GroupWithAxesItem(parent=self)
         self._sceneGroup.setLabel('Data')
 
-        self._bbox = axes.LabelledAxes()
-        self._bbox.children = [self._sceneGroup._getScenePrimitive()]
-        self.viewport.scene.children.append(self._bbox)
+        self.viewport.scene.children.append(self._sceneGroup._getScenePrimitive())
 
     def model(self):
         """Returns the model corresponding the scene of this widget
@@ -202,20 +200,6 @@ class SceneWidget(Plot3DWidget):
 
     # Axes labels
 
-    def isBoundingBoxVisible(self):
-        """Returns axes labels, grid and bounding box visibility.
-
-        :rtype: bool
-        """
-        return self._bbox.boxVisible
-
-    def setBoundingBoxVisible(self, visible):
-        """Set axes labels, grid and bounding box visibility.
-
-        :param bool visible: True to show axes, False to hide
-        """
-        self._bbox.boxVisible = bool(visible)
-
     def setAxesLabels(self, xlabel=None, ylabel=None, zlabel=None):
         """Set the text labels of the axes.
 
@@ -223,14 +207,15 @@ class SceneWidget(Plot3DWidget):
         :param str ylabel: Label of the Y axis, None to leave unchanged.
         :param str zlabel: Label of the Z axis, None to leave unchanged.
         """
+        bbox = self._sceneGroup._getScenePrimitive()  # TODO move in group
         if xlabel is not None:
-            self._bbox.xlabel = xlabel
+            bbox.xlabel = xlabel
 
         if ylabel is not None:
-            self._bbox.ylabel = ylabel
+            bbox.ylabel = ylabel
 
         if zlabel is not None:
-            self._bbox.zlabel = zlabel
+            bbox.zlabel = zlabel
 
     class _Labels(tuple):
         """Return type of :meth:`getAxesLabels`"""
@@ -265,16 +250,18 @@ class SceneWidget(Plot3DWidget):
 
         :return: object describing the labels
         """
-        return self._Labels((self._bbox.xlabel,
-                             self._bbox.ylabel,
-                             self._bbox.zlabel))
+        bbox = self._sceneGroup._getScenePrimitive()  # TODO move in group
+        return self._Labels((bbox.xlabel,
+                             bbox.ylabel,
+                             bbox.zlabel))
 
     # Colors
 
     def _updateColors(self):
         """Update item depending on foreground/highlight color"""
-        self._bbox.tickColor = self._textColor
-        self._bbox.color = self._foregroundColor
+        bbox = self._sceneGroup._getScenePrimitive()  # TODO move in group
+        bbox.tickColor = self._textColor
+        bbox.color = self._foregroundColor
 
     def getTextColor(self):
         """Return color used for text

--- a/silx/gui/plot3d/SceneWidget.py
+++ b/silx/gui/plot3d/SceneWidget.py
@@ -315,8 +315,7 @@ class SceneWidget(Plot3DWidget):
 
             # Update scene items
             for item in self.getSceneGroup().visit():
-                if isinstance(item, items.DataItem3D):
-                    item._setBoundingBoxColor(color)
+                item._setForegroundColor(color)
 
     def getHighlightColor(self):
         """Return color used for highlighted item bounding box

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -252,6 +252,20 @@ class Item3DRow(StaticRow):
         return super(Item3DRow, self).setData(column, value, role)
 
 
+class DataItem3DBoundingBoxRow(ProxyRow):
+    """Represents :class:`DataItem3D` bounding box visibility
+
+    :param DataItem3D item: The item for which to display/control bounding box
+    """
+
+    def __init__(self, item):
+        super(DataItem3DBoundingBoxRow, self).__init__(
+            name='Bounding box',
+            fget=item.isBoundingBoxVisible,
+            fset=item.setBoundingBoxVisible,
+            notify=item.sigItemChanged)
+
+
 class MatrixProxyRow(ProxyRow):
     """Proxy for a row of a DataItem3D 3x3 matrix transform
 
@@ -1335,6 +1349,7 @@ def nodeFromItem(item):
     node = Item3DRow(item)
 
     if isinstance(item, items.DataItem3D):
+        node.addRow(DataItem3DBoundingBoxRow(item))
         node.addRow(DataItem3DTransformRow(item))
 
     # Specific extra init

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -481,8 +481,12 @@ class GroupItemRow(Item3DRow):
     :param str name: The optional name of the group
     """
 
+    _CHILDREN_ROW_OFFSET = 2
+    """Number of rows for group parameters. Children are added after"""
+
     def __init__(self, item, name=None):
         super(GroupItemRow, self).__init__(item, name)
+        self.addRow(DataItem3DBoundingBoxRow(item))
         self.addRow(DataItem3DTransformRow(item))
 
         item.sigItemAdded.connect(self._itemAdded)
@@ -501,7 +505,7 @@ class GroupItemRow(Item3DRow):
             return
 
         row = group.getItems().index(item)
-        self.addRow(nodeFromItem(item), row + 1)
+        self.addRow(nodeFromItem(item), row + self._CHILDREN_ROW_OFFSET)
 
     def _itemRemoved(self, item):
         """Handle item removal from the group and remove it from the model.

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -151,6 +151,11 @@ class Settings(StaticRow):
             fget=sceneWidget.getForegroundColor,
             fset=sceneWidget.setForegroundColor)
 
+        text = ColorProxyRow(
+            name='Text',
+            fget=sceneWidget.getTextColor,
+            fset=sceneWidget.setTextColor)
+
         highlight = ColorProxyRow(
             name='Highlight',
             fget=sceneWidget.getHighlightColor,
@@ -188,7 +193,7 @@ class Settings(StaticRow):
                                    children=(azimuthNode, altitudeNode))
 
         # Settings row
-        children = (background, foreground, highlight,
+        children = (background, foreground, text, highlight,
                     boundingBox, axesIndicator, lightDirection)
         super(Settings, self).__init__(('Settings', None), children=children)
 

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -161,11 +161,6 @@ class Settings(StaticRow):
             fget=sceneWidget.getHighlightColor,
             fset=sceneWidget.setHighlightColor)
 
-        boundingBox = ProxyRow(
-            name='Bounding Box',
-            fget=sceneWidget.isBoundingBoxVisible,
-            fset=sceneWidget.setBoundingBoxVisible)
-
         axesIndicator = ProxyRow(
             name='Axes Indicator',
             fget=sceneWidget.isOrientationIndicatorVisible,
@@ -194,7 +189,7 @@ class Settings(StaticRow):
 
         # Settings row
         children = (background, foreground, text, highlight,
-                    boundingBox, axesIndicator, lightDirection)
+                    axesIndicator, lightDirection)
         super(Settings, self).__init__(('Settings', None), children=children)
 
 
@@ -1344,7 +1339,7 @@ def nodeFromItem(item):
     assert isinstance(item, items.Item3D)
 
     # Item with specific model row class
-    if isinstance(item, items.GroupItem):
+    if isinstance(item, (items.GroupItem, items.GroupWithAxesItem)):
         return GroupItemRow(item)
     elif isinstance(item, Isosurface):
         return IsosurfaceRow(item)

--- a/silx/gui/plot3d/items/__init__.py
+++ b/silx/gui/plot3d/items/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,7 @@ __license__ = "MIT"
 __date__ = "15/11/2017"
 
 
-from .core import DataItem3D, Item3D, GroupItem  # noqa
+from .core import DataItem3D, Item3D, GroupItem, GroupWithAxesItem  # noqa
 from .core import ItemChangedType, Item3DChangedType  # noqa
 from .mixins import (ColormapMixIn, InterpolationMixIn,  # noqa
                      PlaneMixIn, SymbolMixIn)  # noqa

--- a/silx/gui/plot3d/items/core.py
+++ b/silx/gui/plot3d/items/core.py
@@ -109,7 +109,7 @@ class Item3D(qt.QObject):
                 parent.sigItemChanged.disconnect(self._parentItemChanged)
 
         elif event.type() == qt.QEvent.ParentChange:
-            self.sigItemChanged.emit(Item3DChangedType.ROOT_ITEM)
+            self._updated(Item3DChangedType.ROOT_ITEM)
 
             parent = self.parent()
             if isinstance(parent, Item3D):
@@ -123,7 +123,7 @@ class Item3D(qt.QObject):
         :param Item3DChangedType event:
         """
         if event == Item3DChangedType.ROOT_ITEM:
-            self.sigItemChanged.emit(Item3DChangedType.ROOT_ITEM)
+            self._updated(Item3DChangedType.ROOT_ITEM)
 
     def root(self):
         """Returns the root of the scene this item belongs to.

--- a/silx/gui/plot3d/items/core.py
+++ b/silx/gui/plot3d/items/core.py
@@ -101,21 +101,18 @@ class Item3D(qt.QObject):
             self._label += u' %d' % labelIndex
         self._LABEL_INDICES[self.__class__] += 1
 
-    def event(self, event):
-        """Handle QEvents to handle change of parent."""
-        if event.type() == qt.QEvent.ParentAboutToChange:
-            parent = self.parent()
-            if isinstance(parent, Item3D):
-                parent.sigItemChanged.disconnect(self._parentItemChanged)
+    def setParent(self, parent):
+        """Override set parent to handle root item change"""
+        previousParent = self.parent()
+        if isinstance(previousParent, Item3D):
+            previousParent.sigItemChanged.disconnect(self._parentItemChanged)
 
-        elif event.type() == qt.QEvent.ParentChange:
-            self._updated(Item3DChangedType.ROOT_ITEM)
+        super(Item3D, self).setParent(parent)
 
-            parent = self.parent()
-            if isinstance(parent, Item3D):
-                parent.sigItemChanged.connect(self._parentItemChanged)
+        if isinstance(parent, Item3D):
+            parent.sigItemChanged.connect(self._parentItemChanged)
 
-        return super(Item3D, self).event(event)
+        self._updated(Item3DChangedType.ROOT_ITEM)
 
     def _parentItemChanged(self, event):
         """Handle updates of the parent if it is an Item3D
@@ -400,7 +397,8 @@ class DataItem3D(Item3D):
     def setBoundingBoxVisible(self, visible):
         """Set item's bounding box visibility.
 
-        :param bool visible: True to show the bounding box, False to hide
+        :param bool visible:
+            True to show the bounding box, False (default) to hide it
         """
         visible = bool(visible)
         primitive = self._getScenePrimitive()

--- a/silx/gui/plot3d/items/core.py
+++ b/silx/gui/plot3d/items/core.py
@@ -101,6 +101,9 @@ class Item3D(qt.QObject):
             self._label += u' %d' % labelIndex
         self._LABEL_INDICES[self.__class__] += 1
 
+        if isinstance(parent, Item3D):
+            parent.sigItemChanged.connect(self._parentItemChanged)
+
     def setParent(self, parent):
         """Override set parent to handle root item change"""
         previousParent = self.parent()

--- a/silx/gui/plot3d/items/core.py
+++ b/silx/gui/plot3d/items/core.py
@@ -559,3 +559,60 @@ class GroupWithAxesItem(_BaseGroupItem):
         """
         super(GroupWithAxesItem, self).__init__(parent=parent,
                                                 group=axes.LabelledAxes())
+
+    # Axes labels
+
+    def setAxesLabels(self, xlabel=None, ylabel=None, zlabel=None):
+        """Set the text labels of the axes.
+
+        :param str xlabel: Label of the X axis, None to leave unchanged.
+        :param str ylabel: Label of the Y axis, None to leave unchanged.
+        :param str zlabel: Label of the Z axis, None to leave unchanged.
+        """
+        labelledAxes = self._getScenePrimitive()
+        if xlabel is not None:
+            labelledAxes.xlabel = xlabel
+
+        if ylabel is not None:
+            labelledAxes.ylabel = ylabel
+
+        if zlabel is not None:
+            labelledAxes.zlabel = zlabel
+
+    class _Labels(tuple):
+        """Return type of :meth:`getAxesLabels`"""
+
+        def getXLabel(self):
+            """Label of the X axis (str)"""
+            return self[0]
+
+        def getYLabel(self):
+            """Label of the Y axis (str)"""
+            return self[1]
+
+        def getZLabel(self):
+            """Label of the Z axis (str)"""
+            return self[2]
+
+    def getAxesLabels(self):
+        """Returns the text labels of the axes
+
+        >>> group = GroupWithAxesItem()
+        >>> group.setAxesLabels(xlabel='X')
+
+        You can get the labels either as a 3-tuple:
+
+        >>> xlabel, ylabel, zlabel = group.getAxesLabels()
+
+        Or as an object with methods getXLabel, getYLabel and getZLabel:
+
+        >>> labels = group.getAxesLabels()
+        >>> labels.getXLabel()
+        ... 'X'
+
+        :return: object describing the labels
+        """
+        labelledAxes = self._getScenePrimitive()
+        return self._Labels((labelledAxes.xlabel,
+                             labelledAxes.ylabel,
+                             labelledAxes.zlabel))

--- a/silx/gui/plot3d/items/core.py
+++ b/silx/gui/plot3d/items/core.py
@@ -40,7 +40,7 @@ from silx.third_party import enum, six
 from ... import qt
 from ...plot.items import ItemChangedType
 from .. import scene
-from ..scene import transform
+from ..scene import primitives, transform
 
 
 @enum.unique
@@ -61,6 +61,9 @@ class Item3DChangedType(enum.Enum):
 
     LABEL = 'labelChanged'
     """Item's label changed flag."""
+
+    BOUNDING_BOX_VISIBLE = 'boundingBoxVisibleChanged'
+    """Item's bounding box visibility changed"""
 
 
 class Item3D(qt.QObject):
@@ -152,10 +155,13 @@ class DataItem3D(Item3D):
     """Base class representing a data item with transform in the scene.
 
     :param parent: The View widget this item belongs to.
-    :param primitive: An optional primitive to use as scene primitive
     """
 
-    def __init__(self, parent, primitive=None):
+    def __init__(self, parent):
+        primitive = primitives.GroupBBox()
+        primitive.boxVisible = False
+        primitive.axesVisible = False
+
         Item3D.__init__(self, parent=parent, primitive=primitive)
 
         # Transformations
@@ -339,6 +345,26 @@ class DataItem3D(Item3D):
         :return: 3x3 matrix
         :rtype: numpy.ndarray"""
         return self._matrix.getMatrix(copy=True)[:3, :3]
+
+    # Bounding box
+
+    def isBoundingBoxVisible(self):
+        """Returns item's bounding box visibility.
+
+        :rtype: bool
+        """
+        return self._getScenePrimitive().boxVisible
+
+    def setBoundingBoxVisible(self, visible):
+        """Set item's bounding box visibility.
+
+        :param bool visible: True to show the bounding box, False to hide
+        """
+        visible = bool(visible)
+        primitive = self._getScenePrimitive()
+        if visible != primitive.boxVisible:
+            primitive.boxVisible = visible
+            self._updated(Item3DChangedType.BOUNDING_BOX_VISIBLE)
 
 
 class GroupItem(DataItem3D):

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,6 @@ import collections
 import numpy
 
 from silx.math.combo import min_max
-from ... import qt
 
 from ...plot.items.core import ItemMixInBase
 from ...plot.items.core import ColormapMixIn as _ColormapMixIn
@@ -293,15 +292,11 @@ class PlaneMixIn(ItemMixInBase):
 
     # Border stroke
 
-    def getStrokeColor(self):
-        """Returns the color of the plane border (QColor)"""
-        return qt.QColor.fromRgbF(*self.__plane.color)
-
-    def setStrokeColor(self, color):
+    def _setForegroundColor(self, color):
         """Set the color of the plane border.
 
-        :param color: RGB color: name, #RRGGBB or RGB values
-        :type color:
-            QColor, str or array-like of 3 or 4 float in [0., 1.] or uint8
+        :param color: RGBA color as 4 floats in [0, 1]
         """
         self.__plane.color = rgba(color)
+        if hasattr(super(PlaneMixIn, self), '_setForegroundColor'):
+            super(PlaneMixIn, self)._setForegroundColor(color)

--- a/silx/gui/plot3d/scene/axes.py
+++ b/silx/gui/plot3d/scene/axes.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -86,6 +86,23 @@ class LabelledAxes(primitives.GroupBBox):
 
         # Sync color
         self.tickColor = 1., 1., 1., 1.
+
+    def _updateBoxAndAxes(self):
+        """Update bbox and axes position and size according to children.
+
+        Overridden from GroupBBox
+        """
+        super(LabelledAxes, self)._updateBoxAndAxes()
+
+        bounds = self._group.bounds(dataBounds=True)
+        if bounds is not None:
+            tx, ty, tz = (bounds[1] - bounds[0]) / 2.
+        else:
+            tx, ty, tz = 0.5, 0.5, 0.5
+
+        self._xlabel.transforms[-1].tx = tx
+        self._ylabel.transforms[-1].ty = ty
+        self._zlabel.transforms[-1].tz = tz
 
     @property
     def tickColor(self):


### PR DESCRIPTION
This PR:
- Adds a bounding box to each data item.
- Separates text color from foreground color (used for bounding boxes)
- Updates the model to add bounding box and text color control in the tree view.
- Adds a convenient `Item3D.root` method to retrieve the root of a tree of item.

Related to #1311