### PR TITLE
[gui] Change PyQt preference order

### DIFF
--- a/doc/source/modules/gui/plot/getting_started.rst
+++ b/doc/source/modules/gui/plot/getting_started.rst
@@ -20,6 +20,8 @@ For a complete description of the API, see :mod:`silx.gui.plot`.
 Use :mod:`silx.gui.plot` from (I)Python console
 -----------------------------------------------
 
+We recommend to use (I)Python 3.x and PyQt5.
+
 From a Python or IPython interpreter, the simplest way is to import the :mod:`silx.sx` module:
 
 >>> from silx import sx
@@ -28,19 +30,27 @@ The :mod:`silx.sx` module initializes Qt and provides access to :mod:`silx.gui.p
 
 .. note:: From a notebook, the :mod:`silx.sx` module does NOT initialize Qt and does NOT expose silx widget.
 
+An alternative to run :mod:`silx.gui` widgets from `IPython <http://ipython.org/>`_,
+is to set IPython to use Qt(5), e.g., with the `--gui` option::
+
+  ipython --gui=qt5
+
+
 Compatibility with IPython
 ++++++++++++++++++++++++++
 
-To run :mod:`silx.gui` widgets from `IPython <http://ipython.org/>`_,
-IPython must be set to use Qt (and in case of using PyQt4 and Python 2.7,
-PyQt must be set to use API version 2, see note below for explanation).
+silx widgets require Qt to be initialized.
+If Qt is not yet loaded, silx tries to load PyQt5 first before trying other supported bindings.
 
-As *silx* is performing some configuration of the Qt binding and `matplotlib <http://matplotlib.org/>`_, the safest way to use *silx* from IPython is to import :mod:`silx.gui.plot` first and then run either `%gui <http://ipython.org/ipython-doc/stable/interactive/magics.html#magic-gui>`_ qt  or `%pylab <http://ipython.org/ipython-doc/stable/interactive/magics.html#magic-pylab>`_ qt::
+With versions of IPython lower than 3.0 (e.g., on Debian 8), there is an incompatibility between
+the way silx loads Qt and the way IPython is doing it through the ``--gui`` option,
+`%gui <http://ipython.org/ipython-doc/stable/interactive/magics.html#magic-gui>`_ or
+`%pylab <http://ipython.org/ipython-doc/stable/interactive/magics.html#magic-pylab>`_ magics.
+In this case, IPython magics that initialize Qt might not work after importing modules from silx.gui.
 
-  In [1]: from silx.gui.plot import *
-  In [2]: %pylab qt
-
-Alternatively, when using Python 2.7 and PyQt4, you can start IPython with the ``QT_API`` environment variable set to ``pyqt``.
+When using Python2.7 and PyQt4, there is another incompatibility to deal with as
+silx requires PyQt4 API version 2 (See note below for explanation).
+In this case, start IPython with the ``QT_API`` environment variable set to ``pyqt``.
 
 On Linux and MacOS X, run::
 

--- a/silx/gui/qt/__init__.py
+++ b/silx/gui/qt/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,12 +24,13 @@
 # ###########################################################################*/
 """Common wrapper over Python Qt bindings:
 
-- `PyQt5 <http://pyqt.sourceforge.net/Docs/PyQt5/>`_,
-- `PyQt4 <http://pyqt.sourceforge.net/Docs/PyQt4/>`_ or
-- `PySide <http://www.pyside.org>`_.
+- `PyQt5 <http://pyqt.sourceforge.net/Docs/PyQt5/>`_
+- `PyQt4 <http://pyqt.sourceforge.net/Docs/PyQt4/>`_
+- `PySide <http://www.pyside.org>`_
+- `PySide2 <https://wiki.qt.io/PySide2>`_
 
 If a Qt binding is already loaded, it will use it, otherwise the different
-Qt bindings are tried in this order: PyQt4, PySide, PyQt5.
+Qt bindings are tried in this order: PyQt5, PyQt4, PySide, PySide2.
 
 The name of the loaded Qt binding is stored in the BINDING variable.
 
@@ -50,7 +51,6 @@ see `qtpy <https://pypi.python.org/pypi/QtPy/>`_ which
 provides the namespace of PyQt5 over PyQt4 and PySide.
 """
 
-import sys
 from ._qt import *  # noqa
 from ._utils import *  # noqa
 

--- a/silx/gui/qt/_qt.py
+++ b/silx/gui/qt/_qt.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -78,27 +78,27 @@ elif 'PyQt4.QtCore' in sys.modules:
 
 else:  # Then try Qt bindings
     try:
-        import PyQt4  # noqa
+        import PyQt5  # noqa
     except ImportError:
         try:
-            import PySide  # noqa
+            import PyQt4  # noqa
         except ImportError:
             try:
-                import PyQt5  # noqa
+                import PySide  # noqa
             except ImportError:
                 try:
                     import PySide2  # noqa
                 except ImportError:
                     raise ImportError(
-                        'No Qt wrapper found. Install PyQt4, PyQt5 or PySide2.')
+                        'No Qt wrapper found. Install PyQt5, PyQt4 or PySide2.')
                 else:
                     BINDING = 'PySide2'
             else:
-                BINDING = 'PyQt5'
+                BINDING = 'PySide'
         else:
-            BINDING = 'PySide'
+            BINDING = 'PyQt4'
     else:
-        BINDING = 'PyQt4'
+        BINDING = 'PyQt5'
 
 
 if BINDING == 'PyQt4':

--- a/silx/sx/__init__.py
+++ b/silx/sx/__init__.py
@@ -99,8 +99,11 @@ else:
 
 # %pylab
 if _get_ipython is not None and _get_ipython() is not None:
-    _get_ipython().enable_pylab(gui='inline' if _IS_NOTEBOOK else 'qt',
-                                import_all=False)
+    if _IS_NOTEBOOK:
+        _get_ipython().enable_pylab(gui='inline', import_all=False)
+    else:
+        from IPython.core.pylabtools import import_pylab as _import_pylab
+        _import_pylab(_get_ipython().user_ns, import_all=False)
 
 
 # Clean-up


### PR DESCRIPTION
This PR tries to load PyQt5 first, then PyQt4, PySide and PySide2.

Doc is updated accordingly to acknowledge pitfalls with IPython.
sx module is also updated to perform imports as %pylab but to avoid the initialization of Qt by IPython.