### PR TITLE
[plot] Make set|getSelectionMask support/return None

### DIFF
--- a/examples/findContours.py
+++ b/examples/findContours.py
@@ -465,8 +465,6 @@ class FindContours(qt.QMainWindow):
         if mask is None:
             if self.__useMaskButton.isChecked():
                 mask = self.__plot.getMaskToolsDockWidget().getSelectionMask()
-                if mask is not None and mask.size == 0:
-                    mask = None
 
         self.__image = image
         self.__mask = mask

--- a/examples/scatterMask.py
+++ b/examples/scatterMask.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -91,7 +91,7 @@ class MaskScatterWidget(qt.QMainWindow):
         :param bool copy: True (default) to get a copy of the mask.
                           If False, the returned array MUST not be modified.
         :return: The array of the mask with dimension of the scatter data.
-                 If there is no scatter data, an empty array is returned.
+                 If there is no scatter data, None is returned.
         :rtype: 1D numpy.ndarray of uint8
         """
         return self._maskToolsWidget.getSelectionMask(copy=copy)

--- a/silx/gui/plot/ScatterMaskToolsWidget.py
+++ b/silx/gui/plot/ScatterMaskToolsWidget.py
@@ -192,7 +192,8 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
     def setSelectionMask(self, mask, copy=True):
         """Set the mask to a new array.
 
-        :param numpy.ndarray mask: The array to use for the mask.
+        :param numpy.ndarray mask:
+            The array to use for the mask or None to reset the mask.
         :type mask: numpy.ndarray of uint8, C-contiguous.
                     Array of other types are converted.
         :param bool copy: True (the default) to copy the array,
@@ -201,6 +202,10 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
                  The mask can be cropped or padded to fit active scatter,
                  the returned shape is that of the scatter data.
         """
+        if mask is None:
+            self.resetSelectionMask()
+            return self._data_scatter.getXData(copy=False).shape
+
         mask = numpy.array(mask, copy=False, dtype=numpy.uint8)
 
         if self._data_scatter.getXData(copy=False).shape == (0,) \
@@ -216,7 +221,7 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
     def _updatePlotMask(self):
         """Update mask image in plot"""
         mask = self.getSelectionMask(copy=False)
-        if len(mask):
+        if mask is not None:
             self.plot.addScatter(self._data_scatter.getXData(),
                                  self._data_scatter.getYData(),
                                  mask,
@@ -248,7 +253,7 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
         if not self.browseAction.isChecked():
             self.browseAction.trigger()  # Disable drawing tool
 
-        if len(self.getSelectionMask(copy=False)):
+        if self.getSelectionMask(copy=False) is not None:
             self.plot.sigActiveScatterChanged.connect(
                 self._activeScatterChangedAfterCare)
 
@@ -274,7 +279,7 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
 
             self._z = activeScatter.getZValue() + 1
             self._data_scatter = activeScatter
-            if self._data_scatter.getXData(copy=False).shape != self.getSelectionMask(copy=False).shape:
+            if self._data_scatter.getXData(copy=False).shape != self._mask.getMask(copy=False).shape:
                 # scatter has not the same size, remove mask and stop listening
                 if self.plot._getItem(kind="scatter", legend=self._maskName):
                     self.plot.remove(self._maskName, kind='scatter')
@@ -310,7 +315,7 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
             self._z = activeScatter.getZValue() + 1
             self._data_scatter = activeScatter
             self._mask.setDataItem(self._data_scatter)
-            if self._data_scatter.getXData(copy=False).shape != self.getSelectionMask(copy=False).shape:
+            if self._data_scatter.getXData(copy=False).shape != self._mask.getMask(copy=False).shape:
                 self._mask.reset(self._data_scatter.getXData(copy=False).shape)
                 self._mask.commit()
             else:

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -409,12 +409,21 @@ class BaseMaskToolsWidget(qt.QWidget):
 
         :param bool copy: True (default) to get a copy of the mask.
                           If False, the returned array MUST not be modified.
-        :return: The array of the mask with dimension of the 'active' plot item.
-                 If there is no active image or scatter, an empty array is
-                 returned.
-        :rtype: numpy.ndarray of uint8
+        :return: The mask (as an array of uint8) with dimension of
+                 the 'active' plot item.
+                 If there is no active image or scatter, it returns None.
+        :rtype: Union[numpy.ndarray,None]
         """
-        return self._mask.getMask(copy=copy)
+        mask = self._mask.getMask(copy=copy)
+        return None if mask.size == 0 else mask
+
+    def setSelectionMask(self, mask):
+        """Set the mask: Must be implemented in subclass"""
+        raise NotImplementedError()
+
+    def resetSelectionMask(self):
+        """Reset the mask: Must be implemented in subclass"""
+        raise NotImplementedError()
 
     def multipleMasks(self):
         """Return the current mode of multiple masks support.


### PR DESCRIPTION
This PR changes the returned value of `getSelectionMask` to None when there is no mask and makes `setSelectionMask` accept None as input to reset the mask.

closes #1765
closes #834

Please check if it breaks anything in applications before merging.
Maybe not merge for v0.8?