### PR TITLE
[convert]preserve dtype for file series

### DIFF
--- a/silx/io/convert.py
+++ b/silx/io/convert.py
@@ -223,6 +223,7 @@ class Hdf5Writer(object):
                     # write frame by frame to save memory usage low
                     ds = self._h5f.create_dataset(h5_name,
                                                   shape=obj.shape,
+                                                  dtype=obj.dtype,
                                                   **self.create_dataset_args)
                     for i, frame in enumerate(obj):
                         ds[i] = frame


### PR DESCRIPTION
Close #1976 

When initializing the output dataset prior to writing frames, the dtype must be specified.