### PR TITLE
[plot] rework ROI curve widget with object (Fix 1711)

### DIFF
--- a/doc/source/modules/gui/plot/roi.rst
+++ b/doc/source/modules/gui/plot/roi.rst
@@ -1,11 +1,14 @@
-.. currentmodule:: silx.gui.plot
+.. currentmodule:: silx.gui.plot.CurvesROIWidget
 
 :mod:`CurvesROIWidget`: ROI from curves
 =======================================
 
+
 .. |roiWidgetImage| image:: img/roiwidget.png
    :height: 400px
    :align: middle
+
+.. automodule:: silx.gui.plot.CurvesROIWidget
 
 You can access to the ROIWidget from a Plot window by :
 
@@ -14,4 +17,28 @@ You can access to the ROIWidget from a Plot window by :
 
 |roiWidgetImage|
 
-.. automodule:: silx.gui.plot.CurvesROIWidget
+
+
+
+:class:`ROI` class
+------------------
+
+.. autoclass:: ROI
+   :show-inheritance:
+   :members:
+
+
+:class:`CurvesROIWidget` class
+-------------------------------
+
+.. autoclass:: CurvesROIWidget
+   :show-inheritance:
+   :members:
+
+
+:class:`ROITable` class
+-----------------------
+
+.. autoclass:: ROITable
+   :show-inheritance:
+   :members:

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -159,6 +159,7 @@ class CurvesROIWidget(qt.QWidget):
         self.loadButton.clicked.connect(self._load)
         self.saveButton.clicked.connect(self._save)
 
+<<<<<<< HEAD
         self._middleROIMarkerFlag = False
         self._isConnected = False  # True if connected to plot signals
         self._isInit = False
@@ -173,6 +174,9 @@ class CurvesROIWidget(qt.QWidget):
     def showEvent(self, event):
         self._visibilityChangedHandler(visible=True)
         qt.QWidget.showEvent(self, event)
+=======
+        self.sigROIWidgetSignal = self.roiTable.sigROITableSignal
+>>>>>>> bea1245... [CurvesROIWidget] move up the active roi
 
         self.roiTable.activeROIChanged.connect(self._emitCurrentROISignal)
 
@@ -422,6 +426,10 @@ class CurvesROIWidget(qt.QWidget):
         else:
             ddict['current'] = None
         self.sigROISignal.emit(ddict)
+
+    @property
+    def currentRoi(self):
+        return self.roiTable.activeRoi
 
 
 class _FloatItem(qt.QTableWidgetItem):
@@ -1507,7 +1515,10 @@ class CurvesROIDockWidget(qt.QDockWidget):
         self.getRois = self.roiWidget.getRois
 
         self.roiWidget.sigROISignal.connect(self._forwardSigROISignal)
+<<<<<<< HEAD
         self.currentROI = self.roiWidget.currentROI
+=======
+>>>>>>> bea1245... [CurvesROIWidget] move up the active roi
 
         self.layout().setContentsMargins(0, 0, 0, 0)
         self.setWidget(self.roiWidget)
@@ -1535,3 +1546,7 @@ class CurvesROIDockWidget(qt.QDockWidget):
         """
         self.raise_()
         qt.QDockWidget.showEvent(self, event)
+
+    @property
+    def currentROI(self):
+        return self.roiWidget.currentRoi

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -1083,12 +1083,13 @@ class _RoiMarkerManager(object):
         for roiHandler in roisHandler:
             self.remove(roiHandler.roi)
 
-    def remove(self, roiID):
-        if roiID is None:
+    def remove(self, roi):
+        if roi is None:
             return
-        if roiID in self._roiMarkerHandlers:
-            self._roiMarkerHandlers[roiID].clear()
-            del self._roiMarkerHandlers[roiID]
+        assert isinstance(roi, ROI)
+        if roi.getID() in self._roiMarkerHandlers:
+            self._roiMarkerHandlers[roi.getID()].clear()
+            del self._roiMarkerHandlers[roi.getID()]
 
     def hasMarker(self, markerID):
         assert type(markerID) is str

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -570,7 +570,7 @@ class ROITable(TableWidget):
             deprecation.deprecated_warning(name='rois', type_='Parameter',
                                            reason='Rois should now be a list '
                                                   'of ROI object',
-                                           since_version="0.8.0")
+                                           since_version="0.10.0")
             for roiName, roi in rois.items():
                 roi['name'] = roiName
                 _roi = ROI._fromDict(roi)
@@ -1012,7 +1012,14 @@ class ROITable(TableWidget):
         :param dict roidict: Dict of ROI information
         :param currentroi: Name of the selected ROI or None (no selection)
         """
-        self.setRois(roilist)
+        if roidict is not None:
+            deprecation.deprecated_warning(name='roidict', type_='Parameter',
+                                           reason='Rois should now be a list '
+                                                  'of ROI object',
+                                           since_version="0.10.0")
+            self.setRois(roidict)
+        else:
+            self.setRois(roilist)
         if currentroi:
             self.setActiveRoi(currentroi)
 

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -159,7 +159,6 @@ class CurvesROIWidget(qt.QWidget):
         self.loadButton.clicked.connect(self._load)
         self.saveButton.clicked.connect(self._save)
 
-<<<<<<< HEAD
         self._middleROIMarkerFlag = False
         self._isConnected = False  # True if connected to plot signals
         self._isInit = False
@@ -174,10 +173,6 @@ class CurvesROIWidget(qt.QWidget):
     def showEvent(self, event):
         self._visibilityChangedHandler(visible=True)
         qt.QWidget.showEvent(self, event)
-=======
-        self.sigROIWidgetSignal = self.roiTable.sigROITableSignal
->>>>>>> bea1245... [CurvesROIWidget] move up the active roi
-
         self.roiTable.activeROIChanged.connect(self._emitCurrentROISignal)
 
     @property
@@ -456,12 +451,9 @@ class ROITable(qt.QTableWidget):
     visible. Otherwise won't compute the row and net counts...
     """
 
-    sigROITableSignal = qt.Signal(object)
-    """Signal of ROI table modifications.
-    """
-
     activeROIChanged = qt.Signal()
-    """Signal emitted when the active roi changed"""
+    """Signal emitted when the active roi changed or when the value of the
+    active roi are changing"""
 
     COLUMNS_INDEX = OrderedDict([
         ('ID', 0),
@@ -787,9 +779,14 @@ class ROITable(qt.QTableWidget):
         netArea = str(netArea) if netArea is not None else self.INFO_NOT_FOUND
         itemNetArea.setText(netArea)
 
+        if self.activeRoi and roi.getID() == self.activeRoi.getID():
+            self.activeROIChanged.emit()
+
     def currentChanged(self, current, previous):
         if previous and current.row() != previous.row() and current.row() >= 0:
-            roiItem = self.item(current.row(), self.COLUMNS_INDEX['ID'])
+            roiItem = self.item(current.row(),
+                                self.COLUMNS_INDEX['ID'])
+
             assert roiItem
             self.setActiveRoi(self._roiDict[int(roiItem.text())])
             self._markersHandler.updateAllMarkers()
@@ -927,16 +924,6 @@ class ROITable(qt.QTableWidget):
                 self._markersHandler.changePosition(markerID=label,
                                                     x=ddict['x'])
                 self._updateRoiInfo(roiID)
-                self._emitCurrentROISignal()
-
-    def _emitCurrentROISignal(self):
-        ddict = {}
-        ddict['event'] = "currentROISignal"
-        if self.activeRoi:
-            ddict['ROI'] = self.activeRoi.toDict()
-        ddict['current'] = self.activeRoi.getName() if self.activeRoi else None
-
-        self.sigROITableSignal .emit(ddict)
 
     def showEvent(self, event):
         self._visibilityChangedHandler(visible=True)
@@ -1515,10 +1502,6 @@ class CurvesROIDockWidget(qt.QDockWidget):
         self.getRois = self.roiWidget.getRois
 
         self.roiWidget.sigROISignal.connect(self._forwardSigROISignal)
-<<<<<<< HEAD
-        self.currentROI = self.roiWidget.currentROI
-=======
->>>>>>> bea1245... [CurvesROIWidget] move up the active roi
 
         self.layout().setContentsMargins(0, 0, 0, 0)
         self.setWidget(self.roiWidget)

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -191,11 +191,12 @@ class CurvesROIWidget(qt.QWidget):
             if nrois == 0:
                 return "ICR"
             else:
-                for i in range(nrois):
+                i = 1
+                newroi = "newroi %d" % i
+                while newroi in self.roiTable.roidict.keys():
                     i += 1
                     newroi = "newroi %d" % i
-                    if newroi not in self.roiTable.roidict.keys():
-                        return newroi
+                return newroi
 
         roi = ROI(name=getNextROIName())
 

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -616,6 +616,10 @@ class ROITable(qt.QTableWidget):
             assert roi.name in self.roidict
             del self._roidict[roi._id]
 
+            callback = functools.partial(WeakMethodProxy(self._updateRoiInfo),
+                                         roi._id)
+            roi.sigChanged.connect(callback)
+
     def setActiveRoi(self, roi):
         """
         Define the given roi as the active one.
@@ -967,12 +971,10 @@ class ROI(qt.QObject):
         self._id = _indexNextROI
         _indexNextROI += 1
 
