### PR TITLE
[plot gl] Overcome float32 precision 

### DIFF
--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1172,13 +1172,6 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         if isConstraint:
             x, y = constraint(x, y)
 
-        if x is not None and self._plotFrame.xAxis.isLog and x <= 0.:
-            raise RuntimeError(
-                'Cannot add marker with X <= 0 with X axis log scale')
-        if y is not None and self._plotFrame.yAxis.isLog and y <= 0.:
-            raise RuntimeError(
-                'Cannot add marker with Y <= 0 with Y axis log scale')
-
         self._markers[legend] = {
             'x': x,
             'y': y,

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -643,9 +643,6 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
         plotWidth, plotHeight = self.getPlotBoundsInPixels()[2:]
 
-        isXLog = self._plotFrame.xAxis.isLog
-        isYLog = self._plotFrame.yAxis.isLog
-
         # Render in plot area
         gl.glScissor(self._plotFrame.margins.left,
                      self._plotFrame.margins.bottom,
@@ -659,7 +656,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         gl.glUniformMatrix4fv(
             self._progBase.uniforms['matrix'], 1, gl.GL_TRUE,
             self.matScreenProj.astype(numpy.float32))
-        gl.glUniform2i(self._progBase.uniforms['isLog'], isXLog, isYLog)
+        gl.glUniform2i(self._progBase.uniforms['isLog'], False, False)
         gl.glUniform1i(self._progBase.uniforms['hatchStep'], 0)
         gl.glUniform1f(self._progBase.uniforms['tickLen'], 0.)
         posAttrib = self._progBase.attributes['position']
@@ -670,10 +667,12 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         for marker in self._markers.values():
             xCoord, yCoord = marker['x'], marker['y']
 
-            if ((isXLog and xCoord is not None and
-                    xCoord < FLOAT32_MINPOS) or
-                    (isYLog and yCoord is not None and
-                     yCoord < FLOAT32_MINPOS)):
+            if ((self._plotFrame.xAxis.isLog and
+                    xCoord is not None and
+                    xCoord <= 0) or
+                    (self._plotFrame.yAxis.isLog and
+                    yCoord is not None and
+                    yCoord <= 0)):
                 # Do not render markers with negative coords on log axis
                 continue
 
@@ -756,7 +755,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                     marker=marker['symbol'],
                     markerColor=marker['color'],
                     markerSize=11)
-                markerCurve.render(self.matScreenProj, isXLog, isYLog)
+                markerCurve.render(self.matScreenProj, False, False)
                 markerCurve.discard()
 
         gl.glViewport(0, 0, self._plotFrame.size[0], self._plotFrame.size[1])

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -499,7 +499,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
         gl.glUniform1i(self._progTex.uniforms['tex'], texUnit)
         gl.glUniformMatrix4fv(self._progTex.uniforms['matrix'], 1, gl.GL_TRUE,
-                              mat4Identity())
+                              mat4Identity().astype(numpy.float32))
 
         stride = self._plotVertices.shape[-1] * self._plotVertices.itemsize
         gl.glEnableVertexAttribArray(self._progTex.attributes['position'])
@@ -663,8 +663,9 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
         # Prepare vertical and horizontal markers rendering
         self._progBase.use()
-        gl.glUniformMatrix4fv(self._progBase.uniforms['matrix'], 1, gl.GL_TRUE,
-                              self._plotFrame.transformedDataProjMat)
+        gl.glUniformMatrix4fv(
+            self._progBase.uniforms['matrix'], 1, gl.GL_TRUE,
+            self._plotFrame.transformedDataProjMat.astype(numpy.float32))
         gl.glUniform2i(self._progBase.uniforms['isLog'], isXLog, isYLog)
         gl.glUniform1i(self._progBase.uniforms['hatchStep'], 0)
         gl.glUniform1f(self._progBase.uniforms['tickLen'], 0.)
