### PR TITLE
[plot3d] Add selection support to SceneWidget

### DIFF
--- a/silx/gui/plot3d/ParamTreeView.py
+++ b/silx/gui/plot3d/ParamTreeView.py
@@ -46,6 +46,7 @@ from silx.third_party import six
 
 from .. import qt
 from ..widgets.FloatEdit import FloatEdit as _FloatEdit
+from ._model import visitQAbstractItemModel
 
 
 class FloatEditor(_FloatEdit):
@@ -430,33 +431,6 @@ class ParameterTreeDelegate(qt.QStyledItemDelegate):
             super(ParameterTreeDelegate, self).setModelData(editor, model, index)
 
 
-def visitQAbstractItemMode(model, parent=qt.QModelIndex()):
-    """Iterate over indices in the model starting from parent
-
-    It iterates column by column and row by row
-    (i.e., from left to right and from top to bottom).
-    Parent are returned before their children.
-    It only iterates through the children for the first column of a row.
-
-    :param QAbstractItemModel model: The model to visit
-    :param QModelIndex parent:
-        Index from which to start visiting the model.
-        Default: start from the root
-    """
-    assert isinstance(model, qt.QAbstractItemModel)
-    assert isinstance(parent, qt.QModelIndex)
-    assert parent.model() is model or not parent.isValid()
-
-    for row in range(model.rowCount(parent)):
-        for column in range(model.columnCount(parent)):
-            index = model.index(row, column, parent)
-            yield index
-
-        index = model.index(row, 0, parent)
-        for index in visitQAbstractItemMode(model, index):
-            yield index
-
-
 class ParamTreeView(qt.QTreeView):
     """QTreeView specific to handle plot3d scene and object parameters.
 
@@ -509,7 +483,7 @@ class ParamTreeView(qt.QTreeView):
         """
         model = self.model()
         if model is not None:
-            for index in visitQAbstractItemMode(model, parent):
+            for index in visitQAbstractItemModel(model, parent):
                 self._openEditorForIndex(index)
 
     def setModel(self, model):

--- a/silx/gui/plot3d/ParamTreeView.py
+++ b/silx/gui/plot3d/ParamTreeView.py
@@ -529,3 +529,10 @@ class ParamTreeView(qt.QTreeView):
         :rtype: bool
         """
         return index in self.__persistentEditors
+
+    def selectionCommand(self, index, event=None):
+        """Filter out selection of not selectable items"""
+        if index.flags() & qt.Qt.ItemIsSelectable:
+            return super(ParamTreeView, self).selectionCommand(index, event)
+        else:
+            return qt.QItemSelectionModel.NoUpdate

--- a/silx/gui/plot3d/SceneWindow.py
+++ b/silx/gui/plot3d/SceneWindow.py
@@ -73,6 +73,10 @@ class SceneWindow(qt.QMainWindow):
         self._paramTreeView = ParamTreeView()
         self._paramTreeView.setModel(self._sceneWidget.model())
 
+        selectionModel = self._paramTreeView.selectionModel()
+        self._sceneWidget.selection()._setSyncSelectionModel(
+            selectionModel)
+
         paramDock = qt.QDockWidget()
         paramDock.setWindowTitle('Object parameters')
         paramDock.setWidget(self._paramTreeView)

--- a/silx/gui/plot3d/_model/__init__.py
+++ b/silx/gui/plot3d/_model/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -32,4 +32,4 @@ __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "11/01/2018"
 
-from .model import SceneModel  # noqa
+from .model import SceneModel, visitQAbstractItemModel  # noqa

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -211,8 +211,9 @@ class Item3DRow(StaticRow):
         super(Item3DRow, self).__init__((name, None))
 
         self.setFlags(
-            self.flags(0) | qt.Qt.ItemIsUserCheckable,
+            self.flags(0) | qt.Qt.ItemIsUserCheckable | qt.Qt.ItemIsSelectable,
             0)
+        self.setFlags(self.flags(1) | qt.Qt.ItemIsSelectable, 1)
 
         self._item = weakref.ref(item)
         item.sigItemChanged.connect(self._itemChanged)

--- a/silx/gui/plot3d/_model/model.py
+++ b/silx/gui/plot3d/_model/model.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -39,6 +39,33 @@ from ... import qt
 
 from .core import BaseRow
 from .items import Settings, nodeFromItem
+
+
+def visitQAbstractItemModel(model, parent=qt.QModelIndex()):
+    """Iterate over indices in the model starting from parent
+
+    It iterates column by column and row by row
+    (i.e., from left to right and from top to bottom).
+    Parent are returned before their children.
+    It only iterates through the children for the first column of a row.
+
+    :param QAbstractItemModel model: The model to visit
+    :param QModelIndex parent:
+        Index from which to start visiting the model.
+        Default: start from the root
+    """
+    assert isinstance(model, qt.QAbstractItemModel)
+    assert isinstance(parent, qt.QModelIndex)
+    assert parent.model() is model or not parent.isValid()
+
+    for row in range(model.rowCount(parent)):
+        for column in range(model.columnCount(parent)):
+            index = model.index(row, column, parent)
+            yield index
+
+        index = model.index(row, 0, parent)
+        for index in visitQAbstractItemModel(model, index):
+            yield index
 
 
 class Root(BaseRow):

--- a/silx/gui/plot3d/items/core.py
+++ b/silx/gui/plot3d/items/core.py
@@ -528,15 +528,19 @@ class _BaseGroupItem(DataItem3D):
         for item in self.getItems():
             self.removeItem(item)
 
-    def visit(self):
+    def visit(self, included=True):
         """Generator visiting the group content.
 
         It traverses the group sub-tree in a top-down left-to-right way.
+
+        :param bool included: True (default) to include self in visit
         """
+        if included:
+            yield self
         for child in self.getItems():
             yield child
             if hasattr(child, 'visit'):
-                for item in child.visit():
+                for item in child.visit(included=False):
                     yield item
 
 

--- a/silx/gui/plot3d/items/volume.py
+++ b/silx/gui/plot3d/items/volume.py
@@ -448,11 +448,15 @@ class ScalarField3D(DataItem3D):
                            key=lambda isosurface: - isosurface.getLevel())
         self._isogroup.children = [iso._getScenePrimitive() for iso in sortedIso]
 
-    def visit(self):
+    def visit(self, included=True):
         """Generator visiting the ScalarField3D content.
 
         It first access cut planes and then isosurface
+
+        :param bool included: True (default) to include self in visit
         """
+        if included:
+            yield self
         for cutPlane in self.getCutPlanes():
             yield cutPlane
         for isosurface in self.getIsosurfaces():


### PR DESCRIPTION
Merge #1570 (cherry-picked here)

This PR adds a single item selection management to `SceneWidget` (through a `SceneSelection` object accessible with `SceneWidget.selection()`.
A corresponding selection model is available to sync the treeview selection with it.
Upon selection, Item bounding box is shown and color is changed by the selection management. I am not convinced by this mode but it is simple, so this can be disabled and the API leaves room to implement other modes of highlight.

Related to #1311 