### PR TITLE
Fixed opengl backend not receiving mouse move events, causing state lockups

### DIFF
--- a/silx/gui/_glutils/OpenGLWidget.py
+++ b/silx/gui/_glutils/OpenGLWidget.py
@@ -116,6 +116,9 @@ else:
                 format_.setSwapBehavior(qt.QSurfaceFormat.DoubleBuffer)
                 self.setFormat(format_)
 
+            # Enable receiving mouse move events when no buttons are pressed
+            self.setMouseTracking(True)
+
 
         def getDevicePixelRatio(self):
             """Returns the ratio device-independent / device pixel size


### PR DESCRIPTION
Fixes issue #1455.

Matplotlib backend always sends mouse move events. Opengl backend by default does not.
This fix configures Qt to send the mouse move events to the opengl backend.