### PR TITLE
[doc] Add docstring to __init__ of main packages

### DIFF
--- a/silx/__init__.py
+++ b/silx/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,18 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
+"""The silx package contains the following main sub-packages:
+
+- silx.gui: Qt widgets for data visualization and data file browsing
+- silx.image: some processing functions for 2D images
+- silx.io: Reading and writing data files (HDF5/NeXus, SPEC, ...)
+- silx.math: Some processing functions for 1D, 2D, 3D, nD arrays
+- silx.opencl: OpenCL-based data processing
+- silx.sx: High-level silx functions suited for (I)Python console.
+- silx.utils: Miscellaneous convenient functions
+
+See silx documentation: http://www.silx.org/doc/silx/latest/
+"""
 
 from __future__ import absolute_import, print_function, division
 

--- a/silx/app/__init__.py
+++ b/silx/app/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-"""Application provided by the launcher"""
+"""This package contains the application provided by the launcher"""
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"

--- a/silx/gui/__init__.py
+++ b/silx/gui/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,27 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-"""Set of Qt widgets"""
+"""This package provides a set of Qt widgets.
+
+It contains the following sub-packages and modules:
+
+- silx.gui.colors: Functions to handle colors and colormap
+- silx.gui.console: IPython console widget
+- silx.gui.data:
+  Widgets for displaying data arrays using table views and plot widgets
+- silx.gui.dialog: Specific dialog widgets
+- silx.gui.fit: Widgets for controlling curve fitting
+- silx.gui.hdf5: Widgets for displaying content relative to HDF5 format
+- silx.gui.icons: Functions to access embedded icons
+- silx.gui.plot: Widgets for 1D and 2D plotting and related tools
+- silx.gui.plot3d: Widgets for visualizing data in 3D based on OpenGL
+- silx.gui.printer: Shared printer used by the library
+- silx.gui.qt: Common wrapper over different Python Qt binding
+- silx.gui.utils: Miscellaneous helpers for Qt
+- silx.gui.widgets: Miscellaneous standalone widgets
+
+See silx documentation: http://www.silx.org/doc/silx/latest/
+"""
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"

--- a/silx/image/__init__.py
+++ b/silx/image/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2017 European Synchrotron Radiation Facility
+# Copyright (C) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,12 @@
 # THE SOFTWARE.
 #
 # ############################################################################*/
+"""This package provides some processing functions for 2D images.
+
+For more processing functions, see the silx.math and silx.opencl packages.
+
+See silx documentation: http://www.silx.org/doc/silx/latest/
+"""
 
 __authors__ = ["H. Payno"]
 __license__ = "MIT"

--- a/silx/io/__init__.py
+++ b/silx/io/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,7 +22,12 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-"""I/O modules"""
+"""This package provides functionalities to read and write data files.
+
+It is geared towards support of and conversion to HDF5/NeXus.
+
+See silx documentation: http://www.silx.org/doc/silx/latest/
+"""
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"

--- a/silx/math/__init__.py
+++ b/silx/math/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,14 @@
 # THE SOFTWARE.
 #
 # ############################################################################*/
+"""This package provides some processing functions for 1D, 2D, 3D or nD arrays.
+
+For additional processing functions dedicated to 2D images,
+see the silx.image package.
+For OpenCL-based processing functions see the silx.opencl package.
+
+See silx documentation: http://www.silx.org/doc/silx/latest/
+"""
 
 __authors__ = ["D. Naudet", "V.A. Sole", "P. Knobel"]
 __license__ = "MIT"

--- a/silx/opencl/__init__.py
+++ b/silx/opencl/__init__.py
@@ -4,7 +4,7 @@
 #    Project: S I L X project
 #             https://github.com/silx-kit/silx
 #
-#    Copyright (C) 2012-2017 European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2012-2018 European Synchrotron Radiation Facility, Grenoble, France
 #
 #    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
 #
@@ -29,6 +29,12 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 # OTHER DEALINGS IN THE SOFTWARE.
 #
+"""This package provides OpenCl-based optimized processing functions.
+
+For more processing functions, see the silx.math and silx.image packages.
+
+See silx documentation: http://www.silx.org/doc/silx/latest/
+"""
 
 __author__ = "Jerome Kieffer"
 __contact__ = "Jerome.Kieffer@ESRF.eu"

--- a/silx/test/__init__.py
+++ b/silx/test/__init__.py
@@ -22,7 +22,7 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-"""Full silx test suite.
+"""This package provides access to the full silx test suite.
 
 It is possible to disable tests depending on Qt by setting
 `silx.test.utils.test_options.WITH_QT_TEST = False`

--- a/silx/third_party/__init__.py
+++ b/silx/third_party/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2016 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,11 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
+"""This package embeds a few dependency of silx.
+
+This is meant for internal use.
+"""
+
 
 __authors__ = ["Jérôme Kieffer"]
 __license__ = "MIT"

--- a/silx/utils/__init__.py
+++ b/silx/utils/__init__.py
@@ -1,0 +1,28 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This package contains a set of miscellaneous convenient features.
+
+See silx documentation: http://www.silx.org/doc/silx/latest/
+"""


### PR DESCRIPTION
This PR adds a small description and list of content of main silx packages along with the URL of silx documentation.

closes #1743