### PR TITLE
[test] replace deprecated assertEquals by assertEqual

### DIFF
--- a/silx/gui/data/test/test_dataviewer.py
+++ b/silx/gui/data/test/test_dataviewer.py
@@ -183,7 +183,7 @@ class AbstractDataViewerTests(TestCaseQt):
         widget.dataChanged.connect(listener)
         widget.setData(10)
         widget.setData(None)
-        self.assertEquals(listener.callCount(), 2)
+        self.assertEqual(listener.callCount(), 2)
 
     def test_display_mode_event(self):
         listener = SignalListener()
@@ -192,7 +192,7 @@ class AbstractDataViewerTests(TestCaseQt):
         widget.setData(10)
         widget.setData(None)
         modes = [v.modeId() for v in listener.arguments(argumentIndex=0)]
-        self.assertEquals(modes, [DataViews.RAW_MODE, DataViews.EMPTY_MODE])
+        self.assertEqual(modes, [DataViews.RAW_MODE, DataViews.EMPTY_MODE])
         listener.clear()
 
     def test_change_display_mode(self):
@@ -201,13 +201,13 @@ class AbstractDataViewerTests(TestCaseQt):
         widget = self.create_widget()
         widget.setData(data)
         widget.setDisplayMode(DataViews.PLOT1D_MODE)
-        self.assertEquals(widget.displayedView().modeId(), DataViews.PLOT1D_MODE)
+        self.assertEqual(widget.displayedView().modeId(), DataViews.PLOT1D_MODE)
         widget.setDisplayMode(DataViews.IMAGE_MODE)
-        self.assertEquals(widget.displayedView().modeId(), DataViews.IMAGE_MODE)
+        self.assertEqual(widget.displayedView().modeId(), DataViews.IMAGE_MODE)
         widget.setDisplayMode(DataViews.RAW_MODE)
-        self.assertEquals(widget.displayedView().modeId(), DataViews.RAW_MODE)
+        self.assertEqual(widget.displayedView().modeId(), DataViews.RAW_MODE)
         widget.setDisplayMode(DataViews.EMPTY_MODE)
-        self.assertEquals(widget.displayedView().modeId(), DataViews.EMPTY_MODE)
+        self.assertEqual(widget.displayedView().modeId(), DataViews.EMPTY_MODE)
 
     def test_create_default_views(self):
         widget = self.create_widget()

--- a/silx/gui/data/test/test_textformatter.py
+++ b/silx/gui/data/test/test_textformatter.py
@@ -49,10 +49,10 @@ class TestTextFormatter(TestCaseQt):
         copy = TextFormatter(formatter=formatter)
         self.assertIsNot(formatter, copy)
         copy.setFloatFormat("%.3f")
-        self.assertEquals(formatter.integerFormat(), copy.integerFormat())
+        self.assertEqual(formatter.integerFormat(), copy.integerFormat())
         self.assertNotEquals(formatter.floatFormat(), copy.floatFormat())
-        self.assertEquals(formatter.useQuoteForText(), copy.useQuoteForText())
-        self.assertEquals(formatter.imaginaryUnit(), copy.imaginaryUnit())
+        self.assertEqual(formatter.useQuoteForText(), copy.useQuoteForText())
+        self.assertEqual(formatter.imaginaryUnit(), copy.imaginaryUnit())
 
     def test_event(self):
         listener = SignalListener()
@@ -62,19 +62,19 @@ class TestTextFormatter(TestCaseQt):
         formatter.setIntegerFormat("%03i")
         formatter.setUseQuoteForText(False)
         formatter.setImaginaryUnit("z")
-        self.assertEquals(listener.callCount(), 4)
+        self.assertEqual(listener.callCount(), 4)
 
     def test_int(self):
         formatter = TextFormatter()
         formatter.setIntegerFormat("%05i")
         result = formatter.toString(512)
-        self.assertEquals(result, "00512")
+        self.assertEqual(result, "00512")
 
     def test_float(self):
         formatter = TextFormatter()
         formatter.setFloatFormat("%.3f")
         result = formatter.toString(1.3)
-        self.assertEquals(result, "1.300")
+        self.assertEqual(result, "1.300")
 
     def test_complex(self):
         formatter = TextFormatter()
@@ -82,25 +82,25 @@ class TestTextFormatter(TestCaseQt):
         formatter.setImaginaryUnit("i")
         result = formatter.toString(1.0 + 5j)
         result = result.replace(" ", "")
-        self.assertEquals(result, "1.0+5.0i")
+        self.assertEqual(result, "1.0+5.0i")
 
     def test_string(self):
         formatter = TextFormatter()
         formatter.setIntegerFormat("%.1f")
         formatter.setImaginaryUnit("z")
         result = formatter.toString("toto")
-        self.assertEquals(result, '"toto"')
+        self.assertEqual(result, '"toto"')
 
     def test_numpy_void(self):
         formatter = TextFormatter()
         result = formatter.toString(numpy.void(b"\xFF"))
-        self.assertEquals(result, 'b"\\xFF"')
+        self.assertEqual(result, 'b"\\xFF"')
 
     def test_char_cp1252(self):
         # degree character in cp1252
         formatter = TextFormatter()
         result = formatter.toString(numpy.bytes_(b"\xB0"))
-        self.assertEquals(result, u'"\u00B0"')
+        self.assertEqual(result, u'"\u00B0"')
 
 
 class TestTextFormatterWithH5py(TestCaseQt):
@@ -130,74 +130,74 @@ class TestTextFormatterWithH5py(TestCaseQt):
     def testAscii(self):
         d = self.create_dataset(data=b"abc")
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, '"abc"')
+        self.assertEqual(result, '"abc"')
 
     def testUnicode(self):
         d = self.create_dataset(data=u"i\u2661cookies")
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(len(result), 11)
-        self.assertEquals(result, u'"i\u2661cookies"')
+        self.assertEqual(len(result), 11)
+        self.assertEqual(result, u'"i\u2661cookies"')
 
     def testBadAscii(self):
         d = self.create_dataset(data=b"\xF0\x9F\x92\x94")
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, 'b"\\xF0\\x9F\\x92\\x94"')
+        self.assertEqual(result, 'b"\\xF0\\x9F\\x92\\x94"')
 
     def testVoid(self):
         d = self.create_dataset(data=numpy.void(b"abc\xF0"))
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, 'b"\\x61\\x62\\x63\\xF0"')
+        self.assertEqual(result, 'b"\\x61\\x62\\x63\\xF0"')
 
     def testEnum(self):
         dtype = h5py.special_dtype(enum=('i', {"RED": 0, "GREEN": 1, "BLUE": 42}))
         d = numpy.array(42, dtype=dtype)
         d = self.create_dataset(data=d)
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, 'BLUE(42)')
+        self.assertEqual(result, 'BLUE(42)')
 
     def testRef(self):
         dtype = h5py.special_dtype(ref=h5py.Reference)
         d = numpy.array(self.h5File.ref, dtype=dtype)
         d = self.create_dataset(data=d)
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, 'REF')
+        self.assertEqual(result, 'REF')
 
     def testArrayAscii(self):
         d = self.create_dataset(data=[b"abc"])
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, '["abc"]')
+        self.assertEqual(result, '["abc"]')
 
     def testArrayUnicode(self):
         dtype = h5py.special_dtype(vlen=six.text_type)
         d = numpy.array([u"i\u2661cookies"], dtype=dtype)
         d = self.create_dataset(data=d)
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(len(result), 13)
-        self.assertEquals(result, u'["i\u2661cookies"]')
+        self.assertEqual(len(result), 13)
+        self.assertEqual(result, u'["i\u2661cookies"]')
 
     def testArrayBadAscii(self):
         d = self.create_dataset(data=[b"\xF0\x9F\x92\x94"])
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, '[b"\\xF0\\x9F\\x92\\x94"]')
+        self.assertEqual(result, '[b"\\xF0\\x9F\\x92\\x94"]')
 
     def testArrayVoid(self):
         d = self.create_dataset(data=numpy.void([b"abc\xF0"]))
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, '[b"\\x61\\x62\\x63\\xF0"]')
+        self.assertEqual(result, '[b"\\x61\\x62\\x63\\xF0"]')
 
     def testArrayEnum(self):
         dtype = h5py.special_dtype(enum=('i', {"RED": 0, "GREEN": 1, "BLUE": 42}))
         d = numpy.array([42, 1, 100], dtype=dtype)
         d = self.create_dataset(data=d)
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, '[BLUE(42) GREEN(1) 100]')
+        self.assertEqual(result, '[BLUE(42) GREEN(1) 100]')
 
     def testArrayRef(self):
         dtype = h5py.special_dtype(ref=h5py.Reference)
         d = numpy.array([self.h5File.ref, None], dtype=dtype)
         d = self.create_dataset(data=d)
         result = self.formatter.toString(d[()], dtype=d.dtype)
