### PR TITLE
Clear silx view

### DIFF
--- a/silx/app/view/Viewer.py
+++ b/silx/app/view/Viewer.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "05/06/2018"
+__date__ = "11/06/2018"
 
 
 import os
@@ -252,6 +252,12 @@ class Viewer(qt.QMainWindow):
 
     def closeEvent(self, event):
         self.__context.saveSettings()
+
+        # Clean up as much as possible Python objects
+        model = self.__customNxdata.model()
+        model.clear()
+        model = self.__treeview.findHdf5TreeModel()
+        model.clear()
 
     def saveSettings(self, settings):
         """Save the window settings to this settings object

--- a/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/silx/gui/hdf5/Hdf5TreeModel.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "04/05/2018"
+__date__ = "11/06/2018"
 
 
 import os
@@ -689,6 +689,12 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         except IOError:
             _logger.debug("File '%s' can't be read.", filename, exc_info=True)
             raise
+
+    def clear(self):
+        """Remove all the content of the model"""
+        for _ in range(self.rowCount()):
+            qindex = self.index(0, 0, qt.QModelIndex())
+            self.removeIndex(qindex)
 
     def appendFile(self, filename):
         self.insertFile(filename, -1)


### PR DESCRIPTION
The PR clear the models when closing silx view.

This avoid to trust Python for releasing objects, which can introduce unpredictable behaviors.

Relative to https://github.com/silx-kit/fabio/issues/220