### PR TITLE
[plot3d] Add alternative interaction when ctrl is pressed

### DIFF
--- a/silx/gui/plot/Interaction.py
+++ b/silx/gui/plot/Interaction.py
@@ -82,8 +82,6 @@ __date__ = "18/02/2016"
 
 import weakref
 
-from silx.third_party import enum
-
 
 # state machine ###############################################################
 
@@ -204,32 +202,6 @@ RIGHT_BTN = 'right'
 
 MIDDLE_BTN = 'middle'
 """Middle mouse button."""
-
-
-# Key codes
-@enum.unique
-class KeyCodes(enum.Enum):
-    """Keyboard key codes"""
-
-    BACKSPACE = 8
-    TAB = 9
-    ENTER = 13
-    SHIFT = 16
-    CONTROL = 17
-    ALT = 18
-    PAUSE_BREAK = 19
-    CAPS_LOCK = 20
-    ESCAPE = 27
-    PAGE_UP = 33
-    PAGE_DOWN = 34
-    END = 35
-    HOME = 36
-    LEFT_ARROW = 37
-    UP_ARROW = 38
-    RIGHT_ARROW = 39
-    DOWN_ARROW = 40
-    INSERT = 45
-    DELETE = 46
 
 
 class ClickOrDrag(StateMachine):

--- a/silx/gui/plot/Interaction.py
+++ b/silx/gui/plot/Interaction.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2016 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -81,6 +81,8 @@ __date__ = "18/02/2016"
 
 
 import weakref
+
+from silx.third_party import enum
 
 
 # state machine ###############################################################
@@ -202,6 +204,32 @@ RIGHT_BTN = 'right'
 
 MIDDLE_BTN = 'middle'
 """Middle mouse button."""
+
+
+# Key codes
+@enum.unique
+class KeyCodes(enum.Enum):
+    """Keyboard key codes"""
+
+    BACKSPACE = 8
+    TAB = 9
+    ENTER = 13
+    SHIFT = 16
+    CONTROL = 17
+    ALT = 18
+    PAUSE_BREAK = 19
+    CAPS_LOCK = 20
+    ESCAPE = 27
+    PAGE_UP = 33
+    PAGE_DOWN = 34
+    END = 35
+    HOME = 36
+    LEFT_ARROW = 37
+    UP_ARROW = 38
+    RIGHT_ARROW = 39
+    DOWN_ARROW = 40
+    INSERT = 45
+    DELETE = 46
 
 
 class ClickOrDrag(StateMachine):

--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -178,8 +178,7 @@ class Plot3DWidget(glu.OpenGLWidget):
 
         if (mode is not None and
                 qt.QApplication.keyboardModifiers() & qt.Qt.ControlModifier):
-            self.eventHandler.handleEvent('keyPress',
-                                          interaction.KeyCodes.CONTROL)
+            self.eventHandler.handleEvent('keyPress', qt.Qt.Key_Control)
 
         self.sigInteractiveModeChanged.emit()
 
@@ -365,8 +364,7 @@ class Plot3DWidget(glu.OpenGLWidget):
             if (keyCode == qt.Qt.Key_Control and
                     self.eventHandler is not None and
                     self.isValid()):
-                self.eventHandler.handleEvent('keyPress',
-                                              interaction.KeyCodes.CONTROL)
+                self.eventHandler.handleEvent('keyPress', keyCode)
 
             # Key not handled, call base class implementation
             super(Plot3DWidget, self).keyPressEvent(event)
@@ -377,8 +375,7 @@ class Plot3DWidget(glu.OpenGLWidget):
         if (keyCode == qt.Qt.Key_Control and
                 self.eventHandler is not None and
                 self.isValid()):
-            self.eventHandler.handleEvent('keyRelease',
-                                          interaction.KeyCodes.CONTROL)
+            self.eventHandler.handleEvent('keyRelease', keyCode)
         super(Plot3DWidget, self).keyReleaseEvent(event)
 
     # Mouse events #

--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -162,11 +162,13 @@ class Plot3DWidget(glu.OpenGLWidget):
                 self.viewport,
                 orbitAroundCenter=False,
                 mode='position',
-                scaleTransform=self._sceneScale)
+                scaleTransform=self._sceneScale,
+                selectCB=None)
 
         elif mode == 'pan':
             self.eventHandler = interaction.PanCameraControl(
                 self.viewport,
+                orbitAroundCenter=False,
                 mode='position',
                 scaleTransform=self._sceneScale,
                 selectCB=None)