-        self.setName(name)
-        self.setFrom(fromdata)
-        self.setTo(todata)
-
-        self.setMarkerDraggable(False)
-        self.setType(type_ or 'Default')
+        self._name = name
+        self._fromdata = fromdata
+        self._todata = todata
+        self._type = type_ or 'Default'
 
     def setType(self, type_):
         """
@@ -980,6 +982,7 @@ class ROI(qt.QObject):
         :param str type_:
         """
         self._type = type_
+        self.sigChanged.emit()
 
     def getType(self):
         """
@@ -995,6 +998,7 @@ class ROI(qt.QObject):
         :param str name:
         """
         self._name = name
+        self.sigChanged.emit()
 
     def getName(self):
         """
@@ -1009,6 +1013,7 @@ class ROI(qt.QObject):
         :param frm: set x coordinate of the left limit
         """
         self._fromdata = frm
+        self.sigChanged.emit()
 
     def getFrom(self):
         """
@@ -1023,6 +1028,7 @@ class ROI(qt.QObject):
         :param to: x coordinate of the right limit
         """
         self._todata = to
+        self.sigChanged.emit()
 
     def getTo(self):
         """

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -1083,13 +1083,12 @@ class _RoiMarkerManager(object):
         for roiHandler in roisHandler:
             self.remove(roiHandler.roi)
 
-    def remove(self, roi):
-        if roi is None:
+    def remove(self, roiID):
+        if roiID is None:
             return
-        assert isinstance(roi, ROI)
-        if roi.getID() in self._roiMarkerHandlers:
-            self._roiMarkerHandlers[roi.getID()].clear()
-            del self._roiMarkerHandlers[roi.getID()]
+        if roiID in self._roiMarkerHandlers:
+            self._roiMarkerHandlers[roiID].clear()
+            del self._roiMarkerHandlers[roiID]
 
     def hasMarker(self, markerID):
         assert type(markerID) is str

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -51,7 +51,6 @@ from collections import OrderedDict
 import logging
 import os
 import sys
-import weakref
 import functools
 import numpy
 from silx.io import dictdump
@@ -209,7 +208,7 @@ class CurvesROIWidget(qt.QWidget):
                 for i in range(nrois):
                     i += 1
                     newroi = "newroi %d" % i
-                    if newroi not in roiDict.keys():
+                    if newroi not in self.roiTable.roiDict.keys():
                         return newroi
 
         roi = ROI(name=getNextROIName())
@@ -629,7 +628,7 @@ class ROITable(qt.QTableWidget):
             self.removeRow(item.row())
             del self._RoiToItems[roi._id]
 
-            assert name in self.roidict
+            assert roi.name in self.roidict
             del self._roidict[roi._id]
 
     def setActiveRoi(self, roi):

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -453,7 +453,6 @@ class ROITable(qt.QTableWidget):
         self.sortByColumn(0, qt.Qt.AscendingOrder)
         self.hideColumn(self.COLUMNS_INDEX['ID'])
 
-
     def setPlot(self, plot):
         self.clear()
         self.plot = plot
@@ -878,6 +877,33 @@ class ROITable(qt.QTableWidget):
     def _activeCurveChanged(self, curve):
         self.calculateRois()
 
+    def setCountsVisible(self, visible):
+        """
+        Display the columns relative to areas or not
+
+        :param bool visible: True if the columns 'Raw Area' and 'Net Area'
+                             should be visible.
+        """
+        if visible is True:
+            self.showColumn(self.COLUMNS_INDEX['Raw Counts'])
+            self.showColumn(self.COLUMNS_INDEX['Net Counts'])
+        else:
+            self.hideColumn(self.COLUMNS_INDEX['Raw Counts'])
+            self.hideColumn(self.COLUMNS_INDEX['Net Counts'])
+
+    def setAreaVisible(self, visible):
+        """
+        Display the columns relative to areas or not
+
+        :param bool visible: True if the columns 'Raw Area' and 'Net Area'
+                             should be visible.
+        """
+        if visible is True:
+            self.showColumn(self.COLUMNS_INDEX['Raw Area'])
+            self.showColumn(self.COLUMNS_INDEX['Net Area'])
+        else:
+            self.hideColumn(self.COLUMNS_INDEX['Raw Area'])
+            self.hideColumn(self.COLUMNS_INDEX['Net Area'])
 
 _indexNextROI = 0
 
@@ -1371,6 +1397,9 @@ class CurvesROIDockWidget(qt.QDockWidget):
 
         self.layout().setContentsMargins(0, 0, 0, 0)
         self.setWidget(self.roiWidget)
+
+        self.setAreaVisible = self.roiWidget.roiTable.setAreaVisible
+        self.setCountsVisible = self.roiWidget.roiTable.setCountsVisible
 
     def _forwardSigROISignal(self, ddict):
         # emit deprecated signal for backward compatibility (silx < 0.7)

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -553,12 +553,16 @@ class ROITable(qt.QTableWidget):
             return item
 
     def _itemChanged(self, item):
-        if item.column() in (self.COLUMNS_INDEX['To'], self.COLUMNS_INDEX['From']):
+        def getROI():
             IDItem = self.item(item.row(), self.COLUMNS_INDEX['ID'])
             assert IDItem
             id = int(IDItem.text())
             assert id in self._roidict
             roi = self._roidict[id]
+            return roi
+
+        if item.column() in (self.COLUMNS_INDEX['To'], self.COLUMNS_INDEX['From']):
+            roi = getROI()
             if item.text() not in ('', self.INFO_NOT_FOUND):
                 try:
                     value = float(item.text())
@@ -570,6 +574,9 @@ class ROITable(qt.QTableWidget):
                     assert(item.column() == self.COLUMNS_INDEX['From'])
                     roi.fromdata = value
                 self._updateMarker(roi.name)
+        if item.column() is self.COLUMNS_INDEX['ROI']:
+            roi = getROI()
+            roi.name = item.text()
 
     def deleteActiveRoi(self):
         """

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -879,14 +879,17 @@ class ROITable(qt.QTableWidget):
             assert self.plot
             if self._isConnected is False:
                 self.plot.sigPlotSignal.connect(self._handleROIMarkerEvent)
-                self.plot.sigActiveCurveChanged.connect(self.calculateRois)
+                self.plot.sigActiveCurveChanged.connect(self._activeCurveChanged)
                 self._isConnected = True
             self.calculateRois()
         else:
             if self._isConnected:
                 self.plot.sigPlotSignal.disconnect(self._handleROIMarkerEvent)
-                self.plot.sigActiveCurveChanged.disconnect(self.calculateRois)
+                self.plot.sigActiveCurveChanged.disconnect(self._activeCurveChanged)
                 self._isConnected = False
+
+    def _activeCurveChanged(self, curve):
+        self.calculateRois()
 
 
 class ROI(qt.QObject):

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -22,15 +22,16 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-"""Widget to handle regions of interest (ROI) on curves displayed in a PlotWindow.
+"""
+Widget to handle regions of interest (ROI) on curves displayed in a PlotWindow.
 
 This widget is meant to work with :class:`PlotWindow`.
 
 ROI are defined by :
 
 - A name (`ROI` column)
-- A type. The type is the label of the x axis.
-  This can be used to apply or not some ROI to a curve and do some post processing.
+- A type. The type is the label of the x axis. This can be used to apply or
+  not some ROI to a curve and do some post processing.
 - The x coordinate of the left limit (`from` column)
 - The x coordinate of the right limit (`to` column)
 - Raw counts: Sum of the curve's values in the defined Region Of Intereset.
@@ -66,9 +67,9 @@ _logger = logging.getLogger(__name__)
 class CurvesROIWidget(qt.QWidget):
     """
     Widget displaying a table of ROI information.
-    
+
     Implements also the following behavior:
-    
+
     * if the roiTable has no ROI when showing create the default ICR one
 
     :param parent: See :class:`QWidget`
@@ -131,7 +132,8 @@ class CurvesROIWidget(qt.QWidget):
         self.addButton.setToolTip('Remove the selected ROI')
         self.resetButton = qt.QPushButton(hbox)
         self.resetButton.setText("Reset")
-        self.addButton.setToolTip('Clear all created ROIs. We only let the default ROI')
+        self.addButton.setToolTip('Clear all created ROIs. We only let the '
+                                  'default ROI')
 
         hboxlayout.addWidget(self.addButton)
         hboxlayout.addWidget(self.delButton)
@@ -186,7 +188,7 @@ class CurvesROIWidget(qt.QWidget):
     def roiFileDir(self, roiFileDir):
         self._roiFileDir = str(roiFileDir)
 
-    def setRois(self, roidict, order=None):
+    def setRois(self, rois, order=None):
         return self.roiTable.setRois(rois, order)
 
     def getRois(self, order=None):
@@ -386,7 +388,7 @@ class ROITable(qt.QTableWidget):
     """Table widget displaying ROI information.
 
     See :class:`QTableWidget` for constructor arguments.
-    
+
     Behavior: listen at the active curve changed only when the widget is
     visible. Otherwise won't compute the row and net counts...
     """
@@ -474,15 +476,13 @@ class ROITable(qt.QTableWidget):
             if isinstance(roi, weakref.ref):
                 _roi = _roi()
             if _roi:
-                assert isinstance(roi, _ROI)
+                assert isinstance(roi, ROI)
                 self.addRoi(roi)
 
     def addRoi(self, roi):
         """
-        TODO
 
