### PR TITLE
[plot] Fix position info update when active image changes

### DIFF
--- a/silx/gui/plot/tools/PositionInfo.py
+++ b/silx/gui/plot/tools/PositionInfo.py
@@ -155,6 +155,22 @@ class PositionInfo(qt.QWidget):
             xPixel, yPixel = event['xpixel'], event['ypixel']
             self._updateStatusBar(x, y, xPixel, yPixel)
 
+    def updateInfo(self):
+        """Update displayed information"""
+        plot = self.plot
+        if plot is None:
+            _logger.error("Trying to update PositionInfo "
+                          "while PlotWidget no longer exists")
+            return
+
+        widget = plot.getWidgetHandle()
+        position = widget.mapFromGlobal(qt.QCursor.pos())
+        xPixel, yPixel = position.x(), position.y()
+        dataPos = plot.pixelToData(xPixel, yPixel, check=True)
+        if dataPos is not None:  # Inside plot area
+            x, y = dataPos
+            self._updateStatusBar(x, y, xPixel, yPixel)
+
     def _updateStatusBar(self, x, y, xPixel, yPixel):
         """Update information from the status bar using the definitions.
 

--- a/silx/gui/plot/tools/test/testTools.py
+++ b/silx/gui/plot/tools/test/testTools.py
@@ -29,8 +29,9 @@ __license__ = "MIT"
 __date__ = "02/03/2018"
 
 
-import numpy
+import functools
 import unittest
+import numpy
 
 from silx.utils.testutils import TestLogging
 from silx.gui.test.utils import qWaitForWindowExposedAndActivate
@@ -131,6 +132,21 @@ class TestPositionInfo(PlotWidgetTestCase):
             plot=self.plot,
             converters=[('Exception', raiseException)])
         self._test(positionWidget, ['Exception'], error=2)
+
+    def testUpdate(self):
+        """Test :meth:`PositionInfo.updateInfo`"""
+        calls = []
+
+        def update(calls, x, y):  # Get number of calls
+            calls.append((x, y))
+            return len(calls)
+
+        positionWidget = tools.PositionInfo(
+            plot=self.plot,
+            converters=[('Call count', functools.partial(update, calls))])
+
+        positionWidget.updateInfo()
+        self.assertEqual(len(calls), 1)
 
 
 class TestPlotToolsToolbars(PlotWidgetTestCase):


### PR DESCRIPTION
Merge #1902 first.

This PR adds an `updateInfo` method to `PositionInfo` widget and makes use of it in `Plot2D` to update the displayed info when the active image changes.

closes #1682

While it would be worth to refactor/improve the `PositionInfo` widget, this PR only fixes the active image update issue.