### PR TITLE
[plot] Refactor PositionInfo widget snapping mode

### DIFF
--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -259,7 +259,13 @@ class PlotWindow(PlotWidget):
                     converters = None
                 self._positionWidget = tools.PositionInfo(
                     plot=self, converters=converters)
-                self._positionWidget.autoSnapToActiveCurve = True
+                # Set a snapping mode that is consistent with legacy one
+                self._positionWidget.setSnappingMode(
+                    tools.PositionInfo.SNAPPING_CROSSHAIR |
+                    tools.PositionInfo.SNAPPING_ACTIVE_ONLY |
+                    tools.PositionInfo.SNAPPING_SYMBOLS_ONLY |
+                    tools.PositionInfo.SNAPPING_CURVE |
+                    tools.PositionInfo.SNAPPING_SCATTER)
 
                 hbox.addWidget(self._positionWidget)
 

--- a/silx/gui/plot/ScatterView.py
+++ b/silx/gui/plot/ScatterView.py
@@ -214,6 +214,13 @@ class ScatterView(qt.QMainWindow):
         """
         return self._plot()
 
+    def getPositionInfoWidget(self):
+        """Returns the widget display mouse coordinates information.
+
+        :rtype: ~silx.gui.plot.tools.PositionInfo
+        """
+        return self._positionInfo
+
     def getMaskToolsWidget(self):
         """Returns the widget controlling mask drawing
 

--- a/silx/gui/plot/tools/PositionInfo.py
+++ b/silx/gui/plot/tools/PositionInfo.py
@@ -221,7 +221,10 @@ class PositionInfo(qt.QWidget):
             if qt.BINDING in ('PyQt5', 'PySide2'):
                 window = plot.window()
                 windowHandle = window.windowHandle()
-                ratio = windowHandle.devicePixelRatio()
+                if windowHandle is not None:
+                    ratio = windowHandle.devicePixelRatio()
+                else:
+                    ratio = qt.QGuiApplication.primaryScreen().devicePixelRatio()
             else:
                 ratio = 1.
 

--- a/silx/gui/plot/tools/PositionInfo.py
+++ b/silx/gui/plot/tools/PositionInfo.py
@@ -307,13 +307,6 @@ class PositionInfo(qt.QWidget):
     SNAPPING_SCATTER = 1 << 4
     """Snapping on scatter"""
 
-    SNAPPING_DEFAULT = (SNAPPING_CROSSHAIR |
-                        SNAPPING_ACTIVE_ONLY |
-                        SNAPPING_SYMBOLS_ONLY |
-                        SNAPPING_CURVE |
-                        SNAPPING_SCATTER)
-    """Default snapping mode"""
-
     def setSnappingMode(self, mode):
         """Set the snapping mode.
 
@@ -332,13 +325,20 @@ class PositionInfo(qt.QWidget):
         """
         return self._snappingMode
 
+    _SNAPPING_LEGACY = (SNAPPING_CROSSHAIR |
+                        SNAPPING_ACTIVE_ONLY |
+                        SNAPPING_SYMBOLS_ONLY |
+                        SNAPPING_CURVE |
+                        SNAPPING_SCATTER)
+    """Legacy snapping mode"""
+
     @property
     @deprecated(replacement="getSnappingMode", since_version="0.8")
     def autoSnapToActiveCurve(self):
-        return self.getSnappingMode() == self.SNAPPING_DEFAULT
+        return self.getSnappingMode() == self._SNAPPING_LEGACY
 
     @autoSnapToActiveCurve.setter
     @deprecated(replacement="setSnappingMode", since_version="0.8")
     def autoSnapToActiveCurve(self, flag):
         self.setSnappingMode(
-            self.SNAPPING_DEFAULT if flag else self.SNAPPING_DISABLED)
+            self._SNAPPING_LEGACY if flag else self.SNAPPING_DISABLED)


### PR DESCRIPTION
This PR allows a better control of the snapping of the position used by the `PositionInfo` widget through a `setSnappingMode` method.
It also adds support of snapping on scatter plots.
When used inside `PlotWindow`, it remains consistent with the previous automated snapping mode.

closes #1611