-        :param roi: 
-        :return: 
+        :param :class:`ROI` roi: roi to add to the table
         """
         assert isinstance(roi, ROI)
         self.setRowCount(self.rowCount() + 1)
@@ -503,7 +503,7 @@ class ROITable(qt.QTableWidget):
         else:
             if name == 'ROI':
                 item = qt.QTableWidgetItem(roi.name if roi else '',
-                                               type=qt.QTableWidgetItem.Type)
+                                           type=qt.QTableWidgetItem.Type)
                 if roi.name.upper() in ('ICR', 'DEFAULT'):
                     item.setFlags(qt.Qt.ItemIsSelectable | qt.Qt.ItemIsEnabled)
                 else:
@@ -552,9 +552,7 @@ class ROITable(qt.QTableWidget):
 
     def deleteActiveRoi(self):
         """
-        TODO
-        
-        :return: 
+        remove the current active roi
         """
         activeItem = self.selectedItems()
         if len(activeItem) is 0:
@@ -568,10 +566,9 @@ class ROITable(qt.QTableWidget):
 
     def removeROI(self, name):
         """
-        TODO
-        
-        :param name: 
-        :return: 
+        remove the requested roi
+
+        :param str name: the name of the roi to remove from the table
         """
         if name in self._RoiToItems:
             item = self._RoiToItems[name]
@@ -583,10 +580,11 @@ class ROITable(qt.QTableWidget):
 
     def setActiveRoi(self, roi):
         """
-        TODO
-        
-        :param roi: 
-        :return: 
+        Define the given roi as the active one.
+
+        .. warning:: this roi should already be registred / added to the table
+
+        :param :class:`ROI` roi: the roi to defined as active
         """
         assert isinstance(roi, ROI)
         if roi.name in self._RoiToItems.keys():
@@ -625,8 +623,6 @@ class ROITable(qt.QTableWidget):
 
     def currentChanged(self, current, previous):
         if previous and current.row() != previous.row():
-            # note: roi is registred as a weak ref
-
             roiItem = self.item(current.row(), self.COLUMNS_INDEX['ROI'])
             assert roiItem
             self.activeRoi = self.roidict[roiItem.text()]
@@ -635,19 +631,18 @@ class ROITable(qt.QTableWidget):
 
     def getROIListAndDict(self):
         """
-        TODO
-        
-        :return: 
+
+        :return: the list of roi objects and the dictionnary of roi name to roi
+                 object.
         """
         return list(self.roidict.values()), self.roidict
 
     def calculateRois(self, roiList=None, roiDict=None):
         """
-        TODO
-        
-        :param roiList: 
-        :param roiDict: 
-        :return: 
+        Update values of all registred rois (raw and net counts in particular)
+
+        :param roiList: deprecated parameter
+        :param roiDict: deprecated parameter
         """
         if roiDict:
             from silx.utils.deprecation import deprecated_warning
@@ -663,8 +658,8 @@ class ROITable(qt.QTableWidget):
 
     def _updateMarker(self, roiname):
         """Make sure the marker of the given roi name is updated"""
-        if self._showAllMarkers or \
-            (self.activeRoi and self.activeRoi.name == roiname):
+        if self._showAllMarkers or (self.activeRoi
+                                    and self.activeRoi.name == roiname):
             self._updateMarkers()
 
     def _updateMarkers(self):
@@ -733,7 +728,7 @@ class ROITable(qt.QTableWidget):
 
         The dictionary keys are the ROI names.
         Each value is a :class:`ROI` object..
-        
+
         :param order: Field used for ordering the ROIs.
              One of "from", "to", "type", "netcounts", "rawcounts".
              None (default) to get the same order as displayed in the widget.
@@ -785,9 +780,10 @@ class ROITable(qt.QTableWidget):
 
     def showAllMarkers(self, _show=True):
         """
-        TODO
-        :param _show: 
-        :return: 
+
+        :param bool _show: if true show all the markers of all the ROIs
+                           boundaries otherwise will only show the one of
+                           the active ROI.
         """
         if self._showAllMarkers == _show:
             return
@@ -813,7 +809,7 @@ class ROITable(qt.QTableWidget):
             if label in ['ROI min', 'ROI max', 'ROI middle']:
                 roiMoved = self.activeRoi
             else:
-                raise NotImplemendedError('')
+                raise NotImplementedError('')
 
             assert roiMoved
             if roiMoved.name not in self.roidict:

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -514,7 +514,7 @@ class ROITable(qt.QTableWidget):
         assert isinstance(roi, ROI)
         self._getItem(name='ID', row=None, roi=roi)
         self._roiDict[roi.getID()] = roi
-        self._markersHandler.add(roi, _RoiMarkerHandler(roi, self.plot))
+        self._markersHandler.add(_RoiMarkerHandler(roi, self.plot))
         self.activeRoi = roi
         self._updateRoiInfo(roi.getID())
         callback = functools.partial(WeakMethodProxy(self._updateRoiInfo),
@@ -631,7 +631,7 @@ class ROITable(qt.QTableWidget):
 
             assert roi.getID() in self._roiDict
             del self._roiDict[roi.getID()]
-            self._markersHandler.remove(roi)
+            self._markersHandler.remove(roi.getID())
 
             callback = functools.partial(WeakMethodProxy(self._updateRoiInfo),
                                          roi.getID())
@@ -1064,13 +1064,13 @@ class _RoiMarkerManager(object):
             self._showAllMarkers = show
             self.updateAllMarkers()
 
-    def add(self, roi, markersHandler):
-        assert isinstance(roi, ROI)
+    def add(self, markersHandler):
+        assert isinstance(markersHandler.roi, ROI)
         assert isinstance(markersHandler, _RoiMarkerHandler)
-        if roi.getID() in self._roiMarkerHandlers:
+        if markersHandler.roi.getID() in self._roiMarkerHandlers:
             raise ValueError('roi with the same ID already existing')
         else:
-            self._roiMarkerHandlers[roi.getID()] = markersHandler
+            self._roiMarkerHandlers[markersHandler.roi.getID()] = markersHandler
 
     def getMarkerHandler(self, roiID):
         if roiID in self._roiMarkerHandlers:

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -626,16 +626,14 @@ class ROITable(qt.QTableWidget):
             elif name == 'Type':
                 item = qt.QTableWidgetItem(type=qt.QTableWidgetItem.Type)
                 item.setFlags((qt.Qt.ItemIsSelectable | qt.Qt.ItemIsEnabled))
-            elif name == 'To':
+            elif name in ('To', 'From'):
                 item = _FloatItem()
-                item.setFlags(qt.Qt.ItemIsSelectable |
-                              qt.Qt.ItemIsEnabled |
-                              qt.Qt.ItemIsEditable)
-            elif name == 'From':
-                item = _FloatItem()
-                item.setFlags(qt.Qt.ItemIsSelectable |
-                              qt.Qt.ItemIsEnabled |
-                              qt.Qt.ItemIsEditable)
+                if roi.getName().upper() in ('ICR', 'DEFAULT'):
+                    item.setFlags(qt.Qt.ItemIsSelectable | qt.Qt.ItemIsEnabled)
+                else:
+                    item.setFlags(qt.Qt.ItemIsSelectable |
+                                  qt.Qt.ItemIsEnabled |
+                                  qt.Qt.ItemIsEditable)
             elif name in ('Raw Counts', 'Net Counts', 'Raw Area', 'Net Area'):
                 item = _FloatItem()
                 item.setFlags((qt.Qt.ItemIsSelectable | qt.Qt.ItemIsEnabled))

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -395,6 +395,8 @@ class ROITable(qt.QTableWidget):
         ('To', 4),
         ('Raw Counts', 5),
         ('Net Counts', 6),
+        ('Raw Area', 7),
+        ('Net Area', 8),
     ])
 
     COLUMNS = list(COLUMNS_INDEX.keys())
@@ -564,7 +566,7 @@ class ROITable(qt.QTableWidget):
                 item.setFlags(qt.Qt.ItemIsSelectable |
                               qt.Qt.ItemIsEnabled |
                               qt.Qt.ItemIsEditable)
-            elif name in ('Raw Counts', 'Net Counts'):
+            elif name in ('Raw Counts', 'Net Counts', 'Raw Area', 'Net Area'):
                 item = _FloatItem()
                 item.setFlags((qt.Qt.ItemIsSelectable | qt.Qt.ItemIsEnabled))
             else:
@@ -683,6 +685,18 @@ class ROITable(qt.QTableWidget):
                                       roi=roi)
         netCounts = str(netCounts) if netCounts is not None else self.INFO_NOT_FOUND
         itemNetCounts.setText(netCounts)
+
+        rawArea, netArea = roi.computeRawAndNetArea(
+            curve=self.plot.getActiveCurve(just_legend=False))
+        itemRawArea = self._getItem(name='Raw Area', row=itemID.row(),
+                                      roi=roi)
+        rawArea = str(rawArea) if rawArea is not None else self.INFO_NOT_FOUND
+        itemRawArea.setText(rawArea)
+
+        itemNetArea = self._getItem(name='Net Area', row=itemID.row(),
+                                    roi=roi)
+        netArea = str(netArea) if netArea is not None else self.INFO_NOT_FOUND
+        itemNetArea.setText(netArea)
 
     def currentChanged(self, current, previous):
         if previous and current.row() != previous.row() and current.row() >= 0:

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -473,7 +473,6 @@ class ROITable(qt.QTableWidget):
 
     def __init__(self, parent=None, plot=None, rois=None):
         super(ROITable, self).__init__(parent)
-        self.activeRoi = None
         self._showAllMarkers = False
         self._middleROIMarkerFlag = False
         self._userIsEditingROI = False
@@ -482,6 +481,7 @@ class ROITable(qt.QTableWidget):
         self._roiToItems = {}
         self._roiDict = {}
         self._markersHandler = _RoiMarkerManager()
+
         """
         Associate for each marker legend used when the `_showAllMarkers` option
         is active a roi.
