### PR TITLE
Add support of NaN in cpp median filter

### DIFF
--- a/silx/math/medianfilter/include/median_filter.hpp
+++ b/silx/math/medianfilter/include/median_filter.hpp
@@ -220,6 +220,7 @@ void median_filter(
                 T min = 0;
                 T max = 0;
                 getMinMax(window_values, min, max, window_end);
+                // NaNs are propagated through unchanged
                 if ((*currentPixelValue == max) || (*currentPixelValue == min)){
                     output[image_dim[1]*y_pixel + x_pixel] = *(median<T>(window_values, window_size));
                 }else{

--- a/silx/math/medianfilter/include/median_filter.hpp
+++ b/silx/math/medianfilter/include/median_filter.hpp
@@ -46,54 +46,43 @@ enum MODE{
 // Simple function browsing a deque and registring the min and max values
 // and if those values are unique or not
 template<typename T>
-void getMinMax(std::vector<const T*>& v, T& min, T&max,
-    typename std::vector<const T*>::const_iterator end){
+void getMinMax(std::vector<T>& v, T& min, T&max,
+    typename std::vector<T>::const_iterator end){
     // init min and max values
-    typename std::vector<const T*>::const_iterator it = v.begin();
+    typename std::vector<T>::const_iterator it = v.begin();
     if (v.size() == 0){
         raise(SIGINT);
     }else{
-        min = max = *(*it);
+        min = max = *it;
     }
     it++;
 
     // Browse all the deque
     while(it!=end){
         // check if repeated (should always be before min/max setting)
-        if(*(*it) > max) max = *(*it);
-        if(*(*it) < min) min = *(*it);
+        T value = *it;
+        if(value > max) max = value;
+        if(value < min) min = value;
 
         it++;
     }
 }
 
-template<typename T>
-bool cmp(const T* a, const T* b){
-    return *a < *b;
-}
 
 // apply the median filter only on limited part of the vector
 // In case of even number of elements (either due to NaNs in the window
 // or for image borders in shrink mode):
 // the highest of the 2 central values is returned
 template<typename T>
-const T* median(std::vector<const T*>& v, int window_size) {
-    std::nth_element(v.begin(), v.begin() + window_size/2, v.begin()+window_size, cmp<T>);
-    return v[window_size/2];
+inline T median(std::vector<T>& v, int window_size) {
+    int pivot = window_size / 2;
+    std::nth_element(v.begin(), v.begin() + pivot, v.begin()+window_size);
+    return v[pivot];
 }
 
-template<typename T>
-void print_window(std::vector<const T*>& v,
-    typename std::vector<const T*>::const_iterator end){
-    typename std::vector<const T*>::const_iterator it;
-    for(it = v.begin(); it != end; ++it){
-        std::cout << *(*it) << " ";
-    }
-    std::cout << std::endl;
-}
 
 // return the index into 0, (length_max - 1) in reflect mode
-int reflect(int index, int length_max){
+inline int reflect(int index, int length_max){
     int res = index;
     // if the index is negative get the positive symetrical value
     if(res < 0){
@@ -110,13 +99,12 @@ int reflect(int index, int length_max){
 }
 
 // return the index into 0, (length_max - 1) in mirror mode
-int mirror(int index, int length_max){
+inline int mirror(int index, int length_max){
     int res = index;
     // if the index is negative get the positive symetrical value
     if(res < 0){
         res = -res;
     }
-
     int rightLimit = length_max -1;
     // apply the redundancy each two right limit
     res = res % (2*rightLimit);
@@ -130,7 +118,7 @@ int mirror(int index, int length_max){
 // Browse the column of pixel_x
 template<typename T>
 void median_filter(
-    const T* input, 
+    const T* input,
     T* output,
     int* kernel_dim,        // two values : 0:width, 1:height
     int* image_dim,         // two values : 0:width, 1:height
@@ -160,47 +148,64 @@ void median_filter(
     MODE mode = static_cast<MODE>(pMode);
 
     // init buffer
-    std::vector<const T*> window_values(kernel_dim[0]*kernel_dim[1]);
+    std::vector<T> window_values(kernel_dim[0]*kernel_dim[1]);
 
     for(int x_pixel=x_pixel_range_min; x_pixel <= x_pixel_range_max; x_pixel ++ ){
-        typename std::vector<const T*>::iterator it = window_values.begin();
+        typename std::vector<T>::iterator it = window_values.begin();
         // fill the vector
-        for(int win_y=y_pixel-halfKernel_y; win_y<= y_pixel+halfKernel_y; win_y++)
-        {
-            for(int win_x = x_pixel-halfKernel_x; win_x <= x_pixel+halfKernel_x; win_x++)
-            {
-                int index_x = win_x;
-                int index_y = win_y;
-                switch(mode){
-                    case NEAREST:
-                        index_x = std::min(std::max(win_x, 0), image_dim[1] - 1);
-                        index_y = std::min(std::max(win_y, 0), image_dim[0] - 1);
-                        break;
 
-                    case REFLECT:
-                        index_x = reflect(win_x, image_dim[1]);
-                        index_y = reflect(win_y, image_dim[0]);
-                        break;
-
-                    case MIRROR:
-                        index_x = mirror(win_x, image_dim[1]);
-                        index_y = mirror(win_y, image_dim[0]);
-                        break;
-
-                    case SHRINK:
-                        if((index_x < 0) || (index_x > image_dim[1] -1)){
-                            continue;
-                        }
-                        if((index_y < 0) || (index_y > image_dim[0] -1)){
-                            continue;
-                        }
-                        break;
+        if (y_pixel >= halfKernel_y && x_pixel >= halfKernel_x &&
+            y_pixel < image_dim[0] - halfKernel_y && x_pixel < image_dim[1] - halfKernel_x) {
+            //This is not a border, just fill it
+            for(int win_y=y_pixel-halfKernel_y; win_y<= y_pixel+halfKernel_y; win_y++) {
+                for(int win_x = x_pixel-halfKernel_x; win_x <= x_pixel+halfKernel_x; win_x++){
+                    T value = input[win_y*image_dim[1] + win_x];
+                    if (value == value) {  // Ignore NaNs
+                        *it = value;
+                        ++it;
+                    }
                 }
+            }
 
-                T value = input[index_y*image_dim[1] + index_x];
-                if (value == value) {  // Ignore NaNs
-                    *it = (&input[index_y*image_dim[1] + index_x]);
-                    ++it;
+        } else { // This is a border, handle the special case
+            for(int win_y=y_pixel-halfKernel_y; win_y<= y_pixel+halfKernel_y; win_y++)
+            {
+                for(int win_x = x_pixel-halfKernel_x; win_x <= x_pixel+halfKernel_x; win_x++)
+                {
+                    int index_x = win_x;
+                    int index_y = win_y;
+
+                    switch(mode){
+                        case NEAREST:
+                            index_x = std::min(std::max(win_x, 0), image_dim[1] - 1);
+                            index_y = std::min(std::max(win_y, 0), image_dim[0] - 1);
+                            break;
+
+                        case REFLECT:
+                            index_x = reflect(win_x, image_dim[1]);
+                            index_y = reflect(win_y, image_dim[0]);
+                            break;
+
+                        case MIRROR:
+                            index_x = mirror(win_x, image_dim[1]);
+                            index_y = mirror(win_y, image_dim[0]);
+                            break;
+
+                        case SHRINK:
+                            if((index_x < 0) || (index_x > image_dim[1] -1)){
+                                continue;
+                            }
+                            if((index_y < 0) || (index_y > image_dim[0] -1)){
+                                continue;
+                            }
+                            break;
+                    }
+
+                    T value = input[index_y*image_dim[1] + index_x];
+                    if (value == value) {  // Ignore NaNs
+                        *it = value;
+                        ++it;
+                    }
                 }
             }
         }
@@ -214,20 +219,20 @@ void median_filter(
 
         } else {
             // apply the median value if needed for this pixel
-            const T* currentPixelValue = &input[image_dim[1]*y_pixel + x_pixel];
+            const T currentPixelValue = input[image_dim[1]*y_pixel + x_pixel];
             if (conditional == true){
-                typename std::vector<const T*>::iterator window_end = window_values.begin() + window_size;
+                typename std::vector<T>::iterator window_end = window_values.begin() + window_size;
                 T min = 0;
                 T max = 0;
                 getMinMax(window_values, min, max, window_end);
                 // NaNs are propagated through unchanged
-                if ((*currentPixelValue == max) || (*currentPixelValue == min)){
-                    output[image_dim[1]*y_pixel + x_pixel] = *(median<T>(window_values, window_size));
+                if ((currentPixelValue == max) || (currentPixelValue == min)){
+                    output[image_dim[1]*y_pixel + x_pixel] = median<T>(window_values, window_size);
                 }else{
-                    output[image_dim[1]*y_pixel + x_pixel] = *currentPixelValue;
+                    output[image_dim[1]*y_pixel + x_pixel] = currentPixelValue;
                 }
             }else{
-                output[image_dim[1]*y_pixel + x_pixel] = *(median<T>(window_values, window_size));
+                output[image_dim[1]*y_pixel + x_pixel] = median<T>(window_values, window_size);
             }
         }
     }

--- a/silx/math/medianfilter/include/median_filter.hpp
+++ b/silx/math/medianfilter/include/median_filter.hpp
@@ -34,6 +34,16 @@
 #include <signal.h>
 #include <iostream>
 #include <cmath>
+#include <cfloat>
+
+/* Needed for pytohn2.7 on Windows... */
+#ifndef INFINITY
+#define INFINITY (DBL_MAX+DBL_MAX)
+#endif
+
+#ifndef NAN
+#define NAN (INFINITY-INFINITY)
+#endif
 
 // Modes for the median filter
 enum MODE{

--- a/silx/math/medianfilter/medianfilter.pyx
+++ b/silx/math/medianfilter/medianfilter.pyx
@@ -64,6 +64,7 @@ def medfilt1d(data, kernel_size=3, bool conditional=False, mode='nearest'):
     return medfilt(data, kernel_size, conditional, mode)
 
 
+
 def medfilt2d(image, kernel_size=3, bool conditional=False, mode='nearest'):
     """Function computing the median filter of the given input.
     Behavior at boundaries: the algorithm is reducing the size of the
@@ -89,10 +90,10 @@ def medfilt(data, kernel_size=3, bool conditional=False, mode='nearest'):
     Behavior at boundaries: the algorithm is reducing the size of the
     window/kernel for pixels at boundaries (there is no mirroring).
 
-    :param numpy.ndarray data: the array for which we want to apply 
+    :param numpy.ndarray data: the array for which we want to apply
         the median filter. Should be 1d or 2d.
     :param kernel_size: the dimension of the kernel.
-    :type kernel_size: For 1D should be an int for 2D should be a tuple or 
+    :type kernel_size: For 1D should be an int for 2D should be a tuple or
         a list of (kernel_height, kernel_width)
     :param bool conditional: True if we want to apply a conditional median
         filtering.

--- a/silx/math/medianfilter/medianfilter.pyx
+++ b/silx/math/medianfilter/medianfilter.pyx
@@ -47,8 +47,16 @@ MODES = {'nearest':0, 'reflect':1, 'mirror':2, 'shrink':3}
 
 def medfilt1d(data, kernel_size=3, bool conditional=False, mode='nearest'):
     """Function computing the median filter of the given input.
+
     Behavior at boundaries: the algorithm is reducing the size of the
     window/kernel for pixels at boundaries (there is no mirroring).
+
+    Not-a-Number (NaN) float values are ignored.
+    If the window only contains NaNs, it evaluates to NaN.
+
+    In event of an even number of valid values in the window (either
+    because of NaN values or on image border in shrink mode),
+    the highest of the 2 central sorted values is taken.
 
     :param numpy.ndarray data: the array for which we want to apply
         the median filter. Should be 1d.
@@ -70,6 +78,13 @@ def medfilt2d(image, kernel_size=3, bool conditional=False, mode='nearest'):
     Behavior at boundaries: the algorithm is reducing the size of the
     window/kernel for pixels at boundaries (there is no mirroring).
 
+    Not-a-Number (NaN) float values are ignored.
+    If the window only contains NaNs, it evaluates to NaN.
+
+    In event of an even number of valid values in the window (either
+    because of NaN values or on image border in shrink mode),
+    the highest of the 2 central sorted values is taken.
+
     :param numpy.ndarray data: the array for which we want to apply
         the median filter. Should be 2d.
     :param kernel_size: the dimension of the kernel.
@@ -89,6 +104,13 @@ def medfilt(data, kernel_size=3, bool conditional=False, mode='nearest'):
     """Function computing the median filter of the given input.
     Behavior at boundaries: the algorithm is reducing the size of the
     window/kernel for pixels at boundaries (there is no mirroring).
+
+    Not-a-Number (NaN) float values are ignored.
+    If the window only contains NaNs, it evaluates to NaN.
+
+    In event of an even number of valid values in the window (either
+    because of NaN values or on image border in shrink mode),
+    the highest of the 2 central sorted values is taken.
 
     :param numpy.ndarray data: the array for which we want to apply
         the median filter. Should be 1d or 2d.

--- a/silx/math/medianfilter/test/__init__.py
+++ b/silx/math/medianfilter/test/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,10 +27,10 @@ __date__ = "22/06/2016"
 
 import unittest
 
-from .test_medianfilter import suite as test_medianfilter
+from . import test_medianfilter
 
 
 def suite():
     test_suite = unittest.TestSuite()
-    test_suite.addTest(test_medianfilter())
+    test_suite.addTest(test_medianfilter.suite())
     return test_suite

--- a/silx/math/medianfilter/test/test_medianfilter.py
+++ b/silx/math/medianfilter/test/test_medianfilter.py
@@ -510,7 +510,7 @@ class TestGeneralExecution(ParametricTestCase):
         """Test that NaNs are propagated through conditional median filter"""
         for mode in silx_mf_modes:
             with self.subTest(mode=mode):
-                image = numpy.empty((10, 10), dtype=numpy.float32)
+                image = numpy.ones((10, 10), dtype=numpy.float32)
                 nan_mask = numpy.zeros_like(image, dtype=bool)
                 nan_mask[0, 0] = True
                 nan_mask[4, :] = True

--- a/silx/math/medianfilter/test/test_medianfilter.py
+++ b/silx/math/medianfilter/test/test_medianfilter.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # ##########################################################################
-# Copyright (C) 2017 European Synchrotron Radiation Facility
+# Copyright (C) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -138,6 +138,30 @@ class TestMedianFilterNearest(ParametricTestCase):
         self.assertTrue(dataOut[9] == 9)
         self.assertTrue(dataOut[99] == 99)
 
+    def testNaNs(self):
+        """Test median filter on image with NaNs in nearest mode"""
+        # Data with a NaN in first corner
+        nan_corner = numpy.arange(100.).reshape(10, 10)
+        nan_corner[0, 0] = numpy.nan
+        output = medfilt2d(
+            nan_corner, kernel_size=3, conditional=False, mode='nearest')
+        self.assertEqual(output[0, 0], 10)
+        self.assertEqual(output[0, 1], 2)
+        self.assertEqual(output[1, 0], 11)
+        self.assertEqual(output[1, 1], 12)
+
+        # Data with some NaNs
+        some_nans = numpy.arange(100.).reshape(10, 10)
+        some_nans[0, 1] = numpy.nan
+        some_nans[1, 1] = numpy.nan
+        some_nans[1, 0] = numpy.nan
+        output = medfilt2d(
+            some_nans, kernel_size=3, conditional=False, mode='nearest')
+        self.assertEqual(output[0, 0], 0)
+        self.assertEqual(output[0, 1], 2)
+        self.assertEqual(output[1, 0], 20)
+        self.assertEqual(output[1, 1], 20)
+
 
 class TestMedianFilterReflect(ParametricTestCase):
     """Unit test for the median filter in reflect mode"""
@@ -209,6 +233,30 @@ class TestMedianFilterReflect(ParametricTestCase):
                         mode='reflect')
         self.assertTrue(numpy.array_equal(thRes, res))
 
+    def testNaNs(self):
+        """Test median filter on image with NaNs in reflect mode"""
+        # Data with a NaN in first corner
+        nan_corner = numpy.arange(100.).reshape(10, 10)
+        nan_corner[0, 0] = numpy.nan
+        output = medfilt2d(
+            nan_corner, kernel_size=3, conditional=False, mode='reflect')
+        self.assertEqual(output[0, 0], 10)
+        self.assertEqual(output[0, 1], 2)
+        self.assertEqual(output[1, 0], 11)
+        self.assertEqual(output[1, 1], 12)
+
+        # Data with some NaNs
+        some_nans = numpy.arange(100.).reshape(10, 10)
+        some_nans[0, 1] = numpy.nan
+        some_nans[1, 1] = numpy.nan
+        some_nans[1, 0] = numpy.nan
+        output = medfilt2d(
+            some_nans, kernel_size=3, conditional=False, mode='reflect')
+        self.assertEqual(output[0, 0], 0)
+        self.assertEqual(output[0, 1], 2)
+        self.assertEqual(output[1, 0], 20)
+        self.assertEqual(output[1, 1], 20)
+
 
 class TestMedianFilterMirror(ParametricTestCase):
     """Unit test for the median filter in mirror mode
@@ -268,6 +316,30 @@ class TestMedianFilterMirror(ParametricTestCase):
                         mode='mirror')
 
         self.assertTrue(numpy.array_equal(thRes, res))
+
+    def testNaNs(self):
+        """Test median filter on image with NaNs in mirror mode"""
+        # Data with a NaN in first corner
+        nan_corner = numpy.arange(100.).reshape(10, 10)
+        nan_corner[0, 0] = numpy.nan
+        output = medfilt2d(
+            nan_corner, kernel_size=3, conditional=False, mode='mirror')
+        self.assertEqual(output[0, 0], 11)
+        self.assertEqual(output[0, 1], 11)
+        self.assertEqual(output[1, 0], 11)
+        self.assertEqual(output[1, 1], 12)
+
+        # Data with some NaNs
+        some_nans = numpy.arange(100.).reshape(10, 10)
+        some_nans[0, 1] = numpy.nan
+        some_nans[1, 1] = numpy.nan
+        some_nans[1, 0] = numpy.nan
+        output = medfilt2d(
+            some_nans, kernel_size=3, conditional=False, mode='mirror')
+        self.assertEqual(output[0, 0], 0)
+        self.assertEqual(output[0, 1], 12)
+        self.assertEqual(output[1, 0], 21)
+        self.assertEqual(output[1, 1], 20)
 
 
 class TestMedianFilterShrink(ParametricTestCase):
@@ -362,6 +434,30 @@ class TestMedianFilterShrink(ParametricTestCase):
 
         self.assertTrue(numpy.array_equal(resK1, thRes))
 
+    def testNaNs(self):
+        """Test median filter on image with NaNs in shrink mode"""
+        # Data with a NaN in first corner
+        nan_corner = numpy.arange(100.).reshape(10, 10)
+        nan_corner[0, 0] = numpy.nan
+        output = medfilt2d(
+            nan_corner, kernel_size=3, conditional=False, mode='shrink')
+        self.assertEqual(output[0, 0], 10)
+        self.assertEqual(output[0, 1], 10)
+        self.assertEqual(output[1, 0], 11)
+        self.assertEqual(output[1, 1], 12)
+
+        # Data with some NaNs
+        some_nans = numpy.arange(100.).reshape(10, 10)
+        some_nans[0, 1] = numpy.nan
+        some_nans[1, 1] = numpy.nan
+        some_nans[1, 0] = numpy.nan
+        output = medfilt2d(
+            some_nans, kernel_size=3, conditional=False, mode='shrink')
+        self.assertEqual(output[0, 0], 0)
+        self.assertEqual(output[0, 1], 2)
+        self.assertEqual(output[1, 0], 20)
+        self.assertEqual(output[1, 1], 20)
+
 
 class TestGeneralExecution(ParametricTestCase):
     """Some general test on median filter application"""
@@ -395,6 +491,16 @@ class TestGeneralExecution(ParametricTestCase):
                           conditional=False,
                           mode=mode)
                 self.assertTrue(numpy.array_equal(dataIn, dataInCopy))
+
+    def testAllNaNs(self):
+        """Test median filter on image all NaNs"""
+        for mode in silx_mf_modes:
+            with self.subTest(mode=mode):
+                all_nans = numpy.empty((10, 10), dtype=numpy.float32)
+                all_nans[:] = numpy.nan
+                output = medfilt2d(
+                    all_nans, kernel_size=3, conditional=False, mode='shrink')
+                self.assertTrue(numpy.all(numpy.isnan(output)))
 
 
 def _getScipyAndSilxCommonModes():


### PR DESCRIPTION
This PR adds support of NaNs by ignoring them in cpp median filters.

In case of an even number of values on which to do the median, it gets the highest of the 2 central values.

closes #2016