### PR TITLE
[CI] Add pinned requirements file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ before_script:
     # First install any temporary pinned/additional requirements
     - if [ -s "ci/requirements-pinned.txt" ];
       then
-          pip install -r ci/requirements-pinned.txt
+          pip install -r ci/requirements-pinned.txt;
       fi
 
     # Install optional dependencies for running test

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,12 @@ before_script:
           sleep 3;
       fi
 
+    # First install any temporary pinned/additional requirements
+    - if [ -s "ci/requirements-pinned.txt" ];
+      then
+          pip install -r ci/requirements-pinned.txt
+      fi
+
     # Install optional dependencies for running test
     - pip install --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ pyopencl==$PYOPENCL_VERSION
     # This installs PyQt and scipy if wheels are available

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -23,7 +23,6 @@ environment:
         WIN_SDK_ROOT: "C:\\Program Files\\Microsoft SDKs\\Windows"
         VENV_BUILD_DIR: "venv_build"
         VENV_TEST_DIR: "venv_test"
-        PINNED_REQ: ci\requirements-pinned.txt
 
     matrix:
         # Python 3.6
@@ -82,7 +81,7 @@ before_test:
     - "%VENV_TEST_DIR%\\Scripts\\activate.bat"
 
     # First install any temporary pinned/additional requirements
-    - ps: If ((Test-Path $env:PINNED_REQ) -and ((Get-Item $env:PINNED_REQ).length -gt 0)) { pip install -r $env:PINNED_REQ }
+    - pip install -r "ci\requirements-pinned.txt
 
     # Install dependencies
     - pip install --pre -r requirements.txt

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -23,7 +23,7 @@ environment:
         WIN_SDK_ROOT: "C:\\Program Files\\Microsoft SDKs\\Windows"
         VENV_BUILD_DIR: "venv_build"
         VENV_TEST_DIR: "venv_test"
-        PINNED_REQ: "ci\requirements-pinned.txt"
+        PINNED_REQ: ci\requirements-pinned.txt
 
     matrix:
         # Python 3.6
@@ -82,7 +82,7 @@ before_test:
     - "%VENV_TEST_DIR%\\Scripts\\activate.bat"
 
     # First install any temporary pinned/additional requirements
-    - ps: If ((Test-Path $PINNED_REQ) -and ((Get-Item $PINNED_REQ).length -gt 0)) { pip install -r $PINNED_REQ }
+    - ps: If ((Test-Path $env:PINNED_REQ) -and ((Get-Item $env:PINNED_REQ).length -gt 0)) { pip install -r $env:PINNED_REQ }
 
     # Install dependencies
     - pip install --pre -r requirements.txt

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -23,6 +23,7 @@ environment:
         WIN_SDK_ROOT: "C:\\Program Files\\Microsoft SDKs\\Windows"
         VENV_BUILD_DIR: "venv_build"
         VENV_TEST_DIR: "venv_test"
+        PINNED_REQ: "ci\requirements-pinned.txt"
 
     matrix:
         # Python 3.6
@@ -79,6 +80,9 @@ before_test:
     # Create test virtualenv
     - "virtualenv --clear %VENV_TEST_DIR%"
     - "%VENV_TEST_DIR%\\Scripts\\activate.bat"
+
+    # First install any temporary pinned/additional requirements
+    - ps: If ((Test-Path $PINNED_REQ) -and ((Get-Item $PINNED_REQ).length -gt 0)) { pip install -r $PINNED_REQ }
 
     # Install dependencies
     - pip install --pre -r requirements.txt

--- a/ci/requirements-pinned.txt
+++ b/ci/requirements-pinned.txt
@@ -1,0 +1,1 @@
+unittest2; python_version == '2.7'  # Needed for h5py 2.8.0rc1 on python2


### PR DESCRIPTION
This PR proposes to add a file `ci/requirements-pinned.txt` for temporary version pinning or additional dependencies.

As we test with pre-released version of our dependencies, we regularly fall into issues with such versions.
While this is the purpose of testing, the idea here is to **temporarily** pin a version/add a dependency in a single file until the issue is fixed upstream.