@@ -495,6 +495,10 @@ class ROITable(qt.QTableWidget):
     @property
     def roidict(self):
         return self._getRoiDict()
+
+    @property
+    def activeRoi(self):
+        return self._markersHandler._activeRoi
 
     def _getRoiDict(self):
         ddict = {}
@@ -584,7 +588,6 @@ class ROITable(qt.QTableWidget):
         self._getItem(name='ID', row=None, roi=roi)
         self._roiDict[roi.getID()] = roi
         self._markersHandler.add(roi, _RoiMarkerHandler(roi, self.plot))
-        self.activeRoi = roi
         self._updateRoiInfo(roi.getID())
         callback = functools.partial(WeakMethodProxy(self._updateRoiInfo),
                                      roi.getID())
@@ -716,9 +719,8 @@ class ROITable(qt.QTableWidget):
         """
         assert isinstance(roi, ROI)
         if roi and roi.getID() in self._roiToItems.keys():
-            self.activeRoi = roi
             self.selectRow(self._roiToItems[roi.getID()].row())
-            self._markersHandler.setActiveRoi(self.activeRoi)
+            self._markersHandler.setActiveRoi(roi)
             self.activeROIChanged.emit()
 
     def _updateRoiInfo(self, roiID):

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -679,7 +679,7 @@ class ROITable(qt.QTableWidget):
         itemNetCounts.setText(netCounts)
 
     def currentChanged(self, current, previous):
-        if previous and current.row() != previous.row():
+        if previous and current.row() != previous.row() and current.row() >= 0:
             roiItem = self.item(current.row(), self.COLUMNS_INDEX['ID'])
             assert roiItem
             self.activeRoi = self._roiDict[int(roiItem.text())]

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -263,7 +263,7 @@ class CurvesROIWidget(qt.QWidget):
         ddict = {}
         roilist, roidict = self.roiTable.getROIListAndDict()
         ddict['event'] = "ResetROI"
-        dict['roilist'] = roilist
+        ddict['roilist'] = roilist
         ddict['roidict'] = roidict
         self.sigROIWidgetSignal.emit(ddict)
         # end back compatibility pymca roi signals
@@ -290,7 +290,7 @@ class CurvesROIWidget(qt.QWidget):
         ddict = {}
         roilist, roidict = self.roiTable.getROIListAndDict()
         ddict['event'] = "LoadROI"
-        dict['roilist'] = roilist
+        ddict['roilist'] = roilist
         ddict['roidict'] = roidict
         self.sigROIWidgetSignal.emit(ddict)
         # end back compatibility pymca roi signals

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -388,8 +388,7 @@ class ROITable(qt.QTableWidget):
         ('From', 2),
         ('To', 3),
         ('Raw Counts', 4),
-        ('Net Counts', 5),
-        ('ROI Object', 6)
+        ('Net Counts', 5)
     ])
 
     COLUMNS = list(COLUMNS_INDEX.keys())
@@ -415,7 +414,6 @@ class ROITable(qt.QTableWidget):
         self.setHorizontalHeaderLabels(self.COLUMNS)
         self.horizontalHeader().setSectionResizeMode(
             qt.QHeaderView.ResizeToContents)
-        self.setColumnHidden(self.COLUMNS_INDEX['ROI Object'], True)
         self.sortByColumn(2, qt.Qt.AscendingOrder)
 
     def setPlot(self, plot):
@@ -512,10 +510,6 @@ class ROITable(qt.QTableWidget):
                               qt.Qt.ItemIsEditable)
             elif name in ('Raw Counts', 'Net Counts'):
                 item = _FloatItem()
-            elif name == 'ROI object':
-                item = qt.QTableWidgetItem(type=qt.QTableWidgetItem.Type)
-                if roi:
-                    item.setData(qt.QTableWidgetItem.Type, weakref.ref(roi))
             else:
                 raise ValueError('item type not recognized')
 

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -695,6 +695,7 @@ class ROITable(TableWidget):
             itemID = self.item(row, self.COLUMNS_INDEX['ID'])
             roiToRm.add(self._roiDict[int(itemID.text())])
         [self.removeROI(roi) for roi in roiToRm]
+        self.setActiveRoi(None)
 
     def removeROI(self, roi):
         """
@@ -723,11 +724,16 @@ class ROITable(TableWidget):
 
         :param :class:`ROI` roi: the roi to defined as active
         """
-        assert isinstance(roi, ROI)
-        if roi and roi.getID() in self._roiToItems.keys():
-            self.selectRow(self._roiToItems[roi.getID()].row())
-            self._markersHandler.setActiveRoi(roi)
+        if roi is None:
+            self.clearSelection()
+            self._markersHandler.setActiveRoi(None)
             self.activeROIChanged.emit()
+        else:
+            assert isinstance(roi, ROI)
+            if roi and roi.getID() in self._roiToItems.keys():
+                self.selectRow(self._roiToItems[roi.getID()].row())
+                self._markersHandler.setActiveRoi(roi)
+                self.activeROIChanged.emit()
 
     def _updateRoiInfo(self, roiID):
         if self._userIsEditingROI is True:

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -446,6 +446,7 @@ class ROITable(qt.QTableWidget):
             header.setResizeMode(qt.QHeaderView.ResizeToContents)
         self.sortByColumn(0, qt.Qt.AscendingOrder)
         self.hideColumn(self.COLUMNS_INDEX['ID'])
+        self._roiDict = {}
 
     def setPlot(self, plot):
         self.clear()

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -405,6 +405,12 @@ class CurvesROIWidget(qt.QWidget):
                 self._add()
                 self.calculateRois()
 
+    @deprecation.deprecated(reason="API modification",
+                            replacement="setRois",
+                            since_version="0.8.0")
+    def fillFromROIDict(self, *args, **kwargs):
+        self.roiTable.fillFromROIDict(*args, **kwargs)
+
 
 class _FloatItem(qt.QTableWidgetItem):
     """

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -1041,23 +1041,31 @@ class ROI(qt.QObject):
 
         :return: dict containing the roi parameters
         """
-        return {
+        ddict = {
             'type': self._type,
             'name': self._name,
             'from': self._fromdata,
             'to': self._todata,
         }
+        if hasattr(self, '_extraInfo'):
+            ddict.update(self._extraInfo)
+        return ddict
 
     @staticmethod
     def _fromDict(dic):
         assert 'name' in dic
         roi = ROI(name=dic['name'])
-        if 'from' in dic:
-            roi.setFrom(dic['from'])
-        if 'to' in dic:
-            roi.setTo(dic['to'])
-        if 'type' in dic:
-            roi.setType(dic['type'])
+        roi._extraInfo = {}
+        for key in dic:
+            if key == 'from':
+                roi.setFrom(dic['from'])
+            elif key == 'to':
+                roi.setTo(dic['to'])
+            elif key == 'type':
+                roi.setType(dic['type'])
+            else:
+                roi._extraInfo[key] = dic[key]
+
         return roi
 
     def isICR(self):

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -194,7 +194,7 @@ class CurvesROIWidget(qt.QWidget):
         return self.roiTable.getRois(order)
 
     @deprecation.deprecated(reason="Moved to ROITable",
-                            since_version="0.8.0")
+                            since_version="0.10.0")
     def setMiddleROIMarkerFlag(self, flag=True):
         return self.roiTable.setMiddleROIMarkerFlag(flag)
 
@@ -409,7 +409,7 @@ class CurvesROIWidget(qt.QWidget):
 
     @deprecation.deprecated(reason="API modification",
                             replacement="setRois",
-                            since_version="0.8.0")
+                            since_version="0.10.0")
     def fillFromROIDict(self, *args, **kwargs):
         self.roiTable.fillFromROIDict(*args, **kwargs)
 
@@ -565,7 +565,7 @@ class ROITable(TableWidget):
         assert order in [None, "from", "to", "type"]
         self.clear()
 
-        # backward comptaibility since 0.8.0
+        # backward comptaibility since 0.10.0
         if isinstance(rois, dict):
             deprecation.deprecated_warning(name='rois', type_='Parameter',
                                            reason='Rois should now be a list '
@@ -806,7 +806,7 @@ class ROITable(TableWidget):
 
     @deprecation.deprecated(reason="Removed",
                             replacement="roidict and roidict.values()",
-                            since_version="0.8.0")
+                            since_version="0.10.0")
     def getROIListAndDict(self):
         """
 
@@ -826,11 +826,11 @@ class ROITable(TableWidget):
         if roiDict:
             deprecation.deprecated_warning(name='roiDict', type_='Parameter',
                                            reason='Unused parameter',
-                                           since_version="0.8.0")
+                                           since_version="0.10.0")
         if roiList:
             deprecation.deprecated_warning(name='roiList', type_='Parameter',
                                            reason='Unused parameter',
-                                           since_version="0.8.0")
+                                           since_version="0.10.0")
 
         for roiID in self._roiDict:
             self._updateRoiInfo(roiID)
