### PR TITLE
[CurvesROIWidget] fix #1710

### DIFF
--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -416,6 +416,7 @@ class CurvesROIWidget(qt.QWidget):
                 draggable = False
                 color = 'black'
             else:
+                # find the next index free for newroi.
                 for i in range(nrois):
                     i += 1
                     newroi = "newroi %d" % i
@@ -690,10 +691,7 @@ class CurvesROIWidget(qt.QWidget):
         if visible:
             if not self._isInit:
                 # Deferred ROI widget init finalization
-                self._isInit = True
-                self.sigROIWidgetSignal.connect(self._roiSignal)
-                # initialize with the ICR
-                self._roiSignal({'event': "AddROI"})
+                self._finalizeInit()
 
             if not self._isConnected:
                 self.plot.sigPlotSignal.connect(self._handleROIMarkerEvent)
@@ -712,6 +710,13 @@ class CurvesROIWidget(qt.QWidget):
     def _activeCurveChanged(self, *args):
         """Recompute ROIs when active curve changed."""
         self.calculateRois()
+
+    def _finalizeInit(self):
+        self._isInit = True
+        self.sigROIWidgetSignal.connect(self._roiSignal)
+        # initialize with the ICR if no ROi existing yet
+        if len(self.getRois()) is 0:
+            self._roiSignal({'event': "AddROI"})
 
 
 class ROITable(qt.QTableWidget):

--- a/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/silx/gui/plot/test/testCurvesROIWidget.py
@@ -24,7 +24,7 @@
 # ###########################################################################*/
 """Basic tests for CurvesROIWidget"""
 
-__authors__ = ["T. Vincent", "P. Knobel"]
+__authors__ = ["T. Vincent", "P. Knobel", "H. Payno"]
 __license__ = "MIT"
 __date__ = "16/11/2017"
 
@@ -32,9 +32,8 @@ __date__ = "16/11/2017"
 import logging
 import os.path
 import unittest
-
+from collections import OrderedDict
 import numpy
-
 from silx.gui import qt
 from silx.test.utils import temp_dir
 from silx.gui.test.utils import TestCaseQt
@@ -152,6 +151,25 @@ class TestCurvesROIWidget(TestCaseQt):
                                   (-x <= output["negative"]["to"]))[0]
         self.assertEqual(output["negative"]["rawcounts"],
                          y[selection].sum(), "Calculation failed on negative X coordinates")
+
+    def testDeferedInit(self):
+        x = numpy.arange(100.)
+        y = numpy.arange(100.)
+        self.plot.addCurve(x=x, y=y, legend="name", replace="True")
+        roisDefs = OrderedDict([
+            ["range1",
+             OrderedDict([["from", 20], ["to", 200], ["type", "energy"]])],
+            ["range2",
+             OrderedDict([["from", 300], ["to", 500], ["type", "energy"]])]
+        ])
+
+        roiWidget = self.plot.getCurvesRoiDockWidget().roiWidget
+        self.assertFalse(roiWidget._isInit)
+        self.plot.getCurvesRoiDockWidget().setRois(roisDefs)
+        self.assertTrue(len(roiWidget.getRois()) is len(roisDefs))
+        self.plot.getCurvesRoiDockWidget().setVisible(True)
+        self.assertTrue(len(roiWidget.getRois()) is len(roisDefs))
+
 
 def suite():
     test_suite = unittest.TestSuite()


### PR DESCRIPTION
Do not ask for a new ROI when doing the deferred initialization (only if no ROI are existing yet)

Add unit test for @alemirone issue. /closes #1710