### PR TITLE
[plot] Fix circular reference in plot widgets

### DIFF
--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -31,7 +31,9 @@ __date__ = "24/04/2018"
 
 
 import logging
+import weakref
 import numpy
+
 from ._utils import ticklayout
 from .. import qt
 from silx.gui import colors
@@ -70,7 +72,7 @@ class ColorBarWidget(qt.QWidget):
 
     def __init__(self, parent=None, plot=None, legend=None):
         self._isConnected = False
-        self._plot = None
+        self._plotRef = None
         self._colormap = None
         self._data = None
 
@@ -96,7 +98,7 @@ class ColorBarWidget(qt.QWidget):
 
     def getPlot(self):
         """Returns the :class:`Plot` associated to this widget or None"""
-        return self._plot
+        return None if self._plotRef is None else self._plotRef()
 
     def setPlot(self, plot):
         """Associate a plot to the ColorBar
@@ -105,24 +107,26 @@ class ColorBarWidget(qt.QWidget):
                      If None will remove any connection with a previous plot.
         """
         self._disconnectPlot()
-        self._plot = plot
+        self._plotRef = None if plot is None else weakref.ref(plot)
         self._connectPlot()
 
     def _disconnectPlot(self):
         """Disconnect from Plot signals"""
-        if self._plot is not None and self._isConnected:
+        plot = self.getPlot()
+        if plot is not None and self._isConnected:
             self._isConnected = False
