### PR TITLE
Use destroyed signal instead of __del__ for QWidget

### DIFF
--- a/silx/app/test/test_view.py
+++ b/silx/app/test/test_view.py
@@ -64,6 +64,9 @@ class ViewerMock(object):
     def appendFile(self, filename):
         self.appendFileCalls.append(filename)
 
+    def setAttribute(self, attr, value):
+        pass
+
     def resize(self, size):
         pass
 

--- a/silx/app/view.py
+++ b/silx/app/view.py
@@ -286,6 +286,7 @@ def main(argv):
 
     sys.excepthook = qt.exceptionHandler
     window = Viewer()
+    window.setAttribute(qt.Qt.WA_DeleteOnClose, True)
     window.resize(qt.QSize(640, 480))
 
     for filename in options.files:

--- a/silx/gui/dialog/AbstractDataFileDialog.py
+++ b/silx/gui/dialog/AbstractDataFileDialog.py
@@ -877,14 +877,14 @@ class AbstractDataFileDialog(qt.QDialog):
     # Logic
 
     def __navigateBackward(self):
-        """Navigate throug  the history one step backward."""
+        """Navigate through  the history one step backward."""
         if len(self.__currentHistory) > 0 and self.__currentHistoryLocation > 0:
             self.__currentHistoryLocation -= 1
             url = self.__currentHistory[self.__currentHistoryLocation]
             self.selectUrl(url)
 
     def __navigateForward(self):
-        """Navigate throug  the history one step forward."""
+        """Navigate through  the history one step forward."""
         if len(self.__currentHistory) > 0 and self.__currentHistoryLocation < len(self.__currentHistory) - 1:
             self.__currentHistoryLocation += 1
             url = self.__currentHistory[self.__currentHistoryLocation]

--- a/silx/gui/dialog/AbstractDataFileDialog.py
+++ b/silx/gui/dialog/AbstractDataFileDialog.py
@@ -1054,7 +1054,7 @@ class AbstractDataFileDialog(qt.QDialog):
             if fabio is None:
                 raise ImportError("Fabio module is not available")
             self.__fabio = fabio.open(filename)
-            self.__openedFiles[:] = [self.__fabio]
+            self.__openedFiles.append(self.__fabio)
             self.__selectedFile = filename
         except Exception as e:
             _logger.error("Error while loading file %s: %s", filename, e.args[0])
@@ -1068,7 +1068,7 @@ class AbstractDataFileDialog(qt.QDialog):
         self.__closeFile()
         try:
             self.__h5 = silx.io.open(filename)
-            self.__openedFiles[:] = [self.__h5]
+            self.__openedFiles.append(self.__h5)
             self.__selectedFile = filename
         except IOError as e:
             _logger.error("Error while loading file %s: %s", filename, e.args[0])

--- a/silx/gui/dialog/AbstractDataFileDialog.py
+++ b/silx/gui/dialog/AbstractDataFileDialog.py
@@ -35,6 +35,7 @@ import sys
 import os
 import logging
 import numpy
+import functools
 import silx.io.url
 from silx.gui import qt
 from silx.gui.hdf5.Hdf5TreeModel import Hdf5TreeModel
@@ -567,13 +568,27 @@ class AbstractDataFileDialog(qt.QDialog):
         self.__fileTypeCombo.setCurrentIndex(0)
         self.__filterSelected(0)
 
+        self.__openedFiles = []
+        """Store the list of files opened by the model itself."""
+        # FIXME: It should be managed one by one by Hdf5Item itself
+
         # It is not possible to override the QObject destructor nor
         # to access to the content of the Python object with the `destroyed`
         # signal cause the Python method was already removed with the QWidget,
         # while the QObject still exists.
-        # Using lambda function looks to force a self-reference to the object
-        # which allow to access to it at the destroy time.
-        self.destroyed.connect(lambda: self._clear())
+        # We use a static method plus explicit references to objects to
+        # release. The callback do not use any ref to self.
+        onDestroy = functools.partial(self._closeFileList, self.__openedFiles)
+        self.destroyed.connect(onDestroy)
+
+    @staticmethod
+    def _closeFileList(fileList):
+        """Static method to close explicit references to internal objects."""
+        _logger.debug("Clear AbstractDataFileDialog")
+        for obj in fileList:
+            _logger.debug("Close file %s", obj.filename)
+            obj.close()
+        fileList[:] = []
 
     def done(self, result):
         self._clear()