@@ -802,8 +803,9 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                               self._plotFrame.margins.bottom,
                               plotWidth, plotHeight)
 
-                gl.glUniformMatrix4fv(matrixUnif, 1, gl.GL_TRUE,
-                                      self._plotFrame.transformedDataProjMat)
+                gl.glUniformMatrix4fv(
+                    matrixUnif, 1, gl.GL_TRUE,
+                    self._plotFrame.transformedDataProjMat.astype(numpy.float32))
 
                 for shape in self._selectionAreas.values():
                     if shape.isVideoInverted:
@@ -821,7 +823,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                     0, 0, self._plotFrame.size[0], self._plotFrame.size[1])
 
                 gl.glUniformMatrix4fv(matrixUnif, 1, gl.GL_TRUE,
-                                      self.matScreenProj)
+                                      self.matScreenProj.astype(numpy.float32))
 
                 color, lineWidth = self._crosshairCursor
                 gl.glUniform4f(colorUnif, *color)
@@ -884,7 +886,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
         self._progBase.use()
         gl.glUniformMatrix4fv(self._progBase.uniforms['matrix'], 1, gl.GL_TRUE,
-                              self.matScreenProj)
+                              self.matScreenProj.astype(numpy.float32))
         gl.glUniform2i(self._progBase.uniforms['isLog'], False, False)
         gl.glUniform1f(self._progBase.uniforms['tickLen'], 0.)
 

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1346,6 +1346,16 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                         else:
                             yPickMin, yPickMax = yPick1, yPick0
 
+                        # Apply log scale if axis is log
+                        if self._plotFrame.xAxis.isLog:
+                            xPickMin = numpy.log10(xPickMin)
+                            xPickMax = numpy.log10(xPickMax)
+
+                        if (yAxis == 'left' and self._plotFrame.yAxis.isLog) or (
+                                yAxis == 'right' and self._plotFrame.y2Axis.isLog):
+                            yPickMin = numpy.log10(yPickMin)
+                            yPickMax = numpy.log10(yPickMax)
+
                         pickedIndices = item.pick(xPickMin, yPickMin,
                                                   xPickMax, yPickMax)
                         if pickedIndices:

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -721,8 +721,6 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                                                 (xCoord, yMax)),
                                                dtype=numpy.float32)
 
-                self._progBase.use()
-
                 gl.glUniform4f(self._progBase.uniforms['color'],
                                *marker['color'])
 

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -953,8 +953,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             assert parameter is not None
         assert yaxis in ('left', 'right')
 
-        x = numpy.array(x, dtype=numpy.float32, copy=False, order='C')
-        y = numpy.array(y, dtype=numpy.float32, copy=False, order='C')
+        x = numpy.array(x, dtype=numpy.float64, copy=False, order='C')
+        y = numpy.array(y, dtype=numpy.float64, copy=False, order='C')
         if xerror is not None:
             xerror = numpy.array(
                 xerror, dtype=numpy.float32, copy=False, order='C')

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -982,8 +982,10 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
             x = logX
 
-        if (yaxis == 'left' and self._plotFrame.yAxis.isLog) or (
-                yaxis == 'right' and self._plotFrame.y2Axis.isLog):
+        isYLog = (yaxis == 'left' and self._plotFrame.yAxis.isLog) or (
+            yaxis == 'right' and self._plotFrame.y2Axis.isLog)
+
+        if isYLog:
             logY = numpy.log10(y)
 
             if yerror is not None:
@@ -1034,7 +1036,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                               marker=symbol,
                               markerColor=color,
                               markerSize=symbolsize,
