### PR TITLE
[sx] Do not populate the global namespace with pylab

### DIFF
--- a/silx/sx/__init__.py
+++ b/silx/sx/__init__.py
@@ -99,7 +99,8 @@ else:
 
 # %pylab
 if _get_ipython is not None and _get_ipython() is not None:
-    _get_ipython().enable_pylab(gui='inline' if _IS_NOTEBOOK else 'qt')
+    _get_ipython().enable_pylab(gui='inline' if _IS_NOTEBOOK else 'qt',
+                                import_all=False)
 
 
 # Clean-up


### PR DESCRIPTION
This PR is related to #1633, but instead of removing pylab, it enables it but disable `from numpy|matplotlib import *` which avoids confusion between namespaces...

closes #1633