--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -173,10 +173,13 @@ class Plot3DWidget(glu.OpenGLWidget):
                 scaleTransform=self._sceneScale,
                 selectCB=None)
 
+        elif isinstance(mode, interaction.StateMachine):
+            self.eventHandler = mode
+
         else:
             raise ValueError('Unsupported interactive mode %s', str(mode))
 
-        if (mode is not None and
+        if (self.eventHandler is not None and
                 qt.QApplication.keyboardModifiers() & qt.Qt.ControlModifier):
             self.eventHandler.handleEvent('keyPress', qt.Qt.Key_Control)
 

--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -176,6 +176,11 @@ class Plot3DWidget(glu.OpenGLWidget):
         else:
             raise ValueError('Unsupported interactive mode %s', str(mode))
 
+        if (mode is not None and
+                qt.QApplication.keyboardModifiers() & qt.Qt.ControlModifier):
+            self.eventHandler.handleEvent('keyPress',
+                                          interaction.KeyCodes.CONTROL)
+
         self.sigInteractiveModeChanged.emit()
 
     def getInteractiveMode(self):
@@ -338,7 +343,7 @@ class Plot3DWidget(glu.OpenGLWidget):
             self.eventHandler.handleEvent('wheel', xpixel, ypixel, angle)
 
     def keyPressEvent(self, event):
-        keycode = event.key()
+        keyCode = event.key()
         # No need to accept QKeyEvent
 
         converter = {
@@ -347,7 +352,7 @@ class Plot3DWidget(glu.OpenGLWidget):
             qt.Qt.Key_Up: 'up',
             qt.Qt.Key_Down: 'down'
         }
-        direction = converter.get(keycode, None)
+        direction = converter.get(keyCode, None)
         if direction is not None:
             if event.modifiers() == qt.Qt.ControlModifier:
                 self.viewport.camera.rotate(direction)
@@ -357,8 +362,24 @@ class Plot3DWidget(glu.OpenGLWidget):
                 self.viewport.orbitCamera(direction)
 
         else:
+            if (keyCode == qt.Qt.Key_Control and
+                    self.eventHandler is not None and
+                    self.isValid()):
+                self.eventHandler.handleEvent('keyPress',
+                                              interaction.KeyCodes.CONTROL)
+
             # Key not handled, call base class implementation
             super(Plot3DWidget, self).keyPressEvent(event)
+
+    def keyReleaseEvent(self, event):
+        """Catch Ctrl key release"""
+        keyCode = event.key()
+        if (keyCode == qt.Qt.Key_Control and
+                self.eventHandler is not None and
+                self.isValid()):
+            self.eventHandler.handleEvent('keyRelease',
+                                          interaction.KeyCodes.CONTROL)
+        super(Plot3DWidget, self).keyReleaseEvent(event)
 
     # Mouse events #
     _MOUSE_BTNS = {1: 'left', 2: 'right', 4: 'middle'}

--- a/silx/gui/plot3d/ScalarFieldView.py
+++ b/silx/gui/plot3d/ScalarFieldView.py
@@ -1065,7 +1065,8 @@ class ScalarFieldView(Plot3DWindow):
         self._panPlaneAction.setIcon(icons.getQIcon('3d-plane-pan'))
         self._panPlaneAction.setText('plane')
         self._panPlaneAction.setCheckable(True)
-        self._panPlaneAction.setToolTip('pan the cutting plane')
+        self._panPlaneAction.setToolTip(
+            'Pan the cutting plane. Press <b>Ctrl</b> to rotate the scene.')
         self._panPlaneAction.setEnabled(False)
 
         self._panPlaneAction.triggered[bool].connect(self._planeActionTriggered)
@@ -1110,6 +1111,7 @@ class ScalarFieldView(Plot3DWindow):
                     self.getPlot3DWidget().viewport,
                     self._cutPlane._get3DPrimitives()[0],
                     mode='position',
+                    orbitAroundCenter=False,
                     scaleTransform=sceneScale)
         else:
             self.getPlot3DWidget().setInteractiveMode(mode)

--- a/silx/gui/plot3d/ScalarFieldView.py
+++ b/silx/gui/plot3d/ScalarFieldView.py
@@ -1104,17 +1104,14 @@ class ScalarFieldView(Plot3DWindow):
 
         sceneScale = self.getPlot3DWidget().viewport.scene.transforms[0]
         if mode == 'plane':
