### PR TITLE
[plot] Removing right click management from ClickOrDrag interaction

### DIFF
--- a/silx/gui/plot/Interaction.py
+++ b/silx/gui/plot/Interaction.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2016 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -218,18 +218,6 @@ class ClickOrDrag(StateMachine):
             if btn == LEFT_BTN:
                 self.goto('clickOrDrag', x, y)
                 return True
-            elif btn == RIGHT_BTN:
-                self.goto('rightClick', x, y)
-                return True
-
-    class RightClick(State):
-        def onMove(self, x, y):
-            self.goto('idle')
-
-        def onRelease(self, x, y, btn):
-            if btn == RIGHT_BTN:
-                self.machine.click(x, y, btn)
-                self.goto('idle')
 
     class ClickOrDrag(State):
         def enterState(self, x, y):
@@ -263,7 +251,6 @@ class ClickOrDrag(StateMachine):
     def __init__(self):
         states = {
             'idle': ClickOrDrag.Idle,
-            'rightClick': ClickOrDrag.RightClick,
             'clickOrDrag': ClickOrDrag.ClickOrDrag,
             'drag': ClickOrDrag.Drag
         }

--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -1,7 +1,7 @@
 #  coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -129,7 +129,6 @@ class _ZoomOnWheel(ClickOrDrag, _PlotInteraction):
 
         states = {
             'idle': _ZoomOnWheel.ZoomIdle,
-            'rightClick': ClickOrDrag.RightClick,
             'clickOrDrag': ClickOrDrag.ClickOrDrag,
             'drag': ClickOrDrag.Drag
         }
@@ -994,7 +993,6 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
 
         states = {
             'idle': ItemsInteraction.Idle,
-            'rightClick': ClickOrDrag.RightClick,
             'clickOrDrag': ClickOrDrag.ClickOrDrag,
             'drag': ClickOrDrag.Drag
         }


### PR DESCRIPTION
This PR removes right click management from plot interaction.
Handling of right click in interaction is no more needed since we decided to keep right click free for context menu and this was useless.

Related to #1455 and #1563.