### PR TITLE
bootstrap.py: Support entry_point optional "extras" declaration

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -128,8 +128,9 @@ def run_entry_point(entry_point, argv):
     target_name = elements[0].strip()
     elements = elements[1].split(":")
     module_name = elements[0].strip()
-    function_name = elements[1].strip()
-
+    # Take care of entry_point optional "extra" requirements declaration
+    function_name = elements[1].split()[0].strip()
+    
     logger.info("Execute target %s (function %s from module %s) using importlib", target_name, function_name, module_name)
     full_args = [target_name]
     full_args.extend(argv)

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -121,7 +121,7 @@ def run_entry_point(entry_point, argv):
     (http://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation)
 
     :param str entry_point: A string identifying a function from a module
-        (NAME = PACKAGE.MODULE:FUNCTION)
+        (NAME = PACKAGE.MODULE:FUNCTION [EXTRA])
     """
     import importlib
     elements = entry_point.split("=")


### PR DESCRIPTION
Add support of entry_point optional extra requirement declaration

See https://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies