### PR TITLE
Improve scatter profile test and scatter profile thread life-cycle

### DIFF
--- a/silx/gui/plot/tools/profile/ScatterProfileToolBar.py
+++ b/silx/gui/plot/tools/profile/ScatterProfileToolBar.py
@@ -153,7 +153,7 @@ class _InterpolatorInitThread(qt.QThread):
                         _logger.info("Interpolator initialised in %f s",
                                      time.time() - startTime)
 
-                        # Wrapinterpolator to have same API as scipy's one
+                        # Wrap interpolator to have same API as scipy's one
                         def wrapper(points):
                             return interpolator(*points.T)
 

--- a/silx/gui/plot/tools/profile/ScatterProfileToolBar.py
+++ b/silx/gui/plot/tools/profile/ScatterProfileToolBar.py
@@ -344,6 +344,9 @@ class ScatterProfileToolBar(_BaseProfileToolBar):
         self.__interpolatorCache = None if interpolator is None else data
         self.updateProfile()
 
+    def hasPendingOperations(self):
+        return self.__initThread.isRunning()
+
     # Number of points
 
     def getNPoints(self):
@@ -376,7 +379,7 @@ class ScatterProfileToolBar(_BaseProfileToolBar):
         :return: Title to use
         :rtype: str
         """
-        if self.__initThread.isRunning():
+        if self.hasPendingOperations():
             return 'Pre-processing data...'
 
         else:

--- a/silx/gui/plot/tools/test/testScatterProfileToolBar.py
+++ b/silx/gui/plot/tools/test/testScatterProfileToolBar.py
@@ -96,7 +96,7 @@ class TestScatterProfileToolBar(TestCaseQt, ParametricTestCase):
         # Wait for async interpolator init
         for i in range(10):
             self.qWait(200)
-            if self.profile.getProfileValues(copy=False) is not None:
+            if not self.profile.hasPendingOperations():
                 break
 
         self.assertIsNotNone(self.profile.getProfileValues())
@@ -141,7 +141,7 @@ class TestScatterProfileToolBar(TestCaseQt, ParametricTestCase):
         # Wait for async interpolator init
         for i in range(10):
             self.qWait(200)
-            if self.profile.getProfileValues(copy=False) is not None:
+            if not self.profile.hasPendingOperations():
                 break
 
         self.assertIsNotNone(self.profile.getProfileValues())
@@ -191,7 +191,7 @@ class TestScatterProfileToolBar(TestCaseQt, ParametricTestCase):
         # Wait for async interpolator init
         for i in range(10):
             self.qWait(200)
-            if self.profile.getProfileValues(copy=False) is not None:
+            if not self.profile.hasPendingOperations():
                 break
 
         self.assertIsNotNone(self.profile.getProfileValues())

--- a/silx/gui/plot/tools/test/testScatterProfileToolBar.py
+++ b/silx/gui/plot/tools/test/testScatterProfileToolBar.py
@@ -59,15 +59,9 @@ class TestScatterProfileToolBar(TestCaseQt, ParametricTestCase):
         del self.plot
         super(TestScatterProfileToolBar, self).tearDown()
 
-    def test(self):
-        """Test ScatterProfileToolBar"""
+    def testNoProfile(self):
+        """Test ScatterProfileToolBar without profile"""
         self.assertEqual(self.profile.getPlotWidget(), self.plot)
-
-        roiManager = weakref.proxy(self.profile._getRoiManager())
-
-        nPoints = 8
-        self.profile.setNPoints(nPoints)
-        self.assertEqual(self.profile.getNPoints(), nPoints)
 
         # Add a scatter plot
         self.plot.addScatter(
@@ -79,14 +73,26 @@ class TestScatterProfileToolBar(TestCaseQt, ParametricTestCase):
         self.assertIsNone(self.profile.getProfileValues())
         self.assertIsNone(self.profile.getProfilePoints())
 
+    def testHorizontalProfile(self):
+        """Test ScatterProfileToolBar horizontal profile"""
+        nPoints = 8
+        self.profile.setNPoints(nPoints)
+        self.assertEqual(self.profile.getNPoints(), nPoints)
+
+        # Add a scatter plot
+        self.plot.addScatter(
+            x=(0., 1., 1., 0.), y=(0., 0., 1., 1.), value=(0., 1., 2., 3.))
+        self.plot.resetZoom(dataMargins=(.1, .1, .1, .1))
+        self.qapp.processEvents()
+
         # Activate Horizontal profile
         hlineAction = self.profile.actions()[0]
         hlineAction.trigger()
         self.qapp.processEvents()
 
         # Set a ROI profile
-        roiManager.createRegionOfInterest(kind='hline',
-                                          points=((0., 0.5), (0., 0.5)))
+        self.profile._getRoiManager().createRegionOfInterest(
+            kind='hline', points=((0., 0.5), (0., 0.5)))
         # Wait for async interpolator init
         for i in range(10):
             self.qWait(200)
@@ -111,14 +117,27 @@ class TestScatterProfileToolBar(TestCaseQt, ParametricTestCase):
         self.assertIsNone(self.profile.getProfilePoints())
         self.assertEqual(self.profile.getProfileTitle(), '')
 
+    def testVerticalProfile(self):
+        """Test ScatterProfileToolBar vertical profile"""
+        nPoints = 8
+        self.profile.setNPoints(nPoints)
+        self.assertEqual(self.profile.getNPoints(), nPoints)
+
+        # Add a scatter plot
+        self.plot.addScatter(
+            x=(0., 1., 1., 0.), y=(0., 0., 1., 1.), value=(0., 1., 2., 3.))
+        self.plot.resetZoom(dataMargins=(.1, .1, .1, .1))
+        self.qapp.processEvents()
+
         # Activate vertical profile
         vlineAction = self.profile.actions()[1]
         vlineAction.trigger()
         self.qapp.processEvents()
 
         # Set a ROI profile
-        roiManager.createRegionOfInterest(kind='vline',
-                                          points=((0.5, 0.), (0.5, 1.)))
+        self.profile._getRoiManager().createRegionOfInterest(
+            kind='vline', points=((0.5, 0.), (0.5, 1.)))
+
         # Wait for async interpolator init
         for i in range(10):
             self.qWait(200)
@@ -144,8 +163,15 @@ class TestScatterProfileToolBar(TestCaseQt, ParametricTestCase):
 
         # Clear the plot
         self.plot.clear()
+        self.qapp.processEvents()
         self.assertIsNone(self.profile.getProfileValues())
         self.assertIsNone(self.profile.getProfilePoints())
+
+    def testLineProfile(self):
+        """Test ScatterProfileToolBar line profile"""
+        nPoints = 8
+        self.profile.setNPoints(nPoints)
+        self.assertEqual(self.profile.getNPoints(), nPoints)
 
         # Activate line profile
         lineAction = self.profile.actions()[2]
@@ -159,8 +185,9 @@ class TestScatterProfileToolBar(TestCaseQt, ParametricTestCase):
         self.qapp.processEvents()
 
         # Set a ROI profile
-        roiManager.createRegionOfInterest(kind='line',
-                                          points=((0., 0.), (1., 1.)))
+        self.profile._getRoiManager().createRegionOfInterest(
+            kind='line', points=((0., 0.), (1., 1.)))
+
         # Wait for async interpolator init
         for i in range(10):
             self.qWait(200)

--- a/silx/gui/plot/tools/test/testScatterProfileToolBar.py
+++ b/silx/gui/plot/tools/test/testScatterProfileToolBar.py
@@ -65,7 +65,7 @@ class TestScatterProfileToolBar(TestCaseQt, ParametricTestCase):
 
         roiManager = weakref.proxy(self.profile._getRoiManager())
 
-        nPoints = 128
+        nPoints = 8
         self.profile.setNPoints(nPoints)
         self.assertEqual(self.profile.getNPoints(), nPoints)
 
@@ -87,7 +87,11 @@ class TestScatterProfileToolBar(TestCaseQt, ParametricTestCase):
         # Set a ROI profile
         roiManager.createRegionOfInterest(kind='hline',
                                           points=((0., 0.5), (0., 0.5)))
-        self.qWait(200)  # Wait for async interpolator init
+        # Wait for async interpolator init
+        for i in range(10):
+            self.qWait(200)
+            if self.profile.getProfileValues(copy=False) is not None:
+                break
 
         self.assertIsNotNone(self.profile.getProfileValues())
         points = self.profile.getProfilePoints()
@@ -115,7 +119,11 @@ class TestScatterProfileToolBar(TestCaseQt, ParametricTestCase):
         # Set a ROI profile
         roiManager.createRegionOfInterest(kind='vline',
                                           points=((0.5, 0.), (0.5, 1.)))
-        self.qWait(200)  # Wait for async init of interpolator
+        # Wait for async interpolator init
+        for i in range(10):
+            self.qWait(200)
+            if self.profile.getProfileValues(copy=False) is not None:
+                break
 
         self.assertIsNotNone(self.profile.getProfileValues())
         points = self.profile.getProfilePoints()
@@ -153,7 +161,11 @@ class TestScatterProfileToolBar(TestCaseQt, ParametricTestCase):
         # Set a ROI profile
         roiManager.createRegionOfInterest(kind='line',
                                           points=((0., 0.), (1., 1.)))
-        self.qWait(200)  # Wait for async interpolator init
+        # Wait for async interpolator init
+        for i in range(10):
+            self.qWait(200)
+            if self.profile.getProfileValues(copy=False) is not None:
+                break
 
         self.assertIsNotNone(self.profile.getProfileValues())
         points = self.profile.getProfilePoints()


### PR DESCRIPTION
This PR:
- Extend the time to wait for asynchronous profile interpolator init
- Split scatter plot tests into different functions