### PR TITLE
[nxdata] bug when reading back unicode and testing for str type (PY2)

### DIFF
--- a/silx/io/nxdata.py
+++ b/silx/io/nxdata.py
@@ -86,7 +86,11 @@ def get_attr_as_string(item, attr_name, default=None):
     """
     attr = item.attrs.get(attr_name, default)
     if six.PY2:
-        return attr
+        if isinstance(attr, six.text_type):
+            # unicode
+            return attr.encode("utf-8")
+        else:
+            return attr
     if six.PY3:
         if hasattr(attr, "decode"):
             # byte-string


### PR DESCRIPTION
Found a bug when trying to run `examples/hdf5Widget.py`, `NXdata/1D_spectrum`. Single unicode string attr was not cast as list because I'm testing for type `str`.

