### PR TITLE
Deprecate pyqt4

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ Silx follows the permissive MIT license although it may include contributions fo
 Silx uses the Qt library for its graphical user interfaces.
 A word of caution is to be provided.
 If users develop and distribute software using modules accessing Qt by means of Riverbank Computing Qt bindings PyQt4 or PyQt5, those users will be conditioned by the license of their PyQt4/5 software (GPL or commercial).
-If the end user does not own a commercial license of PyQt4 or PyQt5 and wishes to be free of any distribution condition, (s)he should be able to use PySide because it uses the LGPL license.
+If the end user does not own a commercial license of PyQt4 or PyQt5 and wishes to be free of any distribution condition, (s)he should be able to use PySide2 because it uses the LGPL license.
 
 The MIT license follows:
 

--- a/ci/info_platform.py
+++ b/ci/info_platform.py
@@ -55,9 +55,9 @@ else:
 have_qt_binding = False
 
 try:
-    import PySide.QtCore
+    import PyQt5.QtCore
     have_qt_binding = True
-    print("Qt (from PySide): %s" % PySide.QtCore.qVersion())
+    print("Qt (from PyQt5): %s" % PyQt5.QtCore.qVersion())
 except ImportError:
     pass
 
@@ -69,9 +69,16 @@ except ImportError:
     pass
 
 try:
-    import PyQt5.QtCore
+    import PySide2.QtCore
     have_qt_binding = True
-    print("Qt (from PyQt5): %s" % PyQt5.QtCore.qVersion())
+    print("Qt (from PySide2): %s" % PySide2.QtCore.qVersion())
+except ImportError:
+    pass
+
+try:
+    import PySide.QtCore
+    have_qt_binding = True
+    print("Qt (from PySide): %s" % PySide.QtCore.qVersion())
 except ImportError:
     pass
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -10,16 +10,16 @@ graphical widgets require Qt, management of data files requires
 `fabio <https://github.com/silx-kit/fabio>`_, and high performance data-analysis
 code on GPU requires `pyopencl <https://mathema.tician.de/software/pyopencl/>`_.
 
-This table summarized the the support matrix of silx v0.7:
+This table summarized the the support matrix of silx:
 
 +------------+--------------+---------------------+
 | System     | Python vers. | Qt and its bindings |
 +------------+--------------+---------------------+
-| `Windows`_ | 3.5, 3.6     | PyQt5.6+            |
+| `Windows`_ | 3.5, 3.6-3.7 | PyQt5.6+, PySide2   |
 +------------+--------------+---------------------+
-| `MacOS`_   | 2.7, 3.5-3.6 | PyQt5.6+            |
+| `MacOS`_   | 2.7, 3.5-3.7 | PyQt5.6+, PySide2   |
 +------------+--------------+---------------------+
-| `Linux`_   | 2.7, 3.4-3.6 | PyQt4.8+, PyQt5.3+  |
+| `Linux`_   | 2.7, 3.4-3.7 | PyQt5.3+, PySide2   |
 +------------+--------------+---------------------+
 
 For all platform, you can install *silx* from the source, see `Installing from source`_.
@@ -32,7 +32,7 @@ Dependencies
 
 The GUI widgets depend on the following extra packages:
 
-* A Qt binding: either `PyQt5, PyQt4 <https://riverbankcomputing.com/software/pyqt/intro>`_,
+* A Qt binding: either `PyQt5 <https://riverbankcomputing.com/software/pyqt/intro>`_,
   or `PySide2 <https://wiki.qt.io/Qt_for_Python>`_
 * `matplotlib <http://matplotlib.org/>`_
 * `PyOpenGL <http://pyopengl.sourceforge.net/>`_

--- a/doc/source/virtualenv.rst
+++ b/doc/source/virtualenv.rst
@@ -162,11 +162,11 @@ is not as simple.
 The simplest way, assuming that PyQt is installed on your system, is to use that
 system package directly. For this, you need to add a symbolic link to your virtualenv.
 
-If you want to use PyQt4 installed in ``/usr/lib/python2.7/dist-packages/``, type:
+If you want to use PyQt5 installed in ``/usr/lib/python2.7/dist-packages/``, type:
 
 .. code-block:: bash
 
