### PR TITLE
Use previous stable PyQt5 with Appveyor

### DIFF
--- a/ci/requirements-pinned.txt
+++ b/ci/requirements-pinned.txt
@@ -1,1 +1,2 @@
 unittest2; python_version == '2.7'  # Needed for h5py 2.8.0rc1 on python2
+PyQt5 == 5.9.2


### PR DESCRIPTION
Test Appveyor with the previous PyQt5, just in case.