### PR TITLE
[plot3d] Add missing method to access Global scene parameters widget

### DIFF
--- a/silx/gui/plot3d/SceneWindow.py
+++ b/silx/gui/plot3d/SceneWindow.py
@@ -163,6 +163,13 @@ class SceneWindow(qt.QMainWindow):
         """
         return self._sceneWidget
 
+    def getGroupResetWidget(self):
+        """Returns the :class:`GroupPropertiesWidget` of this window.
+
+        :rtype: GroupPropertiesWidget
+        """
+        return self._sceneGroupResetWidget
+
     def getParamTreeView(self):
         """Returns the :class:`ParamTreeView` of this window.
 


### PR DESCRIPTION
This PR adds a method that was missing to access a widget of the `SceneWindow` main window.