### PR TITLE
[plot] StackView/FrameBrowser API update + fix

### DIFF
--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -156,6 +156,12 @@ class StackView(qt.QMainWindow):
     integer.
     """
 
+    sigFrameChanged = qt.Signal(int)
+    """Signal emitter when the frame number has changed.
+
+    This signal provides the current frame number.
+    """
+
     def __init__(self, parent=None, resetzoom=True, backend=None,
                  autoScale=False, logScale=False, grid=False,
                  colormap=True, aspectRatio=True, yinverted=True,
@@ -221,6 +227,7 @@ class StackView(qt.QMainWindow):
         self._browser_label = qt.QLabel("Image index (Dim0):")
 
         self._browser = HorizontalSliderWithBrowser(central_widget)
+        self._browser.setRange(0, 0)
         self._browser.valueChanged[int].connect(self.__updateFrameNumber)
         self._browser.setEnabled(False)
 
@@ -345,6 +352,7 @@ class StackView(qt.QMainWindow):
                             legend=self.__imageLegend,
                             resetzoom=False)
         self._updateTitle()
+        self.sigFrameChanged.emit(index)
 
     def _set3DScaleAndOrigin(self, calibrations):
         """Set scale and origin for all 3 axes, to be used when plotting
@@ -587,6 +595,14 @@ class StackView(qt.QMainWindow):
         """
         self._browser.setValue(number)
 
+    def getFrameNumber(self):
+        """Set the frame selection to a specific value
+
+        :return: Index of currently displayed frame
+        :rtype: int
+        """
+        return self._browser.value()
+
     def setFirstStackDimension(self, first_stack_dimension):
         """When viewing the last 3 dimensions of an n-D array (n>3), you can
         use this method to change the text in the combobox.
@@ -642,6 +658,7 @@ class StackView(qt.QMainWindow):
         self.__transposed_view = None
         self._perspective = 0
         self._browser.setEnabled(False)
+        self._browser.setRange(0, 0)
         self._plot.clear()
 
     def setLabels(self, labels=None):

--- a/silx/gui/plot/test/testStackView.py
+++ b/silx/gui/plot/test/testStackView.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,7 @@ __date__ = "20/03/2017"
 import unittest
 import numpy
 
-from silx.gui.test.utils import TestCaseQt
+from silx.gui.test.utils import TestCaseQt, SignalListener
 
 from silx.gui import qt
 from silx.gui.plot import StackView
@@ -186,6 +186,17 @@ class TestStackView(TestCaseQt):
                     "Là, vous faites sirop de vingt-et-un et vous dites : "
                     "beau sirop, mi-sirop, siroté, gagne-sirop, sirop-grelot,"
                     " passe-montagne, sirop au bon goût.")
+
+    def testStackFrameNumber(self):
+        self.stackview.setStack(self.mystack)
+        self.assertEqual(self.stackview.getFrameNumber(), 0)
+
+        listener = SignalListener()
+        self.stackview.sigFrameChanged.connect(listener)
+
+        self.stackview.setFrameNumber(1)
+        self.assertEqual(self.stackview.getFrameNumber(), 1)
+        self.assertEqual(listener.arguments(), [(1,)])
 
 
 class TestStackViewMainWindow(TestCaseQt):

--- a/silx/gui/widgets/FrameBrowser.py
+++ b/silx/gui/widgets/FrameBrowser.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -208,7 +208,18 @@ class FrameBrowser(qt.QWidget):
     def setValue(self, value):
         """Set 0-based frame index
 
+        Value is clipped to current range.
+
         :param int value: Frame number"""
+        bottom = self.lineEdit().validator().bottom()
+        top = self.lineEdit().validator().top()
+        value = int(value)
+
+        if value < bottom:
+            value = bottom
+        elif value > top:
+            value = top
+
         self._lineEdit.setText("%d" % value)
         self._textChangedSlot()
 