@@ -996,7 +996,7 @@ class ROITable(TableWidget):
 
     @deprecation.deprecated(reason="API modification",
                             replacement="setRois",
-                            since_version="0.8.0")
+                            since_version="0.10.0")
     def fillFromROIDict(self, roilist=(), roidict=None, currentroi=None):
         """Set the ROIs by providing a list of ROI names and a dictionary
         of ROI information for each ROI.

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -307,7 +307,8 @@ class CurvesROIWidget(qt.QWidget):
         self.headerLabel.setText("<b>%s<\b>" % text)
 
     @deprecation.deprecated(replacement="calculateRois",
-                            reason="CamelCase convention")
+                            reason="CamelCase convention",
+                            since_version="0.7")
     def calculateROIs(self, *args, **kw):
         self.calculateRois(*args, **kw)
 

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -684,6 +684,9 @@ class ROITable(qt.QTableWidget):
             self._updateMarkers()
         qt.QTableWidget.currentChanged(self, current, previous)
 
+    @deprecation.deprecated(reason="Removed",
+                            replacement="roidict and roidict.values()",
+                            since_version="0.8.0")
     def getROIListAndDict(self):
         """
 

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -202,8 +202,7 @@ class CurvesROIWidget(qt.QWidget):
     def _add(self):
         """Add button clicked handler"""
         def getNextROIName():
-            roiList, roiDict = self.roiTable.getROIListAndDict()
-            nrois = len(roiList)
+            nrois = len(self.roiTable.roidict)
             if nrois == 0:
                 return "ICR"
             else:
@@ -791,15 +790,14 @@ class ROITable(qt.QTableWidget):
         :return: Ordered dictionary of ROI information
         """
 
-        roilist, roidict = self.getROIListAndDict()
         if order is None or order.lower() == "none":
-            ordered_roilist = roilist
-            res = OrderedDict([(roi.name, roidict[roi.name]) for roi in ordered_roilist])
+            ordered_roilist = list(self.roidict.values)
+            res = OrderedDict([(roi.name, self.roidict[roi.name]) for roi in ordered_roilist])
         else:
             assert order in ["from", "to", "type", "netcounts", "rawcounts"]
-            ordered_roilist = sorted(roidict.keys(),
-                                     key=lambda roi_name: roidict[roi_name].get(order))
-            res = OrderedDict([(name, roidict[name]) for name in ordered_roilist])
+            ordered_roilist = sorted(self.roidict.keys(),
+                                     key=lambda roi_name: self.roidict[roi_name].get(order))
+            res = OrderedDict([(name, self.roidict[name]) for name in ordered_roilist])
 
         return res
 

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -46,6 +46,7 @@ from .. import icons, qt
 from silx.gui.plot.items.curve import Curve
 from silx.math.combo import min_max
 import weakref
+from silx.gui.widgets.TableWidget import TableWidget
 
 
 _logger = logging.getLogger(__name__)
@@ -442,7 +443,7 @@ class _FloatItem(qt.QTableWidgetItem):
         return float(self.text()) < float(other.text())
 
 
-class ROITable(qt.QTableWidget):
+class ROITable(TableWidget):
     """Table widget displaying ROI information.
 
     See :class:`QTableWidget` for constructor arguments.

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -448,8 +448,11 @@ class ROITable(qt.QTableWidget):
         qt.QTableWidget.clear(self)
         self.setRowCount(0)
         self.setHorizontalHeaderLabels(self.COLUMNS)
-        self.horizontalHeader().setSectionResizeMode(
-            qt.QHeaderView.ResizeToContents)
+        header = self.horizontalHeader()
+        if hasattr(header, 'setSectionResizeMode'):  # Qt5
+            header.setSectionResizeMode(qt.QHeaderView.ResizeToContents)
+        else:  # Qt4
+            header.setResizeMode(qt.QHeaderView.ResizeToContents)
         self.sortByColumn(0, qt.Qt.AscendingOrder)
         self.hideColumn(self.COLUMNS_INDEX['ID'])
 
@@ -863,7 +866,6 @@ class ROITable(qt.QTableWidget):
                                          text='',
                                          color='yellow',
                                          draggable=True)
-                    roiMoved._markers.add(labelMiddle)
             elif label.endswith('ROI max'):
                 roiMoved.todata = x
                 if self._middleROIMarkerFlag:
@@ -874,7 +876,6 @@ class ROITable(qt.QTableWidget):
                                          text='',
                                          color='yellow',
                                          draggable=True)
-                    roiMoved._markers.add(labelMiddle)
             elif label.endswith('ROI middle'):
                 delta = x - 0.5 * (roiMoved.fromdata + roiMoved.todata)
                 roiMoved.fromdata += delta
@@ -886,14 +887,12 @@ class ROITable(qt.QTableWidget):
                                      text=labelMin,
                                      color='blue',
                                      draggable=True)
-                roiMoved._markers.add(labelMin)
                 labelMax = roi.name + ' ROI max'
                 self.plot.addXMarker(roiMoved.todata,
                                      legend=labelMax,
                                      text=labelMax,
                                      color='blue',
                                      draggable=True)
-                roiMoved._markers.add(labelMax)
 
             self._updateRoiInfo(roiMoved._id)
             self._emitCurrentROISignal()

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -63,6 +63,16 @@ class CurvesROIWidget(qt.QWidget):
     :param str name: The title of this widget
     """
 
+    sigROIWidgetSignal = qt.Signal(object)
+    """Signal of ROIs modifications.
+       Modification information if given as a dict with an 'event' key
+       providing the type of events.
+       Type of events:
+        - AddROI, DelROI, LoadROI and ResetROI with keys: 'roilist', 'roidict'
+        - selectionChanged with keys: 'row', 'col' 'roi', 'key', 'colheader',
+          'rowheader'
+    """
+
     sigROISignal = qt.Signal(object)
     """Deprecated signal for backward compatibility with silx < 0.7.
     Prefer connecting directly to :attr:`CurvesRoiWidget.sigRoiSignal`
@@ -220,14 +230,41 @@ class CurvesROIWidget(qt.QWidget):
 
         self.roiTable.addRoi(roi)
 
+        # back compatibility pymca roi signals
+        ddict = {}
+        ddict['event'] = "AddROI"
+        roilist, roidict = self.roiTable.getROIListAndDict()
+        ddict['roilist'] = roilist
+        ddict['roidict'] = roidict
+        self.sigROIWidgetSignal.emit(ddict)
+        # end back compatibility pymca roi signals
+
     def _del(self):
         """Delete button clicked handler"""
         self.roiTable.deleteActiveRoi()
+
+        # back compatibility pymca roi signals
+        ddict = {}
+        roilist, roidict = self.roiTable.getROIListAndDict()
+        ddict['event'] = "DelROI"
+        ddict['roilist'] = roilist
+        ddict['roidict'] = roidict
+        self.sigROIWidgetSignal.emit(ddict)
+        # end back compatibility pymca roi signals
 
     def _reset(self):
         """Reset button clicked handler"""
         self.roiTable.clear()
         self._add()
+
+        # back compatibility pymca roi signals
+        ddict = {}
+        roilist, roidict = self.roiTable.getROIListAndDict()
+        ddict['event'] = "ResetROI"
+        dict['roilist'] = roilist
+        ddict['roidict'] = roidict
+        self.sigROIWidgetSignal.emit(ddict)
+        # end back compatibility pymca roi signals
 
     def _load(self):
         """Load button clicked handler"""
@@ -246,6 +283,15 @@ class CurvesROIWidget(qt.QWidget):
 
         self.roiFileDir = os.path.dirname(outputFile)
         self.roiTable.load(outputFile)
+
+        # back compatibility pymca roi signals
+        ddict = {}
+        roilist, roidict = self.roiTable.getROIListAndDict()
+        ddict['event'] = "LoadROI"
+        dict['roilist'] = roilist
+        ddict['roidict'] = roidict
+        self.sigROIWidgetSignal.emit(ddict)
+        # end back compatibility pymca roi signals
 
     def load(self, filename):
         """Load ROI widget information from a file storing a dict of ROI.

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -164,6 +164,8 @@ class CurvesROIWidget(qt.QWidget):
         self._isConnected = False  # True if connected to plot signals
         self._isInit = False
 
+        # expose API
+        self.getROIListAndDict = self.roiTable.getROIListAndDict
     def getPlotWidget(self):
         """Returns the associated PlotWidget or None
 

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -235,9 +235,8 @@ class CurvesROIWidget(qt.QWidget):
         # back compatibility pymca roi signals
         ddict = {}
         ddict['event'] = "AddROI"
-        roilist, roidict = self.roiTable.getROIListAndDict()
-        ddict['roilist'] = roilist
-        ddict['roidict'] = roidict
+        ddict['roilist'] = self.roiTable.roidict.values()
+        ddict['roidict'] = self.roiTable.roidict
         self.sigROIWidgetSignal.emit(ddict)
         # end back compatibility pymca roi signals
 
@@ -247,10 +246,9 @@ class CurvesROIWidget(qt.QWidget):
 
         # back compatibility pymca roi signals
         ddict = {}
-        roilist, roidict = self.roiTable.getROIListAndDict()
         ddict['event'] = "DelROI"
-        ddict['roilist'] = roilist
-        ddict['roidict'] = roidict
+        ddict['roilist'] = self.roiTable.roidict.values()
+        ddict['roidict'] = self.roiTable.roidict
         self.sigROIWidgetSignal.emit(ddict)
         # end back compatibility pymca roi signals
 
