### PR TITLE
[SaveAction] Activate "curves" filter even for single curve

### DIFF
--- a/silx/gui/plot/actions/io.py
+++ b/silx/gui/plot/actions/io.py
@@ -37,7 +37,7 @@ from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "02/02/2018"
+__date__ = "12/07/2018"
 
 from . import PlotAction
 from silx.io.utils import save1D, savespec
@@ -546,7 +546,7 @@ class SaveAction(PlotAction):
         if (self.plot.getActiveCurve() is not None or
                 len(self.plot.getAllCurves()) == 1):
             filters.update(self._filters['curve'].items())
-        if len(self.plot.getAllCurves()) > 1:
+        if len(self.plot.getAllCurves()) >= 1:
             filters.update(self._filters['curves'].items())
 
         # Add scatter filters if there is a scatter

--- a/silx/io/__init__.py
+++ b/silx/io/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-#Don't change shape inplace, use an array view. Closes #2014
+#
 # Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/silx/io/__init__.py
+++ b/silx/io/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-#
+#Don't change shape inplace, use an array view. Closes #2014
 # Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -204,7 +204,7 @@ def save1D(fname, x, y, xlabel=None, ylabels=None, filetype=None,
 
         # make sure y_array is a 2D array even for a single curve
         if len(y_array.shape) == 1:
-            y_array.shape = (1, y_array.shape[0])
+            y_array = y_array.reshape(1, y_array.shape[0])
         elif len(y_array.shape) > 2 or len(y_array.shape) < 1:
             raise IndexError("y must be a 1D or 2D array")
 


### PR DESCRIPTION
Until now, we activated "curve" filters if there was an active curve or a single curve, and we activated "curve**s**" filters when there was at least curve.

There is an issue if one wants to add a function that can save indifferently one or more curves. The only solution with silx <= 0.8 is to add the filter twice.

This PR activates "curves" filters for  plot with one or more curves. As far as I can tell, the only function currently provided for multiple curves can already handle one or more curves.