### PR TITLE
[plot] Scatter mask pencil

### DIFF
--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -614,7 +614,7 @@ class MaskToolsWidget(BaseMaskToolsWidget):
             # convert from plot to array coords
             col, row = (event['points'][-1] - self._origin) / self._scale
             col, row = int(col), int(row)
-            brushSize = self.pencilSpinBox.value()
+            brushSize = self._getPencilWidth()
 
             if self._lastPencilPos != (row, col):
                 if self._lastPencilPos is not None:

--- a/silx/gui/plot/ScatterMaskToolsWidget.py
+++ b/silx/gui/plot/ScatterMaskToolsWidget.py
@@ -443,6 +443,21 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
                 shape=self._data_scatter.getXData(copy=False).shape)
         self._mask.commit()
 
+    def _getPencilWidth(self):
+        """Returns the width of the pencil to use in data coordinates`
+
+        :rtype: float
+        """
+        width = super(ScatterMaskToolsWidget, self)._getPencilWidth()
+
+        if self._data_scatter is not None:
+            # Adjust brush size to data range
+            from ...math.combo import min_max
+            xMin, xMax = min_max(self._data_scatter.getXData(copy=False))
+            yMin, yMax = min_max(self._data_scatter.getYData(copy=False))
+            width *= 0.01 * max(xMax - xMin, yMax - yMin)
+        return width
+
     def _plotDrawEvent(self, event):
         """Handle draw events from the plot"""
         if (self._drawingMode is None or
@@ -479,7 +494,8 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
             doMask = self._isMasking()
             # convert from plot to array coords
             x, y = event['points'][-1]
-            brushSize = self.pencilSpinBox.value()
+
+            brushSize = self._getPencilWidth()
 
             if self._lastPencilPos != (y, x):
                 if self._lastPencilPos is not None:

--- a/silx/gui/plot/ScatterMaskToolsWidget.py
+++ b/silx/gui/plot/ScatterMaskToolsWidget.py
@@ -333,9 +333,14 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
             self._data_scatter = activeScatter
 
             # Adjust brush size to data range
-            xMin, xMax = min_max(self._data_scatter.getXData(copy=False))
-            yMin, yMax = min_max(self._data_scatter.getYData(copy=False))
-            self._data_extent = max(xMax - xMin, yMax - yMin)
+            xData = self._data_scatter.getXData(copy=False)
+            yData = self._data_scatter.getYData(copy=False)
+            if xData.size > 0 and yData.size > 0:
+                xMin, xMax = min_max(xData)
+                yMin, yMax = min_max(yData)
+                self._data_extent = max(xMax - xMin, yMax - yMin)
+            else:
+                self._data_extent = None
 
             self._mask.setDataItem(self._data_scatter)
             if self._data_scatter.getXData(copy=False).shape != self._mask.getMask(copy=False).shape:

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -976,13 +976,20 @@ class BaseMaskToolsWidget(qt.QWidget):
         self.plot.setInteractiveMode('draw', shape='polygon', source=self, color=color)
         self._updateDrawingModeWidgets()
 
+    def _getPencilWidth(self):
+        """Returns the width of the pencil to use in data coordinates`
+
+        :rtype: float
+        """
+        return self.pencilSpinBox.value()
+
     def _activePencilMode(self):
         """Handle pencil action mode triggering"""
         self._releaseDrawingMode()
         self._drawingMode = 'pencil'
         self.plot.sigPlotSignal.connect(self._plotDrawEvent)
         color = self.getCurrentMaskColor()
-        width = self.pencilSpinBox.value()
+        width = self._getPencilWidth()
         self.plot.setInteractiveMode(
             'draw', shape='pencil', source=self, color=color, width=width)
         self._updateDrawingModeWidgets()


### PR DESCRIPTION
This PR makes the scatter mask tool pencil size relative to the extent of the scatter data.
This makes this tool more usable with scatter plots of different data range

related to #1796

To me, this is a temporary solution for the 0.8 release. The ideal solution is that the pencil shape is defined in screen coordinates rather than in data coordinates.

