### PR TITLE
Use MDI window for GUI tests (WIP)

### DIFF
--- a/silx/gui/dialog/test/test_colormapdialog.py
+++ b/silx/gui/dialog/test/test_colormapdialog.py
@@ -26,11 +26,12 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "23/05/2018"
+__date__ = "18/07/2018"
 
 
 import doctest
 import unittest
+import weakref
 
 from silx.gui.test.utils import qWaitForWindowExposedAndActivate
 from silx.gui import qt
@@ -76,7 +77,11 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.colormapDiag.setAttribute(qt.Qt.WA_DeleteOnClose)
 
     def tearDown(self):
-        del self.colormapDiag
+        if self.colormapDiag is not None:
+            self.colormapDiag.close()
+            ref = weakref.ref(self.colormapDiag)
+            self.colormapDiag = None
+            self.qWaitForDestroy(ref)
         ParametricTestCase.tearDown(self)
         TestCaseQt.tearDown(self)
 
@@ -106,6 +111,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         """Make sure the colormap is modified if gone through accept"""
         assert self.colormap.isAutoscale() is False
         self.colormapDiag.setModal(True)
+        self.addSubTestedWindow(self.colormapDiag)
         self.colormapDiag.show()
         self.colormapDiag.setColormap(self.colormap)
         self.assertTrue(self.colormap.getVMin() is not None)
@@ -119,11 +125,13 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.assertTrue(self.colormap.getVMin() is None)
         self.assertTrue(self.colormap.getVMax() is None)
         self.assertTrue(self.colormap.isAutoscale() is True)
+        self.colormapDiag = None
 
     def testGUIModalCancel(self):
         """Make sure the colormap is not modified if gone through reject"""
         assert self.colormap.isAutoscale() is False
         self.colormapDiag.setModal(True)
+        self.addSubTestedWindow(self.colormapDiag)
         self.colormapDiag.show()
         self.colormapDiag.setColormap(self.colormap)
         self.assertTrue(self.colormap.getVMin() is not None)
@@ -134,10 +142,12 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
             button=qt.Qt.LeftButton
         )
         self.assertTrue(self.colormap.getVMin() is not None)
+        self.colormapDiag = None
 
     def testGUIModalClose(self):
         assert self.colormap.isAutoscale() is False
         self.colormapDiag.setModal(False)
+        self.addSubTestedWindow(self.colormapDiag)
         self.colormapDiag.show()
         self.colormapDiag.setColormap(self.colormap)
         self.assertTrue(self.colormap.getVMin() is not None)
@@ -148,10 +158,12 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
             button=qt.Qt.LeftButton
         )
         self.assertTrue(self.colormap.getVMin() is None)
+        self.colormapDiag = None
 
     def testGUIModalReset(self):
         assert self.colormap.isAutoscale() is False
         self.colormapDiag.setModal(False)
+        self.addSubTestedWindow(self.colormapDiag)
         self.colormapDiag.show()
         self.colormapDiag.setColormap(self.colormap)
         self.assertTrue(self.colormap.getVMin() is not None)
@@ -162,17 +174,15 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
             button=qt.Qt.LeftButton
         )
         self.assertTrue(self.colormap.getVMin() is not None)
-        self.colormapDiag.close()
 
     def testGUIClose(self):
         """Make sure the colormap is modify if go through reject"""
         assert self.colormap.isAutoscale() is False
+        self.addSubTestedWindow(self.colormapDiag)
         self.colormapDiag.show()
         self.colormapDiag.setColormap(self.colormap)
         self.assertTrue(self.colormap.getVMin() is not None)
         self.colormapDiag._minValue.setValue(None)
-        self.assertTrue(self.colormap.getVMin() is None)
-        self.colormapDiag.close()
         self.assertTrue(self.colormap.getVMin() is None)
 
     def testSetColormapIsCorrect(self):
@@ -208,6 +218,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         """Check behavior if the colormap has been deleted outside. For now
         we make sure the colormap is still running and nothing more"""
         self.colormapDiag.setColormap(self.colormap)
+        self.addSubTestedWindow(self.colormapDiag)
         self.colormapDiag.show()
         del self.colormap
         self.assertTrue(self.colormapDiag.getColormap() is None)
@@ -217,6 +228,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         """Make sure the GUI is still up to date if the colormap is modified
         outside"""
         self.colormapDiag.setColormap(self.colormap)
