### PR TITLE
[specfile]improve handling of empty scans

### DIFF
--- a/silx/io/specfile.pyx
+++ b/silx/io/specfile.pyx
@@ -883,6 +883,11 @@ cdef class SpecFile(object):
                                                &mydata,
                                                &data_info,
                                                &error)
+        if sfdata_error == -1 and not error:
+            # this has happened in some situations with empty scans (#1759)
+            _logger.warning("SfData returned -1 without an error."
+                            " Assuming aborted scan.")
+
         self._handle_error(error)
 
         if <long>data_info != 0:
@@ -931,6 +936,12 @@ cdef class SpecFile(object):
                                                   &data_column,
                                                   &error)
         self._handle_error(error)
+
+        if nlines == -1:
+            # this can happen on empty scans in some situations (see 1759)
+            _logger.warning("SfDataColByName returned -1 without an error."
+                            " Assuming aborted scan.")
+            nlines = 0
 
         ret_array = numpy.empty((nlines,), dtype=numpy.double)
 

--- a/silx/io/specfile.pyx
+++ b/silx/io/specfile.pyx
@@ -938,7 +938,7 @@ cdef class SpecFile(object):
         self._handle_error(error)
 
         if nlines == -1:
-            # this can happen on empty scans in some situations (see 1759)
+            # this can happen on empty scans in some situations (see #1759)
             _logger.warning("SfDataColByName returned -1 without an error."
                             " Assuming aborted scan.")
             nlines = 0


### PR DESCRIPTION
Addresses #1759: SpecH5 sometimes raised an error when encountering an empty scan in a large specfile. 

Unfortunately, the error was intermittent. I have no idea how I could write a unittest for this issue.
Also, I still don't understand why the error was intermittent. I seems to be related to memory usage. But I never caused a segfault, and it only ever happened on empty aborted scans (AFAIK). 

The source of the intermittent error seems to be that `SfData` may return -1 without setting an error code, which seems inconsistent. https://github.com/silx-kit/silx/blob/master/silx/io/specfile/src/sfdata.c#L244.

When running a memory profiling tool on a script that used to reproduce the error, nothing unusual shows up.

```
$ python  -m memprof --plot spech5_memleak.py 
...
Nothing with more than 1.00 MBs found!
There is nothing to plot... Exiting
memprof done
```