-        self.assertEquals(result, '[REF NULL_REF]')
+        self.assertEqual(result, '[REF NULL_REF]')
 
 
 def suite():

--- a/silx/gui/dialog/test/test_datafiledialog.py
+++ b/silx/gui/dialog/test/test_datafiledialog.py
@@ -120,7 +120,7 @@ class _UtilsMixin(object):
         path2_ = os.path.normcase(path2)
         if path1_ != path2_:
             # Use the unittest API to log and display error
-            self.assertEquals(path1, path2)
+            self.assertEqual(path1, path2)
 
     def assertNotSamePath(self, path1, path2):
         path1_ = os.path.normcase(path1)
@@ -144,7 +144,7 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
 
         self.keyClick(dialog, qt.Qt.Key_Escape)
         self.assertFalse(dialog.isVisible())
-        self.assertEquals(dialog.result(), qt.QDialog.Rejected)
+        self.assertEqual(dialog.result(), qt.QDialog.Rejected)
 
     def testDisplayAndClickCancel(self):
         dialog = self.createDialog()
@@ -156,7 +156,7 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         self.mouseClick(button, qt.Qt.LeftButton)
         self.assertFalse(dialog.isVisible())
         self.assertFalse(dialog.isVisible())
-        self.assertEquals(dialog.result(), qt.QDialog.Rejected)
+        self.assertEqual(dialog.result(), qt.QDialog.Rejected)
 
     def testDisplayAndClickLockedOpen(self):
         dialog = self.createDialog()
@@ -168,7 +168,7 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         self.mouseClick(button, qt.Qt.LeftButton)
         # open button locked, dialog is not closed
         self.assertTrue(dialog.isVisible())
-        self.assertEquals(dialog.result(), qt.QDialog.Rejected)
+        self.assertEqual(dialog.result(), qt.QDialog.Rejected)
 
     def testSelectRoot_Activate(self):
         if fabio is None:
@@ -194,7 +194,7 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         url = silx.io.url.DataUrl(dialog.selectedUrl())
         self.assertTrue(url.data_path() is not None)
         self.assertFalse(dialog.isVisible())
-        self.assertEquals(dialog.result(), qt.QDialog.Accepted)
+        self.assertEqual(dialog.result(), qt.QDialog.Accepted)
 
     def testSelectGroup_Activate(self):
         if fabio is None:
@@ -226,7 +226,7 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         url = silx.io.url.DataUrl(dialog.selectedUrl())
         self.assertEqual(url.data_path(), "/group")
         self.assertFalse(dialog.isVisible())
-        self.assertEquals(dialog.result(), qt.QDialog.Accepted)
+        self.assertEqual(dialog.result(), qt.QDialog.Accepted)
 
     def testSelectDataset_Activate(self):
         if fabio is None:
@@ -258,7 +258,7 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         url = silx.io.url.DataUrl(dialog.selectedUrl())
         self.assertEqual(url.data_path(), "/scalar")
         self.assertFalse(dialog.isVisible())
-        self.assertEquals(dialog.result(), qt.QDialog.Accepted)
+        self.assertEqual(dialog.result(), qt.QDialog.Accepted)
 
     def testClickOnBackToParentTool(self):
         if h5py is None:
@@ -600,7 +600,7 @@ class TestDataFileDialog_FilterDataset(utils.TestCaseQt, _UtilsMixin):
         url = silx.io.url.DataUrl(dialog.selectedUrl())
         self.assertEqual(url.data_path(), "/scalar")
         self.assertFalse(dialog.isVisible())
-        self.assertEquals(dialog.result(), qt.QDialog.Accepted)
+        self.assertEqual(dialog.result(), qt.QDialog.Accepted)
 
         data = dialog.selectedData()
         self.assertEqual(data, 10)
@@ -647,7 +647,7 @@ class TestDataFileDialog_FilterGroup(utils.TestCaseQt, _UtilsMixin):
         url = silx.io.url.DataUrl(dialog.selectedUrl())
         self.assertEqual(url.data_path(), "/group")
         self.assertFalse(dialog.isVisible())
-        self.assertEquals(dialog.result(), qt.QDialog.Accepted)
+        self.assertEqual(dialog.result(), qt.QDialog.Accepted)
 
         self.assertRaises(Exception, dialog.selectedData)
 
@@ -755,7 +755,7 @@ class TestDataFileDialog_FilterNXdata(utils.TestCaseQt, _UtilsMixin):
         url = silx.io.url.DataUrl(dialog.selectedUrl())
         self.assertEqual(url.data_path(), "/nxdata")
         self.assertFalse(dialog.isVisible())
-        self.assertEquals(dialog.result(), qt.QDialog.Accepted)
+        self.assertEqual(dialog.result(), qt.QDialog.Accepted)
 
 
 class TestDataFileDialogApi(utils.TestCaseQt, _UtilsMixin):

--- a/silx/gui/dialog/test/test_imagefiledialog.py
+++ b/silx/gui/dialog/test/test_imagefiledialog.py
@@ -129,7 +129,7 @@ class _UtilsMixin(object):
         path2_ = os.path.normcase(path2)
         if path1_ != path2_:
             # Use the unittest API to log and display error
-            self.assertEquals(path1, path2)
+            self.assertEqual(path1, path2)
 
     def assertNotSamePath(self, path1, path2):
         path1_ = os.path.normcase(path1)
@@ -153,7 +153,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
 
         self.keyClick(dialog, qt.Qt.Key_Escape)
         self.assertFalse(dialog.isVisible())
-        self.assertEquals(dialog.result(), qt.QDialog.Rejected)
+        self.assertEqual(dialog.result(), qt.QDialog.Rejected)
 
     def testDisplayAndClickCancel(self):
         dialog = self.createDialog()
@@ -165,7 +165,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         self.mouseClick(button, qt.Qt.LeftButton)
         self.assertFalse(dialog.isVisible())
         self.assertFalse(dialog.isVisible())
-        self.assertEquals(dialog.result(), qt.QDialog.Rejected)
+        self.assertEqual(dialog.result(), qt.QDialog.Rejected)
 
     def testDisplayAndClickLockedOpen(self):
         dialog = self.createDialog()
@@ -177,7 +177,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         self.mouseClick(button, qt.Qt.LeftButton)
         # open button locked, dialog is not closed
         self.assertTrue(dialog.isVisible())
-        self.assertEquals(dialog.result(), qt.QDialog.Rejected)
+        self.assertEqual(dialog.result(), qt.QDialog.Rejected)
 
     def testDisplayAndClickOpen(self):
         if fabio is None:
@@ -194,7 +194,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         self.assertTrue(button.isEnabled())
         self.mouseClick(button, qt.Qt.LeftButton)
         self.assertFalse(dialog.isVisible())
-        self.assertEquals(dialog.result(), qt.QDialog.Accepted)
+        self.assertEqual(dialog.result(), qt.QDialog.Accepted)
 
     def testClickOnShortcut(self):
         dialog = self.createDialog()

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -123,9 +123,9 @@ class TestHdf5TreeModel(TestCaseQt):
     def testAppendFilename(self):
         filename = _tmpDirectory + "/data.h5"
         model = hdf5.Hdf5TreeModel()
-        self.assertEquals(model.rowCount(qt.QModelIndex()), 0)
+        self.assertEqual(model.rowCount(qt.QModelIndex()), 0)
         model.appendFile(filename)
-        self.assertEquals(model.rowCount(qt.QModelIndex()), 1)
+        self.assertEqual(model.rowCount(qt.QModelIndex()), 1)
         # clean up
         index = model.index(0, 0, qt.QModelIndex())
         h5File = model.data(index, hdf5.Hdf5TreeModel.H5PY_OBJECT_ROLE)
@@ -141,9 +141,9 @@ class TestHdf5TreeModel(TestCaseQt):
         filename = _tmpDirectory + "/data.h5"
         try:
             model = hdf5.Hdf5TreeModel()
-            self.assertEquals(model.rowCount(qt.QModelIndex()), 0)
+            self.assertEqual(model.rowCount(qt.QModelIndex()), 0)
             model.insertFile(filename)
-            self.assertEquals(model.rowCount(qt.QModelIndex()), 1)
+            self.assertEqual(model.rowCount(qt.QModelIndex()), 1)
             # clean up
             index = model.index(0, 0, qt.QModelIndex())
             h5File = model.data(index, hdf5.Hdf5TreeModel.H5PY_OBJECT_ROLE)
