### PR TITLE
[plot3d] sx function for plot3d

### DIFF
--- a/silx/sx/__init__.py
+++ b/silx/sx/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -82,6 +82,14 @@ else:
 
     from silx.gui.plot import *  # noqa
     from ._plot import plot, imshow  # noqa
+
+    try:
+        import OpenGL
+    except ImportError:
+        _logger.warning(
+            'Not loading silx.gui.plot3d features: PyOpenGL is not installed')
+    else:
+        from ._plot3d import contour3d  # noqa
 
 
 # %pylab

--- a/silx/sx/__init__.py
+++ b/silx/sx/__init__.py
@@ -89,7 +89,7 @@ else:
         _logger.warning(
             'Not loading silx.gui.plot3d features: PyOpenGL is not installed')
     else:
-        from ._plot3d import contour3d  # noqa
+        from ._plot3d import contour3d, points3d  # noqa
 
 
 # %pylab

--- a/silx/sx/_plot3d.py
+++ b/silx/sx/_plot3d.py
@@ -35,6 +35,7 @@ import logging
 import numpy
 
 from ..gui import qt
+from ..gui.plot3d.SceneWindow import SceneWindow
 from ..gui.plot3d.ScalarFieldView import ScalarFieldView
 from ..gui.plot3d import SFViewParamTree
 from ..gui.plot.Colormap import Colormap
@@ -54,7 +55,7 @@ def contour3d(scalars,
               opacity=1.):
     """Plot isosurfaces of a 3D scalar field in a dedicated widget.
 
-    It opens a silx plot3d.SceneWindow.
+    It opens a silx plot3d ScalarFieldView.
 
     Examples:
 
@@ -96,7 +97,7 @@ def contour3d(scalars,
     :param float opacity:
         Transparency of the isosurfaces as a float in [0., 1.]
     :return: The widget used to visualize the data
-    :rtype: ~silx.gui.plot3d.SceneWindow.SceneWindow
+    :rtype: ~silx.gui.plot3d.ScalarFieldView.ScalarFieldView
     """
     # Prepare isolevel values
     if isinstance(contours, int):
