### PR TITLE
[plot3d] Add pan selected plane interaction to SceneWindow

### DIFF
--- a/silx/gui/plot3d/ScalarFieldView.py
+++ b/silx/gui/plot3d/ScalarFieldView.py
@@ -1063,7 +1063,7 @@ class ScalarFieldView(Plot3DWindow):
         """Creates and init the pan plane action"""
         self._panPlaneAction = qt.QAction(self)
         self._panPlaneAction.setIcon(icons.getQIcon('3d-plane-pan'))
-        self._panPlaneAction.setText('plane')
+        self._panPlaneAction.setText('Pan plane')
         self._panPlaneAction.setCheckable(True)
         self._panPlaneAction.setToolTip(
             'Pan the cutting plane. Press <b>Ctrl</b> to rotate the scene.')
@@ -1117,9 +1117,8 @@ class ScalarFieldView(Plot3DWindow):
     def getInteractiveMode(self):
         """Returns the current interaction mode, see :meth:`setInteractiveMode`
         """
-        if (isinstance(self.getPlot3DWidget().eventHandler,
-                       interaction.PanPlaneZoomOnWheelControl) or
-                self.getPlot3DWidget().eventHandler is None):
+        if isinstance(self.getPlot3DWidget().eventHandler,
+                      interaction.PanPlaneZoomOnWheelControl):
             return 'plane'
         else:
             return self.getPlot3DWidget().getInteractiveMode()

--- a/silx/gui/plot3d/SceneWindow.py
+++ b/silx/gui/plot3d/SceneWindow.py
@@ -69,7 +69,10 @@ class _PanPlaneAction(InteractiveModeAction):
         if event in (items.ItemChangedType.VISIBLE,
                      items.ItemChangedType.POSITION):
             plane = self.sender()
-            isPlaneInteractive = plane.isValid() and plane.isVisible()
+
+            isPlaneInteractive = \
+                plane._getPlane().plane.isPlane and plane.isVisible()
+
             if isPlaneInteractive != self.isEnabled():
                 self.setEnabled(isPlaneInteractive)
                 mode = 'panSelectedPlane' if isPlaneInteractive else 'rotate'

--- a/silx/gui/plot3d/SceneWindow.py
+++ b/silx/gui/plot3d/SceneWindow.py
@@ -32,11 +32,12 @@ __license__ = "MIT"
 __date__ = "29/11/2017"
 
 
-from silx.gui import qt
+from ...gui import qt, icons
 
+from .actions.mode import InteractiveModeAction
 from .SceneWidget import SceneWidget
 from .tools import OutputToolBar, InteractiveModeToolBar, ViewpointToolBar
-from silx.gui.plot3d.tools.GroupPropertiesWidget import GroupPropertiesWidget
+from .tools.GroupPropertiesWidget import GroupPropertiesWidget
 
 from .ParamTreeView import ParamTreeView
 
@@ -45,6 +46,61 @@ from . import items  # noqa
 
 
 __all__ = ['items', 'SceneWidget', 'SceneWindow']
+
+
+class _PanPlaneAction(InteractiveModeAction):
+    """QAction to set plane pan interaction on a Plot3DWidget
+
+    :param parent: See :class:`QAction`
+    :param ~silx.gui.plot3d.Plot3DWidget.Plot3DWidget plot3d:
+        Plot3DWidget the action is associated with
+    """
+    def __init__(self, parent, plot3d=None):
+        super(_PanPlaneAction, self).__init__(
+            parent, 'panSelectedPlane', plot3d)
+        self.setIcon(icons.getQIcon('3d-plane-pan'))
+        self.setText('Pan plane')
+        self.setCheckable(True)
+        self.setToolTip(
+            'Pan selected plane. Press <b>Ctrl</b> to rotate the scene.')
+
+    def _planeChanged(self, event):
+        """Handle plane updates"""
+        if event in (items.ItemChangedType.VISIBLE,
+                     items.ItemChangedType.POSITION):
+            plane = self.sender()
+            isPlaneInteractive = plane.isValid() and plane.isVisible()
+            if isPlaneInteractive != self.isEnabled():
+                self.setEnabled(isPlaneInteractive)
+                mode = 'panSelectedPlane' if isPlaneInteractive else 'rotate'
+                self.getPlot3DWidget().setInteractiveMode(mode)
+
+    def _selectionChanged(self, current, previous):
+        """Handle selected object change"""
+        if isinstance(previous, items.PlaneMixIn):
+            previous.sigItemChanged.disconnect(self._planeChanged)
+
+        if isinstance(current, items.PlaneMixIn):
+            current.sigItemChanged.connect(self._planeChanged)
+            self.setEnabled(True)
+            self.getPlot3DWidget().setInteractiveMode('panSelectedPlane')
+        else:
+            self.setEnabled(False)
+
+    def setPlot3DWidget(self, widget):
+        previous = self.getPlot3DWidget()
+        if isinstance(previous, SceneWidget):
+            previous.selection().sigCurrentChanged.disconnect(
+                self._selectionChanged)
+            self._selectionChanged(
+                None, previous.selection().getCurrentItem())
+
+        super(_PanPlaneAction, self).setPlot3DWidget(widget)
+
+        if isinstance(widget, SceneWidget):
+            self._selectionChanged(widget.selection().getCurrentItem(), None)
+            widget.selection().sigCurrentChanged.connect(
+                self._selectionChanged)
 
 
 class SceneWindow(qt.QMainWindow):
@@ -60,6 +116,9 @@ class SceneWindow(qt.QMainWindow):
         self.setCentralWidget(self._sceneWidget)
 
         self._interactiveModeToolBar = InteractiveModeToolBar(parent=self)
+        panPlaneAction = _PanPlaneAction(self, plot3d=self._sceneWidget)
+        self._interactiveModeToolBar.addAction(panPlaneAction)
+
         self._viewpointToolBar = ViewpointToolBar(parent=self)
         self._outputToolBar = OutputToolBar(parent=self)
 


### PR DESCRIPTION
This PR adds support for pan interaction of the selected plane (clip plane or cut plane) in `SceneWidget`.
It adds a QAction in `SceneWindow` to toggle this interaction mode.
This QAction is not in the public API yet as I am not very happy with the way it is done, but the functionality is available:

The user can pan the selected plane in the parameter tree with the mouse.
For now, if the user press Ctrl and drag the mouse, it rotates the scene... In the future I might use Ctrl to interactively rotate the plane...

I also optimized the model structure as during plane interaction most of the time was spent in `QObject.parent()` up to the point that interaction was not smooth!