### PR TITLE
Allows Compatibility with "simple" projects (like Dahu)

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -10,7 +10,7 @@ example: ./bootstrap.py ipython
 __authors__ = ["Frédéric-Emmanuel Picca", "Jérôme Kieffer"]
 __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"
-__date__ = "08/01/2018"
+__date__ = "02/03/2018"
 
 
 import sys
@@ -193,6 +193,9 @@ os.chdir(home)
 build = subprocess.Popen([sys.executable, "setup.py", "build"],
                          shell=False, cwd=os.path.dirname(os.path.abspath(__file__)))
 build_rc = build.wait()
+if not os.path.exists(LIBPATH):
+    logger.warning("`lib` directory does not exist, trying common Python3 lib")
+    LIBPATH = os.path.join(os.path.split(LIBPATH)[0], "lib")
 os.chdir(cwd)
 
 if build_rc == 0:

--- a/run_tests.py
+++ b/run_tests.py
@@ -32,7 +32,7 @@ Test coverage dependencies: coverage, lxml.
 """
 
 __authors__ = ["Jérôme Kieffer", "Thomas Vincent"]
-__date__ = "29/01/2018"
+__date__ = "02/03/2018"
 __license__ = "MIT"
 
 import distutils.util
@@ -292,7 +292,12 @@ def build_project(name, root_dir):
     p = subprocess.Popen([sys.executable, "setup.py", "build"],
                          shell=False, cwd=root_dir)
     logger.debug("subprocess ended with rc= %s", p.wait())
-    return home
+
+    if os.path.isdir(home):
+        return home
+    alt_home = os.path.join(os.path.dirname(home), "lib")
+    if os.path.isdir(alt_home):
+        return alt_home
 
 
 def import_project_module(project_name, project_dir):
@@ -311,7 +316,8 @@ def import_project_module(project_name, project_dir):
                 PROJECT_NAME)
     else:  # Use built source
         build_dir = build_project(project_name, project_dir)
-
+        if build_dir is None:
+            logging.error("Built project is not available !!! investigate")
         sys.path.insert(0, build_dir)
         logger.warning("Patched sys.path, added: '%s'", build_dir)
         module = importer(project_name)


### PR DESCRIPTION
In Python3, packages without binary extension land in "build/lib" and
not in "build/lib.linux-x86_64-3.5"