+        self.addSubTestedWindow(self.colormapDiag)
         self.colormapDiag.show()
 
         self.colormap.setName('red')
@@ -246,6 +258,8 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
                              normalization='log')
         colormap3 = Colormap(name='blue', vmin=None, vmax=None,
                              normalization='linear')
+        self.addSubTestedWindow(self.colormapDiag)
+        self.colormapDiag.show()
         self.colormapDiag.setColormap(self.colormap)
         self.colormapDiag.setColormap(colormap1)
         del colormap1
@@ -270,6 +284,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         assert colormapName is not None
         colormap = Colormap(name=colormapName)
         self.colormapDiag.setColormap(colormap)
+        self.addSubTestedWindow(self.colormapDiag)
         self.colormapDiag.show()
         cb = self.colormapDiag._comboBoxColormap
         self.assertTrue(cb.getCurrentName() == colormapName)

--- a/silx/gui/dialog/test/test_datafiledialog.py
+++ b/silx/gui/dialog/test/test_datafiledialog.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "03/07/2018"
+__date__ = "18/07/2018"
 
 
 import unittest
@@ -106,9 +106,12 @@ def tearDownModule():
 
 class _UtilsMixin(object):
 
-    def createDialog(self):
+    def createDialog(self, show=False):
         self._deleteDialog()
         self._dialog = self._createDialog()
+        if show:
+            self.addSubTestedWindow(self._dialog)
+            self._dialog.show()
         return self._dialog
 
     def _createDialog(self):
@@ -151,20 +154,20 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         utils.TestCaseQt.tearDown(self)
 
     def testDisplayAndKeyEscape(self):
-        dialog = self.createDialog()
-        dialog.show()
+        dialog = self.createDialog(True)
         self.qWaitForWindowExposed(dialog)
         self.assertTrue(dialog.isVisible())
+        self.qWaitForPendingActions(dialog)
 
         self.keyClick(dialog, qt.Qt.Key_Escape)
         self.assertFalse(dialog.isVisible())
         self.assertEqual(dialog.result(), qt.QDialog.Rejected)
 
     def testDisplayAndClickCancel(self):
-        dialog = self.createDialog()
-        dialog.show()
+        dialog = self.createDialog(True)
         self.qWaitForWindowExposed(dialog)
         self.assertTrue(dialog.isVisible())
+        self.qWaitForPendingActions(dialog)
 
         button = utils.findChildren(dialog, qt.QPushButton, name="cancel")[0]
         self.mouseClick(button, qt.Qt.LeftButton)
@@ -173,8 +176,7 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         self.assertEqual(dialog.result(), qt.QDialog.Rejected)
 
     def testDisplayAndClickLockedOpen(self):
-        dialog = self.createDialog()
-        dialog.show()
+        dialog = self.createDialog(True)
         self.qWaitForWindowExposed(dialog)
         self.assertTrue(dialog.isVisible())
 