@@ -158,3 +159,89 @@ def contour3d(scalars,
     scalarField.show()
 
     return scalarField
+
+
+_POINTS3D_MODE_CONVERSION = {
+    '2dcircle': 'o',
+    '2dcross': 'x',
+    '2ddash': '_',
+    '2ddiamond': 'd',
+    '2dsquare': 's',
+    'point': ','
+}
+
+
+def points3d(x, y, z=None,
+             values=0.,
+             copy=True,
+             colormap='viridis',
+             vmin=None,
+             vmax=None,
+             mode='o'):
+    """Plot a 3D scatter plot in a dedicated widget.
+
+    It opens a silx plot3d SceneWindow.
+
+    Examples:
+
+    First import :mod:`sx` functions:
+
+    >>> from silx import sx
+
+    Provided x, y, z, values, 4 numpy array of float32:
+
+    >>> plot3d_window = sx.points3d(x, y, z)
+
+    >>> plot3d_window = sx.points3d(x, y, z, values)
+
+    This function is similar to mayavi.mlab.points3d.
+
+    :param numpy.ndarray x: X coordinates of the points
+    :param numpy.ndarray y: Y coordinates of the points
+    :param numpy.ndarray z: Z coordinates of the points (optional)
+    :param numpy.ndarray values: Values at each point (optional)
+    :param bool copy:
+        True (default) to make a copy of scalars.
+        False to avoid this copy (do not modify provided data afterwards)
+    :param str colormap:
+        Colormap to use for coding points as colors.
+    :param Union[float, None] vmin:
+        Minimum value of the colormap
+    :param Union[float, None] vmax:
+        Maximum value of the colormap
+    :param str mode: The type of marker to use
+
+        - Circle: 'o', '2dcircle'
+        - Diamond: 'd', '2ddiamond'
+        - Square: 's', '2dsquare'
+        - Plus: '+'
+        - Cross: 'x', '2dcross'
+        - Star: '*'
+        - Vertical line: '|'
+        - Horizontal line: '_', '2ddash'
+        - Point: '.'
+        - Pixel: ','
+    :return: The widget used to visualize the data
+    :rtype: ~silx.gui.plot3d.SceneWindow.SceneWindow
+    """
+    # Prepare widget
+    window = SceneWindow()
+    sceneWidget = window.getSceneWidget()
+    sceneWidget.setBackgroundColor((0.9, 0.9, 0.9))
+    sceneWidget.setForegroundColor((0.5, 0.5, 0.5))
+    sceneWidget.setTextColor((0.1, 0.1, 0.1))
+
+    mode = _POINTS3D_MODE_CONVERSION.get(mode, mode)
+
+    if z is None:  # 2D scatter plot
+        scatter = sceneWidget.add2DScatter(x, y, values, copy=copy)
+    else:  # 3D scatter plot
+        scatter = sceneWidget.add3DScatter(x, y, z, values, copy=copy)
+
+    colormap = Colormap(name=colormap, vmin=vmin, vmax=vmax)
+    scatter.setColormap(colormap)
+    scatter.setSymbol(mode)
+
+    window.show()
+
+    return window

--- a/silx/sx/_plot3d.py
+++ b/silx/sx/_plot3d.py
@@ -71,7 +71,7 @@ def contour3d(scalars,
 
     >>> plot3d_window = sx.contour3d(data, contours=[0.2, 0.4])
 
-    This function is similar to mayavi.mlab.contour3d.
+    This function provides a subset of mayavi.mlab.contour3d.
 
     :param scalars: The 3D scalar field to visualize
     :type: numpy.ndarray of float32 with 3 dimensions
@@ -194,7 +194,7 @@ def points3d(x, y, z=None,
 
     >>> plot3d_window = sx.points3d(x, y, z, values)
 
-    This function is similar to mayavi.mlab.points3d.
+    This function provides a subset of mayavi.mlab.points3d.
 
     :param numpy.ndarray x: X coordinates of the points
     :param numpy.ndarray y: Y coordinates of the points

--- a/silx/sx/_plot3d.py
+++ b/silx/sx/_plot3d.py
@@ -1,0 +1,160 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This module adds convenient functions to use plot3d widgets from the console.
+"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "07/02/2018"
+
+
+from collections import Iterable
+import logging
+import numpy
+
+from ..gui import qt
+from ..gui.plot3d.ScalarFieldView import ScalarFieldView
+from ..gui.plot3d import SFViewParamTree
+from ..gui.plot.Colormap import Colormap
+from ..gui.plot.Colors import rgba
+
+
+_logger = logging.getLogger(__name__)
+
+
+def contour3d(scalars,
+              contours=1,
+              copy=True,
+              color=None,
+              colormap='viridis',
+              vmin=None,
+              vmax=None,
+              opacity=1.):
+    """Plot isosurfaces of a 3D scalar field in a dedicated widget.
+
+    It opens a silx plot3d.SceneWindow.
+
+    Examples:
+
+    First import :mod:`sx` functions:
+
+    >>> from silx import sx
+
+    Provided data, a 3D scalar field as a numpy array of float32:
+
+    >>> plot3d_window = sx.contour3d(data)
+
+    Alternatively you can provide the level of the isosurfaces:
+
+    >>> plot3d_window = sx.contour3d(data, contours=[0.2, 0.4])
+
+    This function is similar to mayavi.mlab.contour3d.
+
+    :param scalars: The 3D scalar field to visualize
+    :type: numpy.ndarray of float32 with 3 dimensions
+    :param Union[int, float, List[float]] contours:
+        Either the number of isosurfaces to draw (as an int) or
+        the isosurface level (as a float) or a list of isosurface levels
+        (as a list of float)
+    :param bool copy:
+        True (default) to make a copy of scalars.
+        False to avoid this copy (do not modify provided data afterwards)
+    :param color:
+        Color.s to use for isosurfaces.
+        Either a single color or a list of colors (one for each isosurface).
+        A color can be defined by its name (as a str) or
+        as RGB(A) as float or uint8.
+    :param str colormap:
+        If color is not provided, this colormap is used
+        for coloring isosurfaces.
+    :param Union[float, None] vmin:
+        Minimum value of the colormap
+    :param Union[float, None] vmax:
+        Maximum value of the colormap
+    :param float opacity:
+        Transparency of the isosurfaces as a float in [0., 1.]
+    :return: The widget used to visualize the data
+    :rtype: ~silx.gui.plot3d.SceneWindow.SceneWindow
+    """
+    # Prepare isolevel values
+    if isinstance(contours, int):
+        # Compute contours number of isovalues
+        mean = numpy.mean(scalars)
+        std = numpy.std(scalars)
+
+        start = mean - std * ((contours - 1) // 2)
+        contours = [start + std * index for index in range(contours)]
+
+    elif isinstance(contours, float):
+        contours = [contours]
+
+    assert isinstance(contours, Iterable)
+
+    # Prepare colors
+    if color is not None:
+        if isinstance(color, str) or isinstance(color[0], (int, float)):
+            # Single color provided, use it for all isosurfaces
+            colors = [rgba(color)] * len(contours)
+        else:
+            # As many colors as contours
+            colors = [rgba(c) for c in color]
+
+        # convert colors from float to uint8
+        colors = (numpy.array(colors) * 255).astype(numpy.uint8)
+
+    else:  # Use colormap
+        colormap = Colormap(name=colormap, vmin=vmin, vmax=vmax)
+        colors = colormap.applyToData(contours)
+
+    assert len(colors) == len(contours)
+
+    # Prepare and apply opacity
+    assert isinstance(opacity, float)
+    opacity = min(max(0., opacity), 1.)  # Clip opacity
+    colors[:, -1] = (colors[:, -1] * opacity).astype(numpy.uint8)
+
+    # Prepare widget
+    scalarField = ScalarFieldView()
+
+    scalarField.setBackgroundColor((0.9, 0.9, 0.9))
+    scalarField.setForegroundColor((0.1, 0.1, 0.1))
+    scalarField.setData(scalars, copy=copy)
+
+    # Create a parameter tree for the scalar field view
+    treeView = SFViewParamTree.TreeView(scalarField)
+    treeView.setSfView(scalarField)  # Attach the parameter tree to the view
+
+    # Add the parameter tree to the main window in a dock widget
+    dock = qt.QDockWidget()
+    dock.setWindowTitle('Parameters')
+    dock.setWidget(treeView)
+    scalarField.addDockWidget(qt.Qt.RightDockWidgetArea, dock)
+
+    for level, color in zip(contours, colors):
+        scalarField.addIsosurface(level, color)
+
+    scalarField.show()
+
+    return scalarField

--- a/silx/test/test_sx.py
+++ b/silx/test/test_sx.py
@@ -220,6 +220,33 @@ else:
 
             self._expose_and_close(window)
 
+        @unittest.skipUnless(test_options.WITH_GL_TEST,
+                             test_options.WITH_GL_TEST_REASON)
+        def test_points3d(self):
+            """Test points3d function"""
+            x = numpy.random.random(1024)
+            y = numpy.random.random(1024)
+            z = numpy.random.random(1024)
+            values = numpy.random.random(1024)
+
+            # 3D positions, no value
+            window = sx.points3d(x, y, z)
+            self._expose_and_close(window)
+
+            # 3D positions, values
+            window = sx.points3d(x, y, z, values, mode='2dsquare',
+                                 colormap='magma', vmin=0.4, vmax=0.5)
+            self._expose_and_close(window)
+
+            # 2D positions, no value
+            window = sx.points3d(x, y)
+            self._expose_and_close(window)
+
+            # 2D positions, values
+            window = sx.points3d(x, y, values=values, mode=',',
+                                 colormap='magma', vmin=0.4, vmax=0.5)
+            self._expose_and_close(window)
+
 
     def suite():
         test_suite = unittest.TestSuite()

--- a/silx/test/test_sx.py
+++ b/silx/test/test_sx.py
@@ -34,7 +34,6 @@ import unittest
 import numpy
 
 from silx.test.utils import test_options
-from silx.gui.plot.Colors import rgba
 
 
 _logger = logging.getLogger(__name__)
@@ -74,6 +73,7 @@ else:
     from silx.gui import qt
     # load TestCaseQt before sx
     from silx.gui.test.utils import TestCaseQt
+    from silx.gui.plot.Colors import rgba
     from silx import sx
 
     class SXTest(TestCaseQt):


### PR DESCRIPTION
This PR adds 2 functions to the `sx` module wrapping `silx.gui.plot3d`:
- `contour3d` (for isosurfaces)
- `points3d` (for 2D/3D scatter plots)
The signature of those functions is a subset of mayavi.mlab functions.

This PR also provides corresponding tests

Related to #1311