@@ -261,10 +259,9 @@ class CurvesROIWidget(qt.QWidget):
 
         # back compatibility pymca roi signals
         ddict = {}
-        roilist, roidict = self.roiTable.getROIListAndDict()
         ddict['event'] = "ResetROI"
-        ddict['roilist'] = roilist
-        ddict['roidict'] = roidict
+        ddict['roilist'] = self.roiTable.roidict.values()
+        ddict['roidict'] = self.roiTable.roidict
         self.sigROIWidgetSignal.emit(ddict)
         # end back compatibility pymca roi signals
 
@@ -288,10 +285,9 @@ class CurvesROIWidget(qt.QWidget):
 
         # back compatibility pymca roi signals
         ddict = {}
-        roilist, roidict = self.roiTable.getROIListAndDict()
         ddict['event'] = "LoadROI"
-        ddict['roilist'] = roilist
-        ddict['roidict'] = roidict
+        ddict['roilist'] = self.roiTable.roidict.values()
+        ddict['roidict'] = self.roiTable.roidict
         self.sigROIWidgetSignal.emit(ddict)
         # end back compatibility pymca roi signals
 

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -514,6 +514,8 @@ class ROITable(qt.QTableWidget):
         callback = functools.partial(WeakMethodProxy(self._updateRoiInfo),
                                      roi.getID())
         roi.sigChanged.connect(callback)
+        # set it as the active one
+        self.setActiveRoi(roi)
 
     def _getItem(self, name, row, roi):
         if row:

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -1007,13 +1007,12 @@ class ROI(qt.QObject):
     def computeRawAndNetCounts(self, curve):
         """Compute the Raw and net counts in the ROI for the given curve.
 
-        - Raw counts: integral of the curve between the min ROI point and the
-        max ROI point to the y = 0 line
+        - Raw counts: Points values sum of the curve in the defined Region Of
+           Interest.
 
           .. image:: img/rawCounts.png
 
-        - Net counts: the integral of the curve between the min ROI point and
-        the max ROI point to [ROI min point, ROI max point] segment
+        - Net counts: Raw counts minus background
 
           .. image:: img/netCounts.png
 

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -849,8 +849,8 @@ class ROITable(TableWidget):
                 return
             assert isinstance(self.activeRoi, ROI)
             markerHandler = self._markersHandler.getMarkerHandler(self.activeRoi.getID())
-            assert markerHandler
-            markerHandler.updateMarkers()
+            if markerHandler is not None:
+                markerHandler.updateMarkers()
 
     def getRois(self, order, asDict=False):
         """

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -654,6 +654,10 @@ class ROITable(qt.QTableWidget):
             roi = self._roiDict[id]
             return roi
 
+        def signalChanged(roi):
+            if self.activeRoi and roi.getID() == self.activeRoi.getID():
+                self.activeROIChanged.emit()
+
         self._userIsEditingROI = True
         if item.column() in (self.COLUMNS_INDEX['To'], self.COLUMNS_INDEX['From']):
             roi = getROI()
@@ -669,11 +673,14 @@ class ROITable(qt.QTableWidget):
                     assert(item.column() == self.COLUMNS_INDEX['From'])
                     roi.setFrom(value)
                 self._updateMarker(roi.getName())
+                signalChanged(roi)
 
         if item.column() is self.COLUMNS_INDEX['ROI']:
             roi = getROI()
             roi.setName(item.text())
             self._markersHandler.getMarkerHandler(roi.getID()).updateTexts()
+            signalChanged(roi)
+
         self._userIsEditingROI = False
 
     def deleteActiveRoi(self):

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -574,8 +574,10 @@ class ROITable(qt.QTableWidget):
             roi = self._roiDict[id]
             return roi
 
+        self._userIsEditingROI = True
         if item.column() in (self.COLUMNS_INDEX['To'], self.COLUMNS_INDEX['From']):
             roi = getROI()
+
             if item.text() not in ('', self.INFO_NOT_FOUND):
                 try:
                     value = float(item.text())
@@ -593,6 +595,7 @@ class ROITable(qt.QTableWidget):
             roi.setName(item.text())
             if self._showAllMarkers:
                 self._updateMarkers()
+        self._userIsEditingROI = False
 
     def deleteActiveRoi(self):
         """
@@ -674,7 +677,7 @@ class ROITable(qt.QTableWidget):
 
     def currentChanged(self, current, previous):
         if previous and current.row() != previous.row():
-            roiItem = self.item(current.row(), self.COLUMNS_INDEX['ROI'])
+            roiItem = self.item(current.row(), self.COLUMNS_INDEX['ID'])
             assert roiItem
             self.activeRoi = self._roiDict[int(roiItem.text())]
             self._updateMarkers()
@@ -764,7 +767,7 @@ class ROITable(qt.QTableWidget):
                                  color=_color,
                                  draggable=_draggable)
             if self._middleROIMarkerFlag:
-                pos = 0.5 * (self.activeRoi.getFrom() + self.activeRoi.getto())
+                pos = 0.5 * (self.activeRoi.getFrom() + self.activeRoi.getTo())
                 self.plot.addXMarker(pos,
                                      legend='ROI middle',
                                      text="",

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -514,7 +514,7 @@ class ROITable(qt.QTableWidget):
         assert isinstance(roi, ROI)
         self._getItem(name='ID', row=None, roi=roi)
         self._roiDict[roi.getID()] = roi
-        self._markersHandler.add(_RoiMarkerHandler(roi, self.plot))
+        self._markersHandler.add(roi, _RoiMarkerHandler(roi, self.plot))
         self.activeRoi = roi
         self._updateRoiInfo(roi.getID())
         callback = functools.partial(WeakMethodProxy(self._updateRoiInfo),
@@ -631,7 +631,7 @@ class ROITable(qt.QTableWidget):
 
             assert roi.getID() in self._roiDict
             del self._roiDict[roi.getID()]
-            self._markersHandler.remove(roi.getID())
+            self._markersHandler.remove(roi)
 
             callback = functools.partial(WeakMethodProxy(self._updateRoiInfo),
                                          roi.getID())
@@ -1064,13 +1064,13 @@ class _RoiMarkerManager(object):
             self._showAllMarkers = show
             self.updateAllMarkers()
 
-    def add(self, markersHandler):
-        assert isinstance(markersHandler.roi, ROI)
+    def add(self, roi, markersHandler):
+        assert isinstance(roi, ROI)
         assert isinstance(markersHandler, _RoiMarkerHandler)
-        if markersHandler.roi.getID() in self._roiMarkerHandlers:
+        if roi.getID() in self._roiMarkerHandlers:
             raise ValueError('roi with the same ID already existing')
         else:
-            self._roiMarkerHandlers[markersHandler.roi.getID()] = markersHandler
+            self._roiMarkerHandlers[roi.getID()] = markersHandler
 
     def getMarkerHandler(self, roiID):
         if roiID in self._roiMarkerHandlers:

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -905,6 +905,29 @@ class ROITable(qt.QTableWidget):
             self.hideColumn(self.COLUMNS_INDEX['Raw Area'])
             self.hideColumn(self.COLUMNS_INDEX['Net Area'])
 
+    @deprecation.deprecated(reason="API modification",
+                            replacement="setRois",
+                            since_version="0.8.0")
+    def fillFromROIDict(self, roilist=(), roidict=None, currentroi=None):
+        """Set the ROIs by providing a list of ROI names and a dictionary
+        of ROI information for each ROI.
+        The ROI names must match an existing dictionary key.
+        The name list is used to provide an order for the ROIs.
+        The dictionary's values are sub-dictionaries containing 3
+        mandatory fields:
+           - ``"from"``: x coordinate of the left limit, as a float
+           - ``"to"``: x coordinate of the right limit, as a float
+           - ``"type"``: type of ROI, as a string (e.g "channels", "energy")
+        :param roilist: List of ROI names (keys of roidict)
+        :type roilist: List
+        :param dict roidict: Dict of ROI information
+        :param currentroi: Name of the selected ROI or None (no selection)
+        """
+        self.setRois(roilist)
+        if currentroi:
+            self.setActiveRoi(currentroi)
+
+
 _indexNextROI = 0
 
 

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -1093,7 +1093,6 @@ class ROI(qt.QObject):
         """
         assert isinstance(curve, Curve) or curve is None
 
-        print('computeRawAndNetCounts')
         if curve is None:
             return None, None
 

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -817,9 +817,9 @@ class ROITable(qt.QTableWidget):
         """
         roilist = []
         roidict = {}
-        for roiID, roi in self._roiDict:
+        for roiID, roi in self._roiDict.items():
             roilist.append(roi.toDict())
-            roidict[roi.name] = roi.toDict()
+            roidict[roi.getName()] = roi.toDict()
         datadict = {'ROI': {'roilist': roilist, 'roidict': roidict}}
         dictdump.dump(datadict, filename)
 

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -477,6 +477,7 @@ class ROITable(TableWidget):
         self._isConnected = False
         self._roiToItems = {}
         self._roiDict = {}
+        """dict of ROI object. Key is ROi id, value is the ROI object"""
         self._markersHandler = _RoiMarkerManager()
 
         """
@@ -500,7 +501,7 @@ class ROITable(TableWidget):
     def _getRoiDict(self):
         ddict = {}
         for id in self._roiDict:
