### PR TITLE
Capture all warnings from the `warnings` module

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -76,7 +76,11 @@ def createBasicHandler():
 
 # Use an handler compatible with unittests, else use_buffer is not working
 logging.root.addHandler(createBasicHandler())
+
+# Capture all default warnings
 logging.captureWarnings(True)
+import warnings
+warnings.simplefilter('default')
 
 logger = logging.getLogger("run_tests")
 logger.setLevel(logging.WARNING)


### PR DESCRIPTION
Just a test.
If it's fine we could merge it.

Else this command is still working:
```
python -Wd ./run_tests.py
```
