### PR TITLE
[plot] Unselect active curve when clicking on empty space

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2393,6 +2393,8 @@ class PlotWidget(qt.QMainWindow):
             if ddict['button'] == "left":
                 self.setActiveCurve(ddict['label'])
                 qt.QToolTip.showText(self.cursor().pos(), ddict['label'])
+        elif ddict['event'] == 'mouseClicked' and ddict['button'] == 'left':
+            self.setActiveCurve(None)
 
     def saveGraph(self, filename, fileFormat=None, dpi=None, **kw):
         """Save a snapshot of the plot.


### PR DESCRIPTION
This PR allows to unselect active curve with a left click in empty area of the plot.
It does not interfere with drag operation

closes #1612