-            ddict[self._roiDict[id].name] = self._roiDict[id]
+            ddict[self._roiDict[id].getName()] = self._roiDict[id]
         return ddict
 
     def clear(self):

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -44,6 +44,7 @@ from silx.utils import deprecation
 from silx.utils.weakref import WeakMethodProxy
 from .. import icons, qt
 from silx.gui.plot.items.curve import Curve
+from silx.math.combo import min_max
 import weakref
 
 
@@ -658,10 +659,21 @@ class ROITable(qt.QTableWidget):
         if roiID not in self._roiDict:
             return
         roi = self._roiDict[roiID]
+        if roi.isICR():
+            activeCurve = self.plot.getActiveCurve()
+            if activeCurve:
+                xData = activeCurve.getXData()
+                if len(xData) > 0:
+                    min, max = min_max(xData)
+                    roi.blockSignals(True)
+                    roi.setFrom(min)
+                    roi.setTo(max)
+                    roi.blockSignals(False)
 
         itemID = self._getItem(name='ID', roi=roi, row=None)
         itemName = self._getItem(name='ROI', row=itemID.row(), roi=roi)
         itemName.setText(roi.getName())
+
         itemType = self._getItem(name='Type', row=itemID.row(), roi=roi)
         itemType.setText(roi.getType() or self.INFO_NOT_FOUND)
 

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -220,9 +220,9 @@ class CurvesROIWidget(qt.QWidget):
         if roi.getName() == "ICR":
             roi.setType("Default")
         else:
-            roi.setType(self.plot.getXAxis().getLabel())
+            roi.setType(self.getPlotWidget().getXAxis().getLabel())
 
-        xmin, xmax = self.plot.getXAxis().getLimits()
+        xmin, xmax = self.getPlotWidget().getXAxis().getLimits()
         fromdata = xmin + 0.25 * (xmax - xmin)
         todata = xmin + 0.75 * (xmax - xmin)
         if roi.isICR():

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -564,7 +564,7 @@ class ROITable(TableWidget):
         assert order in [None, "from", "to", "type"]
         self.clear()
 
-        # backward comptaibility since 0.10.0
+        # backward compatibility since 0.10.0
         if isinstance(rois, dict):
             deprecation.deprecated_warning(name='rois', type_='Parameter',
                                            reason='Rois should now be a list '
@@ -578,6 +578,7 @@ class ROITable(TableWidget):
             for roi in rois:
                 assert isinstance(roi, ROI)
                 self.addRoi(roi)
+        self._updateMarkers()
 
     def addRoi(self, roi):
         """

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -202,7 +202,7 @@ class CurvesROIWidget(qt.QWidget):
 
     def _add(self):
         """Add button clicked handler"""
-        def getNextROIName():
+        def getNextRoiName():
             rois = self.roiTable.getRois(order=None)
             roisNames = []
             [roisNames.append(roiName) for roiName in rois]
@@ -217,7 +217,7 @@ class CurvesROIWidget(qt.QWidget):
                     newroi = "newroi %d" % i
                 return newroi
 
-        roi = ROI(name=getNextROIName())
+        roi = ROI(name=getNextRoiName())
 
         if roi.getName() == "ICR":
             roi.setType("Default")
@@ -474,7 +474,7 @@ class ROITable(TableWidget):
         super(ROITable, self).__init__(parent)
         self._showAllMarkers = False
         self._middleROIMarkerFlag = False
-        self._userIsEditingROI = False
+        self._userIsEditingRoi = False
         """bool used to avoid conflict when editing the ROI object"""
         self._isConnected = False
         self._roiToItems = {}
@@ -644,7 +644,7 @@ class ROITable(TableWidget):
             return item
 
     def _itemChanged(self, item):
-        def getROI():
+        def getRoi():
             IDItem = self.item(item.row(), self.COLUMNS_INDEX['ID'])
             assert IDItem
             id = int(IDItem.text())
@@ -656,9 +656,9 @@ class ROITable(TableWidget):
             if self.activeRoi and roi.getID() == self.activeRoi.getID():
                 self.activeROIChanged.emit()
 
-        self._userIsEditingROI = True
+        self._userIsEditingRoi = True
         if item.column() in (self.COLUMNS_INDEX['To'], self.COLUMNS_INDEX['From']):
-            roi = getROI()
+            roi = getRoi()
 
             if item.text() not in ('', self.INFO_NOT_FOUND):
                 try:
@@ -674,12 +674,12 @@ class ROITable(TableWidget):
                 signalChanged(roi)
 
         if item.column() is self.COLUMNS_INDEX['ROI']:
-            roi = getROI()
+            roi = getRoi()
             roi.setName(item.text())
             self._markersHandler.getMarkerHandler(roi.getID()).updateTexts()
             signalChanged(roi)
 
-        self._userIsEditingROI = False
+        self._userIsEditingRoi = False
 
     def deleteActiveRoi(self):
         """
@@ -735,7 +735,7 @@ class ROITable(TableWidget):
                 self.activeROIChanged.emit()
 
     def _updateRoiInfo(self, roiID):
-        if self._userIsEditingROI is True:
+        if self._userIsEditingRoi is True:
             return
         if roiID not in self._roiDict:
             return

--- a/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/silx/gui/plot/test/testCurvesROIWidget.py
@@ -101,7 +101,9 @@ class TestCurvesROIWidget(TestCaseQt):
                             qt.Qt.LeftButton)
             rois = self.widget.getRois()
             self.assertTrue(len(rois) is 1)
-            self.assertTrue(rois[0].name == 'ICR')
+            print(rois)
+            roiID = list(rois.keys())[0]
+            self.assertTrue(rois[roiID].getName() == 'ICR')
 
             # Load ROIs
             self.widget.roiWidget.load(self.tmpFile)

--- a/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/silx/gui/plot/test/testCurvesROIWidget.py
@@ -204,6 +204,13 @@ class TestCurvesROIWidget(TestCaseQt):
         self.plot.getCurvesRoiDockWidget().setVisible(True)
         self.assertTrue(len(roiWidget.getRois()) is len(roisDefs))
 
+    def testDictCompatibility(self):
+        """Test that ROI api is valid with dict and not information is lost"""
+        roiDict = {'from': 20, 'to': 200, 'type': 'energy', 'comment': 'no',
+                   'name': 'myROI', 'calibration': [1, 2, 3]}
+        roi = CurvesROIWidget.ROI._fromDict(roiDict)
+        self.assertTrue(roi.toDict() == roiDict)
+
     def testShowAllROI(self):
         x = numpy.arange(100.)
         y = numpy.arange(100.)

--- a/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/silx/gui/plot/test/testCurvesROIWidget.py
@@ -221,7 +221,7 @@ class TestCurvesROIWidget(TestCaseQt):
         self.widget.calculateROIs()
 
         roiTable = self.widget.roiWidget.roiTable
-        roiItem = roiTable._RoiToItems[roi._id]
+        roiItem = roiTable._roiToItems[roi._id]
         ItemNetCounts = roiTable._getItem(name='Net Counts',
                                           roi=roi,
                                           row=roiItem.row())

--- a/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/silx/gui/plot/test/testCurvesROIWidget.py
@@ -259,8 +259,7 @@ class TestCurvesROIWidget(TestCaseQt):
 
         x = (0, 1, 1, 2, 2, 3)
         y = (1, 1, 2, 2, 1, 1)
-        self.plot.addCurve(x=x, y=y,
-                           legend='linearCurve')
+        self.plot.addCurve(x=x, y=y, legend='linearCurve')
         self.plot.setActiveCurve(legend='linearCurve')
         self.widget.calculateROIs()
 
@@ -271,6 +270,19 @@ class TestCurvesROIWidget(TestCaseQt):
 
         self.assertTrue(itemRawCounts.text() == '8.0')
         self.assertTrue(itemNetCounts.text() == '2.0')
+
+        itemRawArea = roiTable.item(0, indexesColumns['Raw Area'])
+        itemNetArea = roiTable.item(0, indexesColumns['Net Area'])
+
+        self.assertTrue(itemRawArea.text() == '4.0')
+        self.assertTrue(itemNetArea.text() == '1.0')
+
+        roi.setTo(2)
+        itemRawArea = roiTable.item(0, indexesColumns['Raw Area'])
+        self.assertTrue(itemRawArea.text() == '3.0')
+        roi.setFrom(1)
+        itemRawArea = roiTable.item(0, indexesColumns['Raw Area'])
+        self.assertTrue(itemRawArea.text() == '2.0')
 
 
 def suite():

--- a/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/silx/gui/plot/test/testCurvesROIWidget.py
@@ -160,6 +160,37 @@ class TestCurvesROIWidget(TestCaseQt):
         self.assertEqual(roi_neg.computeRawAndNetArea(negCurve),
                          ((-150.0), 0.0))
 
+    def testCountsCalculation(self):
+        x = numpy.arange(100.)
+        y = numpy.arange(100.)
+
+        # Add two curves
+        self.plot.addCurve(x, y, legend="positive")
+        self.plot.addCurve(-x, y, legend="negative")
+
+        # Make sure there is an active curve and it is the positive one
+        self.plot.setActiveCurve("positive")
+
+        # Add two ROIs
+        roi_neg = CurvesROIWidget.ROI(name='negative', fromdata=-20,
+                                      todata=-10, type_='X')
+        roi_pos = CurvesROIWidget.ROI(name='positive', fromdata=10,
+                                      todata=20, type_='X')
+
+        self.widget.roiWidget.setRois((roi_pos, roi_neg))
+
+        posCurve = self.plot.getCurve('positive')
+        negCurve = self.plot.getCurve('negative')
+
+        self.assertEqual(roi_pos.computeRawAndNetCounts(posCurve),
+                         (y[10:21].sum(), 0.0))
+        self.assertEqual(roi_pos.computeRawAndNetCounts(negCurve),
+                         (0.0, 0.0))
+        self.assertEqual(roi_neg.computeRawAndNetCounts(posCurve),
+                         ((0.0), 0.0))
+        self.assertEqual(roi_neg.computeRawAndNetCounts(negCurve),
+                         (y[10:21].sum(), 0.0))
+
     def testDeferedInit(self):
         x = numpy.arange(100.)
         y = numpy.arange(100.)

