### PR TITLE
Allow to flag Cython modules if OpenMP is used at runtime

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@
 # ###########################################################################*/
 
 __authors__ = ["Jérôme Kieffer", "Thomas Vincent"]
-__date__ = "18/04/2018"
+__date__ = "23/04/2018"
 __license__ = "MIT"
 
 
@@ -588,8 +588,7 @@ class BuildExt(build_ext):
             patched_exts = cythonize(
                 [ext],
                 compiler_directives={'embedsignature': True},
-                force=self.force_cython,
-                compile_time_env={"HAVE_OPENMP": self.use_openmp}
+                force=self.force_cython
             )
             ext.sources = patched_exts[0].sources
 
@@ -770,8 +769,7 @@ class SourceDistWithCython(sdist):
         cythonize(
             self.extensions,
             compiler_directives={'embedsignature': True},
-            force=True,
-            compile_time_env={"HAVE_OPENMP": False}
+            force=True
         )
 
 ################################################################################

--- a/silx/image/marchingsquares/_mergeimpl.pyx
+++ b/silx/image/marchingsquares/_mergeimpl.pyx
@@ -27,7 +27,7 @@ Marching squares implementation based on a merge of segements and polygons.
 
 __authors__ = ["Almar Klein", "Jerome Kieffer", "Valentin Valls"]
 __license__ = "MIT"
-__date__ = "18/04/2018"
+__date__ = "23/04/2018"
 
 import numpy
 cimport numpy as cnumpy
@@ -47,6 +47,9 @@ cimport libc.stdlib
 cimport libc.string
 
 cimport cython
+
+include "../../utils/_have_openmp.pxi"
+"""Store in the module if it was compiled with OpenMP"""
 
 cdef double EPSILON = numpy.finfo(numpy.float64).eps
 
@@ -1269,7 +1272,7 @@ cdef class MarchingSquaresMergeImpl(object):
             algo._dim_y = self._dim_y
             algo._group_size = self._group_size
             algo._use_minmax_cache = self._use_minmax_cache
-            # algo._force_sequencial_reduction = True
+            algo._force_sequencial_reduction = COMPILED_WITH_OPENMP == 0
             if self._use_minmax_cache:
                 algo._min_cache = self._min_cache
                 algo._max_cache = self._max_cache
@@ -1303,6 +1306,7 @@ cdef class MarchingSquaresMergeImpl(object):
             algo._dim_y = self._dim_y
             algo._group_size = self._group_size
             algo._use_minmax_cache = self._use_minmax_cache
+            algo._force_sequencial_reduction = COMPILED_WITH_OPENMP == 0
             if self._use_minmax_cache:
                 algo._min_cache = self._min_cache
                 algo._max_cache = self._max_cache

--- a/silx/image/marchingsquares/setup.py
+++ b/silx/image/marchingsquares/setup.py
@@ -24,8 +24,9 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "17/04/2018"
+__date__ = "23/04/2018"
 
+import os
 import numpy
 from numpy.distutils.misc_util import Configuration
 
@@ -34,9 +35,10 @@ def configuration(parent_package='', top_path=None):
     config = Configuration('marchingsquares', parent_package, top_path)
     config.add_subpackage('test')
 
+    silx_include = os.path.join(top_path, "silx", "utils", "include")
     config.add_extension('_mergeimpl',
                          sources=['_mergeimpl.pyx'],
-                         include_dirs=[numpy.get_include()],
+                         include_dirs=[numpy.get_include(), silx_include],
                          language='c++',
                          extra_link_args=['-fopenmp'],
                          extra_compile_args=['-fopenmp'])

--- a/silx/third_party/setup.py
+++ b/silx/third_party/setup.py
@@ -28,7 +28,7 @@
 
 __authors__ = ["Valentin Valls"]
 __license__ = "MIT"
-__date__ = "07/11/2017"
+__date__ = "23/04/2018"
 
 import os
 from numpy.distutils.misc_util import Configuration
@@ -37,7 +37,7 @@ from numpy.distutils.misc_util import Configuration
 def configuration(parent_package='', top_path=None):
     config = Configuration('third_party', parent_package, top_path)
     # includes _local only if it is available
-    local_path = os.path.join(top_path, parent_package, "third_party", "_local")
+    local_path = os.path.join(top_path, "silx", "third_party", "_local")
     if os.path.exists(local_path):
         config.add_subpackage('_local')
         config.add_subpackage('_local.scipy_spatial')

--- a/silx/utils/_have_openmp.pxi
+++ b/silx/utils/_have_openmp.pxi
@@ -1,0 +1,49 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+
+"""
+Store in a Cython module if it was compiled with OpenMP
+
+You have to patch the setup module like that:
+
+.. code-block:: python
+
+    silx_include = os.path.join(top_path, "silx", "utils", "include")
+    config.add_extension('my_extension',
+                         include_dirs=[silx_include],
+                         ...)
+
+Then you can include it like that in your Cython module:
+
+.. code-block:: python
+
+    include "../../utils/_have_openmp.pxi"
+
+"""
+
+
+cdef extern from "silx_store_openmp.h":
+    int COMPILED_WITH_OPENMP
+_COMPILED_WITH_OPENMP = COMPILED_WITH_OPENMP

--- a/silx/utils/include/silx_store_openmp.h
+++ b/silx/utils/include/silx_store_openmp.h
@@ -1,0 +1,10 @@
+
+
+
+/** Flag the C module with a variable to know if it was compiled with OpenMP
+ */
+#ifdef _OPENMP
+static const int COMPILED_WITH_OPENMP = 1;
+#else
+static const int COMPILED_WITH_OPENMP = 0;
+#endif


### PR DESCRIPTION
This flag the C-module binary with a variable.

```
In [1]: from silx.image.marchingsquares import _mergeimpl
In [2]: _mergeimpl._COMPILED_WITH_OPENMP
Out[2]: 1
```

It also can be used in the module to custom the process.