### PR TITLE
Add pythonic callback to DataFileDialog to custom selectable data

### DIFF
--- a/examples/fileDialog.py
+++ b/examples/fileDialog.py
@@ -31,7 +31,7 @@ from __future__ import absolute_import
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "12/02/2018"
+__date__ = "14/02/2018"
 
 import logging
 from silx.gui import qt
@@ -50,6 +50,7 @@ class Mode(enum.Enum):
     DATAFILEDIALOG = 2
     DATAFILEDIALOG_DATASET = 3
     DATAFILEDIALOG_GROUP = 4
+    DATAFILEDIALOG_NXENTRY = 5
 
 
 class DialogExample(qt.QMainWindow):
@@ -138,6 +139,12 @@ class DialogExample(qt.QMainWindow):
         group.addButton(radio)
         layout.addWidget(radio)
 
+        radio = qt.QRadioButton(panel)
+        radio.setText("silx DataFileDialog (filter=NXentry)")
+        radio.setProperty("Mode", Mode.DATAFILEDIALOG_NXENTRY)
+        group.addButton(radio)
+        layout.addWidget(radio)
+
         self.__options = group
         return panel
 
@@ -192,6 +199,16 @@ class DialogExample(qt.QMainWindow):
         elif mode == Mode.DATAFILEDIALOG_GROUP:
             dialog = DataFileDialog(self)
             dialog.setFilterMode(DataFileDialog.FilterMode.ExistingGroup)
+        elif mode == Mode.DATAFILEDIALOG_NXENTRY:
+            def customFilter(obj):
+                if "NX_class" in obj.attrs:
+                    return obj.attrs["NX_class"] in [b"NXentry", u"NXentry"]
+                return False
+            dialog = DataFileDialog(self)
+            dialog.setFilterMode(DataFileDialog.FilterMode.ExistingGroup)
+            dialog.setFilterCallback(customFilter)
+        else:
+            assert(False)
         return dialog
 
     def openDialog(self):

--- a/examples/fileDialog.py
+++ b/examples/fileDialog.py
@@ -182,14 +182,14 @@ class DialogExample(qt.QMainWindow):
         if mode == Mode.DEFAULT_FILEDIALOG:
             dialog = qt.QFileDialog(self)
             dialog.setAcceptMode(qt.QFileDialog.AcceptOpen)
-        if mode == Mode.IMAGEFILEDIALOG:
+        elif mode == Mode.IMAGEFILEDIALOG:
             dialog = ImageFileDialog(self)
-        if mode == Mode.DATAFILEDIALOG:
+        elif mode == Mode.DATAFILEDIALOG:
             dialog = DataFileDialog(self)
-        if mode == Mode.DATAFILEDIALOG_DATASET:
+        elif mode == Mode.DATAFILEDIALOG_DATASET:
             dialog = DataFileDialog(self)
             dialog.setFilterMode(DataFileDialog.FilterMode.ExistingDataset)
-        if mode == Mode.DATAFILEDIALOG_GROUP:
+        elif mode == Mode.DATAFILEDIALOG_GROUP:
             dialog = DataFileDialog(self)
             dialog.setFilterMode(DataFileDialog.FilterMode.ExistingGroup)
         return dialog

--- a/silx/gui/dialog/DataFileDialog.py
+++ b/silx/gui/dialog/DataFileDialog.py
@@ -300,13 +300,13 @@ class DataFileDialog(AbstractDataFileDialog):
         return True
 
     def setFilterCallback(self, callback):
-        """Set the filter callback. This filter is applied if the filter mode
-        (:meth:`filterMode`) accept first the selected data.
+        """Set the filter callback. This filter is applied only if the filter
+        mode (:meth:`filterMode`) first accepts the selected data.
 
-        It is not supposed to be set while the dialog it is used.
+        It is not supposed to be set while the dialog is being used.
 
         :param callable callback: Define a custom function returning a boolean
-            an taking in argument an h5-like node. If the function returns true
+            an taking as argument an h5-like node. If the function returns true
             the dialog can return the associated URL.
         """
         self.__filterCallback = callback
@@ -314,7 +314,7 @@ class DataFileDialog(AbstractDataFileDialog):
     def setFilterMode(self, mode):
         """Set the filter mode.
 
-        It is not supposed to be set while the dialog it is used.
+        It is not supposed to be set while the dialog is being used.
 
         :param DataFileDialog.FilterMode mode: The new filter.
         """

--- a/silx/gui/dialog/DataFileDialog.py
+++ b/silx/gui/dialog/DataFileDialog.py
@@ -306,7 +306,7 @@ class DataFileDialog(AbstractDataFileDialog):
         It is not supposed to be set while the dialog is being used.
 
         :param callable callback: Define a custom function returning a boolean
-            an taking as argument an h5-like node. If the function returns true
+            and taking as argument an h5-like node. If the function returns true
             the dialog can return the associated URL.
         """
         self.__filterCallback = callback

