### PR TITLE
Hdf5tree file event

### DIFF
--- a/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/silx/gui/hdf5/Hdf5TreeModel.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "29/11/2017"
+__date__ = "30/04/2018"
 
 
 import os
@@ -205,6 +205,15 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
     ]
     """List of logical columns available"""
 
+    sigH5pyObjectLoaded = qt.Signal(object)
+    """Emitted when a new root item was loaded and inserted to the model."""
+
+    sigH5pyObjectRemoved = qt.Signal(object)
+    """Emitted when a root item is removed from the model."""
+
+    sigH5pyObjectSynchronized = qt.Signal(object, object)
+    """Emitted when an item was synchronized."""
+
     def __init__(self, parent=None):
         super(Hdf5TreeModel, self).__init__(parent)
 
@@ -295,6 +304,12 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
             self.beginInsertRows(rootIndex, row, row)
             self.__root.insertChild(row, newItem)
             self.endInsertRows()
+
+            if isinstance(oldItem, Hdf5LoadingItem):
+                self.sigH5pyObjectLoaded.emit(newItem.obj)
+            else:
+                self.sigH5pyObjectSynchronized.emit(oldItem.obj, newItem.obj)
+
         # FIXME the error must be displayed
 
     def isFileDropEnabled(self):
@@ -543,8 +558,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
             return
 
         filename = node.obj.filename
-        self.removeIndex(index)
-        self.insertFileAsync(filename, index.row())
+        self.insertFileAsync(filename, index.row(), synchronizingNode=node)
 
     def synchronizeH5pyObject(self, h5pyObject):
         """
@@ -560,8 +574,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
             if item.obj is h5pyObject:
                 qindex = self.index(index, 0, qt.QModelIndex())
                 self.synchronizeIndex(qindex)
-            else:
-                index += 1
+            index += 1
 
     def removeIndex(self, index):
         """
@@ -576,6 +589,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         self.beginRemoveRows(qt.QModelIndex(), index.row(), index.row())
         self.__root.removeChildAtIndex(index.row())
         self.endRemoveRows()
+        self.sigH5pyObjectRemoved.emit(node.obj)
 
     def removeH5pyObject(self, h5pyObject):
         """
@@ -608,14 +622,17 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
     def hasPendingOperations(self):
         return len(self.__runnerSet) > 0
 
-    def insertFileAsync(self, filename, row=-1):
+    def insertFileAsync(self, filename, row=-1, synchronizingNode=None):
         if not os.path.isfile(filename):
             raise IOError("Filename '%s' must be a file path" % filename)
 
         # create temporary item
-        text = os.path.basename(filename)
-        item = Hdf5LoadingItem(text=text, parent=self.__root, animatedIcon=self.__animatedIcon)
-        self.insertNode(row, item)
+        if synchronizingNode is None:
+            text = os.path.basename(filename)
+            item = Hdf5LoadingItem(text=text, parent=self.__root, animatedIcon=self.__animatedIcon)
+            self.insertNode(row, item)
+        else:
+            item = synchronizingNode
 
         # start loading the real one
         runnable = LoadingItemRunnable(filename, item)
@@ -635,6 +652,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         try:
             h5file = silx_io.open(filename)
             self.__openedFiles.append(h5file)
+            self.sigH5pyObjectLoaded.emit(h5file)
             self.insertH5pyObject(h5file, row=row)
         except IOError:
             _logger.debug("File '%s' can't be read.", filename, exc_info=True)

--- a/silx/gui/hdf5/Hdf5TreeView.py
+++ b/silx/gui/hdf5/Hdf5TreeView.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "20/02/2018"
+__date__ = "30/04/2018"
 
 
 import logging
@@ -66,10 +66,8 @@ class Hdf5TreeView(qt.QTreeView):
         """
         qt.QTreeView.__init__(self, parent)
 
-        model = Hdf5TreeModel(self)
-        proxy_model = NexusSortFilterProxyModel(self)
-        proxy_model.setSourceModel(model)
-        self.setModel(proxy_model)
+        model = self.createDefaultModel()
+        self.setModel(model)
 
         self.setHeader(Hdf5HeaderView(qt.Qt.Horizontal, self))
         self.setSelectionBehavior(qt.QAbstractItemView.SelectRows)
@@ -86,6 +84,15 @@ class Hdf5TreeView(qt.QTreeView):
         self.__context_menu_callbacks = silxweakref.WeakList()
         self.setContextMenuPolicy(qt.Qt.CustomContextMenu)
         self.customContextMenuRequested.connect(self._createContextMenu)
+
+    def createDefaultModel(self):
+        """Creates and returns the default model.
+
+        Inherite to custom the default model"""
+        model = Hdf5TreeModel(self)
+        proxy_model = NexusSortFilterProxyModel(self)
+        proxy_model.setSourceModel(model)
+        return proxy_model
 
     def __removeContextMenuProxies(self, ref):
         """Callback to remove dead proxy from the list"""

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "30/04/2018"
+__date__ = "03/05/2018"
 
 
 import time
@@ -377,9 +377,12 @@ class TestHdf5TreeModelSignals(TestCaseQt):
         self.model.sigH5pyObjectSynchronized.connect(self.listener.partial(signal="synchronized"))
 
     def tearDown(self):
-        self.h5 = None
-        self.model = None
         self.signals = None
+        ref = weakref.ref(self.model)
+        self.model = None
+        self.qWaitForDestroy(ref)
+        self.h5.close()
+        self.h5 = None
         TestCaseQt.tearDown(self)
 
     def waitForPendingOperations(self, model):

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -95,7 +95,7 @@ class TestHdf5TreeModel(TestCaseQt):
             self.skipTest("h5py is not available")
 
     def waitForPendingOperations(self, model):
-        for i in range(10):
+        for _ in range(10):
             if not model.hasPendingOperations():
                 break
             self.qWait(10)


### PR DESCRIPTION
Add signals to `Hdf5Model` to be able to manage the life-cycle of the files. Then use it to improve `silx view` (consistency between the data viewer and the tree ).

The PR #1800 have to be merged first.

Closes #268
Closes #1794 
Closes #1803 
