### PR TITLE
Fix fabioh5 float conversion

### DIFF
--- a/silx/io/fabioh5.py
+++ b/silx/io/fabioh5.py
@@ -951,7 +951,13 @@ class File(commonh5.File):
         if first_file_name is not None:
             _, ext = os.path.splitext(first_file_name)
             ext = ext[1:]
-            use_edf_reader = ext in fabio.edfimage.EdfImage.DEFAULT_EXTENSIONS
+            edfimage = fabio.edfimage.EdfImage
+            if hasattr(edfimage, "DEFAULT_EXTENTIONS"):
+                # Typo on fabio 0.5
+                edf_extensions = edfimage.DEFAULT_EXTENTIONS
+            else:
+                edf_extensions = edfimage.DEFAULT_EXTENSIONS
+            use_edf_reader = ext in edf_extensions
         elif first_image is not None:
             use_edf_reader = isinstance(first_image, fabio.edfimage.EdfImage)
         else:

--- a/silx/io/fabioh5.py
+++ b/silx/io/fabioh5.py
@@ -44,6 +44,7 @@ import numpy
 from . import commonh5
 from silx.third_party import six
 from silx import version as silx_version
+import silx.utils.number
 
 try:
     import h5py
@@ -106,7 +107,6 @@ class FrameData(commonh5.LazyLoadableDataset):
             attrs = {"interpretation": "image"}
         commonh5.LazyLoadableDataset.__init__(self, name, parent, attrs=attrs)
         self.__fabio_reader = fabio_reader
-
 
     def _create_data(self):
         return self.__fabio_reader.get_data()
@@ -638,30 +638,11 @@ class FabioReader(object):
         If it is not possible it returns a numpy string.
         """
         try:
-            value = int(value)
-            dtype = numpy.min_scalar_type(value)
-            assert dtype.kind != "O"
-            return dtype.type(value)
+            numpy_type = silx.utils.number.min_numerical_convertible_type(value)
+            converted = numpy_type(value)
         except ValueError:
-            try:
-                # numpy.min_scalar_type is not able to do very well the job
-                # when there is a lot of digit after the dot
-                # https://github.com/numpy/numpy/issues/8207
-                # Let's count the digit of the string
-                digits = len(value) - 1  # minus the dot
-                if digits <= 7:
-                    # A float32 is accurate with about 7 digits
-                    return numpy.float32(value)
-                elif digits <= 16:
-                    # A float64 is accurate with about 16 digits
-                    return numpy.float64(value)
-                else:
-                    if hasattr(numpy, "float128"):
-                        return numpy.float128(value)
-                    else:
-                        return numpy.float64(value)
-            except ValueError:
-                return numpy.string_(value)
+            converted = numpy.string_(value)
+        return converted
 
     def _convert_list(self, value):
         """Convert a string into a typed numpy array.

--- a/silx/io/test/test_fabioh5.py
+++ b/silx/io/test/test_fabioh5.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "24/02/2018"
+__date__ = "24/05/2018"
 
 import os
 import logging

--- a/silx/io/test/test_fabioh5.py
+++ b/silx/io/test/test_fabioh5.py
@@ -226,7 +226,7 @@ class TestFabioH5(unittest.TestCase):
         # There is no equality between items
         self.assertEqual(len(data), len(set(data)))
         # At worst a float32
-        self.assertIn(data.dtype.char, ['d', 'f'])
+        self.assertIn(data.dtype.kind, ['d', 'f'])
         self.assertLessEqual(data.dtype.itemsize, 32 / 8)
 
     def test_float_64(self):
@@ -248,7 +248,7 @@ class TestFabioH5(unittest.TestCase):
         # There is no equality between items
         self.assertEqual(len(data), len(set(data)))
         # At least a float64
-        self.assertIn(data.dtype.char, ['d', 'f'])
+        self.assertIn(data.dtype.kind, ['d', 'f'])
         self.assertGreaterEqual(data.dtype.itemsize, 64 / 8)
 
     def test_ub_matrix(self):
