### PR TITLE
Proposal for a silx.utils.debug module

### DIFF
--- a/silx/utils/debug.py
+++ b/silx/utils/debug.py
@@ -1,0 +1,102 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+
+
+import inspect
+import types
+import logging
+from silx.third_party import six
+
+
+debug_logger = logging.getLogger("silx.DEBUG")
+
+_indent = 0
+
+
+def log_method(func, class_name=None):
+    """Decorator to inject a warning log before an after any function/method.
+
+    .. code-block:: python
+
+        @log_method
+        def foo():
+            return None
+
+    :param callable func: The function to patch
+    :param str class_name: In case a method, provide the class name
+    """
+    def wrapper(*args, **kwargs):
+        global _indent
+
+        indent = "  " * _indent
+        func_name = func.func_name if six.PY2 else func.__name__
+        if class_name is not None:
+            name = "%s.%s" % (class_name, func_name)
+        else:
+            name = "%s" % (func_name)
+
+        debug_logger.warning("%s%s" % (indent, name))
+        _indent += 1
+        result = func(*args, **kwargs)
+        _indent -= 1
+        debug_logger.warning("%sreturn  (%s)" % (indent, name))
+        return result
+    return wrapper
+
+
+def log_all_methods(base_class):
+    """Decorator to inject a warning log before an after any method provided by
+    a class.
+
+    .. code-block:: python
+
+        @log_all_methods
+        class Foo(object):
+
+            def a(self):
+                return None
+
+            def b(self):
+                return self.a()
+
+    Here is the output when calling the `b` method.
+
+    .. code-block::
+
+        WARNING:silx.DEBUG:_Foobar.b
+        WARNING:silx.DEBUG:  _Foobar.a
+        WARNING:silx.DEBUG:  return  (_Foobar.a)
+        WARNING:silx.DEBUG:return  (_Foobar.b)
+
+    :param class base_class: The class to patch
+    """
+    methodTypes = (types.MethodType, types.FunctionType, types.BuiltinFunctionType, types.BuiltinMethodType)
+    for name, func in inspect.getmembers(base_class):
+        if isinstance(func, methodTypes):
+            if func.__name__ not in ["__subclasshook__", "__new__"]:
+                # patching __new__ in Python2 break the object, then we skip it
+                setattr(base_class, name, log_method(func, base_class.__name__))
+
+    return base_class

--- a/silx/utils/test/__init__.py
+++ b/silx/utils/test/__init__.py
@@ -24,7 +24,7 @@
 # ###########################################################################*/
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "02/10/2017"
+__date__ = "27/02/2018"
 
 
 import unittest
@@ -34,6 +34,7 @@ from . import test_array_like
 from . import test_launcher
 from . import test_deprecation
 from . import test_proxy
+from . import test_debug
 
 
 def suite():
@@ -44,4 +45,5 @@ def suite():
     test_suite.addTest(test_launcher.suite())
     test_suite.addTest(test_deprecation.suite())
     test_suite.addTest(test_proxy.suite())
+    test_suite.addTest(test_debug.suite())
     return test_suite

--- a/silx/utils/test/test_debug.py
+++ b/silx/utils/test/test_debug.py
@@ -1,0 +1,99 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Tests for debug module"""
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "27/02/2018"
+
+
+import unittest
+from silx.utils import debug
+from silx.utils import testutils
+
+
+@debug.log_all_methods
+class _Foobar(object):
+
+    def a(self):
+        return None
+
+    def b(self):
+        return self.a()
+
+    def random_args(self, *args, **kwargs):
+        return args, kwargs
+
+    def named_args(self, a, b):
+        return a + 1, b + 1
+
+
+class TestDebug(unittest.TestCase):
+    """Tests for debug module."""
+
+    def logB(self):
+        """
+        Can be used to check the log output using:
+        `./run_tests.py silx.utils.test.test_debug.TestDebug.logB -v`
+        """
+        print()
+        test = _Foobar()
+        test.b()
+
+    @testutils.test_logging(debug.debug_logger.name, warning=2)
+    def testMethod(self):
+        test = _Foobar()
+        test.a()
+
+    @testutils.test_logging(debug.debug_logger.name, warning=4)
+    def testInterleavedMethod(self):
+        test = _Foobar()
+        test.b()
+
+    @testutils.test_logging(debug.debug_logger.name, warning=2)
+    def testNamedArgument(self):
+        # Arguments arre still provided to the patched method
+        test = _Foobar()
+        result = test.named_args(10, 11)
+        self.assertEqual(result, (11, 12))
+
+    @testutils.test_logging(debug.debug_logger.name, warning=2)
+    def testRandomArguments(self):
+        # Arguments arre still provided to the patched method
+        test = _Foobar()
+        result = test.random_args("foo", 50, a=10, b=100)
+        self.assertEqual(result[0], ("foo", 50))
+        self.assertEqual(result[1], {"a": 10, "b": 100})
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(TestDebug))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
It was very useful to debug segfaulting and deadlocking Qt class, then i think it can be helpful for everybody.

It can be used like that:
```
        @log_all_methods
        class Foobar(object):

            def a(self):
                return None

            def b(self):
                return self.a()
```

A simple example
```
f = Foobar()
f.b()
```

Here is the output when calling the `b` method.
```
        WARNING:silx.DEBUG:Foobar.b
        WARNING:silx.DEBUG:  Foobar.a
        WARNING:silx.DEBUG:  return  (Foobar.a)
        WARNING:silx.DEBUG:return  (Foobar.b)
```

Closes #1673