@@ -157,7 +157,7 @@ class TestHdf5TreeModel(TestCaseQt):
         filename = _tmpDirectory + "/data.h5"
         try:
             model = hdf5.Hdf5TreeModel()
-            self.assertEquals(model.rowCount(qt.QModelIndex()), 0)
+            self.assertEqual(model.rowCount(qt.QModelIndex()), 0)
             model.insertFileAsync(filename)
             index = model.index(0, 0, qt.QModelIndex())
             self.assertIsInstance(model.nodeFromIndex(index), hdf5.Hdf5LoadingItem.Hdf5LoadingItem)
@@ -172,25 +172,25 @@ class TestHdf5TreeModel(TestCaseQt):
     def testInsertObject(self):
         h5 = commonh5.File("/foo/bar/1.mock", "w")
         model = hdf5.Hdf5TreeModel()
-        self.assertEquals(model.rowCount(qt.QModelIndex()), 0)
+        self.assertEqual(model.rowCount(qt.QModelIndex()), 0)
         model.insertH5pyObject(h5)
-        self.assertEquals(model.rowCount(qt.QModelIndex()), 1)
+        self.assertEqual(model.rowCount(qt.QModelIndex()), 1)
 
     def testRemoveObject(self):
         h5 = commonh5.File("/foo/bar/1.mock", "w")
         model = hdf5.Hdf5TreeModel()
-        self.assertEquals(model.rowCount(qt.QModelIndex()), 0)
+        self.assertEqual(model.rowCount(qt.QModelIndex()), 0)
         model.insertH5pyObject(h5)
-        self.assertEquals(model.rowCount(qt.QModelIndex()), 1)
+        self.assertEqual(model.rowCount(qt.QModelIndex()), 1)
         model.removeH5pyObject(h5)
-        self.assertEquals(model.rowCount(qt.QModelIndex()), 0)
+        self.assertEqual(model.rowCount(qt.QModelIndex()), 0)
 
     def testSynchronizeObject(self):
         filename = _tmpDirectory + "/data.h5"
         h5 = h5py.File(filename)
         model = hdf5.Hdf5TreeModel()
         model.insertH5pyObject(h5)
-        self.assertEquals(model.rowCount(qt.QModelIndex()), 1)
+        self.assertEqual(model.rowCount(qt.QModelIndex()), 1)
         index = model.index(0, 0, qt.QModelIndex())
         node1 = model.nodeFromIndex(index)
         model.synchronizeH5pyObject(h5)
@@ -220,15 +220,15 @@ class TestHdf5TreeModel(TestCaseQt):
 
     def testFileMoveState(self):
         model = hdf5.Hdf5TreeModel()
-        self.assertEquals(model.isFileMoveEnabled(), True)
+        self.assertEqual(model.isFileMoveEnabled(), True)
         model.setFileMoveEnabled(False)
-        self.assertEquals(model.isFileMoveEnabled(), False)
+        self.assertEqual(model.isFileMoveEnabled(), False)
 
     def testFileDropState(self):
         model = hdf5.Hdf5TreeModel()
-        self.assertEquals(model.isFileDropEnabled(), True)
+        self.assertEqual(model.isFileDropEnabled(), True)
         model.setFileDropEnabled(False)
-        self.assertEquals(model.isFileDropEnabled(), False)
+        self.assertEqual(model.isFileDropEnabled(), False)
 
     def testSupportedDrop(self):
         model = hdf5.Hdf5TreeModel()
@@ -236,7 +236,7 @@ class TestHdf5TreeModel(TestCaseQt):
 
         model.setFileMoveEnabled(False)
         model.setFileDropEnabled(False)
-        self.assertEquals(model.supportedDropActions(), 0)
+        self.assertEqual(model.supportedDropActions(), 0)
 
         model.setFileMoveEnabled(False)
         model.setFileDropEnabled(True)
@@ -252,7 +252,7 @@ class TestHdf5TreeModel(TestCaseQt):
         mimeData = qt.QMimeData()
         mimeData.setUrls([qt.QUrl.fromLocalFile(filename)])
         model.dropMimeData(mimeData, qt.Qt.CopyAction, 0, 0, qt.QModelIndex())
-        self.assertEquals(model.rowCount(qt.QModelIndex()), 1)
+        self.assertEqual(model.rowCount(qt.QModelIndex()), 1)
         # after sync
         self.waitForPendingOperations(model)
         index = model.index(0, 0, qt.QModelIndex())
@@ -285,13 +285,13 @@ class TestHdf5TreeModel(TestCaseQt):
         model = hdf5.Hdf5TreeModel()
         model.insertH5pyObject(h5)
         displayed = self.getRowDataAsDict(model, row=0)
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.NAME_COLUMN, qt.Qt.DisplayRole], "1.mock")
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.NAME_COLUMN, qt.Qt.DisplayRole], "1.mock")
         self.assertIsInstance(displayed[hdf5.Hdf5TreeModel.NAME_COLUMN, qt.Qt.DecorationRole], qt.QIcon)
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.TYPE_COLUMN, qt.Qt.DisplayRole], "")
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.SHAPE_COLUMN, qt.Qt.DisplayRole], "")
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.VALUE_COLUMN, qt.Qt.DisplayRole], "")
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.DESCRIPTION_COLUMN, qt.Qt.DisplayRole], "")
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.NODE_COLUMN, qt.Qt.DisplayRole], "File")
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.TYPE_COLUMN, qt.Qt.DisplayRole], "")
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.SHAPE_COLUMN, qt.Qt.DisplayRole], "")
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.VALUE_COLUMN, qt.Qt.DisplayRole], "")
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.DESCRIPTION_COLUMN, qt.Qt.DisplayRole], "")
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.NODE_COLUMN, qt.Qt.DisplayRole], "File")
 
     def testGroupData(self):
         h5 = commonh5.File("/foo/bar/1.mock", "w")
@@ -301,13 +301,13 @@ class TestHdf5TreeModel(TestCaseQt):
         model = hdf5.Hdf5TreeModel()
         model.insertH5pyObject(d)
         displayed = self.getRowDataAsDict(model, row=0)
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.NAME_COLUMN, qt.Qt.DisplayRole], "1.mock::foo")
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.NAME_COLUMN, qt.Qt.DisplayRole], "1.mock::foo")
         self.assertIsInstance(displayed[hdf5.Hdf5TreeModel.NAME_COLUMN, qt.Qt.DecorationRole], qt.QIcon)
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.TYPE_COLUMN, qt.Qt.DisplayRole], "")
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.SHAPE_COLUMN, qt.Qt.DisplayRole], "")
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.VALUE_COLUMN, qt.Qt.DisplayRole], "")
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.DESCRIPTION_COLUMN, qt.Qt.DisplayRole], "fooo")
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.NODE_COLUMN, qt.Qt.DisplayRole], "Group")
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.TYPE_COLUMN, qt.Qt.DisplayRole], "")
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.SHAPE_COLUMN, qt.Qt.DisplayRole], "")
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.VALUE_COLUMN, qt.Qt.DisplayRole], "")
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.DESCRIPTION_COLUMN, qt.Qt.DisplayRole], "fooo")
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.NODE_COLUMN, qt.Qt.DisplayRole], "Group")
 
     def testDatasetData(self):
         h5 = commonh5.File("/foo/bar/1.mock", "w")
@@ -317,13 +317,13 @@ class TestHdf5TreeModel(TestCaseQt):
         model = hdf5.Hdf5TreeModel()
         model.insertH5pyObject(d)
         displayed = self.getRowDataAsDict(model, row=0)
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.NAME_COLUMN, qt.Qt.DisplayRole], "1.mock::foo")
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.NAME_COLUMN, qt.Qt.DisplayRole], "1.mock::foo")
         self.assertIsInstance(displayed[hdf5.Hdf5TreeModel.NAME_COLUMN, qt.Qt.DecorationRole], qt.QIcon)
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.TYPE_COLUMN, qt.Qt.DisplayRole], value.dtype.name)
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.SHAPE_COLUMN, qt.Qt.DisplayRole], "3")
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.VALUE_COLUMN, qt.Qt.DisplayRole], "[1 2 3]")
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.DESCRIPTION_COLUMN, qt.Qt.DisplayRole], "")
-        self.assertEquals(displayed[hdf5.Hdf5TreeModel.NODE_COLUMN, qt.Qt.DisplayRole], "Dataset")
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.TYPE_COLUMN, qt.Qt.DisplayRole], value.dtype.name)
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.SHAPE_COLUMN, qt.Qt.DisplayRole], "3")
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.VALUE_COLUMN, qt.Qt.DisplayRole], "[1 2 3]")
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.DESCRIPTION_COLUMN, qt.Qt.DisplayRole], "")
+        self.assertEqual(displayed[hdf5.Hdf5TreeModel.NODE_COLUMN, qt.Qt.DisplayRole], "Dataset")
 
     def testDropLastAsFirst(self):
         model = hdf5.Hdf5TreeModel()