@@ -269,14 +269,14 @@ class TestFabioH5(unittest.TestCase):
         expected = numpy.array([4.08, 4.08, 4.08])
         self.assertIsNotNone(d)
         self.assertEquals(d.shape, (3, ))
-        self.assertIn(d.dtype.char, ['d', 'f'])
+        self.assertIn(d.dtype.kind, ['d', 'f'])
         numpy.testing.assert_array_almost_equal(d[...], expected)
 
         d = sample['unit_cell_alphabetagamma']
         expected = numpy.array([90.0, 90.0, 90.0])
         self.assertIsNotNone(d)
         self.assertEquals(d.shape, (3, ))
-        self.assertIn(d.dtype.char, ['d', 'f'])
+        self.assertIn(d.dtype.kind, ['d', 'f'])
         numpy.testing.assert_array_almost_equal(d[...], expected)
 
         d = sample['ub_matrix']
@@ -285,7 +285,7 @@ class TestFabioH5(unittest.TestCase):
                                  [1.08894, 1.08894, 9.28619e-17]]])
         self.assertIsNotNone(d)
         self.assertEquals(d.shape, (1, 3, 3))
-        self.assertIn(d.dtype.char, ['d', 'f'])
+        self.assertIn(d.dtype.kind, ['d', 'f'])
         numpy.testing.assert_array_almost_equal(d[...], expected)
 
     def test_interpretation_mca_edf(self):

--- a/silx/utils/number.py
+++ b/silx/utils/number.py
@@ -1,0 +1,95 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Utilitary functions dealing with numbers.
+"""
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "24/05/2018"
+
+import numpy
+import re
+
+
+_parse_numeric_value = re.compile("[-+]?(\d*)(?:\.(\d*))?(?:[eE]([-+]?\d+))?")
+"""Match integer or floating-point numbers"""
+
+
+def min_numerical_convertible_type(string):
+    """
+    Parse the string and return the minimal numerical type which fit for a
+    convertion.
+
+    :param str string: Representation of a float/integer with text
+    :raise ValueError: When the string is not a numerical value
+    :retrun: A numpy numerical type
+    """
+    if string == "":
+        raise ValueError("Not a numerical value")
+    match = _parse_numeric_value.match(string)
+    if match.end() != len(string):
+        raise ValueError("Not a numerical value")
+    number, decimal, exponent = match.groups()
+    if decimal is None and exponent is None:
+        # TODO: We could find the int type without converting the number
+        value = int(string)
+        return numpy.min_scalar_type(value).type
+    else:
+        if number is None:
+            number = 0
+        else:
+            number = len(number)
+        if decimal is None:
+            decimal = 0
+        else:
+            decimal = len(decimal)
+        if exponent is None:
+            exponent = 0
+        else:
+            exponent = int(exponent)
+
+        if exponent > 0:
+            digits = number + max(decimal, exponent)
+        elif exponent < 0:
+            exponent = -exponent
+            digits = max(number, exponent) + decimal
+        else:
+            digits = number + decimal
+
+        if digits <= 3:
+            # A float16 is accurate with about 3.311 digits
+            return numpy.float16
+        if digits <= 7:
+            # A float32 is accurate with about 7 digits
+            return numpy.float32
+        elif digits <= 16:
+            # A float64 is accurate with about 16 digits
+            return numpy.float64
+        else:
+            # A float 80-bits if available (padded using 96 or 128 bits)
+            if hasattr(numpy, "longdouble"):
+                return numpy.longdouble
+            else:
+                return numpy.float64

--- a/silx/utils/number.py
+++ b/silx/utils/number.py
@@ -52,8 +52,8 @@ _parse_numeric_value = re.compile("^\s*[-+]?0*(\d+?)?(?:\.(\d+))?(?:[eE]([-+]?\d
 
 def min_numerical_convertible_type(string, check_accuracy=True):
     """
