### PR TITLE
[StackView] prevent error when a non-linear calibration is used

### DIFF
--- a/examples/hdf5widget.py
+++ b/examples/hdf5widget.py
@@ -421,6 +421,16 @@ def get_hdf5_with_nxdata():
     gd1.create_dataset("hypercube",
                        data=numpy.arange(2*3*4*5*6).reshape((2, 3, 4, 5, 6)))
 
+    gd2 = g.create_group("3D_nonlinear_scaling")
+    gd2.attrs["NX_class"] = u"NXdata"
+    gd2.attrs["signal"] = u"cube"
+    gd2.attrs["axes"] = str_attrs(["img_idx", "rows_coordinates", "cols_coordinates"])
+    gd2.create_dataset("cube", data=numpy.arange(4*5*6).reshape((4, 5, 6)))
+    gd2.create_dataset("img_idx", data=numpy.array([2., -0.1, 8, 3.14]))
+    gd2.create_dataset("rows_coordinates", data=0.1*numpy.arange(5))
+    gd2.create_dataset("cols_coordinates", data=[0.1, 0.6, 0.7, 8., 8.1, 8.2])
+
+
     # invalid NXdata
     g = h5.create_group("invalid")
     g0 = g.create_group("invalid NXdata")

--- a/silx/math/calibration.py
+++ b/silx/math/calibration.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2017 European Synchrotron Radiation Facility
+# Copyright (C) 2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -119,21 +119,23 @@ class ArrayCalibration(AbstractCalibration):
 
     def __call__(self, x):
         # calibrate the entire axis
-        if isinstance(x, (list, tuple, numpy.ndarray)):
-            assert len(self.calibration_array) == len(x)
+        if isinstance(x, (list, tuple, numpy.ndarray)) and \
+                        len(self.calibration_array) == len(x):
             return self.calibration_array
         # calibrate one value, by index
-        if isinstance(x, int):
-            assert x < len(self.calibration_array)
+        if isinstance(x, int) and x < len(self.calibration_array):
             return self.calibration_array[x]
-        raise ValueError("")
+        raise ValueError("ArrayCalibration must be applied to array of same size "
+                         "or to index.")
 
     def is_affine(self):
         """If all values in the calibration array are regularly spaced,
         return True."""
         if self._is_affine is None:
             delta_x = self.calibration_array[1:] - self.calibration_array[:-1]
-            if not numpy.isclose(delta_x, delta_x[0]).all():
+            # use a less strict relative tolerance to account for rounding errors
+            # e.g. when using float64 into float32 (see #1823)
+            if not numpy.isclose(delta_x, delta_x[0], rtol=1e-4).all():
                 self._is_affine = False
             else:
                 self._is_affine = True

--- a/silx/math/test/__init__.py
+++ b/silx/math/test/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -36,6 +36,7 @@ from ..fit.test import suite as test_fit_suite
 from .test_marchingcubes import suite as test_marchingcubes_suite
 from ..medianfilter.test import suite as test_medianfilter_suite
 from .test_combo import suite as test_combo_suite
+from .test_calibration import suite as test_calibration_suite
 
 
 def suite():
@@ -48,4 +49,5 @@ def suite():
     test_suite.addTest(test_marchingcubes_suite())
     test_suite.addTest(test_medianfilter_suite())
     test_suite.addTest(test_combo_suite())
+    test_suite.addTest(test_calibration_suite())
     return test_suite

