### PR TITLE
[sx] Add ginput

### DIFF
--- a/doc/source/modules/sx.rst
+++ b/doc/source/modules/sx.rst
@@ -14,6 +14,9 @@ The following functions plot curves and images with silx widgets:
 - :func:`plot` for curves
 - :func:`imshow` for images
 
+The :func:`ginput` function handles user selection on those widgets.
+
+
 .. note:: Those functions are not available from a notebook.
 
 :func:`plot`
@@ -26,6 +29,11 @@ The following functions plot curves and images with silx widgets:
 
 .. autofunction:: imshow
 
+
+:func:`ginput`
+++++++++++++++
+
+.. autofunction:: ginput
 
 3D plot functions
 -----------------

--- a/silx/sx/__init__.py
+++ b/silx/sx/__init__.py
@@ -85,7 +85,7 @@ else:
         del _icons  # clean-up namespace
 
     from silx.gui.plot import *  # noqa
-    from ._plot import plot, imshow  # noqa
+    from ._plot import plot, imshow, ginput  # noqa
 
     try:
         import OpenGL as _OpenGL

--- a/silx/sx/_plot.py
+++ b/silx/sx/_plot.py
@@ -302,7 +302,8 @@ class _GInputHandler(qt.QEventLoop):
         if event.type() == qt.QEvent.Hide:
             self.quit()
         elif event.type() == qt.QEvent.KeyPress:
-            if event.key() in (qt.Qt.Key_Delete, qt.Qt.Key_Backspace):
+            if event.key() in (qt.Qt.Key_Delete, qt.Qt.Key_Backspace) or (
+                    event.key() == qt.Qt.Key_Z and event.modifiers() & qt.Qt.ControlModifier):
                 if len(self._points) > 0:
                     if self._showClicks:
                         legend = self._LEGEND_TEMPLATE % (len(self._points) - 1,)
@@ -310,8 +311,10 @@ class _GInputHandler(qt.QEventLoop):
 
                     self._points.pop()
                     self._updateStatusBar()
+                    return True  # Stop further handling of those keys
             elif event.key() == qt.Qt.Key_Return:
                 self.quit()
+                return True  # Stop further handling of those keys
         return super(_GInputHandler, self).eventFilter(obj, event)
 
     def exec_(self):

--- a/silx/sx/_plot.py
+++ b/silx/sx/_plot.py
@@ -505,6 +505,24 @@ def ginput(n=1, timeout=30, plot=None):
     If no plot is provided, it uses a plot widget created with
     either :func:`silx.sx.plot` or :func:`silx.sx.imshow`.
 
+    How to use:
+
+    >>> from silx import sx
+
+    >>> sx.imshow(image)  # Plot the image
+    >>> sx.ginput(1)  # Request selection on the image plot
+    ((0.598, 1.234))
+
+    How to get more information about the selected positions:
+
+    >>> positions = sx.ginput(1)
+
+    >>> positions[0].getData()  # Returns value(s) at selected position
+
+    >>> positions[0].getIndices()  # Returns data indices at selected position
+
+    >>> positions[0].getItem()  # Returns plot item at selected position
+
     :param int n: Number of points the user need to select
     :param float timeout: Timeout in seconds before ginput returns
         event if selection is not completed

--- a/silx/sx/_plot.py
+++ b/silx/sx/_plot.py
@@ -549,6 +549,8 @@ def ginput(n=1, timeout=30, plot=None):
             plot = Plot1D()
             plot.show()
 
+    plot.raise_()  # So window becomes the top level one
+
     _logger.info('Performing ginput with plot widget %s', str(plot))
     handler = _GInputHandler(plot, n, timeout)
     points = handler.exec_()

--- a/silx/test/test_sx.py
+++ b/silx/test/test_sx.py
@@ -164,6 +164,22 @@ else:
                             title='origin=(10, 10), scale=(2, 2)')
             self._expose_and_close(plt)
 
+        def test_ginput(self):
+            """Test ginput function
+
+            This does NOT perform interactive tests
+            """
+
+            plt = sx.plot()
+            self.qWaitForWindowExposed(plt)
+            self.qapp.processEvents()
+
+            result = sx.ginput(1, timeout=0.1)
+            self.assertEqual(len(result), 0)
+
+            plt.setAttribute(qt.Qt.WA_DeleteOnClose)
+            plt.close()
+
         @unittest.skipUnless(test_options.WITH_GL_TEST,
                              test_options.WITH_GL_TEST_REASON)
         def test_contour3d(self):


### PR DESCRIPTION
This PR adds `sx.ginput` that uses a PlotWidget to get a set of points given by the user.
The function plugs an object on a PlotWidget to handle the interaction and use its status bar to provide indication to the user.
It operates by default the most recent visible plot created with either `sx.plot` or `sx.inshow`.

It blocks until one of the following occurs: the user select all the required points, the PlotWidget gets hidden or a timeout is triggered.
It returns a list of (x,y) coordinates of all the points.
Points can be undo with either Delete, backspace or Ctrl-Z.
Points can only be set while in zoom mode.

I didn't succeeded so far in writing an interactive test for it... 

Closes  #1614