-    Parse the string and return the minimal numerical type which fit for a
-    convertion.
+    Parse the string and return the smallest numerical type to use for a safe
+    conversion.
 
     :param str string: Representation of a float/integer with text
     :param bool check_accuracy: If true, a warning is pushed on the logger

--- a/silx/utils/number.py
+++ b/silx/utils/number.py
@@ -101,7 +101,10 @@ def min_numerical_convertible_type(string):
         expected = max(expected_mantissa, expected_exponent)
         if expected >= 128:
             # Here we lose precision
-            return numpy.longdouble
+            if hasattr(numpy, "longdouble"):
+                return numpy.longdouble
+            else:
+                return numpy.float64
 
         if expected == 32:
             return numpy.float32

--- a/silx/utils/number.py
+++ b/silx/utils/number.py
@@ -88,7 +88,7 @@ def min_numerical_convertible_type(string, check_accuracy=True):
         exponent = "0"
 
     nb_precision_digits = int(exponent) - len(decimal) - 1
-    precision = _biggest_float(10) ** nb_precision_digits
+    precision = _biggest_float(10) ** nb_precision_digits * 2.5
     previous_type = _biggest_float
     for numpy_type in _float_types:
         if numpy_type == _biggest_float:

--- a/silx/utils/number.py
+++ b/silx/utils/number.py
@@ -33,7 +33,7 @@ import numpy
 import re
 
 
-_parse_numeric_value = re.compile("[-+]?(\d*)(?:\.(\d*))?(?:[eE]([-+]?\d+))?")
+_parse_numeric_value = re.compile("\s*[-+]?(\d*)(?:\.(\d*))?(?:[eE]([-+]?\d+))?\s*")
 """Match integer or floating-point numbers"""
 
 

--- a/silx/utils/number.py
+++ b/silx/utils/number.py
@@ -33,7 +33,7 @@ import numpy
 import re
 
 
-_parse_numeric_value = re.compile("\s*[-+]?(\d*)(?:\.(\d*))?(?:[eE]([-+]?\d+))?\s*")
+_parse_numeric_value = re.compile("^\s*[-+]?(\d*)(?:\.(\d*))?(?:[eE]([-+]?\d+))?\s*$")
 """Match integer or floating-point numbers"""
 
 
@@ -49,7 +49,7 @@ def min_numerical_convertible_type(string):
     if string == "":
         raise ValueError("Not a numerical value")
     match = _parse_numeric_value.match(string)
-    if match.end() != len(string):
+    if match is None:
         raise ValueError("Not a numerical value")
     number, decimal, exponent = match.groups()
     if decimal is None and exponent is None:

--- a/silx/utils/number.py
+++ b/silx/utils/number.py
@@ -37,7 +37,7 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
-if hasattr(numpy, "longdouble") and numpy.longdouble != numpy.float64:
+if hasattr(numpy, "longdouble") and numpy.finfo(numpy.longdouble).bits != 64:
     _biggest_float = numpy.longdouble
     # From bigger to smaller
     _float_types = (numpy.longdouble, numpy.float64, numpy.float32, numpy.float16)

--- a/silx/utils/number.py
+++ b/silx/utils/number.py
@@ -33,7 +33,7 @@ import numpy
 import re
 
 
-_parse_numeric_value = re.compile("^\s*[-+]?(\d*)(?:\.(\d*))?(?:[eE]([-+]?\d+))?\s*$")
+_parse_numeric_value = re.compile("^\s*[-+]?0*(\d+?)?(?:\.(\d+?)0*)?(?:[eE]([-+]?\d+))?\s*$")
 """Match integer or floating-point numbers"""
 
 

--- a/silx/utils/number.py
+++ b/silx/utils/number.py
@@ -37,7 +37,7 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
-if hasattr(numpy, "longdouble"):
+if hasattr(numpy, "longdouble") and numpy.longdouble != numpy.float64:
     _biggest_float = numpy.longdouble
     # From bigger to smaller
     _float_types = (numpy.longdouble, numpy.float64, numpy.float32, numpy.float16)

