### PR TITLE
Add dock widget that update widget's layout direction

### DIFF
--- a/silx/gui/widgets/BoxLayoutDockWidget.py
+++ b/silx/gui/widgets/BoxLayoutDockWidget.py
@@ -1,0 +1,90 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""A QDockWidget that update the layout direction of its widget
+"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "06/03/2018"
+
+
+from .. import qt
+
+
+class BoxLayoutDockWidget(qt.QDockWidget):
+    """QDockWidget adjusting its child widget QBoxLayout direction.
+
+    The child widget layout direction is set according to dock widget area.
+    The child widget MUST use a QBoxLayout
+
+    :param parent: See :class:`QDockWidget`
+    :param flags: See :class:`QDockWidget`
+    """
+
+    def __init__(self, parent=None, flags=None):
+        super(BoxLayoutDockWidget, self).__init__(parent, flags)
+        self._currentArea = qt.Qt.NoDockWidgetArea
+        self.dockLocationChanged.connect(self._dockLocationChanged)
+        self.topLevelChanged.connect(self._topLevelChanged)
+
+    def setWidget(self, widget):
+        """Set the widget of this QDockWidget
+
+        See :meth:`QDockWidget.setWidget`
+        """
+        super(BoxLayoutDockWidget, self).setWidget(widget)
+        # Update widget's layout direction
+        self._dockLocationChanged(self._currentArea)
+
+    def _dockLocationChanged(self, area):
+        self._currentArea = area
+
+        widget = self.widget()
+        if widget is not None:
+            layout = widget.layout()
+            if isinstance(layout, qt.QBoxLayout):
+                if area in (qt.Qt.LeftDockWidgetArea, qt.Qt.RightDockWidgetArea):
+                    direction = qt.QBoxLayout.TopToBottom
+                else:
+                    direction = qt.QBoxLayout.LeftToRight
+                layout.setDirection(direction)
+                self.resize(widget.minimumSize())
+                self.adjustSize()
+
+    def _topLevelChanged(self, topLevel):
+        widget = self.widget()
+        if widget is not None and topLevel:
+            layout = widget.layout()
+            if isinstance(layout, qt.QBoxLayout):
+                layout.setDirection(qt.QBoxLayout.LeftToRight)
+                self.resize(widget.minimumSize())
+                self.adjustSize()
+
+    def showEvent(self, event):
+        """Make sure this dock widget is raised when it is shown.
+
+        This is useful for tabbed dock widgets.
+        """
+        self.raise_()

--- a/silx/gui/widgets/BoxLayoutDockWidget.py
+++ b/silx/gui/widgets/BoxLayoutDockWidget.py
@@ -43,7 +43,7 @@ class BoxLayoutDockWidget(qt.QDockWidget):
     :param flags: See :class:`QDockWidget`
     """
 
-    def __init__(self, parent=None, flags=None):
+    def __init__(self, parent=None, flags=qt.Qt.Widget):
         super(BoxLayoutDockWidget, self).__init__(parent, flags)
         self._currentArea = qt.Qt.NoDockWidgetArea
         self.dockLocationChanged.connect(self._dockLocationChanged)

--- a/silx/gui/widgets/test/__init__.py
+++ b/silx/gui/widgets/test/__init__.py
@@ -30,6 +30,7 @@ from . import test_threadpoolpushbutton
 from . import test_hierarchicaltableview
 from . import test_printpreview
 from . import test_framebrowser
+from . import test_boxlayoutdockwidget
 
 __authors__ = ["V. Valls", "P. Knobel"]
 __license__ = "MIT"
@@ -45,5 +46,6 @@ def suite():
          test_printpreview.suite(),
          test_hierarchicaltableview.suite(),
          test_framebrowser.suite(),
+         test_boxlayoutdockwidget.suite(),
          ])
     return test_suite

--- a/silx/gui/widgets/test/test_boxlayoutdockwidget.py
+++ b/silx/gui/widgets/test/test_boxlayoutdockwidget.py
@@ -1,0 +1,83 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Tests for BoxLayoutDockWidget"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "06/03/2018"
+
+import unittest
+
+from silx.gui.widgets.BoxLayoutDockWidget import BoxLayoutDockWidget
+from silx.gui import qt
+from silx.gui.test.utils import TestCaseQt
+
+
+class TestBoxLayoutDockWidget(TestCaseQt):
+    """Tests for BoxLayoutDockWidget"""
+
+    def setUp(self):
+        """Create and show a main window"""
+        self.window = qt.QMainWindow()
+        self.qWaitForWindowExposed(self.window)
+
+    def tearDown(self):
+        """Delete main window"""
+        self.window.setAttribute(qt.Qt.WA_DeleteOnClose)
+        self.window.close()
+        del self.window
+        self.qapp.processEvents()
+
+    def test(self):
+        """Test update of layout direction according to dock area"""
+        # Create a widget with a QBoxLayout
+        layout = qt.QBoxLayout(qt.QBoxLayout.LeftToRight)
+        layout.addWidget(qt.QLabel('First'))
+        layout.addWidget(qt.QLabel('Second'))
+        widget = qt.QWidget()
+        widget.setLayout(layout)
+
+        # Add it to a BoxLayoutDockWidget
+        dock = BoxLayoutDockWidget()
+        dock.setWidget(widget)
+
+        self.window.addDockWidget(qt.Qt.BottomDockWidgetArea, dock)
+        self.qapp.processEvents()
+        self.assertEqual(layout.direction(), qt.QBoxLayout.LeftToRight)
+
+        self.window.addDockWidget(qt.Qt.LeftDockWidgetArea, dock)
+        self.qapp.processEvents()
+        self.assertEqual(layout.direction(), qt.QBoxLayout.TopToBottom)
+
+
+def suite():
+    loader = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite = unittest.TestSuite()
+    test_suite.addTest(loader(TestBoxLayoutDockWidget))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
This PR adds a dock widget which updates the direction of the box layout of its widget.
It can be useful for e.g. the mask dock widget.