### PR TITLE
[PlotWindow] Deprecate pan and zoom actions

### DIFF
--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -483,6 +483,18 @@ class PlotWindow(PlotWidget):
 
     # getters for actions
     @property
+    @deprecated(replacement="getInteractiveModeToolBar().getZoomModeAction()",
+                since_version="0.8.0")
+    def zoomModeAction(self):
+        return self.getInteractiveModeToolBar().getZoomModeAction()
+
+    @property
+    @deprecated(replacement="getInteractiveModeToolBar().getPanModeAction()",
+                since_version="0.8.0")
+    def panModeAction(self):
+        return self.getInteractiveModeToolBar().getPanModeAction()
+
+    @property
     @deprecated(replacement="getConsoleAction()", since_version="0.4.0")
     def consoleAction(self):
         return self.getConsoleAction()


### PR DESCRIPTION
Use a deprecation phase for `PlotWindow.panModeAction` and `PlotWindow.zoomModeAction`.
Addresses https://github.com/vasole/pymca/issues/220

The code will also be modernized on the PyMca side, but it is a good idea to maintain the previous API for a couple of releases.