-    ln -s /usr/lib/python2.7/dist-packages/PyQt4 silx_venv/lib/python2.7/site-packages/
+    ln -s /usr/lib/python2.7/dist-packages/PyQt5 silx_venv/lib/python2.7/site-packages/
     ln -s /usr/lib/python2.7/dist-packages/sip.so silx_venv/lib/python2.7/site-packages/
 
 
@@ -178,7 +178,7 @@ Install silx
     pip install silx
 
 
-To test *silx*, open an interactive python console. If you managed to install PyQt5, PySide2 or PyQt4
+To test *silx*, open an interactive python console. If you managed to install PyQt5 or PySide2
 in your virtualenv, type:
 
 .. code-block:: bash

--- a/run_tests.py
+++ b/run_tests.py
@@ -381,7 +381,7 @@ parser.add_argument("-v", "--verbose", default=0,
                          "INFO messages. Use -vv for full verbosity, " +
                          "including debug messages and test help strings.")
 parser.add_argument("--qt-binding", dest="qt_binding", default=None,
-                    help="Force using a Qt binding, from 'PyQt4', 'PyQt5', or 'PySide'")
+                    help="Force using a Qt binding, from 'PyQt4', 'PyQt5', or 'PySide2'")
 if test_options is not None:
     test_options.add_parser_argument(parser)
 

--- a/silx/app/test_.py
+++ b/silx/app/test_.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -99,7 +99,7 @@ def main(argv):
                              "INFO messages. Use -vv for full verbosity, " +
                              "including debug messages and test help strings.")
     parser.add_argument("--qt-binding", dest="qt_binding", default=None,
-                        help="Force using a Qt binding, from 'PyQt4', 'PyQt5', or 'PySide'")
+                        help="Force using a Qt binding: 'PyQt5' or 'PySide2'")
     utils.test_options.add_parser_argument(parser)
 
     options = parser.parse_args(argv[1:])
@@ -128,6 +128,9 @@ def main(argv):
         elif binding == "pyside":
             _logger.info("Force using PySide")
             import PySide.QtCore  # noqa
+        elif binding == "pyside2":
+            _logger.info("Force using PySide2")
+            import PySide2.QtCore  # noqa
         else:
             raise ValueError("Qt binding '%s' is unknown" % options.qt_binding)
 

--- a/silx/gui/qt/_pyside_dynamic.py
+++ b/silx/gui/qt/_pyside_dynamic.py
@@ -60,7 +60,7 @@ class UiLoader(QUiLoader):
     create a new instance of the top-level widget, but creates the user
     interface in an existing instance of the top-level class.
 
-    This mimics the behaviour of :func:`PyQt4.uic.loadUi`.
+    This mimics the behaviour of :func:`PyQt*.uic.loadUi`.
     """
 
     def __init__(self, baseinstance, customWidgets=None):
@@ -116,7 +116,7 @@ class UiLoader(QUiLoader):
 
             if self.baseinstance:
                 # set an attribute for the new child widget on the base
-                # instance, just like PyQt4.uic.loadUi does.
+                # instance, just like PyQt*.uic.loadUi does.
                 setattr(self.baseinstance, name, widget)
 
                 # this outputs the various widget names, e.g.

--- a/silx/gui/qt/_qt.py
+++ b/silx/gui/qt/_qt.py
@@ -91,6 +91,9 @@ else:  # Then try Qt bindings
 
 if BINDING == 'PyQt4':
     _logger.debug('Using PyQt4 bindings')
+    deprecated_warning("Qt Binding", "PyQt4",
+                       replacement='PyQt4',
+                       since_version='0.9.0')
 
     if sys.version_info < (3, ):
         try:

--- a/silx/gui/widgets/__init__.py
+++ b/silx/gui/widgets/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,6 +22,6 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-"""This package provides a few simple Qt widgets that rely only on a Qt wrapper
-for Python (PyQt5, PyQt4 or PySide). No other optional dependencies of *silx*
-should be required."""
+"""This package provides a few simple Qt widgets that rely only on a Qt binding for Python.
+
+No other optional dependencies of *silx* should be required."""


### PR DESCRIPTION
This PR marks PyQt4 as deprecated, removes it from the documentation and also replaces a few occurrence of PySide with PySide2.

closes #2015