--- a/silx/utils/number.py
+++ b/silx/utils/number.py
@@ -63,14 +63,14 @@ def min_numerical_convertible_type(string):
             decimal = ""
         significante_size = len(number) + len(decimal)
         if exponent is None:
-            if significante_size <= 3:
-                # A float16 is accurate with about 3.311 digits
-                return numpy.float16
             exponent = 0 + len(number)
         else:
             exponent = abs(int(exponent) + len(number))
 
-        if significante_size <= 7:
+        if significante_size <= 3:
+            # A float16 is accurate with about 3.311 digits
+            expected_mantissa = 16
+        elif significante_size <= 7:
             # Expect at least float 32-bits
             expected_mantissa = 32
         elif significante_size <= 15:
@@ -86,7 +86,10 @@ def min_numerical_convertible_type(string):
         else:
             expected_mantissa = 999
 
-        if exponent <= 37:
+        if exponent <= 4:
+            # Up to 6.55040 * 10**4
+            expected_exponent = 16
+        elif exponent <= 37:
             # Up to 3.402823 * 10**38
             expected_exponent = 32
         elif exponent <= 307:
@@ -106,7 +109,9 @@ def min_numerical_convertible_type(string):
             else:
                 return numpy.float64
 
-        if expected == 32:
+        if expected == 16:
+            return numpy.float16
+        elif expected == 32:
             return numpy.float32
         elif expected == 64:
             return numpy.float64

--- a/silx/utils/number.py
+++ b/silx/utils/number.py
@@ -27,7 +27,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "24/05/2018"
+__date__ = "25/05/2018"
 
 import numpy
 import re
@@ -66,9 +66,9 @@ def min_numerical_convertible_type(string):
             if significante_size <= 3:
                 # A float16 is accurate with about 3.311 digits
                 return numpy.float16
-            exponent = 0
+            exponent = 0 + len(number)
         else:
-            exponent = abs(int(exponent))
+            exponent = abs(int(exponent) + len(number))
 
         if significante_size <= 7:
             # Expect at least float 32-bits

--- a/silx/utils/number.py
+++ b/silx/utils/number.py
@@ -57,7 +57,7 @@ def min_numerical_convertible_type(string, check_accuracy=True):
 
     :param str string: Representation of a float/integer with text
     :param bool check_accuracy: If true, a warning is pushed on the logger
