### PR TITLE
[gui] Add a shared QPrinter instance in silx.gui

### DIFF
--- a/silx/gui/plot/actions/io.py
+++ b/silx/gui/plot/actions/io.py
@@ -47,7 +47,7 @@ import sys
 from collections import OrderedDict
 import traceback
 import numpy
-from silx.gui import qt
+from silx.gui import qt, printer
 from silx.third_party.EdfFile import EdfFile
 from silx.third_party.TiffIO import TiffIO
 from silx.gui._utils import convertArrayToQImage
@@ -526,9 +526,6 @@ class PrintAction(PlotAction):
     :param parent: See :class:`QAction`.
     """
 
-    # Share QPrinter instance to propose latest used as default
-    _printer = None
-
     def __init__(self, plot, parent=None):
         super(PrintAction, self).__init__(
             plot, icon='document-print', text='Print...',
@@ -544,9 +541,7 @@ class PrintAction(PlotAction):
 
         This is shared accross all instances of PrintAct
         """
-        if self._printer is None:
-            PrintAction._printer = qt.QPrinter()
-        return self._printer
+        return printer.getDefaultPrinter()
 
     def printPlotAsWidget(self):
         """Open the print dialog and print the plot.

--- a/silx/gui/plot/actions/io.py
+++ b/silx/gui/plot/actions/io.py
@@ -47,6 +47,7 @@ import sys
 from collections import OrderedDict
 import traceback
 import numpy
+from silx.utils.deprecation import deprecated
 from silx.gui import qt, printer
 from silx.third_party.EdfFile import EdfFile
 from silx.third_party.TiffIO import TiffIO
@@ -535,13 +536,17 @@ class PrintAction(PlotAction):
         self.setShortcut(qt.QKeySequence.Print)
         self.setShortcutContext(qt.Qt.WidgetShortcut)
 
-    @property
-    def printer(self):
-        """The QPrinter instance used by the actions.
+    def getPrinter(self):
+        """The QPrinter instance used by the PrintAction.
 
-        This is shared accross all instances of PrintAct
+        :rtype: QPrinter
         """
         return printer.getDefaultPrinter()
+
+    @property
+    @deprecated(replacement="getPrinter()", since_version="0.8.0")
+    def printer(self):
+        return self.getPrinter()
 
     def printPlotAsWidget(self):
         """Open the print dialog and print the plot.
@@ -550,7 +555,7 @@ class PrintAction(PlotAction):
 
         :return: True if successful
         """
-        dialog = qt.QPrintDialog(self.printer, self.plot)
+        dialog = qt.QPrintDialog(self.getPrinter(), self.plot)
         dialog.setWindowTitle('Print Plot')
         if not dialog.exec_():
             return False
@@ -559,10 +564,10 @@ class PrintAction(PlotAction):
         widget = self.plot.centralWidget()
 
         painter = qt.QPainter()
-        if not painter.begin(self.printer):
+        if not painter.begin(self.getPrinter()):
             return False
 
-        pageRect = self.printer.pageRect()
+        pageRect = self.getPrinter().pageRect()
         xScale = pageRect.width() / widget.width()
         yScale = pageRect.height() / widget.height()
         scale = min(xScale, yScale)
@@ -583,7 +588,7 @@ class PrintAction(PlotAction):
         :return: True if successful
         """
         # Init printer and start printer dialog
-        dialog = qt.QPrintDialog(self.printer, self.plot)
+        dialog = qt.QPrintDialog(self.getPrinter(), self.plot)
         dialog.setWindowTitle('Print Plot')
         if not dialog.exec_():
             return False
@@ -594,13 +599,13 @@ class PrintAction(PlotAction):
         pixmap = qt.QPixmap()
         pixmap.loadFromData(pngData, 'png')
 
-        xScale = self.printer.pageRect().width() / pixmap.width()
-        yScale = self.printer.pageRect().height() / pixmap.height()
+        xScale = self.getPrinter().pageRect().width() / pixmap.width()
+        yScale = self.getPrinter().pageRect().height() / pixmap.height()
         scale = min(xScale, yScale)
 
         # Draw pixmap with painter
         painter = qt.QPainter()
-        if not painter.begin(self.printer):
+        if not painter.begin(self.getPrinter()):
             return False
 
         painter.drawPixmap(0, 0,

--- a/silx/gui/plot3d/actions/io.py
+++ b/silx/gui/plot3d/actions/io.py
@@ -39,8 +39,7 @@ import os
 
 import numpy
 
-from silx.gui import qt
-from silx.gui.plot.actions.io import PrintAction as _PrintAction
+from silx.gui import qt, printer
 from silx.gui.icons import getQIcon
 from .Plot3DAction import Plot3DAction
 from ..utils import mng
@@ -157,11 +156,7 @@ class PrintAction(Plot3DAction):
 
         :rtype: QPrinter
         """
-        # TODO This is a hack to sync with silx plot PrintAction
-        # This needs to be centralized
-        if _PrintAction._printer is None:
-            _PrintAction._printer = qt.QPrinter()
-        return _PrintAction._printer
+        return printer.getDefaultPrinter()
 
     def _triggered(self, checked=False):
         plot3d = self.getPlot3DWidget()

--- a/silx/gui/printer.py
+++ b/silx/gui/printer.py
@@ -1,0 +1,62 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This module provides a singleton QPrinter used by default by silx widgets.
+"""
+
+from __future__ import absolute_import
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "01/03/2018"
+
+
+from . import qt
+
+
+_printer = None
+"""Shared QPrinter instance"""
+
+
+def getDefaultPrinter():
+    """Returns the default printer.
+
+    This allows reusing the same QPrinter across widgets.
+
+    :return: QPrinter
+    """
+    global _printer
+    if _printer is None:
+        _printer = qt.QPrinter()
+    return _printer
+
+
+def setDefaultPrinter(printer):
+    """Set the printer used by default by silx widgets.
+
+    :param QPrinter printer:
+    """
+    assert isinstance(printer, qt.QPrinter)
+    global _printer
+    _printer = printer

--- a/silx/gui/widgets/PrintPreview.py
+++ b/silx/gui/widgets/PrintPreview.py
@@ -31,7 +31,7 @@ The user can interactively move and resize the items.
 """
 import sys
 import logging
-from silx.gui import qt
+from silx.gui import qt, printer
 
 
 __authors__ = ["V.A. Sole", "P. Knobel"]
@@ -387,7 +387,7 @@ class PrintPreviewDialog(qt.QDialog):
         *None*.
         """
         if self.printer is None:
-            self.printer = qt.QPrinter()
+            self.printer = printer.getDefaultPrinter()
         if self.printDialog is None:
             self.printDialog = qt.QPrintDialog(self.printer, self)
         if self.printDialog.exec_():


### PR DESCRIPTION
This PR adds a `silx.gui.printer` module with functions to access a shared `QPrinter` instance.
It is used in `PrintAction` in `plot` and `plot3d` and in `PrintPreview`.

It also switch from `printer` property to `getPrinter` method in plot PrintAction.

To make `PrintAction` more generic, it is possible to add a `setPrinter` in order to allow using a different printer from the default one of silx. If desired, let me know.