### PR TITLE
[plot3d] Improve rendering fully transparent points

### DIFF
--- a/silx/gui/plot3d/scene/primitives.py
+++ b/silx/gui/plot3d/scene/primitives.py
@@ -1246,12 +1246,12 @@ class _Points(Geometry):
         $clippingCall(vCameraPosition);
 
         float alpha = alphaSymbol(gl_PointCoord, vSize);
-        if (alpha == 0.0) {
-            discard;
-        }
 
         gl_FragColor = $valueToColorCall(vValue);
         gl_FragColor.a *= alpha;
+        if (gl_FragColor.a == 0.0) {
+            discard;
+        }
     }
     """))
 


### PR DESCRIPTION
This PR does not render points that have a fully transparent color.
It is the case for a mask on a scatter plot.