--- a/silx/math/test/test_calibration.py
+++ b/silx/math/test/test_calibration.py
@@ -1,0 +1,158 @@
+# coding: utf-8
+# /*##########################################################################
+# Copyright (C) 2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+"""Tests of the calibration module"""
+
+from __future__ import division
+
+__authors__ = ["P. Knobel"]
+__license__ = "MIT"
+__date__ = "14/05/2018"
+
+
+import unittest
+
+import numpy
+
+from silx.math.calibration import NoCalibration, LinearCalibration, \
+    ArrayCalibration, FunctionCalibration
+
+
+X = numpy.array([3.14, 2.73, 1337])
+
+
+class TestNoCalibration(unittest.TestCase):
+    def setUp(self):
+        self.calib = NoCalibration()
+
+    def testIsAffine(self):
+        self.assertTrue(self.calib.is_affine())
+
+    def testSlope(self):
+        self.assertEqual(self.calib.get_slope(), 1.)
+
+    def testYIntercept(self):
+        self.assertEqual(self.calib(0.),
+                         0.)
+
+    def testCall(self):
+        self.assertTrue(numpy.array_equal(self.calib(X), X))
+
+
+class TestLinearCalibration(unittest.TestCase):
+    def setUp(self):
+        self.y_intercept = 1.5
+        self.slope = 2.5
+        self.calib = LinearCalibration(y_intercept=self.y_intercept,
+                                       slope=self.slope)
+
+    def testIsAffine(self):
+        self.assertTrue(self.calib.is_affine())
+
+    def testSlope(self):
+        self.assertEqual(self.calib.get_slope(), self.slope)
+
+    def testYIntercept(self):
+        self.assertEqual(self.calib(0.),
+                         self.y_intercept)
+
+    def testCall(self):
+        self.assertTrue(numpy.array_equal(self.calib(X),
+                                          self.y_intercept + self.slope * X))
+
+
+class TestArrayCalibration(unittest.TestCase):
+    def setUp(self):
+        self.arr = numpy.array([45.2, 25.3, 666., -8.])
+        self.calib = ArrayCalibration(self.arr)
+        self.affine_calib = ArrayCalibration([0.1, 0.2, 0.3])
+
+    def testIsAffine(self):
+        self.assertFalse(self.calib.is_affine())
+        self.assertTrue(self.affine_calib.is_affine())
+
+    def testSlope(self):
+        with self.assertRaises(AttributeError):
+            self.calib.get_slope()
+        self.assertEqual(self.affine_calib.get_slope(),
+                         0.1)
+
+    def testYIntercept(self):
+        self.assertEqual(self.calib(0),
+                         self.arr[0])
+
+    def testCall(self):
+        with self.assertRaises(ValueError):
+            # X is an array with a different shape
+            self.calib(X)
+
+        with self.assertRaises(ValueError):
+            # floats are not valid indices
+            self.calib(3.14)
+
+        self.assertTrue(
+            numpy.array_equal(self.calib([1, 2, 3, 4]),
+                              self.arr))
+
+        for idx, value in enumerate(self.arr):
+            self.assertEqual(self.calib(idx), value)
+
+
+class TestFunctionCalibration(unittest.TestCase):
+    def setUp(self):
+        self.non_affine_fun = numpy.sin
+        self.non_affine_calib = FunctionCalibration(self.non_affine_fun)
+
+        self.affine_fun = lambda x: 52. * x + 0.01
+        self.affine_calib = FunctionCalibration(self.affine_fun,
+                                                is_affine=True)
+
+    def testIsAffine(self):
+        self.assertFalse(self.non_affine_calib.is_affine())
+        self.assertTrue(self.affine_calib.is_affine())
+
+    def testSlope(self):
+        with self.assertRaises(AttributeError):
+            self.non_affine_calib.get_slope()
+        self.assertAlmostEqual(self.affine_calib.get_slope(),
+                               52.)
+
+    def testCall(self):
+        for x in X:
+            self.assertAlmostEqual(self.non_affine_calib(x),
+                                   self.non_affine_fun(x))
+            self.assertAlmostEqual(self.affine_calib(x),
+                                   self.affine_fun(x))
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(TestNoCalibration))
+    test_suite.addTest(loadTests(TestArrayCalibration))
+    test_suite.addTest(loadTests(TestLinearCalibration))
+    test_suite.addTest(loadTests(TestFunctionCalibration))
+    return test_suite
+
+if __name__ == '__main__':
+    unittest.main(defaultTest="suite")


### PR DESCRIPTION
Non-linear axes are ignored when scaling the graph axes. A warning is logged. Closes #1825

This PR also increases the relative tolerance when checking for the equidistance of values in an axis. It is now 1e-4 (0.01%), instead of the default 1e-5. Closes #1823 