--- a/silx/gui/widgets/FrameBrowser.py
+++ b/silx/gui/widgets/FrameBrowser.py
@@ -33,6 +33,7 @@
 """
 from silx.gui import qt
 from silx.gui import icons
+from silx.utils import deprecation
 
 __authors__ = ["V.A. Sole", "P. Knobel"]
 __license__ = "MIT"
@@ -50,7 +51,9 @@ class FrameBrowser(qt.QWidget):
     :param QWidget parent: Parent widget
     :param int n: Number of frames. This will set the range
         of frame indices to 0--n-1.
-        If None, the range is initialized to the default QSlider range (0--99)."""
+        If None, the range is initialized to the default QSlider range (0--99).
+    """
+
     sigIndexChanged = qt.pyqtSignal(object)
 
     def __init__(self, parent=None, n=None):
@@ -171,15 +174,6 @@ class FrameBrowser(qt.QWidget):
 
         :param int first: Minimum frame index
         :param int last: Maximum frame index"""
-        return self.setLimits(first, last)
-
-    def setLimits(self, first, last):
-        """Set minimum and maximum frame indices.
-        Initialize the frame index to *first*.
-        Update the label text to *" limits: first, last"*
-
-        :param int first: Minimum frame index
-        :param int last: Maximum frame index"""
         bottom = min(first, last)
         top = max(first, last)
         self._lineEdit.validator().setTop(top)
@@ -188,6 +182,12 @@ class FrameBrowser(qt.QWidget):
 
         # Update limits
         self._label.setText(" limits: %d, %d " % (bottom, top))
+
+   @deprecation.deprecated(
+       replacement="silx.gui.widgets.FrameBrowser.FrameBrowser.setRange",
+       since_version="0.8")
+    def setLimits(self, first, last):
+        return self.setRange(first, last)
 
     def setNFrames(self, nframes):
         """Set minimum=0 and maximum=nframes-1 frame numbers.

--- a/silx/gui/widgets/FrameBrowser.py
+++ b/silx/gui/widgets/FrameBrowser.py
@@ -123,25 +123,19 @@ class FrameBrowser(qt.QWidget):
 
     def _firstClicked(self):
         """Select first/lowest frame number"""
-        self._lineEdit.setText("%d" % self._lineEdit.validator().bottom())
-        self._textChangedSlot()
+        self.setValue(self.getRange()[0])
 
     def _previousClicked(self):
         """Select previous frame number"""
-        if self._index > self._lineEdit.validator().bottom():
-            self._lineEdit.setText("%d" % (self._index - 1))
-            self._textChangedSlot()
+        self.setValue(self.getCurrentIndex() - 1)
 
     def _nextClicked(self):
         """Select next frame number"""
-        if self._index < (self._lineEdit.validator().top()):
-            self._lineEdit.setText("%d" % (self._index + 1))
-            self._textChangedSlot()
+        self.setValue(self.getCurrentIndex() + 1)
 
     def _lastClicked(self):
         """Select last/highest frame number"""
-        self._lineEdit.setText("%d" % self._lineEdit.validator().top())
-        self._textChangedSlot()
+        self.setValue(self.getRange()[1])
 
     def _textChangedSlot(self):
         """Select frame number typed in the line edit widget"""
@@ -161,8 +155,17 @@ class FrameBrowser(qt.QWidget):
         self._index = new_value
         self.sigIndexChanged.emit(ddict)
 
+    def getRange(self):
+        """Returns frame range
+
+        :return: (first_index, last_index)
+        """
+        validator = self.lineEdit().validator()
+        return validator.bottom(), validator.top()
+
     def setRange(self, first, last):
-        """Set minimum and maximum frame indices
+        """Set minimum and maximum frame indices.
+
         Initialize the frame index to *first*.
         Update the label text to *" limits: first, last"*
 
@@ -181,24 +184,22 @@ class FrameBrowser(qt.QWidget):
         top = max(first, last)
         self._lineEdit.validator().setTop(top)
         self._lineEdit.validator().setBottom(bottom)
-        self._index = bottom
-        self._lineEdit.setText("%d" % self._index)
+        self.setValue(bottom)
+
+        # Update limits
         self._label.setText(" limits: %d, %d " % (bottom, top))
 
     def setNFrames(self, nframes):
         """Set minimum=0 and maximum=nframes-1 frame numbers.
+
         Initialize the frame index to 0.
         Update the label text to *"1 of nframes"*
 
         :param int nframes: Number of frames"""
-        bottom = 0
         top = nframes - 1
-        self._lineEdit.validator().setTop(top)
-        self._lineEdit.validator().setBottom(bottom)
-        self._index = bottom
-        self._lineEdit.setText("%d" % self._index)
+        self.setRange(0, top)
         # display 1-based index in label
-        self._label.setText(" %d of %d " % (self._index + 1, top + 1))
+        self._label.setText(" of %d " % top)
 
     def getCurrentIndex(self):
         """Get 0-based frame index