@@ -331,13 +331,13 @@ class TestHdf5TreeModel(TestCaseQt):
         h5_2 = commonh5.File("/foo/bar/2.mock", "w")
         model.insertH5pyObject(h5_1)
         model.insertH5pyObject(h5_2)
-        self.assertEquals(self.getItemName(model, 0), "1.mock")
-        self.assertEquals(self.getItemName(model, 1), "2.mock")
+        self.assertEqual(self.getItemName(model, 0), "1.mock")
+        self.assertEqual(self.getItemName(model, 1), "2.mock")
         index = model.index(1, 0, qt.QModelIndex())
         mimeData = model.mimeData([index])
         model.dropMimeData(mimeData, qt.Qt.MoveAction, 0, 0, qt.QModelIndex())
-        self.assertEquals(self.getItemName(model, 0), "2.mock")
-        self.assertEquals(self.getItemName(model, 1), "1.mock")
+        self.assertEqual(self.getItemName(model, 0), "2.mock")
+        self.assertEqual(self.getItemName(model, 1), "1.mock")
 
     def testDropFirstAsLast(self):
         model = hdf5.Hdf5TreeModel()
@@ -345,13 +345,13 @@ class TestHdf5TreeModel(TestCaseQt):
         h5_2 = commonh5.File("/foo/bar/2.mock", "w")
         model.insertH5pyObject(h5_1)
         model.insertH5pyObject(h5_2)
-        self.assertEquals(self.getItemName(model, 0), "1.mock")
-        self.assertEquals(self.getItemName(model, 1), "2.mock")
+        self.assertEqual(self.getItemName(model, 0), "1.mock")
+        self.assertEqual(self.getItemName(model, 1), "2.mock")
         index = model.index(0, 0, qt.QModelIndex())
         mimeData = model.mimeData([index])
         model.dropMimeData(mimeData, qt.Qt.MoveAction, 2, 0, qt.QModelIndex())
-        self.assertEquals(self.getItemName(model, 0), "2.mock")
-        self.assertEquals(self.getItemName(model, 1), "1.mock")
+        self.assertEqual(self.getItemName(model, 0), "2.mock")
+        self.assertEqual(self.getItemName(model, 1), "1.mock")
 
     def testRootParent(self):
         model = hdf5.Hdf5TreeModel()
@@ -359,7 +359,7 @@ class TestHdf5TreeModel(TestCaseQt):
         model.insertH5pyObject(h5_1)
         index = model.index(0, 0, qt.QModelIndex())
         index = model.parent(index)
-        self.assertEquals(index, qt.QModelIndex())
+        self.assertEqual(index, qt.QModelIndex())
 
 
 class TestHdf5TreeModelSignals(TestCaseQt):
@@ -397,27 +397,27 @@ class TestHdf5TreeModelSignals(TestCaseQt):
         filename = _tmpDirectory + "/data.h5"
         h5 = h5py.File(filename)
         self.model.insertH5pyObject(h5)
-        self.assertEquals(self.listener.callCount(), 0)
+        self.assertEqual(self.listener.callCount(), 0)
 
     def testLoaded(self):
         filename = _tmpDirectory + "/data.h5"
         self.model.insertFile(filename)
-        self.assertEquals(self.listener.callCount(), 1)
-        self.assertEquals(self.listener.karguments(argumentName="signal")[0], "loaded")
+        self.assertEqual(self.listener.callCount(), 1)
+        self.assertEqual(self.listener.karguments(argumentName="signal")[0], "loaded")
         self.assertIsNot(self.listener.arguments(callIndex=0)[0], self.h5)
-        self.assertEquals(self.listener.arguments(callIndex=0)[0].filename, filename)
+        self.assertEqual(self.listener.arguments(callIndex=0)[0].filename, filename)
 
     def testRemoved(self):
         self.model.removeH5pyObject(self.h5)
-        self.assertEquals(self.listener.callCount(), 1)
-        self.assertEquals(self.listener.karguments(argumentName="signal")[0], "removed")
+        self.assertEqual(self.listener.callCount(), 1)
+        self.assertEqual(self.listener.karguments(argumentName="signal")[0], "removed")
         self.assertIs(self.listener.arguments(callIndex=0)[0], self.h5)
 
     def testSynchonized(self):
         self.model.synchronizeH5pyObject(self.h5)
         self.waitForPendingOperations(self.model)
-        self.assertEquals(self.listener.callCount(), 1)
-        self.assertEquals(self.listener.karguments(argumentName="signal")[0], "synchronized")
+        self.assertEqual(self.listener.callCount(), 1)
+        self.assertEqual(self.listener.karguments(argumentName="signal")[0], "synchronized")
         self.assertIs(self.listener.arguments(callIndex=0)[0], self.h5)
         self.assertIsNot(self.listener.arguments(callIndex=0)[1], self.h5)
 
@@ -895,7 +895,7 @@ class TestHdf5TreeView(TestCaseQt):
         view.setSelectedH5Node(tree)
 
         selection = list(view.selectedH5Nodes())
-        self.assertEquals(len(selection), 0)
+        self.assertEqual(len(selection), 0)
 
     def testSelection_Tree(self):
         tree1 = commonh5.File("/foo/bar/1.mock", "w")

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -881,7 +881,7 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         self.plot.getYAxis(axis="right").sigLimitsChanged.connect(listener.partial(axis="y2"))
         self.plot.setLimits(0, 1, 0, 1, 0, 1)
         # at least one event per axis