@@ -586,7 +601,7 @@ class AbstractDataFileDialog(qt.QDialog):
         This method is triggered by the destruction of the object and the
         QDialog :meth:`done`. Then it can be triggered more than once.
         """
-        _logger.debug("Dialog cleared")
+        _logger.debug("Clear dialog")
         self.__errorWhileLoadingFile = None
         self.__clearData()
         if self.__fileModel is not None:
@@ -1021,6 +1036,7 @@ class AbstractDataFileDialog(qt.QDialog):
         self.__processing -= 1
 
     def __closeFile(self):
+        self.__openedFiles[:] = []
         self.__fileDirectoryAction.setEnabled(False)
         self.__parentFileDirectoryAction.setEnabled(False)
         if self.__h5 is not None:
@@ -1038,6 +1054,7 @@ class AbstractDataFileDialog(qt.QDialog):
             if fabio is None:
                 raise ImportError("Fabio module is not available")
             self.__fabio = fabio.open(filename)
+            self.__openedFiles[:] = [self.__fabio]
             self.__selectedFile = filename
         except Exception as e:
             _logger.error("Error while loading file %s: %s", filename, e.args[0])
@@ -1051,6 +1068,7 @@ class AbstractDataFileDialog(qt.QDialog):
         self.__closeFile()
         try:
             self.__h5 = silx.io.open(filename)
+            self.__openedFiles[:] = [self.__h5]
             self.__selectedFile = filename
         except IOError as e:
             _logger.error("Error while loading file %s: %s", filename, e.args[0])

--- a/silx/gui/dialog/test/test_datafiledialog.py
+++ b/silx/gui/dialog/test/test_datafiledialog.py
@@ -875,6 +875,7 @@ class TestDataFileDialogApi(utils.TestCaseQt, _UtilsMixin):
         dialog = self.createDialog()
         dialog.restoreState(state)
         state = qt.QByteArray(self.STATE_VERSION1_QT5)
+        dialog = None
         dialog = self.createDialog()
         dialog.restoreState(state)
 
@@ -886,6 +887,7 @@ class TestDataFileDialogApi(utils.TestCaseQt, _UtilsMixin):
         self.qWaitForPendingActions(dialog)
         state = dialog.saveState()
         os.rmdir(directory)
+        dialog = None
 
         dialog2 = self.createDialog()
         result = dialog2.restoreState(state)

--- a/silx/gui/dialog/test/test_imagefiledialog.py
+++ b/silx/gui/dialog/test/test_imagefiledialog.py
@@ -570,9 +570,11 @@ class TestImageFileDialogApi(utils.TestCaseQt, _UtilsMixin):
         dialog.setColormap(colormap)
         self.qWaitForPendingActions(dialog)
         state = dialog.saveState()
+        dialog = None
 
         dialog2 = self.createDialog()
         result = dialog2.restoreState(state)
+        self.qWaitForPendingActions(dialog2)
         self.assertTrue(result)
         self.assertTrue(dialog2.colormap().getNormalization(), "log")
 
@@ -680,6 +682,7 @@ class TestImageFileDialogApi(utils.TestCaseQt, _UtilsMixin):
         dialog = self.createDialog()
         dialog.restoreState(state)
         state = qt.QByteArray(self.STATE_VERSION1_QT5)
+        dialog = None
         dialog = self.createDialog()
         dialog.restoreState(state)
 
@@ -691,6 +694,7 @@ class TestImageFileDialogApi(utils.TestCaseQt, _UtilsMixin):
         self.qWaitForPendingActions(dialog)
         state = dialog.saveState()
         os.rmdir(directory)
+        dialog = None
 
         dialog2 = self.createDialog()
         result = dialog2.restoreState(state)

--- a/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/silx/gui/hdf5/Hdf5TreeModel.py
@@ -236,22 +236,22 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
 
         self.__openedFiles = []
         """Store the list of files opened by the model itself."""
-        # FIXME: It should managed one by one by Hdf5Item itself
+        # FIXME: It should be managed one by one by Hdf5Item itself
 
-    def __del__(self):
-        self._closeOpened()
-        s = super(Hdf5TreeModel, self)
-        if hasattr(s, "__del__"):
-            # else it fail on Python 3
-            s.__del__()
+        # It is not possible to override the QObject destructor nor
+        # to access to the content of the Python object with the `destroyed`
+        # signal cause the Python method was already removed with the QWidget,
+        # while the QObject still exists.
+        # Using lambda function looks to force a self-reference to the object
+        # which allow to access to it at the destroy time.
+        self.destroyed.connect(lambda: self._closeOpened())
 
     def _closeOpened(self):
         """Close files which was opened by this model.
 
