### PR TITLE
Display float80 in the GUI instead of float128

### DIFF
--- a/silx/gui/hdf5/Hdf5Formatter.py
+++ b/silx/gui/hdf5/Hdf5Formatter.py
@@ -27,7 +27,7 @@ text."""
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "30/04/2018"
+__date__ = "06/06/2018"
 
 import numpy
 from silx.third_party import six
@@ -168,6 +168,16 @@ class Hdf5Formatter(qt.QObject):
                     return "enum"
 
         text = str(dtype.newbyteorder('N'))
+        if numpy.issubdtype(dtype, numpy.floating):
+            if hasattr(numpy, "float128") and dtype == numpy.float128:
+                text = "float80"
+                if full:
+                    text += " (padding 128bits)"
+            elif hasattr(numpy, "float96") and dtype == numpy.float96:
+                text = "float80"
+                if full:
+                    text += " (padding 96bits)"
+
         if full:
             if dtype.byteorder == "<":
                 text = "Little-endian " + text


### PR DESCRIPTION
It is still not accurate (we do not display the type stored by HDF5) but it is less wrong.

![float128-is-float80](https://user-images.githubusercontent.com/7579321/41039010-a5587eda-6987-11e8-8ae9-e9cba9d18d88.png)

Closes #1861 