--- a/silx/gui/widgets/FrameBrowser.py
+++ b/silx/gui/widgets/FrameBrowser.py
@@ -130,11 +130,11 @@ class FrameBrowser(qt.QWidget):
 
     def _previousClicked(self):
         """Select previous frame number"""
-        self.setValue(self.getCurrentIndex() - 1)
+        self.setValue(self.getValue() - 1)
 
     def _nextClicked(self):
         """Select next frame number"""
-        self.setValue(self.getCurrentIndex() + 1)
+        self.setValue(self.getValue() + 1)
 
     def _lastClicked(self):
         """Select last/highest frame number"""
@@ -183,9 +183,8 @@ class FrameBrowser(qt.QWidget):
         # Update limits
         self._label.setText(" limits: %d, %d " % (bottom, top))
 
-   @deprecation.deprecated(
-       replacement="silx.gui.widgets.FrameBrowser.FrameBrowser.setRange",
-       since_version="0.8")
+    @deprecation.deprecated(replacement="FrameBrowser.setRange",
+                            since_version="0.8")
     def setLimits(self, first, last):
         return self.setRange(first, last)
 
@@ -201,9 +200,13 @@ class FrameBrowser(qt.QWidget):
         # display 1-based index in label
         self._label.setText(" of %d " % top)
 
+    @deprecation.deprecated(replacement="FrameBrowser.getValue",
+                            since_version="0.8")
     def getCurrentIndex(self):
-        """Get 0-based frame index
-        """
+        return self._index
+
+    def getValue(self):
+        """Return current frame index"""
         return self._index
 
     def setValue(self, value):

--- a/silx/gui/widgets/test/test_framebrowser.py
+++ b/silx/gui/widgets/test/test_framebrowser.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,28 +22,52 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "23/03/2018"
+
+
 import unittest
 
-from . import test_periodictable
-from . import test_tablewidget
-from . import test_threadpoolpushbutton
-from . import test_hierarchicaltableview
-from . import test_printpreview
-from . import test_framebrowser
+from silx.gui.test.utils import TestCaseQt
+from silx.gui.widgets.FrameBrowser import FrameBrowser
 
-__authors__ = ["V. Valls", "P. Knobel"]
-__license__ = "MIT"
-__date__ = "19/07/2017"
+
+class TestFrameBrowser(TestCaseQt):
+    """Test for FrameBrowser"""
+
+    def test(self):
+        """Test FrameBrowser"""
+        widget = FrameBrowser()
+        widget.show()
+        self.qWaitForWindowExposed(widget)
+
+        nFrames = 20
+        widget.setNFrames(nFrames)
+        self.assertEqual(widget.getRange(), (0, nFrames - 1))
+        self.assertEqual(widget.getValue(), 0)
+
+        range_ = -100, 100
+        widget.setRange(*range_)
+        self.assertEqual(widget.getRange(), range_)
+        self.assertEqual(widget.getValue(), range_[0])
+
+        widget.setValue(0)
+        self.assertEqual(widget.getValue(), 0)
+
+        widget.setValue(range_[1] + 100)
+        self.assertEqual(widget.getValue(), range_[1])
+
+        widget.setValue(range_[0] - 100)
+        self.assertEqual(widget.getValue(), range_[0])
 
 
 def suite():
+    loader = unittest.defaultTestLoader.loadTestsFromTestCase
     test_suite = unittest.TestSuite()
-    test_suite.addTests(
-        [test_threadpoolpushbutton.suite(),
-         test_tablewidget.suite(),
-         test_periodictable.suite(),
-         test_printpreview.suite(),
-         test_hierarchicaltableview.suite(),
-         test_framebrowser.suite(),
-         ])
+    test_suite.addTest(loader(TestFrameBrowser))
     return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
This PR extends `StackView` API:
- `getFrameNumber` to get current frame
- `sigFrameChanged` emitted when frame changes

It also updates `FrameBrowser`:
- Clip value provided by `setValue` to the range
- deprecate duplicated/inconsistent API: `setLimits`, `getCurrentIndex`
- adds `getRange`, `getValue`