### PR TITLE
Fixed deprecated import from IPython which caused a warning.

### DIFF
--- a/silx/gui/console.py
+++ b/silx/gui/console.py
@@ -129,7 +129,10 @@ if qtconsole is None:
 
     IPython.external.qt_loaders.has_binding = has_binding
 
-    from IPython.qtconsole.rich_ipython_widget import RichIPythonWidget
+    try:
+        from IPython.qtconsole.rich_ipython_widget import RichIPythonWidget
+    except ImportError:
+        from IPython.qt.console.rich_ipython_widget import RichIPythonWidget
     from IPython.qt.inprocess import QtInProcessKernelManager
 
 

--- a/silx/gui/console.py
+++ b/silx/gui/console.py
@@ -129,7 +129,7 @@ if qtconsole is None:
 
     IPython.external.qt_loaders.has_binding = has_binding
 
-    from IPython.qt.console.rich_ipython_widget import RichIPythonWidget
+    from IPython.qtconsole.rich_ipython_widget import RichIPythonWidget
     from IPython.qt.inprocess import QtInProcessKernelManager
 
 


### PR DESCRIPTION
Before this commit, I got the warning displayed below when importing from `silx`.
```
/usr/lib/python3/dist-packages/IPython/qt.py:13: ShimWarning: The `IPython.qt` package has been deprecated. You should import from qtconsole instead.
  "You should import from qtconsole instead.", ShimWarning)
```

Stack trace of import resulting in the warning below:
```
    from silx.gui.plot.PlotWidget
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 944, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 673, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/usr/local/lib/python3.5/dist-packages/silx/gui/plot/__init__.py", line 63, in <module>
    from .PlotWindow import PlotWindow, Plot1D, Plot2D  # noqa
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 673, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/usr/local/lib/python3.5/dist-packages/silx/gui/plot/PlotWindow.py", line 53, in <module>
    from ..console import IPythonDockWidget
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 958, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 673, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 673, in exec_module
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "/usr/local/lib/python3.5/dist-packages/silx/gui/console.py", line 132, in <module>
    from IPython.qt.console.rich_ipython_widget import RichIPythonWidget
```