-            self.getPlot3DWidget().setInteractiveMode(None)
+            mode = interaction.PanPlaneZoomOnWheelControl(
+                self.getPlot3DWidget().viewport,
+                self._cutPlane._get3DPrimitives()[0],
+                mode='position',
+                orbitAroundCenter=False,
+                scaleTransform=sceneScale)
 
-            self.getPlot3DWidget().eventHandler = \
-                interaction.PanPlaneZoomOnWheelControl(
-                    self.getPlot3DWidget().viewport,
-                    self._cutPlane._get3DPrimitives()[0],
-                    mode='position',
-                    orbitAroundCenter=False,
-                    scaleTransform=sceneScale)
-        else:
-            self.getPlot3DWidget().setInteractiveMode(mode)
+        self.getPlot3DWidget().setInteractiveMode(mode)
         self._updateColors()
 
     def getInteractiveMode(self):

--- a/silx/gui/plot3d/actions/mode.py
+++ b/silx/gui/plot3d/actions/mode.py
@@ -110,7 +110,7 @@ class RotateArcballAction(InteractiveModeAction):
 
         self.setIcon(getQIcon('rotate-3d'))
         self.setText('Rotate')
-        self.setToolTip('Rotate the view')
+        self.setToolTip('Rotate the view. Press <b>Ctrl</b> to pan.')
 
 
 class PanAction(InteractiveModeAction):
@@ -126,4 +126,4 @@ class PanAction(InteractiveModeAction):
 
         self.setIcon(getQIcon('pan'))
         self.setText('Pan')
-        self.setToolTip('Pan the view')
+        self.setToolTip('Pan the view. Press <b>Ctrl</b> to rotate.')

--- a/silx/gui/plot3d/scene/interaction.py
+++ b/silx/gui/plot3d/scene/interaction.py
@@ -694,7 +694,11 @@ class PanPlaneRotateCameraControl(FocusManager):
 class PanPlaneZoomOnWheelControl(FocusManager):
     """Combine zoom on wheel and pan plane state machines."""
     def __init__(self, viewport, plane,
-                 mode='center', scaleTransform=None):
+                 mode='center',
+                 orbitAroundCenter=False,
+                 scaleTransform=None):
         handlers = (CameraWheel(viewport, mode, scaleTransform),
                     PlanePan(viewport, plane, LEFT_BTN))
-        super(PanPlaneZoomOnWheelControl, self).__init__(handlers)
+        ctrlHandlers = (CameraWheel(viewport, mode, scaleTransform),
+                        CameraRotate(viewport, orbitAroundCenter, LEFT_BTN))
+        super(PanPlaneZoomOnWheelControl, self).__init__(handlers, ctrlHandlers)

--- a/silx/gui/plot3d/scene/interaction.py
+++ b/silx/gui/plot3d/scene/interaction.py
@@ -33,8 +33,9 @@ __date__ = "25/07/2016"
 import logging
 import numpy
 
+from silx.gui import qt
 from silx.gui.plot.Interaction import \
-    StateMachine, State, KeyCodes, LEFT_BTN, RIGHT_BTN  # , MIDDLE_BTN
+    StateMachine, State, LEFT_BTN, RIGHT_BTN  # , MIDDLE_BTN
 
 from . import transform
 
@@ -436,11 +437,11 @@ class FocusManager(StateMachine):
         super(FocusManager, self).__init__(states, 'idle')
 
     def onKeyPress(self, key):
-        if key == KeyCodes.CONTROL and self.ctrlEventHandlers is not None:
+        if key == qt.Qt.Key_Control and self.ctrlEventHandlers is not None:
             self.currentEventHandler = self.ctrlEventHandlers
 
     def onKeyRelease(self, key):
-        if key == KeyCodes.CONTROL:
+        if key == qt.Qt.Key_Control:
             self.currentEventHandler = self.defaultEventHandlers
 
     def cancel(self):


### PR DESCRIPTION
This PR adds support of a second interaction when Ctrl  (command on macOS) is pressed:
- For scene rotation, Ctrl switches to scene panning
- For scene panning, Ctrl switches to scene rotation
- For plane panning (so far only available in ScalarFieldView), Ctrl switches to scene rotation.

closes #1131 