### PR TITLE
[plot] Fix picking issue by making sure Y axes are positive when log scale

### DIFF
--- a/silx/gui/plot/items/axis.py
+++ b/silx/gui/plot/items/axis.py
@@ -219,6 +219,13 @@ class Axis(qt.QObject):
         # For the backward compatibility signal
         emitLog = self._scale == self.LOGARITHMIC or scale == self.LOGARITHMIC
 
+        self._scale = scale
+
+        # TODO hackish way of forcing update of curves and images
+        for item in self._plot._getItems(withhidden=True):
+            item._updated()
+        self._plot._invalidateDataRange()
+
         if scale == self.LOGARITHMIC:
             self._internalSetLogarithmic(True)
         elif scale == self.LINEAR:
@@ -226,12 +233,6 @@ class Axis(qt.QObject):
         else:
             raise ValueError("Scale %s unsupported" % scale)
 
-        self._scale = scale
-
-        # TODO hackish way of forcing update of curves and images
-        for item in self._plot._getItems(withhidden=True):
-            item._updated()
-        self._plot._invalidateDataRange()
         self._plot._forceResetZoom()
 
         self.sigScaleChanged.emit(self._scale)


### PR DESCRIPTION
This PR fixes an issue with matplotlib >= 2.0 when in log scale, there is errors with picking during mouse move.
This was due to right axis (even if not shown) to have a negative bound.
This PR makes sure both Y axes have strictly positive bounds before switching to log scale (at the expense of a flicker redraw)

closes  #1708