-                              fillColor=color if fill else None)
+                              fillColor=color if fill else None,
+                              isYLog=isYLog)
         curve.info = {
             'legend': legend,
             'zOrder': z,

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -35,13 +35,14 @@ __date__ = "03/04/2017"
 
 import math
 import logging
+import warnings
 
 import numpy
 
 from silx.math.combo import min_max
 
 from ...._glutils import gl
-from ...._glutils import numpyToGLType, Program, vertexBuffer
+from ...._glutils import Program, vertexBuffer
 from .GLSupport import buildFillMaskIndices, mat4Identity
 
 
@@ -1126,10 +1127,12 @@ class GLPlotCurve2D(object):
 
         if self.lineStyle is not None:
             # Using Cohen-Sutherland algorithm for line clipping
-            codes = ((self.yData > yPickMax) << 3) | \
-                    ((self.yData < yPickMin) << 2) | \
-                    ((self.xData > xPickMax) << 1) | \
-                    (self.xData < xPickMin)
+            with warnings.catch_warnings():  # Ignore NaN comparison warnings
+                warnings.simplefilter('ignore', category=RuntimeWarning)
+                codes = ((self.yData > yPickMax) << 3) | \
+                        ((self.yData < yPickMin) << 2) | \
+                        ((self.xData > xPickMax) << 1) | \
+                        (self.xData < xPickMin)
 
             # Add all points that are inside the picking area
             indices = numpy.nonzero(codes == 0)[0].tolist()
@@ -1178,9 +1181,11 @@ class GLPlotCurve2D(object):
             indices.sort()
 
         else:
-            indices = numpy.nonzero((self.xData >= xPickMin) &
-                                    (self.xData <= xPickMax) &
-                                    (self.yData >= yPickMin) &
-                                    (self.yData <= yPickMax))[0].tolist()
+            with warnings.catch_warnings():  # Ignore NaN comparison warnings
+                warnings.simplefilter('ignore', category=RuntimeWarning)
+                indices = numpy.nonzero((self.xData >= xPickMin) &
+                                        (self.xData <= xPickMax) &
+                                        (self.yData >= yPickMin) &
+                                        (self.yData <= yPickMax))[0].tolist()
 
         return indices

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -164,7 +164,6 @@ class _Fill2D(object):
         prog = self._programs[transform]
         prog.use()
 
-        matrix = numpy.array(matrix, dtype=numpy.float64)
         normalizationMatrix = numpy.array(((self._scale[0], 0., 0., self._offset[0]),
                                            (0., self._scale[1], 0., self._offset[1]),
                                            (0., 0., 1., 0.),
@@ -419,7 +418,6 @@ class _Lines2D(object):
 
         gl.glEnable(gl.GL_LINE_SMOOTH)
 
-        matrix = numpy.array(matrix, dtype=numpy.float64)
         normalizationMatrix = numpy.array(((self._scale[0], 0., 0., self._offset[0]),
                                            (0., self._scale[1], 0., self._offset[1]),
                                            (0., 0., 1., 0.),
@@ -459,7 +457,6 @@ class _Lines2D(object):
 
         gl.glEnable(gl.GL_LINE_SMOOTH)
 
-        matrix = numpy.array(matrix, dtype=numpy.float64)
         normalizationMatrix = numpy.array(((self._scale[0], 0., 0., self._offset[0]),
                                            (0., self._scale[1], 0., self._offset[1]),
                                            (0., 0., 1., 0.),
@@ -776,7 +773,6 @@ class _Points2D(object):
         prog = self._getProgram(transform, self.marker)
         prog.use()
 
-        matrix = numpy.array(matrix, dtype=numpy.float64)
         normalizationMatrix = numpy.array(((self._scale[0], 0., 0., self._offset[0]),
                                            (0., self._scale[1], 0., self._offset[1]),
                                            (0., 0., 1., 0.),

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -114,7 +114,6 @@ class _Fill2D(object):
         attrib0='xPos')
 
     def __init__(self, xData=None, yData=None,
-                 xMin=None, yMin=None, xMax=None, yMax=None,
                  baseline=0,
                  color=(0., 0., 0., 1.),
                  scale=(1., 1.), offset=(0., 0.)):
@@ -656,8 +655,8 @@ class _Points2D(object):
         if marker not in cls._PROGRAMS:
             cls._PROGRAMS[marker] = Program(
                 vertexShader=cls._VERTEX_SHADER,
-                fragmentShader=cls._FRAGMENT_SHADER_TEMPLATE % \
-                    cls._FRAGMENT_SHADER_SYMBOLS[marker],
+                fragmentShader=(cls._FRAGMENT_SHADER_TEMPLATE %
+                                cls._FRAGMENT_SHADER_SYMBOLS[marker]),
                 attrib0='xPos')
 
         return cls._PROGRAMS[marker]

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -969,10 +969,6 @@ class GLPlotCurve2D(object):
     def prepare(self):
         """Rendering preparation: build indices and bounding box vertices"""
         if self.xVboData is None:
-            #minF32 = numpy.finfo(numpy.float32).min
-            #self.xData[numpy.isnan(self.xData)] = minF32
-            #self.yData[numpy.isnan(self.yData)] = minF32
-
             xAttrib, yAttrib, cAttrib, dAttrib = None, None, None, None
             if self.lineStyle in (DASHED, DASHDOT, DOTTED):
                 dists = _distancesFromArrays(self.xData, self.yData)

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -1112,8 +1112,6 @@ class GLPlotCurve2D(object):
         if (self.marker is None and self.lineStyle is None) or \
                 self.xMin > xPickMax or xPickMin > self.xMax or \
                 self.yMin > yPickMax or yPickMin > self.yMax:
-            # Note: With log scale the bounding box is too large if
-            # some data <= 0.
             return None
 
         # Normalize picking bounds
@@ -1130,12 +1128,16 @@ class GLPlotCurve2D(object):
             with warnings.catch_warnings():  # Ignore NaN comparison warnings
                 warnings.simplefilter('ignore', category=RuntimeWarning)
                 codes = ((self.yData > yPickMax) << 3) | \
-                        ((self.yData < yPickMin) << 2) | \
-                        ((self.xData > xPickMax) << 1) | \
-                        (self.xData < xPickMin)
+                    ((self.yData < yPickMin) << 2) | \
+                    ((self.xData > xPickMax) << 1) | \
+                    (self.xData < xPickMin)
+
+            notNaN = numpy.logical_not(numpy.logical_or(
+                numpy.isnan(self.xData), numpy.isnan(self.yData)))
 
             # Add all points that are inside the picking area
-            indices = numpy.nonzero(codes == 0)[0].tolist()
+            indices = numpy.nonzero(
+                numpy.logical_and(codes == 0, notNaN))[0].tolist()
 
             # Segment that might cross the area with no end point inside it
             segToTestIdx = numpy.nonzero((codes[:-1] != 0) &

--- a/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -337,7 +337,6 @@ class PlotAxis(object):
                             yield ((xPixel, yPixel), dataPos, text)
 
 
-
 # GLPlotFrame #################################################################
 
 class GLPlotFrame(object):

--- a/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -555,7 +555,8 @@ class GLPlotFrame(object):
 
         gl.glLineWidth(self._LINE_WIDTH)
 
-        gl.glUniformMatrix4fv(prog.uniforms['matrix'], 1, gl.GL_TRUE, matProj)
+        gl.glUniformMatrix4fv(prog.uniforms['matrix'], 1, gl.GL_TRUE,
+                              matProj.astype(numpy.float32))
         gl.glUniform4f(prog.uniforms['color'], 0., 0., 0., 1.)
         gl.glUniform1f(prog.uniforms['tickFactor'], 0.)
 
@@ -588,7 +589,8 @@ class GLPlotFrame(object):
         prog.use()
 
         gl.glLineWidth(self._LINE_WIDTH)
-        gl.glUniformMatrix4fv(prog.uniforms['matrix'], 1, gl.GL_TRUE, matProj)
+        gl.glUniformMatrix4fv(prog.uniforms['matrix'], 1, gl.GL_TRUE,
+                              matProj.astype(numpy.float32))
         gl.glUniform4f(prog.uniforms['color'], 0.7, 0.7, 0.7, 1.)
         gl.glUniform1f(prog.uniforms['tickFactor'], 0.)  # 1/2.)  # 1/tickLen
 
@@ -864,11 +866,11 @@ class GLPlotFrame2D(GLPlotFrame):
             # Non-orthogonal axes
             if self.baseVectors != self.DEFAULT_BASE_VECTORS:
                 (xx, xy), (yx, yy) = self.baseVectors
-                mat = mat * numpy.matrix((
+                mat = numpy.dot(mat, numpy.array((
                     (xx, yx, 0., 0.),
                     (xy, yy, 0., 0.),
                     (0., 0., 1., 0.),
-                    (0., 0., 0., 1.)), dtype=numpy.float32)
+                    (0., 0., 0., 1.)), dtype=numpy.float64))
 
             self._transformedDataProjMat = mat
 
@@ -893,11 +895,11 @@ class GLPlotFrame2D(GLPlotFrame):
             # Non-orthogonal axes
             if self.baseVectors != self.DEFAULT_BASE_VECTORS:
                 (xx, xy), (yx, yy) = self.baseVectors
-                mat = mat * numpy.matrix((
+                mat = numpy.dot(mat, numpy.matrix((
                     (xx, yx, 0., 0.),
                     (xy, yy, 0., 0.),
                     (0., 0., 1., 0.),
-                    (0., 0., 0., 1.)), dtype=numpy.float32)
+                    (0., 0., 0., 1.)), dtype=numpy.float64))
 
             self._transformedDataY2ProjMat = mat
 

--- a/silx/gui/plot/backends/glutils/GLPlotImage.py
+++ b/silx/gui/plot/backends/glutils/GLPlotImage.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -350,8 +350,11 @@ class GLPlotColormap(_GLPlotData2D):
 
         gl.glUniform1i(prog.uniforms['data'], self._DATA_TEX_UNIT)
 
-        mat = matrix * mat4Translate(*self.origin) * mat4Scale(*self.scale)
-        gl.glUniformMatrix4fv(prog.uniforms['matrix'], 1, gl.GL_TRUE, mat)
+        mat = numpy.dot(numpy.dot(matrix,
+                                  mat4Translate(*self.origin)),
+                        mat4Scale(*self.scale))
+        gl.glUniformMatrix4fv(prog.uniforms['matrix'], 1, gl.GL_TRUE,
+                              mat.astype(numpy.float32))
 
         gl.glUniform1f(prog.uniforms['alpha'], self.alpha)
 
@@ -377,9 +380,11 @@ class GLPlotColormap(_GLPlotData2D):
 
         gl.glUniform1i(prog.uniforms['data'], self._DATA_TEX_UNIT)
 
-        gl.glUniformMatrix4fv(prog.uniforms['matrix'], 1, gl.GL_TRUE, matrix)
-        mat = mat4Translate(ox, oy) * mat4Scale(*self.scale)
-        gl.glUniformMatrix4fv(prog.uniforms['matOffset'], 1, gl.GL_TRUE, mat)
+        gl.glUniformMatrix4fv(prog.uniforms['matrix'], 1, gl.GL_TRUE,
+                              matrix.astype(numpy.float32))
+        mat = numpy.dot(mat4Translate(ox, oy), mat4Scale(*self.scale))
+        gl.glUniformMatrix4fv(prog.uniforms['matOffset'], 1, gl.GL_TRUE,
+                              mat.astype(numpy.float32))
 
         gl.glUniform2i(prog.uniforms['isLog'], isXLog, isYLog)
 
@@ -598,8 +603,10 @@ class GLPlotRGBAImage(_GLPlotData2D):
 
         gl.glUniform1i(prog.uniforms['tex'], self._DATA_TEX_UNIT)
 
-        mat = matrix * mat4Translate(*self.origin) * mat4Scale(*self.scale)
-        gl.glUniformMatrix4fv(prog.uniforms['matrix'], 1, gl.GL_TRUE, mat)
+        mat = numpy.dot(numpy.dot(matrix, mat4Translate(*self.origin)),
+                        mat4Scale(*self.scale))
+        gl.glUniformMatrix4fv(prog.uniforms['matrix'], 1, gl.GL_TRUE,
+                              mat.astype(numpy.float32))
 
         gl.glUniform1f(prog.uniforms['alpha'], self.alpha)
 
@@ -617,9 +624,11 @@ class GLPlotRGBAImage(_GLPlotData2D):
 
         gl.glUniform1i(prog.uniforms['tex'], self._DATA_TEX_UNIT)
 
-        gl.glUniformMatrix4fv(prog.uniforms['matrix'], 1, gl.GL_TRUE, matrix)
-        mat = mat4Translate(ox, oy) * mat4Scale(*self.scale)
-        gl.glUniformMatrix4fv(prog.uniforms['matOffset'], 1, gl.GL_TRUE, mat)
+        gl.glUniformMatrix4fv(prog.uniforms['matrix'], 1, gl.GL_TRUE,
+                              matrix.astype(numpy.float32))
+        mat = numpy.dot(mat4Translate(ox, oy), mat4Scale(*self.scale))
+        gl.glUniformMatrix4fv(prog.uniforms['matOffset'], 1, gl.GL_TRUE,
+                              mat.astype(numpy.float32))
 
         gl.glUniform2i(prog.uniforms['isLog'], isXLog, isYLog)
 

--- a/silx/gui/plot/backends/glutils/GLSupport.py
+++ b/silx/gui/plot/backends/glutils/GLSupport.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -158,35 +158,35 @@ class Shape2D(object):
 
 def mat4Ortho(left, right, bottom, top, near, far):
     """Orthographic projection matrix (row-major)"""
-    return numpy.matrix((
+    return numpy.array((
         (2./(right - left), 0., 0., -(right+left)/float(right-left)),
         (0., 2./(top - bottom), 0., -(top+bottom)/float(top-bottom)),
         (0., 0., -2./(far-near),    -(far+near)/float(far-near)),
-        (0., 0., 0., 1.)), dtype=numpy.float32)
+        (0., 0., 0., 1.)), dtype=numpy.float64)
 
 
 def mat4Translate(x=0., y=0., z=0.):
     """Translation matrix (row-major)"""
-    return numpy.matrix((
+    return numpy.array((
         (1., 0., 0., x),
         (0., 1., 0., y),
         (0., 0., 1., z),
-        (0., 0., 0., 1.)), dtype=numpy.float32)
+        (0., 0., 0., 1.)), dtype=numpy.float64)
 
 
 def mat4Scale(sx=1., sy=1., sz=1.):
     """Scale matrix (row-major)"""
-    return numpy.matrix((
+    return numpy.array((
         (sx, 0., 0., 0.),
         (0., sy, 0., 0.),
         (0., 0., sz, 0.),
-        (0., 0., 0., 1.)), dtype=numpy.float32)
+        (0., 0., 0., 1.)), dtype=numpy.float64)
 
 
 def mat4Identity():
     """Identity matrix"""
-    return numpy.matrix((
+    return numpy.array((
         (1., 0., 0., 0.),
         (0., 1., 0., 0.),
         (0., 0., 1., 0.),
-        (0., 0., 0., 1.)), dtype=numpy.float32)
+        (0., 0., 0., 1.)), dtype=numpy.float64)

--- a/silx/gui/plot/backends/glutils/GLSupport.py
+++ b/silx/gui/plot/backends/glutils/GLSupport.py
@@ -36,11 +36,20 @@ import numpy
 from ...._glutils import gl
 
 
-def buildFillMaskIndices(nIndices):
-    if nIndices <= numpy.iinfo(numpy.uint16).max + 1:
-        dtype = numpy.uint16
-    else:
-        dtype = numpy.uint32
+def buildFillMaskIndices(nIndices, dtype=None):
+    """Returns triangle strip indices for rendering a filled polygon mask
+
+    :param int nIndices: Number of points
+    :param Union[numpy.dtype,None] dtype:
+       If specified the dtype of the returned indices array
+    :return: 1D array of indices constructing a triangle strip
+    :rtype: numpy.ndarray
+    """
+    if dtype is None:
+        if nIndices <= numpy.iinfo(numpy.uint16).max + 1:
+            dtype = numpy.uint16
+        else:
+            dtype = numpy.uint32
 
     lastIndex = nIndices - 1
     splitIndex = lastIndex // 2 + 1

--- a/silx/gui/plot/backends/glutils/GLText.py
+++ b/silx/gui/plot/backends/glutils/GLText.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -195,8 +195,9 @@ class Text2D(object):
 
         gl.glUniform1i(prog.uniforms['texText'], texUnit)
 
+        mat = numpy.dot(matrix, mat4Translate(int(self.x), int(self.y)))
         gl.glUniformMatrix4fv(prog.uniforms['matrix'], 1, gl.GL_TRUE,
-                              matrix * mat4Translate(int(self.x), int(self.y)))
+                              mat.astype(numpy.float32))
 
         gl.glUniform4f(prog.uniforms['color'], *self.color)
         if self.bgColor is not None:

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -767,7 +767,10 @@ class Points(Item, SymbolMixIn, AlphaMixIn):
                 error = numpy.ravel(error)
 
             # Supports error being scalar, N or 2xN array
-            errorClipped = (value - numpy.atleast_2d(error)[0]) <= 0
+            valueMinusError = value - numpy.atleast_2d(error)[0]
+            errorClipped = numpy.isnan(valueMinusError)
+            mask = numpy.logical_not(errorClipped)
+            errorClipped[mask] = valueMinusError[mask] <= 0
 
             if numpy.any(errorClipped):  # Need filtering
 

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -32,6 +32,7 @@ __date__ = "24/04/2018"
 import collections
 from copy import deepcopy
 import logging
+import warnings
 import weakref
 import numpy
 from silx.third_party import six, enum
@@ -808,10 +809,20 @@ class Points(Item, SymbolMixIn, AlphaMixIn):
         """
         assert xPositive or yPositive
         if (xPositive, yPositive) not in self._clippedCache:
-            x = self.getXData(copy=False)
-            y = self.getYData(copy=False)
-            xclipped = (x <= 0) if xPositive else False
-            yclipped = (y <= 0) if yPositive else False
+            xclipped, yclipped = False, False
+
+            if xPositive:
+                x = self.getXData(copy=False)
+                with warnings.catch_warnings():  # Ignore NaN warnings
+                    warnings.simplefilter('ignore', category=RuntimeWarning)
+                    xclipped = x <= 0
+
+            if yPositive:
+                y = self.getYData(copy=False)
+                with warnings.catch_warnings():  # Ignore NaN warnings
+                    warnings.simplefilter('ignore', category=RuntimeWarning)
+                    yclipped = y <= 0
+
             self._clippedCache[(xPositive, yPositive)] = \
                 numpy.logical_or(xclipped, yclipped)
         return self._clippedCache[(xPositive, yPositive)]


### PR DESCRIPTION
This PR overcomes the float32 precision issue occurring for data with difference only visible with double precision. This is due to sending float32 to OpenGL and using data coordinates as coordinates for the display.

It is not complete and not tested (TODOs: error bars, images, shapes, log scale,...) but it works for the case of #1772.

closes #1772