--- a/silx/gui/dialog/DataFileDialog.py
+++ b/silx/gui/dialog/DataFileDialog.py
@@ -263,7 +263,7 @@ class DataFileDialog(AbstractDataFileDialog):
         elif self.__filter == DataFileDialog.FilterMode.ExistingGroup:
             return silx.io.is_group(data)
         else:
-            raise ValueError("Filter %s is not supported" % self.__nodeFilter)
+            raise ValueError("Filter %s is not supported" % self.__filter)
 
     def setFilterMode(self, mode):
         """Set the filter mode.

--- a/silx/gui/dialog/DataFileDialog.py
+++ b/silx/gui/dialog/DataFileDialog.py
@@ -28,7 +28,7 @@ This module contains an :class:`DataFileDialog`.
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "12/02/2018"
+__date__ = "14/02/2018"
 
 import logging
 from silx.gui import qt
@@ -148,9 +148,33 @@ class DataFileDialog(AbstractDataFileDialog):
 
     The selected data is any kind of group or dataset. It can be restricted
     to only existing datasets or only existing groups using
-    :meth:`setFilterMode`.
+    :meth:`setFilterMode`. A callback can be defining using
+    :meth:`setFilterCallback` to filter even more data which can be returned.
 
-    Using an `DataFileDialog` can be done like that:
+    Filtering data which can be returned by a `DataFileDialog` can be done like
+    that:
+
+    .. code-block:: python
+
+        # Force to return only a dataset
+        dialog = DataFileDialog()
+        dialog.setFilterMode(DataFileDialog.FilterMode.ExistingDataset)
+
+    .. code-block:: python
+
+        def customFilter(obj):
+            if "NX_class" in obj.attrs:
+                return obj.attrs["NX_class"] in [b"NXentry", u"NXentry"]
+            return False
+
+        # Force to return an NX entry
+        dialog = DataFileDialog()
+        # 1st, filter out everything which is not a group
+        dialog.setFilterMode(DataFileDialog.FilterMode.ExistingGroup)
+        # 2nd, check what NX_class is an NXentry
+        dialog.setFilterCallback(customFilter)
+
+    Executing a `DataFileDialog` can be done like that:
 
     .. code-block:: python
 
@@ -206,6 +230,7 @@ class DataFileDialog(AbstractDataFileDialog):
     def __init__(self, parent=None):
         AbstractDataFileDialog.__init__(self, parent=parent)
         self.__filter = DataFileDialog.FilterMode.AnyNode
+        self.__filterCallback = None
 
     def selectedData(self):
         """Returns the selected data by using the :meth:`silx.io.get_data`
@@ -257,13 +282,34 @@ class DataFileDialog(AbstractDataFileDialog):
         :rtype: bool
         """
         if self.__filter == DataFileDialog.FilterMode.AnyNode:
-            return True
+            accepted = True
         elif self.__filter == DataFileDialog.FilterMode.ExistingDataset:
-            return silx.io.is_dataset(data)
+            accepted = silx.io.is_dataset(data)
         elif self.__filter == DataFileDialog.FilterMode.ExistingGroup:
-            return silx.io.is_group(data)
+            accepted = silx.io.is_group(data)
         else:
             raise ValueError("Filter %s is not supported" % self.__filter)
+        if not accepted:
+            return False
+        if self.__filterCallback is not None:
+            try:
+                return self.__filterCallback(data)
+            except Exception:
+                _logger.error("Error while executing custom callback", exc_info=True)
+                return False
+        return True
+
+    def setFilterCallback(self, callback):
+        """Set the filter callback. This filter is applied if the filter mode
+        (:meth:`filterMode`) accept first the selected data.
+
+        It is not supposed to be set while the dialog it is used.
+
+        :param callable callback: Define a custom function returning a boolean
+            an taking in argument an h5-like node. If the function returns true
+            the dialog can return the associated URL.
+        """
+        self.__filterCallback = callback
 
     def setFilterMode(self, mode):
         """Set the filter mode.


### PR DESCRIPTION
Allow to specify even more the objects the dialog can return.

Can be used like that
```
def customFilter(obj):
    if "NX_class" in obj.attrs:
        return obj.attrs["NX_class"] in [b"NXentry", u"NXentry"]
    return False
dialog = DataFileDialog(self)
dialog.setFilterMode(DataFileDialog.FilterMode.ExistingGroup)
dialog.setFilterCallback(customFilter)
```

Closes #1599