@@ -187,9 +189,8 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testSelectRoot_Activate(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         browser = utils.findChildren(dialog, qt.QWidget, name="browser")[0]
-        dialog.show()
         self.qWaitForWindowExposed(dialog)
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"
@@ -213,9 +214,8 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testSelectGroup_Activate(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         browser = utils.findChildren(dialog, qt.QWidget, name="browser")[0]
-        dialog.show()
         self.qWaitForWindowExposed(dialog)
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"
@@ -245,9 +245,8 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testSelectDataset_Activate(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         browser = utils.findChildren(dialog, qt.QWidget, name="browser")[0]
-        dialog.show()
         self.qWaitForWindowExposed(dialog)
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"
@@ -277,8 +276,7 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testClickOnBackToParentTool(self):
         if h5py is None:
             self.skipTest("h5py is missing")
-        dialog = self.createDialog()
-        dialog.show()
+        dialog = self.createDialog(True)
         self.qWaitForWindowExposed(dialog)
 
         url = utils.findChildren(dialog, qt.QLineEdit, name="url")[0]
@@ -309,8 +307,7 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testClickOnBackToRootTool(self):
         if h5py is None:
             self.skipTest("h5py is missing")
-        dialog = self.createDialog()
-        dialog.show()
+        dialog = self.createDialog(True)
         self.qWaitForWindowExposed(dialog)
 
         url = utils.findChildren(dialog, qt.QLineEdit, name="url")[0]
@@ -334,8 +331,7 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testClickOnBackToDirectoryTool(self):
         if h5py is None:
             self.skipTest("h5py is missing")
-        dialog = self.createDialog()
-        dialog.show()
+        dialog = self.createDialog(True)
         self.qWaitForWindowExposed(dialog)
 
         url = utils.findChildren(dialog, qt.QLineEdit, name="url")[0]
@@ -363,8 +359,7 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testClickOnHistoryTools(self):
         if h5py is None:
             self.skipTest("h5py is missing")
-        dialog = self.createDialog()
-        dialog.show()
+        dialog = self.createDialog(True)
         self.qWaitForWindowExposed(dialog)
 
         url = utils.findChildren(dialog, qt.QLineEdit, name="url")[0]
@@ -404,8 +399,7 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testSelectImageFromEdf(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        dialog = self.createDialog()
-        dialog.show()
+        dialog = self.createDialog(True)
         self.qWaitForWindowExposed(dialog)
 
         # init state
@@ -415,12 +409,12 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         self.assertTrue(dialog._selectedData().shape, (100, 100))
         self.assertSamePath(dialog.selectedFile(), filename)
         self.assertSamePath(dialog.selectedUrl(), url.path())
+        self.qWaitForPendingActions(dialog)
 
     def testSelectImage(self):
         if h5py is None:
             self.skipTest("h5py is missing")
-        dialog = self.createDialog()
-        dialog.show()
+        dialog = self.createDialog(True)
         self.qWaitForWindowExposed(dialog)
 
         # init state
@@ -431,12 +425,12 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         self.assertTrue(dialog._selectedData().shape, (100, 100))
         self.assertSamePath(dialog.selectedFile(), filename)
         self.assertSamePath(dialog.selectedUrl(), path)
+        self.qWaitForPendingActions(dialog)
 
     def testSelectScalar(self):
         if h5py is None:
             self.skipTest("h5py is missing")
-        dialog = self.createDialog()
-        dialog.show()
+        dialog = self.createDialog(True)
         self.qWaitForWindowExposed(dialog)
 
         # init state
@@ -447,12 +441,12 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         self.assertEqual(dialog._selectedData()[()], 10)
         self.assertSamePath(dialog.selectedFile(), filename)
         self.assertSamePath(dialog.selectedUrl(), path)
+        self.qWaitForPendingActions(dialog)
 
     def testSelectGroup(self):
         if h5py is None:
             self.skipTest("h5py is missing")
-        dialog = self.createDialog()
-        dialog.show()
+        dialog = self.createDialog(True)
         self.qWaitForWindowExposed(dialog)
 
         # init state
@@ -469,8 +463,7 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testSelectRoot(self):
         if h5py is None:
             self.skipTest("h5py is missing")
-        dialog = self.createDialog()
-        dialog.show()
+        dialog = self.createDialog(True)
         self.qWaitForWindowExposed(dialog)
 
         # init state
@@ -487,8 +480,7 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testSelectH5_Activate(self):
         if h5py is None:
             self.skipTest("h5py is missing")
-        dialog = self.createDialog()
-        dialog.show()
+        dialog = self.createDialog(True)
         self.qWaitForWindowExposed(dialog)
 
         # init state
@@ -507,8 +499,7 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         self.assertSamePath(dialog.selectedUrl(), path)
 
     def testSelectBadFileFormat_Activate(self):
-        dialog = self.createDialog()
-        dialog.show()
+        dialog = self.createDialog(True)
         self.qWaitForWindowExposed(dialog)
 
         # init state
@@ -537,9 +528,8 @@ class TestDataFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
             self.skipTest("h5py is missing")
         if fabio is None:
             self.skipTest("fabio is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         browser = utils.findChildren(dialog, qt.QWidget, name="browser")[0]
-        dialog.show()
         self.qWaitForWindowExposed(dialog)
         dialog.selectUrl(_tmpDirectory)
         self.qWaitForPendingActions(dialog)
@@ -560,9 +550,8 @@ class TestDataFileDialog_FilterDataset(utils.TestCaseQt, _UtilsMixin):
     def testSelectGroup_Activate(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         browser = utils.findChildren(dialog, qt.QWidget, name="browser")[0]
-        dialog.show()
         self.qWaitForWindowExposed(dialog)
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"
@@ -587,9 +576,8 @@ class TestDataFileDialog_FilterDataset(utils.TestCaseQt, _UtilsMixin):
     def testSelectDataset_Activate(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         browser = utils.findChildren(dialog, qt.QWidget, name="browser")[0]
-        dialog.show()
         self.qWaitForWindowExposed(dialog)
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"
@@ -634,9 +622,8 @@ class TestDataFileDialog_FilterGroup(utils.TestCaseQt, _UtilsMixin):
     def testSelectGroup_Activate(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         browser = utils.findChildren(dialog, qt.QWidget, name="browser")[0]
-        dialog.show()
         self.qWaitForWindowExposed(dialog)
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"
@@ -668,9 +655,8 @@ class TestDataFileDialog_FilterGroup(utils.TestCaseQt, _UtilsMixin):
     def testSelectDataset_Activate(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         browser = utils.findChildren(dialog, qt.QWidget, name="browser")[0]
-        dialog.show()
         self.qWaitForWindowExposed(dialog)
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"
@@ -713,9 +699,8 @@ class TestDataFileDialog_FilterNXdata(utils.TestCaseQt, _UtilsMixin):
     def testSelectGroupRefused_Activate(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         browser = utils.findChildren(dialog, qt.QWidget, name="browser")[0]
-        dialog.show()
         self.qWaitForWindowExposed(dialog)
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"
@@ -742,9 +727,8 @@ class TestDataFileDialog_FilterNXdata(utils.TestCaseQt, _UtilsMixin):
     def testSelectNXdataAccepted_Activate(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         browser = utils.findChildren(dialog, qt.QWidget, name="browser")[0]
-        dialog.show()
         self.qWaitForWindowExposed(dialog)
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"

--- a/silx/gui/dialog/test/test_imagefiledialog.py
+++ b/silx/gui/dialog/test/test_imagefiledialog.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "03/07/2018"
+__date__ = "18/07/2018"
 
 
 import unittest
@@ -113,9 +113,12 @@ def tearDownModule():
 
 class _UtilsMixin(object):
 
-    def createDialog(self):
+    def createDialog(self, show=False):
         self._deleteDialog()
         self._dialog = self._createDialog()
+        if show:
+            self.addSubTestedWindow(self._dialog)
+            self._dialog.show()
         return self._dialog
 
     def _createDialog(self):
@@ -158,20 +161,21 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         utils.TestCaseQt.tearDown(self)
 
     def testDisplayAndKeyEscape(self):
-        dialog = self.createDialog()
-        dialog.show()
+        dialog = self.createDialog(True)
         self.qWaitForWindowExposed(dialog)
         self.assertTrue(dialog.isVisible())
+        self.qWaitForPendingActions(dialog)
 
         self.keyClick(dialog, qt.Qt.Key_Escape)
         self.assertFalse(dialog.isVisible())
         self.assertEqual(dialog.result(), qt.QDialog.Rejected)
 
     def testDisplayAndClickCancel(self):
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         dialog.show()
         self.qWaitForWindowExposed(dialog)
         self.assertTrue(dialog.isVisible())
+        self.qWaitForPendingActions(dialog)
 
         button = utils.findChildren(dialog, qt.QPushButton, name="cancel")[0]
         self.mouseClick(button, qt.Qt.LeftButton)
@@ -180,7 +184,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         self.assertEqual(dialog.result(), qt.QDialog.Rejected)
 
     def testDisplayAndClickLockedOpen(self):
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         dialog.show()
         self.qWaitForWindowExposed(dialog)
         self.assertTrue(dialog.isVisible())
@@ -194,7 +198,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testDisplayAndClickOpen(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         dialog.show()
         self.qWaitForWindowExposed(dialog)
         self.assertTrue(dialog.isVisible())
@@ -209,7 +213,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         self.assertEqual(dialog.result(), qt.QDialog.Accepted)
 
     def testClickOnShortcut(self):
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         dialog.show()
         self.qWaitForWindowExposed(dialog)
 
@@ -244,7 +248,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         self.assertNotSamePath(url.text(), _tmpDirectory)
 
     def testClickOnDetailView(self):
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         dialog.show()
         self.qWaitForWindowExposed(dialog)
 
@@ -261,7 +265,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testClickOnBackToParentTool(self):
         if h5py is None:
             self.skipTest("h5py is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         dialog.show()
         self.qWaitForWindowExposed(dialog)
 
@@ -293,7 +297,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testClickOnBackToRootTool(self):
         if h5py is None:
             self.skipTest("h5py is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         dialog.show()
         self.qWaitForWindowExposed(dialog)
 
@@ -318,7 +322,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testClickOnBackToDirectoryTool(self):
         if h5py is None:
             self.skipTest("h5py is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         dialog.show()
         self.qWaitForWindowExposed(dialog)
 
@@ -347,7 +351,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testClickOnHistoryTools(self):
         if h5py is None:
             self.skipTest("h5py is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         dialog.show()
         self.qWaitForWindowExposed(dialog)
 
@@ -388,7 +392,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testSelectImageFromEdf(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         dialog.show()
         self.qWaitForWindowExposed(dialog)
 
@@ -404,7 +408,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testSelectImageFromEdf_Activate(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         dialog.show()
         self.qWaitForWindowExposed(dialog)
 
@@ -428,7 +432,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testSelectFrameFromEdf(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         dialog.show()
         self.qWaitForWindowExposed(dialog)
 
@@ -446,7 +450,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testSelectImageFromMsk(self):
         if fabio is None:
             self.skipTest("fabio is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         dialog.show()
         self.qWaitForWindowExposed(dialog)
 
@@ -462,7 +466,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testSelectImageFromH5(self):
         if h5py is None:
             self.skipTest("h5py is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         dialog.show()
         self.qWaitForWindowExposed(dialog)
 
@@ -474,11 +478,12 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         self.assertTrue(dialog.selectedImage().shape, (100, 100))
         self.assertSamePath(dialog.selectedFile(), filename)
         self.assertSamePath(dialog.selectedUrl(), path)
+        self.qWaitForPendingActions(dialog)
 
     def testSelectH5_Activate(self):
         if h5py is None:
             self.skipTest("h5py is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         dialog.show()
         self.qWaitForWindowExposed(dialog)
 
@@ -500,7 +505,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
     def testSelectFrameFromH5(self):
         if h5py is None:
             self.skipTest("h5py is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         dialog.show()
         self.qWaitForWindowExposed(dialog)
 
@@ -513,9 +518,10 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
         self.assertTrue(dialog.selectedImage()[0, 0], 1)
         self.assertSamePath(dialog.selectedFile(), filename)
         self.assertSamePath(dialog.selectedUrl(), path)
+        self.qWaitForPendingActions(dialog)
 
     def testSelectBadFileFormat_Activate(self):
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         dialog.show()
         self.qWaitForWindowExposed(dialog)
 
@@ -545,7 +551,7 @@ class TestImageFileDialogInteraction(utils.TestCaseQt, _UtilsMixin):
             self.skipTest("h5py is missing")
         if fabio is None:
             self.skipTest("fabio is missing")
-        dialog = self.createDialog()
+        dialog = self.createDialog(True)
         browser = utils.findChildren(dialog, qt.QWidget, name="browser")[0]
         filters = utils.findChildren(dialog, qt.QWidget, name="fileTypeCombo")[0]
         dialog.show()

--- a/silx/gui/test/utils.py
+++ b/silx/gui/test/utils.py
@@ -334,7 +334,7 @@ class TestCaseQt(unittest.TestCase):
             endTimeMS = int(time.time() * 1000) + timeout
             while timeout > 0:
                 _qapp.processEvents(qt.QEventLoop.AllEvents,
-                                        maxtime=timeout)
+                                    maxtime=timeout)
                 timeout = endTimeMS - int(time.time() * 1000)
         else:
             QTest.qWait(ms + cls.TIMEOUT_WAIT)
@@ -385,7 +385,6 @@ class TestCaseQt(unittest.TestCase):
             # (at least on Windows Python 2.7)
             # If it is not skipped on PySide, silx.gui.dialog tests will
             # segfault (at least on Windows Python 2.7)
-            import gc
             gc.collect()
         qobject = ref()
         if qobject is None:


### PR DESCRIPTION
This PR tries to reduce some inconvenience of GUI testing, by using an only one MDI window as container for all GUI tests.

It reduce blinking, then allow to move the tests manually, or reduce them. It could maybe speed up a little the tests.

- This feature do not working with PyQt4. Some widget are not released at the end of each tests.
- Only dialog tests was updated

Can be tested using
```
python ./run_tests.py silx.gui.dialog.test.suite -v
```