### PR TITLE
[ci] unpin installation of unittest2 now that h5py2.8.0 is out

### DIFF
--- a/ci/requirements-pinned.txt
+++ b/ci/requirements-pinned.txt
@@ -1,2 +1,1 @@
-unittest2; python_version == '2.7'  # Needed for h5py 2.8.0rc1 on python2
 numpy  # Do not use pre-release as 1.15.0rc1 seems to break things on Windows


### PR DESCRIPTION
closes #1734