--- a/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/silx/gui/plot/test/testCurvesROIWidget.py
@@ -128,7 +128,7 @@ class TestCurvesROIWidget(TestCaseQt):
             thValue = xleftMarker + (xRightMarker - xleftMarker) / 2.
             self.assertAlmostEqual(xMiddleMarker, thValue)
 
-    def testCalculation(self):
+    def testAreaCalculation(self):
         x = numpy.arange(100.)
         y = numpy.arange(100.)
 
@@ -150,14 +150,14 @@ class TestCurvesROIWidget(TestCaseQt):
         posCurve = self.plot.getCurve('positive')
         negCurve = self.plot.getCurve('negative')
 
-        self.assertEqual(roi_pos.computeRawAndNetCounts(posCurve),
+        self.assertEqual(roi_pos.computeRawAndNetArea(posCurve),
                         (numpy.trapz(y=[10, 20], x=[10, 20]),
                         0.0))
-        self.assertEqual(roi_pos.computeRawAndNetCounts(negCurve),
+        self.assertEqual(roi_pos.computeRawAndNetArea(negCurve),
                          (0.0, 0.0))
-        self.assertEqual(roi_neg.computeRawAndNetCounts(posCurve),
+        self.assertEqual(roi_neg.computeRawAndNetArea(posCurve),
                          ((0.0), 0.0))
-        self.assertEqual(roi_neg.computeRawAndNetCounts(negCurve),
+        self.assertEqual(roi_neg.computeRawAndNetArea(negCurve),
                          ((-150.0), 0.0))
 
     def testDeferedInit(self):
@@ -228,7 +228,7 @@ class TestCurvesROIWidget(TestCaseQt):
 
         x = (0, 1, 1, 2, 2, 3)
         y = (1, 1, 2, 2, 1, 1)
-        self.plot.addCurve(x=(0, 1, 1, 2, 2, 3), y=(1, 1, 2, 2, 1, 1),
+        self.plot.addCurve(x=x, y=y,
                            legend='linearCurve')
         self.plot.setActiveCurve(legend='linearCurve')
         self.widget.calculateROIs()
@@ -238,13 +238,8 @@ class TestCurvesROIWidget(TestCaseQt):
         itemRawCounts = roiTable.item(0, indexesColumns['Raw Counts'])
         itemNetCounts = roiTable.item(0, indexesColumns['Net Counts'])
 
-        self.assertTrue(itemRawCounts.text() == '4.0')
-        self.assertTrue(itemNetCounts.text() == '1.0')
-        roi.setTo(1.0)
-        itemRawCounts = roiTable.item(0, indexesColumns['Raw Counts'])
-        itemNetCounts = roiTable.item(0, indexesColumns['Net Counts'])
-        self.assertTrue(itemRawCounts.text() == '1.0')
-        self.assertTrue(itemNetCounts.text() == '0.0')
+        self.assertTrue(itemRawCounts.text() == '8.0')
+        self.assertTrue(itemNetCounts.text() == '2.0')
 
 
 def suite():

--- a/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/silx/gui/plot/test/testCurvesROIWidget.py
@@ -207,6 +207,33 @@ class TestCurvesROIWidget(TestCaseQt):
                 roiWidget.showAllMarkers(False)
                 self.assertTrue(len(self.plot._getAllMarkers()) is 2)
 
+    def testRoiEdition(self):
+        """Make sure if the ROI object is edited the ROITable will be updated
+        """
+        roi = CurvesROIWidget.ROI(name='linear', fromdata=0, todata=5)
+        self.widget.roiWidget.setRois((roi, ))
+
+        x = (0, 1, 1, 2, 2, 3)
+        y = (1, 1, 2, 2, 1, 1)
+        self.plot.addCurve(x=(0, 1, 1, 2, 2, 3), y=(1, 1, 2, 2, 1, 1),
+                           legend='linearCurve')
+        self.plot.setActiveCurve(legend='linearCurve')
+        self.widget.calculateROIs()
+
+        roiTable = self.widget.roiWidget.roiTable
+        roiItem = roiTable._RoiToItems[roi._id]
+        ItemNetCounts = roiTable._getItem(name='Net Counts',
+                                          roi=roi,
+                                          row=roiItem.row())
+        ItemRawCounts = roiTable._getItem(name='Raw Counts',
+                                          roi=roi,
+                                          row=roiItem.row())
+        self.assertTrue(ItemRawCounts.text() == '4.0')
+        self.assertTrue(ItemNetCounts.text() == '1.0')
+        roi.setTo(1.0)
+        self.assertTrue(ItemRawCounts.text() == '1.0')
+        self.assertTrue(ItemNetCounts.text() == '0.0')
+
 
 def suite():
     test_suite = unittest.TestSuite()

--- a/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/silx/gui/plot/test/testCurvesROIWidget.py
@@ -68,10 +68,6 @@ class TestCurvesROIWidget(TestCaseQt):
 
         super(TestCurvesROIWidget, self).tearDown()
 
-    def testEmptyPlot(self):
-        """Empty plot, display ROI widget"""
-        pass
-
     def testWithCurves(self):
         """Plot with curves: test all ROI widget buttons"""
         for offset in range(2):

--- a/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/silx/gui/plot/test/testCurvesROIWidget.py
@@ -136,13 +136,18 @@ class TestCurvesROIWidget(TestCaseQt):
         # Add two ROIs
         roi_neg = CurvesROIWidget.ROI(name='negative', fromdata=-20,
                                       todata=-10, type_='X')
-        roi_pos = CurvesROIWidget.ROI(name='negative', fromdata=10,
+        roi_pos = CurvesROIWidget.ROI(name='positive', fromdata=10,
                                       todata=20, type_='X')
 
         self.widget.roiWidget.setRois((roi_pos, roi_neg))
 
-        # And calculate the expected output
-        self.widget.calculateROIs()
+        self.plot.setActiveCurve('positive')
+        posCurve = self.plot.getCurve('positive')
+        print(roi_pos.computeRawAndNetCounts(posCurve))
+        print(roi_neg.computeRawAndNetCounts(posCurve))
+
+        self.assertTrue(roi_pos.computeRawAndNetCounts(posCurve),
+                        numpy.trapz(y=[10, 20], x=[10, 20]))
 
         output = self.widget.roiWidget.getRois()
         self.assertEqual(output["positive"]["rawcounts"],

--- a/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/silx/gui/plot/test/testCurvesROIWidget.py
@@ -287,6 +287,16 @@ class TestCurvesROIWidget(TestCaseQt):
         itemRawArea = roiTable.item(0, indexesColumns['Raw Area'])
         self.assertTrue(itemRawArea.text() == '2.0')
 
+    def testRemoveActiveROI(self):
+        roi = CurvesROIWidget.ROI(name='linear', fromdata=0, todata=5)
+        self.widget.roiWidget.setRois((roi,))
+
+        self.widget.roiWidget.roiTable.setActiveRoi(None)
+        self.assertTrue(len(self.widget.roiWidget.roiTable.selectedItems()) is 0)
+        self.widget.roiWidget.setRois((roi,))
+        self.plot.setActiveCurve(legend='linearCurve')
+        self.widget.calculateROIs()
+
 
 def suite():
     test_suite = unittest.TestSuite()

--- a/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/silx/gui/plot/test/testCurvesROIWidget.py
@@ -77,13 +77,16 @@ class TestCurvesROIWidget(TestCaseQt):
 
         # Add two ROI
         self.mouseClick(self.widget.roiWidget.addButton, qt.Qt.LeftButton)
+        self.qWait(200)
         self.mouseClick(self.widget.roiWidget.addButton, qt.Qt.LeftButton)
+        self.qWait(200)
 
         # Change active curve
         self.plot.setActiveCurve(str(1))
 
         # Delete a ROI
         self.mouseClick(self.widget.roiWidget.delButton, qt.Qt.LeftButton)
+        self.qWait(200)
 
         with temp_dir() as tmpDir:
             self.tmpFile = os.path.join(tmpDir, 'test.ini')
@@ -96,6 +99,7 @@ class TestCurvesROIWidget(TestCaseQt):
             # Reset ROIs
             self.mouseClick(self.widget.roiWidget.resetButton,
                             qt.Qt.LeftButton)
+            self.qWait(200)
             rois = self.widget.getRois()
             self.assertTrue(len(rois) is 1)
             print(rois)


### PR DESCRIPTION
- [x]  add the ROI Object
- [x] reset the API
- [x] move listener into the ROITable instead of the CurvesROIWidget
- [x] <s>Move the ROI object somewhere else ?</s>


The roles between CurvesROIWidget and ROITable are:

* ROITable: display ROIs and insure connection with the plot (curves) and rois
* CurvesROIWIdget define behavior to have and clicking 'add ROI' and 'remove ROI'