-        This function may be removed in the future.
-
         File are opened by the model when it was inserted using
         `insertFileAsync`, `insertFile`, `appendFile`."""
+        _logger.debug("Model cleared")
         for h5file in self.__openedFiles:
             h5file.close()
         self.__openedFiles = []

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -40,6 +40,7 @@ from silx.gui import qt
 from silx.gui.test.utils import TestCaseQt
 from silx.gui import hdf5
 from silx.io import commonh5
+import weakref
 
 try:
     import h5py
@@ -133,7 +134,9 @@ class TestHdf5TreeModel(TestCaseQt):
                 index = model.index(0, 0, qt.QModelIndex())
                 self.assertIsInstance(model.nodeFromIndex(index), hdf5.Hdf5Item.Hdf5Item)
             finally:
+                ref = weakref.ref(model)
                 model = None
+                self.qWaitForDestroy(ref)
 
     def testInsertObject(self):
         h5 = commonh5.File("/foo/bar/1.mock", "w")
@@ -505,7 +508,9 @@ class TestH5Node(TestCaseQt):
 
     @classmethod
     def tearDownClass(cls):
+        ref = weakref.ref(cls.model)
         cls.model = None
+        cls.qWaitForDestroy(ref)
         cls.h5File.close()
         shutil.rmtree(cls.tmpDirectory)
         super(TestH5Node, cls).tearDownClass()

--- a/silx/gui/plot/test/testUtilsAxis.py
+++ b/silx/gui/plot/test/testUtilsAxis.py
@@ -88,36 +88,6 @@ class TestAxisSync(TestCaseQt):
         self.assertNotEqual(self.plot2.getXAxis().getLimits(), (10, 500))
         self.assertNotEqual(self.plot3.getXAxis().getLimits(), (10, 500))
 
-    _qobject_destroyed = False
-
-    def _aboutToDestroy(self):
-        self._qobject_destroyed = True
-
-    def qWaitForDestroy(self, ref):
-        """
-        Wait for Qt object destruction.
-
-        Use a weakref as parameter to avoid any reference to the object
-
-        :param weakref ref: A weakref to an object to avoid any reference
-        :return: True if the object was destroyed
-        :rtype: bool
-        """
-        self._qobject_destroyed = False
-        import gc
-        gc.collect()
-        widget = ref()
-        if widget is None:
-            return True
-        widget.destroyed.connect(self._aboutToDestroy)
-        widget.deleteLater()
-        widget = None
-        for _ in range(10):
-            if self._qobject_destroyed:
-                break
-
-        return ref() is None
-
     def testAxisDestruction(self):
         """Test synchronization when an axis disappear"""
         _sync = SyncAxes([self.plot1.getXAxis(), self.plot2.getXAxis(), self.plot3.getXAxis()])

--- a/silx/gui/test/utils.py
+++ b/silx/gui/test/utils.py
@@ -318,24 +318,25 @@ class TestCaseQt(unittest.TestCase):
         """
         QTest.qSleep(ms + self.TIMEOUT_WAIT)
 
-    def qWait(self, ms=None):
+    @classmethod
+    def qWait(cls, ms=None):
         """Waits for ms milliseconds, events will be processed.
 
         See QTest.qWait for details.
         """
         if ms is None:
-            ms = self.DEFAULT_TIMEOUT_WAIT
+            ms = cls.DEFAULT_TIMEOUT_WAIT
 
         if qt.BINDING == 'PySide':
             # PySide has no qWait, provide a replacement
             timeout = int(ms)
             endTimeMS = int(time.time() * 1000) + timeout
             while timeout > 0:
-                self.qapp.processEvents(qt.QEventLoop.AllEvents,
+                _qapp.processEvents(qt.QEventLoop.AllEvents,
                                         maxtime=timeout)
                 timeout = endTimeMS - int(time.time() * 1000)
         else:
-            QTest.qWait(ms + self.TIMEOUT_WAIT)
+            QTest.qWait(ms + cls.TIMEOUT_WAIT)
 
     def qWaitForWindowExposed(self, window, timeout=None):
         """Waits until the window is shown in the screen.
@@ -389,6 +390,7 @@ class TestCaseQt(unittest.TestCase):
         for _ in range(10):
             if cls._qobject_destroyed:
                 break
+            cls.qWait(10)
         else:
             _logger.debug("Object was not destroyed")
 

--- a/silx/gui/test/utils.py
+++ b/silx/gui/test/utils.py
@@ -379,8 +379,13 @@ class TestCaseQt(unittest.TestCase):
         :rtype: bool
         """
         cls._qobject_destroyed = False
-        import gc
-        gc.collect()
+        if qt.BINDING == 'PyQt4':
+            # Without this, QWidget will be still alive on PyQt4
+            # (at least on Windows Python 2.7)
+            # If it is not skipped on PySide, silx.gui.dialog tests will
+            # segfault (at least on Windows Python 2.7)
+            import gc
+            gc.collect()
         qobject = ref()
         if qobject is None:
             return True


### PR DESCRIPTION
It definitly looks very dangerous to use `__del__` on QWidget, while it is very dependent to the MV/OS... This PR.

- Try to use `destroyed` signal on `Hdf5TreeModel` and `AbstractFileDialog`. That's not so easy, but it looks to work ()
- `TestCaseQt` was patched to be able to use `qWait` and a new `qWaitForDestroy` as class method (usable in the `tearDownClass`).
- Rework `SyncAxes` which was segfaulting on PyQt5 (due to an update of qWaitForDestroy)
- Rework `qWaitForDestroy` which was segfaulting on Windows PySide
- Fix `Hdf5TreeModel` to take care of onwed openned files (it was not fully implemented for item synchronization and item remove)

Closes #1638