### PR TITLE
Fix warnings about invalid escape sequence

### DIFF
--- a/silx/app/convert.py
+++ b/silx/app/convert.py
@@ -57,22 +57,22 @@ def c_format_string_to_re(pattern_string):
     :param pattern_string: C style format string with integer patterns
         (e.g. "%d", "%04d").
         Not supported: fixed length padded with whitespaces (e.g "%4d", "%-4d")
-    :return: Equivalent regular expression (e.g. "\d+", "\d{4}")
+    :return: Equivalent regular expression (e.g. "\\d+", "\\d{4}")
     """
     # escape dots and backslashes
     pattern_string = pattern_string.replace("\\", "\\\\")
-    pattern_string = pattern_string.replace(".", "\.")
+    pattern_string = pattern_string.replace(".", r"\.")
 
     # %d
-    pattern_string = pattern_string.replace("%d", "([-+]?\d+)")
+    pattern_string = pattern_string.replace("%d", r"([-+]?\d+)")
 
     # %0nd
-    for sub_pattern in re.findall("%0\d+d", pattern_string):
-        n = int(re.search("%0(\d+)d", sub_pattern).group(1))
+    for sub_pattern in re.findall(r"%0\d+d", pattern_string):
+        n = int(re.search(r"%0(\d+)d", sub_pattern).group(1))
         if n == 1:
-            re_sub_pattern = "([+-]?\d)"
+            re_sub_pattern = r"([+-]?\d)"
         else:
-            re_sub_pattern = "([\d+-]\d{%d})" % (n - 1)
+            re_sub_pattern = r"([\d+-]\d{%d})" % (n - 1)
         pattern_string = pattern_string.replace(sub_pattern, re_sub_pattern, 1)
 
     return pattern_string

--- a/silx/io/configdict.py
+++ b/silx/io/configdict.py
@@ -147,7 +147,7 @@ def _parse_simple_types(sstr):
                 # un-escape string
                 sstr = sstr.lstrip("\\")
                 # un-escape commas
-                sstr = sstr.replace("\,", ",").replace("^@", ",")
+                sstr = sstr.replace(r"\,", ",").replace("^@", ",")
                 return sstr
 
 
@@ -191,7 +191,7 @@ def _parse_container(sstr):
         raise ValueError
     else:
         # if all commas are escaped, it is a strinq, not a list
-        if sstr.count(",") == sstr.count("\,"):
+        if sstr.count(",") == sstr.count(r"\,"):
             raise ValueError
 
         dataline = [line for line in sstr.splitlines()]
@@ -213,7 +213,7 @@ def _parse_list_line(sstr):
 
     # preserve escaped commas in strings before splitting list
     # (_parse_simple_types recognizes ^@ as a comma)
-    sstr.replace("\,", "^@")
+    sstr.replace(r"\,", "^@")
     # it is a list
     if sstr.endswith(','):
         if ',' in sstr[:-1]:
@@ -256,12 +256,12 @@ class OptionStr(str):
         return _boolean(self)
 
     def tostr(self):
-        """Return string after replacing escaped commas ``\,`` with regular
+        """Return string after replacing escaped commas ``\\,`` with regular
         commas ``,`` and removing leading backslash.
 
         :return: str(self)
         """
-        return str(self.replace("\,", ",").lstrip("\\"))
+        return str(self.replace(r"\,", ",").lstrip("\\"))
 
     def tocontainer(self):
         """Return a list or a numpy array.
@@ -306,8 +306,8 @@ class ConfigDict(OrderedDict):
         - sections can be nested to any depth
         - value types are guessed when the file is read back
         - to prevent strings from being interpreted as lists, commas are
-          escaped with a backslash (``\,``)
-        - strings may be prefixed with a leading backslash (``\``) to prevent
+          escaped with a backslash (``\\,``)
+        - strings may be prefixed with a leading backslash (``\\``) to prevent
           conversion to numeric or boolean values
 
     :param defaultdict: Default dictionary used to initialize the
@@ -456,7 +456,7 @@ class ConfigDict(OrderedDict):
             fp.close()
 
     def _escape_str(self, sstr):
-        """Escape strings and special characters in strings with a ``\``
+        """Escape strings and special characters in strings with a ``\\``
         character to ensure they are read back as strings and not parsed.
 
         :param sstr: String to be escaped
@@ -473,7 +473,7 @@ class ConfigDict(OrderedDict):
         if re.match(non_str, sstr.lower()):
             sstr = "\\" + sstr
         # Escape commas
-        sstr = sstr.replace(",", "\,")
+        sstr = sstr.replace(",", r"\,")
 
         if sys.version_info >= (3, ):
             # Escape % characters except in "%%" and "%("

--- a/silx/io/spech5.py
+++ b/silx/io/spech5.py
@@ -312,7 +312,7 @@ def _parse_ctime(ctime_lines, analyser_index=0):
     """
     :param ctime_lines: e.g ``@CTIME %f %f %f``, first word ``@CTIME`` optional
         When multiple CTIME lines are present in a scan header, this argument
-        is a concatenation of them separated by a ``\n`` character.
+        is a concatenation of them separated by a ``\\n`` character.
     :param analyser_index: MCA device/analyser index, when multiple devices
         are in a scan.
     :return: (preset_time, live_time, elapsed_time)
@@ -362,13 +362,13 @@ def spec_date_to_iso8601(date, zone=None):
 
     days_rx = '(?P<day>' + '|'.join(days) + ')'
     months_rx = '(?P<month>' + '|'.join(months) + ')'
