### PR TITLE
[plot] Add select-draw interaction mode to PlotWidget

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2902,7 +2902,7 @@ class PlotWidget(qt.QMainWindow):
         """Switch the interactive mode.
 
         :param str mode: The name of the interactive mode.
-                         In 'draw', 'pan', 'select', 'zoom'.
+                         In 'draw', 'pan', 'select', 'select-draw', 'zoom'.
         :param color: Only for 'draw' and 'zoom' modes.
                       Color to use for drawing selection area. Default black.
         :type color: Color description: The name as a str or


### PR DESCRIPTION
This PR adds a `select-draw` interactive mode which provides items (e.g., markers) selection and dragging and shape drawing interaction at the same time.
This would be useful for PR #1758.