### PR TITLE
Disable OpenCL on Travis Linux targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,16 @@ matrix:
               - PYOPENCL_VERSION=2018.1
               - SILX_OPENCL=0
 
+        # Temporary: Allow to check if AMD APPSDK is back
+        # TODO: Remove it when we are able to enable SILX_OPENCL everywhere
+        - python: 3.6
+          os: linux
+          env:
+              - BUILD_COMMAND=sdist
+              - WITH_QT_TEST=True
+              - PYOPENCL_VERSION=2018.1
+              - SILX_OPENCL=1
+
         - language: generic
           os: osx
           env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
               - BUILD_COMMAND=sdist
               - WITH_QT_TEST=False
               - PYOPENCL_VERSION=2015.1
+              - SILX_OPENCL=0
 
         - python: 3.4
           os: linux
@@ -22,6 +23,7 @@ matrix:
               - WITH_QT_TEST=False
               - PIP_INSTALL_EXTRA_ARGS="--global-option build --global-option --debug"
               - PYOPENCL_VERSION=2015.1
+              - SILX_OPENCL=0
 
         - python: 3.5
           os: linux
@@ -29,6 +31,7 @@ matrix:
               - BUILD_COMMAND=sdist
               - WITH_QT_TEST=True
               - PYOPENCL_VERSION=2015.1
+              - SILX_OPENCL=0
 
         - python: 3.6
           os: linux
@@ -36,6 +39,7 @@ matrix:
               - BUILD_COMMAND=sdist
               - WITH_QT_TEST=True
               - PYOPENCL_VERSION=2018.1
+              - SILX_OPENCL=0
 
         - language: generic
           os: osx

--- a/ci/before_install-linux.sh
+++ b/ci/before_install-linux.sh
@@ -1,13 +1,33 @@
 #!/bin/bash
 echo $(pwd)
-bash ./ci/amd_sdk.sh;
-ls
-tar -xjf AMD-SDK.tar.bz2;
-export AMDAPPSDK=$(pwd)/AMDAPPSDK;
-export OPENCL_VENDOR_PATH=${AMDAPPSDK}/etc/OpenCL/vendors;
-mkdir -p ${OPENCL_VENDOR_PATH};
-sh AMD-APP-SDK*.sh --tar -xf -C ${AMDAPPSDK};
-echo libamdocl64.so > ${OPENCL_VENDOR_PATH}/amdocl64.icd;
-export LD_LIBRARY_PATH=${AMDAPPSDK}/lib/x86_64:${LD_LIBRARY_PATH};
-chmod +x ${AMDAPPSDK}/bin/x86_64/clinfo;
-${AMDAPPSDK}/bin/x86_64/clinfo;
+
+DOWNLOAD_APPSDK=1
+
+if [ -n "$SILX_OPENCL" ]
+then
+	if [ $SILX_OPENCL = "0" ]
+	then
+		DOWNLOAD_APPSDK=0
+	fi
+	if [ $SILX_OPENCL = "False" ]
+	then
+		DOWNLOAD_APPSDK=0
+	fi
+fi
+
+if [ $DOWNLOAD_APPSDK = 1 ]
+then
+	bash ./ci/amd_sdk.sh;
+	ls
+	tar -xjf AMD-SDK.tar.bz2;
+	export AMDAPPSDK=$(pwd)/AMDAPPSDK;
+	export OPENCL_VENDOR_PATH=${AMDAPPSDK}/etc/OpenCL/vendors;
+	mkdir -p ${OPENCL_VENDOR_PATH};
+	sh AMD-APP-SDK*.sh --tar -xf -C ${AMDAPPSDK};
+	echo libamdocl64.so > ${OPENCL_VENDOR_PATH}/amdocl64.icd;
+	export LD_LIBRARY_PATH=${AMDAPPSDK}/lib/x86_64:${LD_LIBRARY_PATH};
+	chmod +x ${AMDAPPSDK}/bin/x86_64/clinfo;
+	${AMDAPPSDK}/bin/x86_64/clinfo;
+else
+	echo "AMDSDK download skipped"
+fi


### PR DESCRIPTION
AMD APPSDK is again broken.

This PR
- Allow to skip the APPSDK installation if OpenCL tests are skipped
- Disable OpenCL for all the Linux platform
- Create a new target including OpenCL tests to check if APPSDK is back