-        self.assertEquals(len(set(listener.karguments(argumentName="axis"))), 3)
+        self.assertEqual(len(set(listener.karguments(argumentName="axis"))), 3)
 
     def testLimitsChanged_resetZoom(self):
         self.plot.addCurve(self.xData, self.yData,
@@ -894,7 +894,7 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         self.plot.getYAxis(axis="right").sigLimitsChanged.connect(listener.partial(axis="y2"))
         self.plot.resetZoom()
         # at least one event per axis
-        self.assertEquals(len(set(listener.karguments(argumentName="axis"))), 3)
+        self.assertEqual(len(set(listener.karguments(argumentName="axis"))), 3)
 
     def testLimitsChanged_setXLimit(self):
         self.plot.addCurve(self.xData, self.yData,
@@ -906,8 +906,8 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         axis.sigLimitsChanged.connect(listener)
         axis.setLimits(20, 30)
         # at least one event per axis
-        self.assertEquals(listener.arguments(callIndex=-1), (20.0, 30.0))
-        self.assertEquals(axis.getLimits(), (20.0, 30.0))
+        self.assertEqual(listener.arguments(callIndex=-1), (20.0, 30.0))
+        self.assertEqual(axis.getLimits(), (20.0, 30.0))
 
     def testLimitsChanged_setYLimit(self):
         self.plot.addCurve(self.xData, self.yData,
@@ -919,8 +919,8 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         axis.sigLimitsChanged.connect(listener)
         axis.setLimits(20, 30)
         # at least one event per axis
-        self.assertEquals(listener.arguments(callIndex=-1), (20.0, 30.0))
-        self.assertEquals(axis.getLimits(), (20.0, 30.0))
+        self.assertEqual(listener.arguments(callIndex=-1), (20.0, 30.0))
+        self.assertEqual(axis.getLimits(), (20.0, 30.0))
 
     def testLimitsChanged_setYRightLimit(self):
         self.plot.addCurve(self.xData, self.yData,
@@ -932,8 +932,8 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         axis.sigLimitsChanged.connect(listener)
         axis.setLimits(20, 30)
         # at least one event per axis
-        self.assertEquals(listener.arguments(callIndex=-1), (20.0, 30.0))
-        self.assertEquals(axis.getLimits(), (20.0, 30.0))
+        self.assertEqual(listener.arguments(callIndex=-1), (20.0, 30.0))
+        self.assertEqual(axis.getLimits(), (20.0, 30.0))
 
     def testScaleProxy(self):
         listener = SignalListener()
@@ -943,9 +943,9 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         yright.sigScaleChanged.connect(listener.partial("right"))
         yright.setScale(yright.LOGARITHMIC)
 
-        self.assertEquals(y.getScale(), y.LOGARITHMIC)
+        self.assertEqual(y.getScale(), y.LOGARITHMIC)
         events = listener.arguments()
-        self.assertEquals(len(events), 2)
+        self.assertEqual(len(events), 2)
         self.assertIn(("left", y.LOGARITHMIC), events)
         self.assertIn(("right", y.LOGARITHMIC), events)
 
@@ -957,9 +957,9 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         yright.sigAutoScaleChanged.connect(listener.partial("right"))
         yright.setAutoScale(False)
 
-        self.assertEquals(y.isAutoScale(), False)
+        self.assertEqual(y.isAutoScale(), False)
         events = listener.arguments()
-        self.assertEquals(len(events), 2)
+        self.assertEqual(len(events), 2)
         self.assertIn(("left", False), events)
         self.assertIn(("right", False), events)
 
@@ -971,9 +971,9 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         yright.sigInvertedChanged.connect(listener.partial("right"))
         yright.setInverted(True)
 
-        self.assertEquals(y.isInverted(), True)
+        self.assertEqual(y.isInverted(), True)
         events = listener.arguments()
-        self.assertEquals(len(events), 2)
+        self.assertEqual(len(events), 2)
         self.assertIn(("left", True), events)
         self.assertIn(("right", True), events)
 

--- a/silx/image/test/test_bilinear.py
+++ b/silx/image/test/test_bilinear.py
@@ -85,17 +85,17 @@ class TestBilinear(unittest.TestCase):
         x2d = numpy.zeros_like(y) + x
         y2d = numpy.zeros_like(x) + y
         res1 = b.map_coordinates((y2d, x2d))
-        self.assertEquals(abs(res1 - img).max(), 0, "images are the same (corners)")
+        self.assertEqual(abs(res1 - img).max(), 0, "images are the same (corners)")
 
         x2d = numpy.zeros_like(y) + (x[:, :-1] + 0.5)
         y2d = numpy.zeros_like(x[:, :-1]) + y
         res1 = b.map_coordinates((y2d, x2d))
-        self.assertEquals(abs(res1 - img[:, :-1] - 0.5).max(), 0, "images are the same (middle)")
+        self.assertEqual(abs(res1 - img[:, :-1] - 0.5).max(), 0, "images are the same (middle)")
 
         x2d = numpy.zeros_like(y[:-1, :]) + (x[:, :-1] + 0.5)
         y2d = numpy.zeros_like(x[:, :-1]) + (y[:-1, :] + 0.5)
         res1 = b.map_coordinates((y2d, x2d))
-        self.assertEquals(abs(res1 - img[:-1, 1:]).max(), 0, "images are the same (center)")
+        self.assertEqual(abs(res1 - img[:-1, 1:]).max(), 0, "images are the same (center)")
 
     def test_profile_grad(self):
         N = 100
@@ -103,7 +103,7 @@ class TestBilinear(unittest.TestCase):
         b = BilinearImage(img)
         res1 = b.profile_line((0, 0), (N - 1, N - 1))
         l = numpy.ceil(numpy.sqrt(2) * N)
-        self.assertEquals(len(res1), l, "Profile has correct length")
+        self.assertEqual(len(res1), l, "Profile has correct length")
         self.assertLess((res1[:-2] - res1[1:-1]).std(), 1e-3, "profile is linear (excluding last point)")
 
     def test_profile_gaus(self):
@@ -114,8 +114,8 @@ class TestBilinear(unittest.TestCase):
         b = BilinearImage(img)
         res_hor = b.profile_line((N // 2, 0), (N // 2, N - 1))
         res_ver = b.profile_line((0, N // 2), (N - 1, N // 2))
-        self.assertEquals(len(res_hor), N, "Profile has correct length")
-        self.assertEquals(len(res_ver), N, "Profile has correct length")
+        self.assertEqual(len(res_hor), N, "Profile has correct length")
+        self.assertEqual(len(res_ver), N, "Profile has correct length")
         self.assertLess(abs(res_hor - g).max(), 1e-5, "correct horizontal profile")
         self.assertLess(abs(res_ver - g).max(), 1e-5, "correct vertical profile")
 
@@ -124,8 +124,8 @@ class TestBilinear(unittest.TestCase):
         res_hor = b.profile_line((N // 2, 0), (N // 2, N - 1), linewidth=3)
         res_ver = b.profile_line((0, N // 2), (N - 1, N // 2), linewidth=3)
 
-        self.assertEquals(len(res_hor), N, "Profile has correct length")
-        self.assertEquals(len(res_ver), N, "Profile has correct length")
+        self.assertEqual(len(res_hor), N, "Profile has correct length")
+        self.assertEqual(len(res_ver), N, "Profile has correct length")
         self.assertLess(abs(res_hor - expected_profile).max(), 1e-5,
                         "correct horizontal profile")
         self.assertLess(abs(res_ver - expected_profile).max(), 1e-5,

--- a/silx/io/test/test_fabioh5.py
+++ b/silx/io/test/test_fabioh5.py
@@ -73,11 +73,11 @@ class TestFabioH5(unittest.TestCase):
         self.h5_image = fabioh5.File(fabio_image=self.fabio_image)
 
     def test_main_groups(self):
-        self.assertEquals(self.h5_image.h5py_class, h5py.File)
-        self.assertEquals(self.h5_image["/"].h5py_class, h5py.File)
-        self.assertEquals(self.h5_image["/scan_0"].h5py_class, h5py.Group)
-        self.assertEquals(self.h5_image["/scan_0/instrument"].h5py_class, h5py.Group)
-        self.assertEquals(self.h5_image["/scan_0/measurement"].h5py_class, h5py.Group)
+        self.assertEqual(self.h5_image.h5py_class, h5py.File)
+        self.assertEqual(self.h5_image["/"].h5py_class, h5py.File)
+        self.assertEqual(self.h5_image["/scan_0"].h5py_class, h5py.Group)
+        self.assertEqual(self.h5_image["/scan_0/instrument"].h5py_class, h5py.Group)
+        self.assertEqual(self.h5_image["/scan_0/measurement"].h5py_class, h5py.Group)
 
     def test_wrong_path_syntax(self):
         # result tested with a default h5py file
@@ -106,12 +106,12 @@ class TestFabioH5(unittest.TestCase):
         h5_image = fabioh5.File(fabio_image=fabio_image)
 
         dataset = h5_image["/scan_0/instrument/detector_0/data"]
-        self.assertEquals(dataset.h5py_class, h5py.Dataset)
+        self.assertEqual(dataset.h5py_class, h5py.Dataset)
         self.assertTrue(isinstance(dataset[()], numpy.ndarray))
-        self.assertEquals(dataset.dtype.kind, "i")
-        self.assertEquals(dataset.shape, (2, 3))
-        self.assertEquals(dataset[...][0, 0], 0)
-        self.assertEquals(dataset.attrs["interpretation"], "image")
+        self.assertEqual(dataset.dtype.kind, "i")
+        self.assertEqual(dataset.shape, (2, 3))
+        self.assertEqual(dataset[...][0, 0], 0)
+        self.assertEqual(dataset.attrs["interpretation"], "image")
 
     def test_multi_frames(self):
         data = numpy.arange(2 * 3)
@@ -121,12 +121,12 @@ class TestFabioH5(unittest.TestCase):
         h5_image = fabioh5.File(fabio_image=fabio_image)
 
         dataset = h5_image["/scan_0/instrument/detector_0/data"]
-        self.assertEquals(dataset.h5py_class, h5py.Dataset)
+        self.assertEqual(dataset.h5py_class, h5py.Dataset)
         self.assertTrue(isinstance(dataset[()], numpy.ndarray))
-        self.assertEquals(dataset.dtype.kind, "i")
-        self.assertEquals(dataset.shape, (2, 2, 3))
-        self.assertEquals(dataset[...][0, 0, 0], 0)
-        self.assertEquals(dataset.attrs["interpretation"], "image")
+        self.assertEqual(dataset.dtype.kind, "i")
+        self.assertEqual(dataset.shape, (2, 2, 3))
+        self.assertEqual(dataset[...][0, 0, 0], 0)
+        self.assertEqual(dataset.attrs["interpretation"], "image")
 
     def test_heterogeneous_frames(self):
         """Frames containing 2 images with different sizes and a cube"""
@@ -142,12 +142,12 @@ class TestFabioH5(unittest.TestCase):
         h5_image = fabioh5.File(fabio_image=fabio_image)
 
         dataset = h5_image["/scan_0/instrument/detector_0/data"]
-        self.assertEquals(dataset.h5py_class, h5py.Dataset)
+        self.assertEqual(dataset.h5py_class, h5py.Dataset)
         self.assertTrue(isinstance(dataset[()], numpy.ndarray))
-        self.assertEquals(dataset.dtype.kind, "i")
-        self.assertEquals(dataset.shape, (3, 2, 5, 1))
-        self.assertEquals(dataset[...][0, 0, 0], 0)
-        self.assertEquals(dataset.attrs["interpretation"], "image")
+        self.assertEqual(dataset.dtype.kind, "i")
+        self.assertEqual(dataset.shape, (3, 2, 5, 1))
+        self.assertEqual(dataset[...][0, 0, 0], 0)
+        self.assertEqual(dataset.attrs["interpretation"], "image")
 
     def test_single_3d_frame(self):
         """Image source contains a cube"""
@@ -160,56 +160,56 @@ class TestFabioH5(unittest.TestCase):
         h5_image = fabioh5.File(fabio_image=fabio_image)
 
         dataset = h5_image["/scan_0/instrument/detector_0/data"]
-        self.assertEquals(dataset.h5py_class, h5py.Dataset)
+        self.assertEqual(dataset.h5py_class, h5py.Dataset)
         self.assertTrue(isinstance(dataset[()], numpy.ndarray))
-        self.assertEquals(dataset.dtype.kind, "i")
-        self.assertEquals(dataset.shape, (2, 3, 4))
-        self.assertEquals(dataset[...][0, 0, 0], 0)
-        self.assertEquals(dataset.attrs["interpretation"], "image")
+        self.assertEqual(dataset.dtype.kind, "i")
+        self.assertEqual(dataset.shape, (2, 3, 4))
+        self.assertEqual(dataset[...][0, 0, 0], 0)
+        self.assertEqual(dataset.attrs["interpretation"], "image")
 
     def test_metadata_int(self):
         dataset = self.h5_image["/scan_0/instrument/detector_0/others/integer"]
-        self.assertEquals(dataset.h5py_class, h5py.Dataset)
-        self.assertEquals(dataset[()], -100)
-        self.assertEquals(dataset.dtype.kind, "i")
-        self.assertEquals(dataset.shape, (1,))
+        self.assertEqual(dataset.h5py_class, h5py.Dataset)
+        self.assertEqual(dataset[()], -100)
+        self.assertEqual(dataset.dtype.kind, "i")
+        self.assertEqual(dataset.shape, (1,))
 
     def test_metadata_float(self):
         dataset = self.h5_image["/scan_0/instrument/detector_0/others/float"]
-        self.assertEquals(dataset.h5py_class, h5py.Dataset)
-        self.assertEquals(dataset[()], 1.0)
-        self.assertEquals(dataset.dtype.kind, "f")
-        self.assertEquals(dataset.shape, (1,))
+        self.assertEqual(dataset.h5py_class, h5py.Dataset)
+        self.assertEqual(dataset[()], 1.0)
+        self.assertEqual(dataset.dtype.kind, "f")
+        self.assertEqual(dataset.shape, (1,))
 
     def test_metadata_string(self):
         dataset = self.h5_image["/scan_0/instrument/detector_0/others/string"]
-        self.assertEquals(dataset.h5py_class, h5py.Dataset)
-        self.assertEquals(dataset[()], numpy.string_("hi!"))
-        self.assertEquals(dataset.dtype.type, numpy.string_)
-        self.assertEquals(dataset.shape, (1,))
+        self.assertEqual(dataset.h5py_class, h5py.Dataset)
+        self.assertEqual(dataset[()], numpy.string_("hi!"))
+        self.assertEqual(dataset.dtype.type, numpy.string_)
+        self.assertEqual(dataset.shape, (1,))
 
     def test_metadata_list_integer(self):
         dataset = self.h5_image["/scan_0/instrument/detector_0/others/list_integer"]
-        self.assertEquals(dataset.h5py_class, h5py.Dataset)
-        self.assertEquals(dataset.dtype.kind, "u")
-        self.assertEquals(dataset.shape, (1, 3))
-        self.assertEquals(dataset[0, 0], 100)
-        self.assertEquals(dataset[0, 1], 50)
+        self.assertEqual(dataset.h5py_class, h5py.Dataset)
+        self.assertEqual(dataset.dtype.kind, "u")
+        self.assertEqual(dataset.shape, (1, 3))
+        self.assertEqual(dataset[0, 0], 100)
+        self.assertEqual(dataset[0, 1], 50)
 
     def test_metadata_list_float(self):
         dataset = self.h5_image["/scan_0/instrument/detector_0/others/list_float"]
-        self.assertEquals(dataset.h5py_class, h5py.Dataset)
-        self.assertEquals(dataset.dtype.kind, "f")
-        self.assertEquals(dataset.shape, (1, 3))
-        self.assertEquals(dataset[0, 0], 1.0)
-        self.assertEquals(dataset[0, 1], 2.0)
+        self.assertEqual(dataset.h5py_class, h5py.Dataset)
+        self.assertEqual(dataset.dtype.kind, "f")
+        self.assertEqual(dataset.shape, (1, 3))
+        self.assertEqual(dataset[0, 0], 1.0)
+        self.assertEqual(dataset[0, 1], 2.0)
 
     def test_metadata_list_looks_like_list(self):
         dataset = self.h5_image["/scan_0/instrument/detector_0/others/string_looks_like_list"]
-        self.assertEquals(dataset.h5py_class, h5py.Dataset)
-        self.assertEquals(dataset[()], numpy.string_("2000 hi!"))
-        self.assertEquals(dataset.dtype.type, numpy.string_)
-        self.assertEquals(dataset.shape, (1,))
+        self.assertEqual(dataset.h5py_class, h5py.Dataset)
+        self.assertEqual(dataset[()], numpy.string_("2000 hi!"))
+        self.assertEqual(dataset.dtype.type, numpy.string_)
+        self.assertEqual(dataset.shape, (1,))
 
     def test_float_32(self):
         float_list = [u'1.2', u'1.3', u'1.4']
@@ -263,19 +263,19 @@ class TestFabioH5(unittest.TestCase):
         h5_image = fabioh5.File(fabio_image=fabio_image)
         sample = h5_image["/scan_0/sample"]
         self.assertIsNotNone(sample)
-        self.assertEquals(sample.attrs["NXclass"], "NXsample")
+        self.assertEqual(sample.attrs["NXclass"], "NXsample")
 
         d = sample['unit_cell_abc']
         expected = numpy.array([4.08, 4.08, 4.08])
         self.assertIsNotNone(d)
-        self.assertEquals(d.shape, (3, ))
+        self.assertEqual(d.shape, (3, ))
         self.assertIn(d.dtype.kind, ['d', 'f'])
         numpy.testing.assert_array_almost_equal(d[...], expected)
 
         d = sample['unit_cell_alphabetagamma']
         expected = numpy.array([90.0, 90.0, 90.0])
         self.assertIsNotNone(d)
-        self.assertEquals(d.shape, (3, ))
+        self.assertEqual(d.shape, (3, ))
         self.assertIn(d.dtype.kind, ['d', 'f'])
         numpy.testing.assert_array_almost_equal(d[...], expected)
 
@@ -284,7 +284,7 @@ class TestFabioH5(unittest.TestCase):
                                  [-1.08894, 1.08894, 1.6083e-16],
                                  [1.08894, 1.08894, 9.28619e-17]]])
         self.assertIsNotNone(d)
-        self.assertEquals(d.shape, (1, 3, 3))
+        self.assertEqual(d.shape, (1, 3, 3))
         self.assertIn(d.dtype.kind, ['d', 'f'])
         numpy.testing.assert_array_almost_equal(d[...], expected)
 
@@ -302,13 +302,13 @@ class TestFabioH5(unittest.TestCase):
         h5_image = fabioh5.File(fabio_image=fabio_image)
 
         data_dataset = h5_image["/scan_0/measurement/image_0/data"]
-        self.assertEquals(data_dataset.attrs["interpretation"], "spectrum")
+        self.assertEqual(data_dataset.attrs["interpretation"], "spectrum")
 
         data_dataset = h5_image["/scan_0/instrument/detector_0/data"]
-        self.assertEquals(data_dataset.attrs["interpretation"], "spectrum")
+        self.assertEqual(data_dataset.attrs["interpretation"], "spectrum")
 
         data_dataset = h5_image["/scan_0/measurement/image_0/info/data"]
-        self.assertEquals(data_dataset.attrs["interpretation"], "spectrum")
+        self.assertEqual(data_dataset.attrs["interpretation"], "spectrum")
 
     def test_get_api(self):
         result = self.h5_image.get("scan_0", getclass=True, getlink=True)
@@ -554,15 +554,15 @@ class TestFabioH5WithFileSeries(unittest.TestCase):
     def _testH5Image(self, h5_image):
         # test data
         dataset = h5_image["/scan_0/instrument/detector_0/data"]
-        self.assertEquals(dataset.h5py_class, h5py.Dataset)
+        self.assertEqual(dataset.h5py_class, h5py.Dataset)
         self.assertTrue(isinstance(dataset[()], numpy.ndarray))
-        self.assertEquals(dataset.dtype.kind, "i")
-        self.assertEquals(dataset.shape, (10, 3, 2))
-        self.assertEquals(list(dataset[:, 0, 0]), list(range(10)))
-        self.assertEquals(dataset.attrs["interpretation"], "image")
+        self.assertEqual(dataset.dtype.kind, "i")
+        self.assertEqual(dataset.shape, (10, 3, 2))
+        self.assertEqual(list(dataset[:, 0, 0]), list(range(10)))
+        self.assertEqual(dataset.attrs["interpretation"], "image")
         # test metatdata
         dataset = h5_image["/scan_0/instrument/detector_0/others/image_id"]
-        self.assertEquals(list(dataset[...]), list(range(10)))
+        self.assertEqual(list(dataset[...]), list(range(10)))
 
     def testFileList(self):
         h5_image = fabioh5.File(file_series=self.edf_filenames)

--- a/silx/io/test/test_utils.py
+++ b/silx/io/test/test_utils.py
@@ -362,14 +362,14 @@ class TestOpen(unittest.TestCase):
         f = utils.open(self.spec_filename)
         self.assertIsNotNone(f)
         if h5py is not None:
-            self.assertEquals(f.h5py_class, h5py.File)
+            self.assertEqual(f.h5py_class, h5py.File)
         f.close()
 
     def testSpecWith(self):
         with utils.open(self.spec_filename) as f:
             self.assertIsNotNone(f)
             if h5py is not None:
-                self.assertEquals(f.h5py_class, h5py.File)
+                self.assertEqual(f.h5py_class, h5py.File)
 
     def testEdf(self):
         if h5py is None:
@@ -379,7 +379,7 @@ class TestOpen(unittest.TestCase):
 
         f = utils.open(self.edf_filename)
         self.assertIsNotNone(f)
-        self.assertEquals(f.h5py_class, h5py.File)
+        self.assertEqual(f.h5py_class, h5py.File)
         f.close()
 
     def testEdfWith(self):
@@ -390,7 +390,7 @@ class TestOpen(unittest.TestCase):
 
         with utils.open(self.edf_filename) as f:
             self.assertIsNotNone(f)
-            self.assertEquals(f.h5py_class, h5py.File)
+            self.assertEqual(f.h5py_class, h5py.File)
 
     def testUnsupported(self):
         self.assertRaises(IOError, utils.open, self.txt_filename)

--- a/silx/utils/test/test_html.py
+++ b/silx/utils/test/test_html.py
@@ -38,16 +38,16 @@ class TestHtml(unittest.TestCase):
 
     def testLtGt(self):
         result = html.escape("<html>'\"")
-        self.assertEquals("&lt;html&gt;&apos;&quot;", result)
+        self.assertEqual("&lt;html&gt;&apos;&quot;", result)
 
     def testLtAmpGt(self):
         # '&' have to be escaped first
         result = html.escape("<&>")
-        self.assertEquals("&lt;&amp;&gt;", result)
+        self.assertEqual("&lt;&amp;&gt;", result)
 
     def testNoQuotes(self):
         result = html.escape("\"m&m's\"", quote=False)
-        self.assertEquals("\"m&amp;m's\"", result)
+        self.assertEqual("\"m&amp;m's\"", result)
 
 
 def suite():

--- a/silx/utils/test/test_launcher.py
+++ b/silx/utils/test/test_launcher.py
@@ -119,16 +119,16 @@ class TestLauncher(ParametricTestCase):
         command = launcher.LauncherCommand("foo", function=callback)
         runner.add_command(command=command)
         status = runner.execute(["prog", "foo", "param1", "param2"])
-        self.assertEquals(status, 42)
-        self.assertEquals(callback._execute_argv, ["prog foo", "param1", "param2"])
-        self.assertEquals(callback._execute_count, 1)
+        self.assertEqual(status, 42)
+        self.assertEqual(callback._execute_argv, ["prog foo", "param1", "param2"])
+        self.assertEqual(callback._execute_count, 1)
 
     def testAddCommand(self):
         runner = launcher.Launcher(prog="prog")
         module_name = "silx.utils.test.test_launcher_command"
         runner.add_command("foo", module_name=module_name)
         status = runner.execute(["prog", "foo"])
-        self.assertEquals(status, 0)
+        self.assertEqual(status, 0)
 
     def testCallHelpOnCommand(self):
         callback = CallbackMock(result=42)
@@ -136,9 +136,9 @@ class TestLauncher(ParametricTestCase):
         command = launcher.LauncherCommand("foo", function=callback)
         runner.add_command(command=command)
         status = runner.execute(["prog", "--help", "foo"])
-        self.assertEquals(status, 42)
-        self.assertEquals(callback._execute_argv, ["prog foo", "--help"])
-        self.assertEquals(callback._execute_count, 1)
+        self.assertEqual(status, 42)
+        self.assertEqual(callback._execute_argv, ["prog foo", "--help"])
+        self.assertEqual(callback._execute_count, 1)
 
     def testCallHelpOnCommand2(self):
         callback = CallbackMock(result=42)
@@ -146,9 +146,9 @@ class TestLauncher(ParametricTestCase):
         command = launcher.LauncherCommand("foo", function=callback)
         runner.add_command(command=command)
         status = runner.execute(["prog", "help", "foo"])
-        self.assertEquals(status, 42)
-        self.assertEquals(callback._execute_argv, ["prog foo", "--help"])
-        self.assertEquals(callback._execute_count, 1)
+        self.assertEqual(status, 42)
+        self.assertEqual(callback._execute_argv, ["prog foo", "--help"])
+        self.assertEqual(callback._execute_count, 1)
 
     def testCallHelpOnUnknownCommand(self):
         callback = CallbackMock(result=42)
@@ -156,7 +156,7 @@ class TestLauncher(ParametricTestCase):
         command = launcher.LauncherCommand("foo", function=callback)
         runner.add_command(command=command)
         status = runner.execute(["prog", "help", "foo2"])
-        self.assertEquals(status, -1)
+        self.assertEqual(status, -1)
 
     def testNotAvailableCommand(self):
         callback = CallbackMock(result=42)
@@ -164,8 +164,8 @@ class TestLauncher(ParametricTestCase):
         command = launcher.LauncherCommand("foo", function=callback)
         runner.add_command(command=command)
         status = runner.execute(["prog", "foo2", "param1", "param2"])
-        self.assertEquals(status, -1)
-        self.assertEquals(callback._execute_count, 0)
+        self.assertEqual(status, -1)
+        self.assertEqual(callback._execute_count, 0)
 
     def testCallHelp(self):
         callback = CallbackMock(result=42)
@@ -173,8 +173,8 @@ class TestLauncher(ParametricTestCase):
         command = launcher.LauncherCommand("foo", function=callback)
         runner.add_command(command=command)
         status = runner.execute(["prog", "help"])
-        self.assertEquals(status, 0)
-        self.assertEquals(callback._execute_count, 0)
+        self.assertEqual(status, 0)
+        self.assertEqual(callback._execute_count, 0)
 
     def testCommonCommands(self):
         runner = launcher.Launcher()
@@ -188,7 +188,7 @@ class TestLauncher(ParametricTestCase):
         for arguments in tests:
             with self.subTest(args=tests):
                 status = runner.execute(arguments)
-                self.assertEquals(status, 0)
+                self.assertEqual(status, 0)
 
 
 def suite():

--- a/silx/utils/test/test_weakref.py
+++ b/silx/utils/test/test_weakref.py
@@ -53,7 +53,7 @@ class TestWeakMethod(unittest.TestCase):
     def testMethod(self):
         dummy = Dummy()
         callable_ = weakref.WeakMethod(dummy.inc)
-        self.assertEquals(callable_()(10), 11)
+        self.assertEqual(callable_()(10), 11)
 
     def testMethodWithDeadObject(self):
         dummy = Dummy()
@@ -70,7 +70,7 @@ class TestWeakMethod(unittest.TestCase):
 
     def testFunction(self):
         callable_ = weakref.WeakMethod(dummy_inc)
-        self.assertEquals(callable_()(10), 11)
+        self.assertEqual(callable_()(10), 11)
 
     def testDeadFunction(self):
         def inc(a):
@@ -82,7 +82,7 @@ class TestWeakMethod(unittest.TestCase):
     def testLambda(self):
         store = lambda a: a + 1  # noqa: E731
         callable_ = weakref.WeakMethod(store)
-        self.assertEquals(callable_()(10), 11)
+        self.assertEqual(callable_()(10), 11)
 
     def testDeadLambda(self):
         callable_ = weakref.WeakMethod(lambda a: a + 1)
@@ -97,7 +97,7 @@ class TestWeakMethod(unittest.TestCase):
         dummy = Dummy()
         callable_ = weakref.WeakMethod(dummy.inc, callback)
         dummy = None
-        self.assertEquals(self.__count, 1)
+        self.assertEqual(self.__count, 1)
 
     def testCallbackOnDeadMethod(self):
         self.__count = 0
@@ -109,7 +109,7 @@ class TestWeakMethod(unittest.TestCase):
         dummy.inc2 = lambda self, a: a + 1
         callable_ = weakref.WeakMethod(dummy.inc2, callback)
         dummy.inc2 = None
-        self.assertEquals(self.__count, 1)
+        self.assertEqual(self.__count, 1)
 
     def testCallbackOnDeadFunction(self):
         self.__count = 0
@@ -120,13 +120,13 @@ class TestWeakMethod(unittest.TestCase):
         store = lambda a: a + 1  # noqa: E731
         callable_ = weakref.WeakMethod(store, callback)
         store = None
-        self.assertEquals(self.__count, 1)
+        self.assertEqual(self.__count, 1)
 
     def testEquals(self):
         dummy = Dummy()
         callable1 = weakref.WeakMethod(dummy.inc)
         callable2 = weakref.WeakMethod(dummy.inc)
-        self.assertEquals(callable1, callable2)
+        self.assertEqual(callable1, callable2)
 
     def testInSet(self):
         callable_set = set([])
@@ -140,7 +140,7 @@ class TestWeakMethod(unittest.TestCase):
         dummy = Dummy()
         callable_dict[weakref.WeakMethod(dummy.inc)] = 10
         callable_ = weakref.WeakMethod(dummy.inc)
-        self.assertEquals(callable_dict.get(callable_), 10)
+        self.assertEqual(callable_dict.get(callable_), 10)
 
 
 class TestWeakMethodProxy(unittest.TestCase):
@@ -148,7 +148,7 @@ class TestWeakMethodProxy(unittest.TestCase):
     def testMethod(self):
         dummy = Dummy()
         callable_ = weakref.WeakMethodProxy(dummy.inc)
-        self.assertEquals(callable_(10), 11)
+        self.assertEqual(callable_(10), 11)
 
     def testMethodWithDeadObject(self):
         dummy = Dummy()
@@ -170,60 +170,60 @@ class TestWeakList(unittest.TestCase):
     def testAppend(self):
         obj = Dummy()
         self.list.append(obj)
-        self.assertEquals(len(self.list), 3)
+        self.assertEqual(len(self.list), 3)
         obj = None
-        self.assertEquals(len(self.list), 2)
+        self.assertEqual(len(self.list), 2)
 
     def testRemove(self):
         self.list.remove(self.object1)
-        self.assertEquals(len(self.list), 1)
+        self.assertEqual(len(self.list), 1)
 
     def testPop(self):
         obj = self.list.pop(0)
         self.assertIs(obj, self.object1)
-        self.assertEquals(len(self.list), 1)
+        self.assertEqual(len(self.list), 1)
 
     def testGetItem(self):
         self.assertIs(self.object1, self.list[0])
 
     def testGetItemSlice(self):
         objects = self.list[:]
-        self.assertEquals(len(objects), 2)
+        self.assertEqual(len(objects), 2)
         self.assertIs(self.object1, objects[0])
         self.assertIs(self.object2, objects[1])
 
     def testIter(self):
         obj_list = list(self.list)
-        self.assertEquals(len(obj_list), 2)
+        self.assertEqual(len(obj_list), 2)
         self.assertIs(self.object1, obj_list[0])
 
     def testLen(self):
-        self.assertEquals(len(self.list), 2)
+        self.assertEqual(len(self.list), 2)
 
     def testSetItem(self):
         obj = Dummy()
         self.list[0] = obj
         self.assertIsNot(self.object1, self.list[0])
         obj = None
-        self.assertEquals(len(self.list), 1)
+        self.assertEqual(len(self.list), 1)
 
     def testSetItemSlice(self):
         obj = Dummy()
         self.list[:] = [obj, obj]
-        self.assertEquals(len(self.list), 2)
+        self.assertEqual(len(self.list), 2)
         self.assertIs(obj, self.list[0])
         self.assertIs(obj, self.list[1])
         obj = None
-        self.assertEquals(len(self.list), 0)
+        self.assertEqual(len(self.list), 0)
 
     def testDelItem(self):
         del self.list[0]
-        self.assertEquals(len(self.list), 1)
+        self.assertEqual(len(self.list), 1)
         self.assertIs(self.object2, self.list[0])
 
     def testDelItemSlice(self):
         del self.list[:]
-        self.assertEquals(len(self.list), 0)
+        self.assertEqual(len(self.list), 0)
 
     def testContains(self):
         self.assertIn(self.object1, self.list)
@@ -232,76 +232,76 @@ class TestWeakList(unittest.TestCase):
         others = [Dummy()]
         l = self.list + others
         self.assertIs(l[0], self.object1)
-        self.assertEquals(len(l), 3)
+        self.assertEqual(len(l), 3)
         others = None
-        self.assertEquals(len(l), 2)
+        self.assertEqual(len(l), 2)
 
     def testExtend(self):
         others = [Dummy()]
         self.list.extend(others)
         self.assertIs(self.list[0], self.object1)
-        self.assertEquals(len(self.list), 3)
+        self.assertEqual(len(self.list), 3)
         others = None
-        self.assertEquals(len(self.list), 2)
+        self.assertEqual(len(self.list), 2)
 
     def testIadd(self):
         others = [Dummy()]
         self.list += others
         self.assertIs(self.list[0], self.object1)
-        self.assertEquals(len(self.list), 3)
+        self.assertEqual(len(self.list), 3)
         others = None
-        self.assertEquals(len(self.list), 2)
+        self.assertEqual(len(self.list), 2)
 
     def testMul(self):
         l = self.list * 2
         self.assertIs(l[0], self.object1)
-        self.assertEquals(len(l), 4)
+        self.assertEqual(len(l), 4)
         self.object1 = None
-        self.assertEquals(len(l), 2)
+        self.assertEqual(len(l), 2)
         self.assertIs(l[0], self.object2)
         self.assertIs(l[1], self.object2)
 
     def testImul(self):
         self.list *= 2
         self.assertIs(self.list[0], self.object1)
-        self.assertEquals(len(self.list), 4)
+        self.assertEqual(len(self.list), 4)
         self.object1 = None
-        self.assertEquals(len(self.list), 2)
+        self.assertEqual(len(self.list), 2)
         self.assertIs(self.list[0], self.object2)
         self.assertIs(self.list[1], self.object2)
 
     def testCount(self):
         self.list.append(self.object2)
-        self.assertEquals(self.list.count(self.object1), 1)
-        self.assertEquals(self.list.count(self.object2), 2)
+        self.assertEqual(self.list.count(self.object1), 1)
+        self.assertEqual(self.list.count(self.object2), 2)
 
     def testIndex(self):
-        self.assertEquals(self.list.index(self.object1), 0)
-        self.assertEquals(self.list.index(self.object2), 1)
+        self.assertEqual(self.list.index(self.object1), 0)
+        self.assertEqual(self.list.index(self.object2), 1)
 
     def testInsert(self):
         obj = Dummy()
         self.list.insert(1, obj)
-        self.assertEquals(len(self.list), 3)
+        self.assertEqual(len(self.list), 3)
         self.assertIs(self.list[1], obj)
         obj = None
-        self.assertEquals(len(self.list), 2)
+        self.assertEqual(len(self.list), 2)
 
     def testReverse(self):
         self.list.reverse()
-        self.assertEquals(len(self.list), 2)
+        self.assertEqual(len(self.list), 2)
         self.assertIs(self.list[0], self.object2)
         self.assertIs(self.list[1], self.object1)
 
     def testReverted(self):
         new_list = reversed(self.list)
-        self.assertEquals(len(new_list), 2)
+        self.assertEqual(len(new_list), 2)
         self.assertIs(self.list[1], self.object2)
         self.assertIs(self.list[0], self.object1)
         self.assertIs(new_list[0], self.object2)
         self.assertIs(new_list[1], self.object1)
         self.object1 = None
-        self.assertEquals(len(new_list), 1)
+        self.assertEqual(len(new_list), 1)
 
     def testStr(self):
         self.assertNotEquals(self.list.__str__(), "[]")
@@ -312,7 +312,7 @@ class TestWeakList(unittest.TestCase):
     def testSort(self):
         # only a coverage
         self.list.sort()
-        self.assertEquals(len(self.list), 2)
+        self.assertEqual(len(self.list), 2)
 
 
 def suite():


### PR DESCRIPTION
This PR replaces deprecated `TestCase.assertEqauls` by `assertEqual` throughout silx.
This avoids warnings when running the tests.