-            self._plot.sigActiveImageChanged.disconnect(
+            plot.sigActiveImageChanged.disconnect(
                 self._activeImageChanged)
-            self._plot.sigActiveScatterChanged.disconnect(
+            plot.sigActiveScatterChanged.disconnect(
                 self._activeScatterChanged)
-            self._plot.sigPlotSignal.disconnect(self._defaultColormapChanged)
+            plot.sigPlotSignal.disconnect(self._defaultColormapChanged)
 
     def _connectPlot(self):
         """Connect to Plot signals"""
-        if self._plot is not None and not self._isConnected:
-            activeImageLegend = self._plot.getActiveImage(just_legend=True)
-            activeScatterLegend = self._plot._getActiveItem(
+        plot = self.getPlot()
+        if plot is not None and not self._isConnected:
+            activeImageLegend = plot.getActiveImage(just_legend=True)
+            activeScatterLegend = plot._getActiveItem(
                 kind='scatter', just_legend=True)
             if activeImageLegend is None and activeScatterLegend is None:
                 # Show plot default colormap
@@ -132,9 +136,9 @@ class ColorBarWidget(qt.QWidget):
             elif activeScatterLegend is not None:  # Show active scatter colormap
                 self._activeScatterChanged(None, activeScatterLegend)
 
-            self._plot.sigActiveImageChanged.connect(self._activeImageChanged)
-            self._plot.sigActiveScatterChanged.connect(self._activeScatterChanged)
-            self._plot.sigPlotSignal.connect(self._defaultColormapChanged)
+            plot.sigActiveImageChanged.connect(self._activeImageChanged)
+            plot.sigActiveScatterChanged.connect(self._activeScatterChanged)
+            plot.sigPlotSignal.connect(self._defaultColormapChanged)
             self._isConnected = True
 
     def setVisible(self, isVisible):
@@ -207,8 +211,10 @@ class ColorBarWidget(qt.QWidget):
 
     def _activeScatterChanged(self, previous, legend):
         """Handle plot active scatter changed"""
+        plot = self.getPlot()
+
         # Do not handle active scatter while there is an image
-        if self._plot.getActiveImage() is not None:
+        if plot.getActiveImage() is not None:
             return
 
         if legend is None:  # No active scatter, display no colormap
@@ -216,21 +222,23 @@ class ColorBarWidget(qt.QWidget):
             return
 
         # Sync with active scatter
-        activeScatter = self._plot._getActiveItem(kind='scatter')
+        activeScatter = plot._getActiveItem(kind='scatter')
 
         self.setColormap(colormap=activeScatter.getColormap(),
                          data=activeScatter.getValueData(copy=False))
 
     def _activeImageChanged(self, previous, legend):
         """Handle plot active image changed"""
+        plot = self.getPlot()
+
         if legend is None:  # No active image, try with active scatter
-            activeScatterLegend = self._plot._getActiveItem(
+            activeScatterLegend = plot._getActiveItem(
                 kind='scatter', just_legend=True)
             # No more active image, use active scatter if any
             self._activeScatterChanged(None, activeScatterLegend)
         else:
             # Sync with active image
-            image = self._plot.getActiveImage().getData(copy=False)
+            image = plot.getActiveImage().getData(copy=False)
 
             # RGB(A) image, display default colormap
             if image.ndim != 2:
@@ -240,19 +248,19 @@ class ColorBarWidget(qt.QWidget):
             # data image, sync with image colormap
             # do we need the copy here : used in the case we are changing
             # vmin and vmax but should have already be done by the plot
-            self.setColormap(colormap=self._plot.getActiveImage().getColormap(),
+            self.setColormap(colormap=plot.getActiveImage().getColormap(),
                              data=image)
 
     def _defaultColormapChanged(self, event):
         """Handle plot default colormap changed"""
         if (event['event'] == 'defaultColormapChanged' and
-                self._plot.getActiveImage() is None):
+                self.getPlot().getActiveImage() is None):
             # No active image, take default colormap update into account
             self._syncWithDefaultColormap()
 
     def _syncWithDefaultColormap(self, data=None):
         """Update colorbar according to plot default colormap"""
-        self.setColormap(self._plot.getDefaultColormap(), data)
+        self.setColormap(self.getPlot().getDefaultColormap(), data)
 
     def getColorScaleBar(self):
         """

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -51,6 +51,7 @@ from collections import OrderedDict
 import logging
 import os
 import sys
+import weakref
 
 import numpy
 
@@ -91,7 +92,8 @@ class CurvesROIWidget(qt.QWidget):
         if name is not None:
             self.setWindowTitle(name)
         assert plot is not None
-        self.plot = plot
+        self.plot = weakref.proxy(plot)
+
         layout = qt.QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
@@ -979,9 +981,6 @@ class CurvesROIDockWidget(qt.QDockWidget):
 
     def __init__(self, parent=None, plot=None, name=None):
         super(CurvesROIDockWidget, self).__init__(name, parent)
-
-        assert plot is not None
-        self.plot = plot
 
         self.roiWidget = CurvesROIWidget(self, name, plot=plot)
         """Main widget of type :class:`CurvesROIWidget`"""

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -92,7 +92,7 @@ class CurvesROIWidget(qt.QWidget):
         if name is not None:
             self.setWindowTitle(name)
         assert plot is not None
-        self.plot = weakref.proxy(plot)
+        self._plotRef = weakref.ref(plot)
 
         layout = qt.QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
@@ -161,6 +161,13 @@ class CurvesROIWidget(qt.QWidget):
         self._middleROIMarkerFlag = False
         self._isConnected = False  # True if connected to plot signals
         self._isInit = False
+
+    def getPlotWidget(self):
+        """Returns the associated PlotWidget or None
+
+        :rtype: Union[PlotWidget,None]
+        """
+        return None if self._plotRef is None else self._plotRef()
 
     def showEvent(self, event):
         self._visibilityChangedHandler(visible=True)
@@ -400,14 +407,18 @@ class CurvesROIWidget(qt.QWidget):
     def _roiSignal(self, ddict):
         """Handle ROI widget signal"""
         _logger.debug("CurvesROIWidget._roiSignal %s", str(ddict))
+        plot = self.getPlotWidget()
+        if plot is None:
+            return
+
         if ddict['event'] == "AddROI":
-            xmin, xmax = self.plot.getXAxis().getLimits()
+            xmin, xmax = plot.getXAxis().getLimits()
             fromdata = xmin + 0.25 * (xmax - xmin)
             todata = xmin + 0.75 * (xmax - xmin)
-            self.plot.remove('ROI min', kind='marker')
-            self.plot.remove('ROI max', kind='marker')
+            plot.remove('ROI min', kind='marker')
+            plot.remove('ROI max', kind='marker')
             if self._middleROIMarkerFlag:
-                self.plot.remove('ROI middle', kind='marker')
+                plot.remove('ROI middle', kind='marker')
             roiList, roiDict = self.roiTable.getROIListAndDict()
             nrois = len(roiList)
             if nrois == 0:
@@ -424,29 +435,29 @@ class CurvesROIWidget(qt.QWidget):
                         break
                 color = 'blue'
                 draggable = True
-            self.plot.addXMarker(fromdata,
-                                 legend='ROI min',
-                                 text='ROI min',
-                                 color=color,
-                                 draggable=draggable)
-            self.plot.addXMarker(todata,
-                                 legend='ROI max',
-                                 text='ROI max',
-                                 color=color,
-                                 draggable=draggable)
+            plot.addXMarker(fromdata,
+                            legend='ROI min',
+                            text='ROI min',
+                            color=color,
+                            draggable=draggable)
+            plot.addXMarker(todata,
+                            legend='ROI max',
+                            text='ROI max',
+                            color=color,
+                            draggable=draggable)
             if draggable and self._middleROIMarkerFlag:
                 pos = 0.5 * (fromdata + todata)
-                self.plot.addXMarker(pos,
-                                     legend='ROI middle',
-                                     text="",
-                                     color='yellow',
-                                     draggable=draggable)
+                plot.addXMarker(pos,
+                                legend='ROI middle',
+                                text="",
+                                color='yellow',
+                                draggable=draggable)
             roiList.append(newroi)
             roiDict[newroi] = {}
             if newroi == "ICR":
                 roiDict[newroi]['type'] = "Default"
             else:
-                roiDict[newroi]['type'] = self.plot.getXAxis().getLabel()
+                roiDict[newroi]['type'] = plot.getXAxis().getLabel()
             roiDict[newroi]['from'] = fromdata
             roiDict[newroi]['to'] = todata
             self.roiTable.fillFromROIDict(roilist=roiList,
@@ -455,10 +466,10 @@ class CurvesROIWidget(qt.QWidget):
             self.currentROI = newroi
             self.calculateRois()
         elif ddict['event'] in ['DelROI', "ResetROI"]:
-            self.plot.remove('ROI min', kind='marker')
-            self.plot.remove('ROI max', kind='marker')
+            plot.remove('ROI min', kind='marker')
+            plot.remove('ROI max', kind='marker')
             if self._middleROIMarkerFlag:
-                self.plot.remove('ROI middle', kind='marker')
+                plot.remove('ROI middle', kind='marker')
             roiList, roiDict = self.roiTable.getROIListAndDict()
             roiDictKeys = list(roiDict.keys())
             if len(roiDictKeys):
@@ -481,37 +492,37 @@ class CurvesROIWidget(qt.QWidget):
             self.roilist, self.roidict = self.roiTable.getROIListAndDict()
             fromdata = ddict['roi']['from']
             todata = ddict['roi']['to']
-            self.plot.remove('ROI min', kind='marker')
-            self.plot.remove('ROI max', kind='marker')
+            plot.remove('ROI min', kind='marker')
+            plot.remove('ROI max', kind='marker')
             if ddict['key'] == 'ICR':
                 draggable = False
                 color = 'black'
             else:
                 draggable = True
                 color = 'blue'
-            self.plot.addXMarker(fromdata,
-                                 legend='ROI min',
-                                 text='ROI min',
-                                 color=color,
-                                 draggable=draggable)
-            self.plot.addXMarker(todata,
-                                 legend='ROI max',
-                                 text='ROI max',
-                                 color=color,
-                                 draggable=draggable)
+            plot.addXMarker(fromdata,
+                            legend='ROI min',
+                            text='ROI min',
+                            color=color,
+                            draggable=draggable)
+            plot.addXMarker(todata,
+                            legend='ROI max',
+                            text='ROI max',
+                            color=color,
+                            draggable=draggable)
             if draggable and self._middleROIMarkerFlag:
                 pos = 0.5 * (fromdata + todata)
-                self.plot.addXMarker(pos,
-                                     legend='ROI middle',
-                                     text="",
-                                     color='yellow',
-                                     draggable=True)
+                plot.addXMarker(pos,
+                                legend='ROI middle',
+                                text="",
+                                color='yellow',
+                                draggable=True)
             self.currentROI = ddict['key']
             if ddict['colheader'] in ['From', 'To']:
                 dict0 = {}
                 dict0['event'] = "SetActiveCurveEvent"
-                dict0['legend'] = self.plot.getActiveCurve(just_legend=1)
-                self.plot.setActiveCurve(dict0['legend'])
+                dict0['legend'] = plot.getActiveCurve(just_legend=1)
+                plot.setActiveCurve(dict0['legend'])
             elif ddict['colheader'] == 'Raw Counts':
                 pass
             elif ddict['colheader'] == 'Net Counts':
@@ -524,7 +535,8 @@ class CurvesROIWidget(qt.QWidget):
 
     def _getAllLimits(self):
         """Retrieve the limits based on the curves."""
-        curves = self.plot.getAllCurves()
+        plot = self.getPlotWidget()
+        curves = () if plot is None else plot.getAllCurves()
         if not curves:
             return 1.0, 1.0, 100., 100.
 
@@ -563,7 +575,12 @@ class CurvesROIWidget(qt.QWidget):
         if roiList is None or roiDict is None:
             roiList, roiDict = self.roiTable.getROIListAndDict()
 
-        activeCurve = self.plot.getActiveCurve(just_legend=False)
+        plot = self.getPlotWidget()
+        if plot is None:
+            activeCurve = None
+        else:
+            activeCurve = plot.getActiveCurve(just_legend=False)
+
         if activeCurve is None:
             xproc = None
             yproc = None
@@ -641,6 +658,11 @@ class CurvesROIWidget(qt.QWidget):
                 return
             if self.currentROI not in roiDict:
                 return
+
+            plot = self.getPlotWidget()
+            if plot is None:
+                return
+
             x = ddict['x']
 
             if label == 'ROI min':
@@ -648,36 +670,36 @@ class CurvesROIWidget(qt.QWidget):
                 if self._middleROIMarkerFlag:
                     pos = 0.5 * (roiDict[self.currentROI]['to'] +
                                  roiDict[self.currentROI]['from'])
-                    self.plot.addXMarker(pos,
-                                         legend='ROI middle',
-                                         text='',
-                                         color='yellow',
-                                         draggable=True)
+                    plot.addXMarker(pos,
+                                    legend='ROI middle',
+                                    text='',
+                                    color='yellow',
+                                    draggable=True)
             elif label == 'ROI max':
                 roiDict[self.currentROI]['to'] = x
                 if self._middleROIMarkerFlag:
                     pos = 0.5 * (roiDict[self.currentROI]['to'] +
                                  roiDict[self.currentROI]['from'])
-                    self.plot.addXMarker(pos,
-                                         legend='ROI middle',
-                                         text='',
-                                         color='yellow',
-                                         draggable=True)
+                    plot.addXMarker(pos,
+                                    legend='ROI middle',
+                                    text='',
+                                    color='yellow',
+                                    draggable=True)
             elif label == 'ROI middle':
                 delta = x - 0.5 * (roiDict[self.currentROI]['from'] +
                                    roiDict[self.currentROI]['to'])
                 roiDict[self.currentROI]['from'] += delta
                 roiDict[self.currentROI]['to'] += delta
-                self.plot.addXMarker(roiDict[self.currentROI]['from'],
-                                     legend='ROI min',
-                                     text='ROI min',
-                                     color='blue',
-                                     draggable=True)
-                self.plot.addXMarker(roiDict[self.currentROI]['to'],
-                                     legend='ROI max',
-                                     text='ROI max',
-                                     color='blue',
-                                     draggable=True)
+                plot.addXMarker(roiDict[self.currentROI]['from'],
+                                legend='ROI min',
+                                text='ROI min',
+                                color='blue',
+                                draggable=True)
+                plot.addXMarker(roiDict[self.currentROI]['to'],
+                                legend='ROI max',
+                                text='ROI max',
+                                color='blue',
+                                draggable=True)
             else:
                 return
             self.calculateRois(roiList, roiDict)
@@ -688,23 +710,26 @@ class CurvesROIWidget(qt.QWidget):
 
         It is connected to plot signals only when visible.
         """
+        plot = self.getPlotWidget()
+
         if visible:
             if not self._isInit:
                 # Deferred ROI widget init finalization
                 self._finalizeInit()
 
-            if not self._isConnected:
-                self.plot.sigPlotSignal.connect(self._handleROIMarkerEvent)
-                self.plot.sigActiveCurveChanged.connect(
+            if not self._isConnected and plot is not None:
+                plot.sigPlotSignal.connect(self._handleROIMarkerEvent)
+                plot.sigActiveCurveChanged.connect(
                     self._activeCurveChanged)
                 self._isConnected = True
 
                 self.calculateRois()
         else:
             if self._isConnected:
-                self.plot.sigPlotSignal.disconnect(self._handleROIMarkerEvent)
-                self.plot.sigActiveCurveChanged.disconnect(
-                    self._activeCurveChanged)
+                if plot is not None:
+                    plot.sigPlotSignal.disconnect(self._handleROIMarkerEvent)
+                    plot.sigActiveCurveChanged.disconnect(
+                        self._activeCurveChanged)
                 self._isConnected = False
 
     def _activeCurveChanged(self, *args):

--- a/silx/gui/plot/PlotToolButtons.py
+++ b/silx/gui/plot/PlotToolButtons.py
@@ -41,6 +41,7 @@ __date__ = "27/06/2017"
 
 import functools
 import logging
+import weakref
 
 from .. import icons
 from .. import qt
@@ -57,7 +58,7 @@ class PlotToolButton(qt.QToolButton):
 
     def __init__(self, parent=None, plot=None):
         super(PlotToolButton, self).__init__(parent)
-        self._plot = None
+        self._plotRef = None
         if plot is not None:
             self.setPlot(plot)
 
@@ -65,7 +66,7 @@ class PlotToolButton(qt.QToolButton):
         """
         Returns the plot connected to the widget.
         """
-        return self._plot
+        return None if self._plotRef is None else self._plotRef()
 
     def setPlot(self, plot):
         """
@@ -73,13 +74,18 @@ class PlotToolButton(qt.QToolButton):
 
         :param plot: :class:`.PlotWidget` instance on which to operate.
         """
-        if self._plot is plot:
+        previousPlot = self.plot()
+
+        if previousPlot is plot:
             return
-        if self._plot is not None:
-            self._disconnectPlot(self._plot)
-        self._plot = plot
-        if self._plot is not None:
-            self._connectPlot(self._plot)
+        if previousPlot is not None:
+            self._disconnectPlot(previousPlot)
+
+        if plot is None:
+            self._plotRef = None
+        else:
+            self._plotRef = weakref.ref(plot)
+            self._connectPlot(plot)
 
     def _connectPlot(self, plot):
         """

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -43,6 +43,7 @@ import logging
 import numpy
 
 import silx
+from silx.utils.weakref import WeakMethodProxy
 from silx.utils import deprecation
 from silx.utils.property import classproperty
 from silx.utils.deprecation import deprecated
@@ -2391,10 +2392,10 @@ class PlotWidget(qt.QMainWindow):
                                  to handle the graph events
                                  If None (default), use a default listener.
         """
-        # TODO allow multiple listeners, keep a weakref on it
+        # TODO allow multiple listeners
         # allow register listener by event type
         if callbackFunction is None:
-            callbackFunction = self.graphCallback
+            callbackFunction = WeakMethodProxy(self.graphCallback)
         self._callback = callbackFunction
 
     def graphCallback(self, ddict=None):

--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -33,6 +33,7 @@ __date__ = "26/04/2018"
 
 import collections
 import logging
+import weakref
 
 import silx
 from silx.utils.deprecation import deprecated
@@ -322,7 +323,7 @@ class PlotWindow(PlotWidget):
         show it or hide it."""
         # create widget if needed (first call)
         if self._consoleDockWidget is None:
-            available_vars = {"plt": self}
+            available_vars = {"plt": weakref.proxy(self)}
             banner = "The variable 'plt' is available. Use the 'whos' "
             banner += "and 'help(plt)' commands for more information.\n\n"
             self._consoleDockWidget = IPythonDockWidget(

--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -36,6 +36,7 @@ import logging
 import weakref
 
 import silx
+from silx.utils.weakref import WeakMethodProxy
 from silx.utils.deprecation import deprecated
 
 from . import PlotWidget
@@ -777,7 +778,7 @@ class Plot2D(PlotWindow):
         posInfo = [
             ('X', lambda x, y: x),
             ('Y', lambda x, y: y),
-            ('Data', self._getImageValue)]
+            ('Data', WeakMethodProxy(self._getImageValue))]
 
         super(Plot2D, self).__init__(parent=parent, backend=backend,
                                      resetzoom=True, autoScale=False,

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -32,6 +32,7 @@ __license__ = "MIT"
 __date__ = "24/04/2018"
 
 import os
+import weakref
 
 import numpy
 
@@ -372,7 +373,7 @@ class BaseMaskToolsWidget(qt.QWidget):
         # as parent have to be the first argument of the widget to fit
         # QtDesigner need but here plot can't be None by default.
         assert plot is not None
-        self._plot = plot
+        self._plotRef = weakref.ref(plot)
         self._maskName = '__MASK_TOOLS_%d' % id(self)  # Legend of the mask
 
         self._colormap = Colormap(name="",
@@ -453,7 +454,11 @@ class BaseMaskToolsWidget(qt.QWidget):
     @property
     def plot(self):
         """The :class:`.PlotWindow` this widget is attached to."""
-        return self._plot
+        plot = self._plotRef()
+        if plot is None:
+            raise RuntimeError(
+                'Mask widget attached to a PlotWidget that no longer exists')
+        return plot
 
     def setDirection(self, direction=qt.QBoxLayout.LeftToRight):
         """Set the direction of the layout of the widget


### PR DESCRIPTION
This PR fixes circular reference at Python level in `PlotWidget`, `PlotWindow`, `Plot1D` and `Plot2D` by using `weakref`.

Related to #1872
