### PR TITLE
Fix hdf5tree selection

### DIFF
--- a/silx/gui/hdf5/Hdf5TreeView.py
+++ b/silx/gui/hdf5/Hdf5TreeView.py
@@ -209,7 +209,7 @@ class Hdf5TreeView(qt.QTreeView):
                 model = model.sourceModel()
             else:
                 break
-        raise RuntimeError("Model from the requested model is not reachable from this view")
+        raise RuntimeError("Model from the requested index is not reachable from this view")
 
     def mapToModel(self, index):
         """Map an index from any model reachable by the view to an index from

--- a/silx/gui/hdf5/Hdf5TreeView.py
+++ b/silx/gui/hdf5/Hdf5TreeView.py
@@ -214,7 +214,6 @@ class Hdf5TreeView(qt.QTreeView):
     def mapToModel(self, index):
         """Map an index from any model reachable by the view to an index from
         the very first model connected to the view.
-        Hdf5Trree model
 
         :param qt.QModelIndex index: Index from the Hdf5Tree model
         :rtype: qt.QModelIndex

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "14/11/2017"
+__date__ = "20/02/2018"
 
 
 import time
@@ -697,6 +697,18 @@ class TestHdf5TreeView(TestCaseQt):
     def testContextMenu(self):
         view = hdf5.Hdf5TreeView()
         view._createContextMenu(qt.QPoint(0, 0))
+
+    def testSelection_OriginalModel(self):
+        tree = commonh5.File("/foo/bar/1.mock", "w")
+        item = tree.create_group("a/b/c/d")
+        item.create_group("e").create_group("f")
+
+        view = hdf5.Hdf5TreeView()
+        view.findHdf5TreeModel().insertH5pyObject(tree)
+        view.setSelectedH5Node(item)
+
+        selected = list(view.selectedH5Nodes())[0]
+        self.assertIs(item, selected.h5py_object)
 
     def testSelection_Simple(self):
         tree = commonh5.File("/foo/bar/1.mock", "w")


### PR DESCRIPTION
The used index was only valid when the view was not using proxy models.

Now we reach the index from the model connected to the view.

Closes #1634