-    year_rx = '(?P<year>\d{4})'
-    day_nb_rx = '(?P<day_nb>[0-3 ]\d)'
-    month_nb_rx = '(?P<month_nb>[0-1]\d)'
-    hh_rx = '(?P<hh>[0-2]\d)'
-    mm_rx = '(?P<mm>[0-5]\d)'
-    ss_rx = '(?P<ss>[0-5]\d)'
-    tz_rx = '(?P<tz>[+-]\d\d:\d\d){0,1}'
+    year_rx = r'(?P<year>\d{4})'
+    day_nb_rx = r'(?P<day_nb>[0-3 ]\d)'
+    month_nb_rx = r'(?P<month_nb>[0-1]\d)'
+    hh_rx = r'(?P<hh>[0-2]\d)'
+    mm_rx = r'(?P<mm>[0-5]\d)'
+    ss_rx = r'(?P<ss>[0-5]\d)'
+    tz_rx = r'(?P<tz>[+-]\d\d:\d\d){0,1}'
 
     # date formats must have either month_nb (1..12) or month (Jan, Feb, ...)
     re_tpls = ['{days} {months} {day_nb} {hh}:{mm}:{ss}{tz} {year}',

--- a/silx/io/test/test_utils.py
+++ b/silx/io/test/test_utils.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -63,7 +63,7 @@ expected_spec1 = r"""#F .*
 3  6\.00
 """
 
-expected_spec2 = expected_spec1 + """
+expected_spec2 = expected_spec1 + r"""
 #S 2 Ordinate2
 #D .*
 #N 2

--- a/silx/math/calibration.py
+++ b/silx/math/calibration.py
@@ -52,7 +52,7 @@ class AbstractCalibration(object):
 
     def is_affine(self):
         """Returns True for an affine calibration of the form
-        :math:`x  \mapsto a + b * x`, or else False.
+        :math:`x  \\mapsto a + b * x`, or else False.
         """
         return False
 
@@ -62,7 +62,7 @@ class AbstractCalibration(object):
 
 
 class NoCalibration(AbstractCalibration):
-    """No calibration :math:`x \mapsto x`
+    """No calibration :math:`x \\mapsto x`
     """
     def __init__(self):
         super(NoCalibration, self).__init__()
@@ -78,7 +78,7 @@ class NoCalibration(AbstractCalibration):
 
 
 class LinearCalibration(AbstractCalibration):
-    """Linear calibration :math:`x \mapsto a + b x`,
+    """Linear calibration :math:`x \\mapsto a + b x`,
     where *a* is the y-intercept and *b* is the slope.
 
     :param y_intercept: y-intercept
@@ -101,7 +101,7 @@ class LinearCalibration(AbstractCalibration):
 
 class ArrayCalibration(AbstractCalibration):
     """One-to-one mapping calibration, defined by an array *x'*,
-    such as :math:`x \mapsto x'`*.
+    such as :math:`x \\mapsto x'`.
 
     This calibration can only be applied to x arrays of the same length as the
     calibration array *x'*.
@@ -151,7 +151,7 @@ class ArrayCalibration(AbstractCalibration):
 
 
 class FunctionCalibration(AbstractCalibration):
-    """Calibration defined by a function *f*, such as :math:`x \mapsto f(x)`*.
+    """Calibration defined by a function *f*, such as :math:`x \\mapsto f(x)`*.
 
     :param function: Calibration function"""
     def __init__(self, function, is_affine=False):

--- a/silx/math/fit/fittheory.py
+++ b/silx/math/fit/fittheory.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 #/*##########################################################################
 #
-# Copyright (c) 2004-2016 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -69,13 +69,13 @@ class FitTheory(object):
             signature, as explained in the documentation for :attr:`function`.
         """
         self.function = function
-        """Regular fit functions must have the signature *f(x, \*params) -> y*,
+        """Regular fit functions must have the signature ``f(x, *params) -> y``,
         where *x* is a 1D array of values for the independent variable,
         *params* are the parameters to be fitted and *y* is the output array
         that we want to have the best fit to a series of data points.
 
         Background functions used by :class:`FitManager` must have a slightly
-        different signature: *f(x, y0, \*params) -> bg*, where *y0* is the
+        different signature: ``f(x, y0, *params) -> bg``, where *y0* is the
         array of original data points and *bg* is the background signal that
         we want to subtract from the data array prior to fitting the regular
         fit function.
@@ -149,7 +149,7 @@ class FitTheory(object):
         A background function is an secondary function that needs to be added
         to the main fit function to better fit the original data.
         If this flag is set to *True*, modules using this theory are informed
-        that :attr:`function` has the signature *f(x, y0, \*params) -> bg*,
+        that :attr:`function` has the signature ``f(x, y0, *params) -> bg``,
         instead of the usual fit function signature."""
 
     def default_estimate(self, x=None, y=None, bg=None):

--- a/silx/utils/number.py
+++ b/silx/utils/number.py
@@ -53,7 +53,7 @@ if _biggest_float is None:
     _float_types = (numpy.float64, numpy.float32, numpy.float16)
 
 
-_parse_numeric_value = re.compile("^\s*[-+]?0*(\d+?)?(?:\.(\d+))?(?:[eE]([-+]?\d+))?\s*$")
+_parse_numeric_value = re.compile(r"^\s*[-+]?0*(\d+?)?(?:\.(\d+))?(?:[eE]([-+]?\d+))?\s*$")
 
 
 def is_longdouble_64bits():


### PR DESCRIPTION
From python 3.6, using \ in a string, when it is not an escape sequence, is deprecated.

Addresses most of the warnings in #2029 , but not all.