-        in case there is a lose of accuracy.
+        in case there is a loss of accuracy.
     :raise ValueError: When the string is not a numerical value
     :retrun: A numpy numerical type
     """

--- a/silx/utils/test/__init__.py
+++ b/silx/utils/test/__init__.py
@@ -24,7 +24,7 @@
 # ###########################################################################*/
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "27/02/2018"
+__date__ = "24/05/2018"
 
 
 import unittest
@@ -35,6 +35,7 @@ from . import test_launcher
 from . import test_deprecation
 from . import test_proxy
 from . import test_debug
+from . import test_number
 
 
 def suite():
@@ -46,4 +47,5 @@ def suite():
     test_suite.addTest(test_deprecation.suite())
     test_suite.addTest(test_proxy.suite())
     test_suite.addTest(test_debug.suite())
+    test_suite.addTest(test_number.suite())
     return test_suite

--- a/silx/utils/test/test_number.py
+++ b/silx/utils/test/test_number.py
@@ -1,0 +1,131 @@
+# coding: utf-8
+# /*##########################################################################
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+"""Tests for silx.uitls.number module"""
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "24/05/2018"
+
+import logging
+import numpy
+import unittest
+from silx.utils import number
+
+_logger = logging.getLogger(__name__)
+
+
+class TestConversionTypes(unittest.TestCase):
+
+    def testInteger(self):
+        dtype = number.min_numerical_convertible_type("1456")
+        self.assertTrue(numpy.issubdtype(dtype, numpy.unsignedinteger))
+
+    def testPositiveInteger(self):
+        dtype = number.min_numerical_convertible_type("+1456")
+        self.assertTrue(numpy.issubdtype(dtype, numpy.unsignedinteger))
+
+    def testNegativeInteger(self):
+        dtype = number.min_numerical_convertible_type("-1456")
+        self.assertTrue(numpy.issubdtype(dtype, numpy.signedinteger))
+
+    def testIntegerExponential(self):
+        dtype = number.min_numerical_convertible_type("14e10")
+        self.assertTrue(numpy.issubdtype(dtype, numpy.floating))
+
+    def testIntegerPositiveExponential(self):
+        dtype = number.min_numerical_convertible_type("14e+10")
+        self.assertTrue(numpy.issubdtype(dtype, numpy.floating))
+
+    def testIntegerNegativeExponential(self):
+        dtype = number.min_numerical_convertible_type("14e-10")
+        self.assertTrue(numpy.issubdtype(dtype, numpy.floating))
+
+    def testNumberDecimal(self):
+        dtype = number.min_numerical_convertible_type("14.5")
+        self.assertTrue(numpy.issubdtype(dtype, numpy.floating))
+
+    def testPositiveNumberDecimal(self):
+        dtype = number.min_numerical_convertible_type("+14.5")
+        self.assertTrue(numpy.issubdtype(dtype, numpy.floating))
+
+    def testNegativeNumberDecimal(self):
+        dtype = number.min_numerical_convertible_type("-14.5")
+        self.assertTrue(numpy.issubdtype(dtype, numpy.floating))
+
+    def testDecimal(self):
+        dtype = number.min_numerical_convertible_type(".50")
+        self.assertTrue(numpy.issubdtype(dtype, numpy.floating))
+
+    def testPositiveDecimal(self):
+        dtype = number.min_numerical_convertible_type("+.5")
+        self.assertTrue(numpy.issubdtype(dtype, numpy.floating))
+
+    def testNegativeDecimal(self):
+        dtype = number.min_numerical_convertible_type("-.5")
+        self.assertTrue(numpy.issubdtype(dtype, numpy.floating))
+
+    def testFloat16(self):
+        dtype = number.min_numerical_convertible_type("1.50")
+        self.assertEqual(dtype, numpy.float16)
+
+    def testFloat32(self):
+        dtype = number.min_numerical_convertible_type("1400.50")
+        self.assertEqual(dtype, numpy.float32)
+
+    def testFloat64(self):
+        dtype = number.min_numerical_convertible_type("10000.000010")
+        self.assertEqual(dtype, numpy.float64)
+
+    def testFloat80(self):
+        if not hasattr(numpy, "float128"):
+            self.skipTest("float-80bits not supported")
+        dtype = number.min_numerical_convertible_type("1000000000.0000101")
+        self.assertIn(dtype, (numpy.float128, numpy.longdouble))
+
+    def testExponentialBiggerThanDecimal(self):
+        dtype = number.min_numerical_convertible_type("14000.0e5")
+        self.assertEqual(dtype, numpy.float64)
+
+    def testExponentialSmallerThanNumber(self):
+        dtype = number.min_numerical_convertible_type("14000.0e-5")
+        self.assertEqual(dtype, numpy.float32)
+
+    def testExponentialSmallerThanDecimal(self):
+        dtype = number.min_numerical_convertible_type("0.00001e5")
+        self.assertEqual(dtype, numpy.float32)
+
+    def testExponentialBiggerThanNumber(self):
+        dtype = number.min_numerical_convertible_type("0.00001e-5")
+        self.assertEqual(dtype, numpy.float64)
+
+
+def suite():
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite = unittest.TestSuite()
+    test_suite.addTest(loadTests(TestConversionTypes))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest="suite")

--- a/silx/utils/test/test_number.py
+++ b/silx/utils/test/test_number.py
@@ -128,8 +128,6 @@ class TestConversionTypes(unittest.TestCase):
         self.assertEqual(dtype, numpy.longdouble)
 
     def testFloat32ToString(self):
-        if not hasattr(numpy, "float128"):
-            self.skipTest("float-80bits not supported")
         value = str(numpy.float32(numpy.pi))
         dtype = number.min_numerical_convertible_type(value)
         self.assertEqual(dtype, numpy.float32)

--- a/silx/utils/test/test_number.py
+++ b/silx/utils/test/test_number.py
@@ -25,11 +25,12 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "25/05/2018"
+__date__ = "01/06/2018"
 
 import logging
 import numpy
 import unittest
+import pkg_resources
 from silx.utils import number
 
 _logger = logging.getLogger(__name__)
@@ -110,8 +111,16 @@ class TestConversionTypes(unittest.TestCase):
     def testMantissa80(self):
         if not hasattr(numpy, "longdouble"):
             self.skipTest("float-80bits not supported")
-        dtype = number.min_numerical_convertible_type("1000000000.0000101")
-        self.assertEqual(dtype, (numpy.longdouble))
+        dtype = number.min_numerical_convertible_type("1000000000.00001013")
+
+        if pkg_resources.parse_version(numpy.version.version) <= pkg_resources.parse_version("1.10.4"):
+            # numpy 1.8.2 -> Debian 8
+            # Checking a float128 precision with numpy 1.8.2 using abs(diff) is not working.
+            # It looks like the difference is done using float64 (diff == 0.0)
+            expected = (numpy.longdouble, numpy.float64)
+        else:
+            expected = (numpy.longdouble, )
+        self.assertIn(dtype, expected)
 
     def testExponent32(self):
         dtype = number.min_numerical_convertible_type("14.0e30")

--- a/silx/utils/test/test_number.py
+++ b/silx/utils/test/test_number.py
@@ -127,6 +127,13 @@ class TestConversionTypes(unittest.TestCase):
         dtype = number.min_numerical_convertible_type("14.0e3000")
         self.assertEqual(dtype, numpy.longdouble)
 
+    def testFloat32ToString(self):
+        if not hasattr(numpy, "float128"):
+            self.skipTest("float-80bits not supported")
+        value = str(numpy.float32(numpy.pi))
+        dtype = number.min_numerical_convertible_type(value)
+        self.assertEqual(dtype, numpy.float32)
+
 
 def suite():
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase

--- a/silx/utils/test/test_number.py
+++ b/silx/utils/test/test_number.py
@@ -95,39 +95,37 @@ class TestConversionTypes(unittest.TestCase):
         dtype = number.min_numerical_convertible_type("-.5")
         self.assertTrue(numpy.issubdtype(dtype, numpy.floating))
 
-    def testFloat16(self):
+    def testMantissa16(self):
         dtype = number.min_numerical_convertible_type("1.50")
         self.assertEqual(dtype, numpy.float16)
 
-    def testFloat32(self):
+    def testMantissa32(self):
         dtype = number.min_numerical_convertible_type("1400.50")
         self.assertEqual(dtype, numpy.float32)
 
-    def testFloat64(self):
+    def testMantissa64(self):
         dtype = number.min_numerical_convertible_type("10000.000010")
         self.assertEqual(dtype, numpy.float64)
 
-    def testFloat80(self):
-        if not hasattr(numpy, "float128"):
+    def testMantissa80(self):
+        if not hasattr(numpy, "longdouble"):
             self.skipTest("float-80bits not supported")
         dtype = number.min_numerical_convertible_type("1000000000.0000101")
-        self.assertIn(dtype, (numpy.float128, numpy.longdouble))
+        self.assertEqual(dtype, (numpy.longdouble))
 
-    def testExponentialBiggerThanDecimal(self):
-        dtype = number.min_numerical_convertible_type("14000.0e5")
-        self.assertEqual(dtype, numpy.float64)
-
-    def testExponentialSmallerThanNumber(self):
-        dtype = number.min_numerical_convertible_type("14000.0e-5")
+    def testExponent32(self):
+        dtype = number.min_numerical_convertible_type("14.0e30")
         self.assertEqual(dtype, numpy.float32)
 
-    def testExponentialSmallerThanDecimal(self):
-        dtype = number.min_numerical_convertible_type("0.00001e5")
-        self.assertEqual(dtype, numpy.float32)
-
-    def testExponentialBiggerThanNumber(self):
-        dtype = number.min_numerical_convertible_type("0.00001e-5")
+    def testExponent64(self):
+        dtype = number.min_numerical_convertible_type("14.0e300")
         self.assertEqual(dtype, numpy.float64)
+
+    def testExponent80(self):
+        if not hasattr(numpy, "longdouble"):
+            self.skipTest("float-80bits not supported")
+        dtype = number.min_numerical_convertible_type("14.0e3000")
+        self.assertEqual(dtype, numpy.longdouble)
 
 
 def suite():

--- a/silx/utils/test/test_number.py
+++ b/silx/utils/test/test_number.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "24/05/2018"
+__date__ = "25/05/2018"
 
 import logging
 import numpy
@@ -130,7 +130,7 @@ class TestConversionTypes(unittest.TestCase):
     def testFloat32ToString(self):
         value = str(numpy.float32(numpy.pi))
         dtype = number.min_numerical_convertible_type(value)
-        self.assertEqual(dtype, numpy.float32)
+        self.assertIn(dtype, (numpy.float32, numpy.float64))
 
 
 def suite():

--- a/silx/utils/test/test_number.py
+++ b/silx/utils/test/test_number.py
@@ -110,8 +110,7 @@ class TestConversionTypes(testutils.ParametricTestCase):
         self.assertEqual(dtype, numpy.float64)
 
     def testMantissa80(self):
-        if not hasattr(numpy, "longdouble"):
-            self.skipTest("float-80bits not supported")
+        self.skipIfFloat80NotSupported()
         dtype = number.min_numerical_convertible_type("1000000000.00001013")
 
         if pkg_resources.parse_version(numpy.version.version) <= pkg_resources.parse_version("1.10.4"):
@@ -132,8 +131,7 @@ class TestConversionTypes(testutils.ParametricTestCase):
         self.assertEqual(dtype, numpy.float64)
 
     def testExponent80(self):
-        if not hasattr(numpy, "longdouble"):
-            self.skipTest("float-80bits not supported")
+        self.skipIfFloat80NotSupported()
         dtype = number.min_numerical_convertible_type("14.0e3000")
         self.assertEqual(dtype, numpy.longdouble)
 
@@ -142,9 +140,14 @@ class TestConversionTypes(testutils.ParametricTestCase):
         dtype = number.min_numerical_convertible_type(value)
         self.assertIn(dtype, (numpy.float32, numpy.float64))
 
-    def testLosePrecisionUsingFloat80(self):
+    def skipIfFloat80NotSupported(self):
         if not hasattr(numpy, "longdouble"):
             self.skipTest("float-80bits not supported")
+        if numpy.longdouble == numpy.float64:
+            self.skipTest("float-80bits not supported")
+
+    def testLosePrecisionUsingFloat80(self):
+        self.skipIfFloat80NotSupported()
         if pkg_resources.parse_version(numpy.version.version) <= pkg_resources.parse_version("1.10.4"):
             self.skipTest("numpy > 1.10.4 expected")
         value = "1000000000.00001013332"

--- a/silx/utils/test/test_number.py
+++ b/silx/utils/test/test_number.py
@@ -37,6 +37,12 @@ _logger = logging.getLogger(__name__)
 
 class TestConversionTypes(unittest.TestCase):
 
+    def testEmptyFail(self):
+        self.assertRaises(ValueError, number.min_numerical_convertible_type, "")
+
+    def testStringFail(self):
+        self.assertRaises(ValueError, number.min_numerical_convertible_type, "a")
+
     def testInteger(self):
         dtype = number.min_numerical_convertible_type("1456")
         self.assertTrue(numpy.issubdtype(dtype, numpy.unsignedinteger))

--- a/silx/utils/test/test_number.py
+++ b/silx/utils/test/test_number.py
@@ -37,7 +37,7 @@ from silx.utils import testutils
 _logger = logging.getLogger(__name__)
 
 
-class TestConversionTypes(unittest.TestCase):
+class TestConversionTypes(testutils.ParametricTestCase):
 
     def testEmptyFail(self):
         self.assertRaises(ValueError, number.min_numerical_convertible_type, "")
@@ -152,6 +152,21 @@ class TestConversionTypes(unittest.TestCase):
         func = func(number.min_numerical_convertible_type)
         dtype = func(value)
         self.assertIn(dtype, (numpy.longdouble, ))
+
+    def testMillisecondEpochTime(self):
+        datetimes = ['1465803236.495412',
+                     '1465803236.999362',
+                     '1465803237.504311',
+                     '1465803238.009261',
+                     '1465803238.512211',
+                     '1465803239.016160',
+                     '1465803239.520110',
+                     '1465803240.026059',
+                     '1465803240.529009']
+        for datetime in datetimes:
+            with self.subTest(datetime=datetime):
+                dtype = number.min_numerical_convertible_type(datetime)
+                self.assertEqual(dtype, numpy.float64)
 
 
 def suite():

--- a/silx/utils/test/test_number.py
+++ b/silx/utils/test/test_number.py
@@ -47,6 +47,10 @@ class TestConversionTypes(unittest.TestCase):
         dtype = number.min_numerical_convertible_type("1456")
         self.assertTrue(numpy.issubdtype(dtype, numpy.unsignedinteger))
 
+    def testTrailledInteger(self):
+        dtype = number.min_numerical_convertible_type(" \t\n\r1456\t\n\r")
+        self.assertTrue(numpy.issubdtype(dtype, numpy.unsignedinteger))
+
     def testPositiveInteger(self):
         dtype = number.min_numerical_convertible_type("+1456")
         self.assertTrue(numpy.issubdtype(dtype, numpy.unsignedinteger))

--- a/silx/utils/test/test_number.py
+++ b/silx/utils/test/test_number.py
@@ -32,6 +32,7 @@ import numpy
 import unittest
 import pkg_resources
 from silx.utils import number
+from silx.utils import testutils
 
 _logger = logging.getLogger(__name__)
 
@@ -140,6 +141,17 @@ class TestConversionTypes(unittest.TestCase):
         value = str(numpy.float32(numpy.pi))
         dtype = number.min_numerical_convertible_type(value)
         self.assertIn(dtype, (numpy.float32, numpy.float64))
+
+    def testLosePrecisionUsingFloat80(self):
+        if not hasattr(numpy, "longdouble"):
+            self.skipTest("float-80bits not supported")
+        if pkg_resources.parse_version(numpy.version.version) <= pkg_resources.parse_version("1.10.4"):
+            self.skipTest("numpy > 1.10.4 expected")
+        value = "1000000000.00001013332"
+        func = testutils.test_logging(number._logger.name, warning=1)
+        func = func(number.min_numerical_convertible_type)
+        dtype = func(value)
+        self.assertIn(dtype, (numpy.longdouble, ))
 
 
 def suite():

--- a/silx/utils/test/test_number.py
+++ b/silx/utils/test/test_number.py
@@ -143,7 +143,7 @@ class TestConversionTypes(testutils.ParametricTestCase):
     def skipIfFloat80NotSupported(self):
         if not hasattr(numpy, "longdouble"):
             self.skipTest("float-80bits not supported")
-        if numpy.longdouble == numpy.float64:
+        if numpy.finfo(numpy.longdouble).bits == 64:
             self.skipTest("float-80bits not supported")
 
     def testLosePrecisionUsingFloat80(self):


### PR DESCRIPTION
- Take care of exponent to choose floating-point size
- Use `numpy.longdouble` if available (instead of `float128`/`float96`)
- Fallback using `float64`
- Create a dedicated module `silx.utils.number`

Relative to #1829
Closes #1830