### PR TITLE
Improve tree sorting

### DIFF
--- a/silx/gui/hdf5/Hdf5Item.py
+++ b/silx/gui/hdf5/Hdf5Item.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "06/07/2018"
+__date__ = "24/07/2018"
 
 
 import logging
@@ -64,6 +64,13 @@ class Hdf5Item(Hdf5Node):
         self.__text = text
         self.__linkClass = linkClass
         Hdf5Node.__init__(self, parent, populateAll=populateAll)
+
+    def _getCanonicalName(self):
+        parent = self.parent
+        if parent is None:
+            return self.__text
+        else:
+            return "%s/%s" % (parent._getCanonicalName(), self.__text)
 
     @property
     def obj(self):

--- a/silx/gui/hdf5/Hdf5Node.py
+++ b/silx/gui/hdf5/Hdf5Node.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "16/06/2017"
+__date__ = "24/07/2018"
 
 import weakref
 
@@ -51,6 +51,13 @@ class Hdf5Node(object):
         if populateAll:
             self.__child = []
             self._populateChild(populateAll=True)
+
+    def _getCanonicalName(self):
+        parent = self.parent
+        if parent is None:
+            return "root"
+        else:
+            return "%s/?" % (parent._getCanonicalName())
 
     @property
     def parent(self):

--- a/silx/gui/hdf5/NexusSortFilterProxyModel.py
+++ b/silx/gui/hdf5/NexusSortFilterProxyModel.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "25/06/2018"
+__date__ = "24/07/2018"
 
 
 import logging
@@ -47,6 +47,24 @@ class NexusSortFilterProxyModel(qt.QSortFilterProxyModel):
         qt.QSortFilterProxyModel.__init__(self, parent)
         self.__split = re.compile("(\\d+|\\D+)")
         self.__iconCache = {}
+
+    def hasChildren(self, parent):
+        """Returns true if parent has any children; otherwise returns false.
+
+        :param qt.QModelIndex parent: Index of the item to check
+        :rtype: bool
+        """
+        parent = self.mapToSource(parent)
+        return self.sourceModel().hasChildren(parent)
+
+    def rowCount(self, parent):
+        """Returns the number of rows under the given parent.
+
+        :param qt.QModelIndex parent: Index of the item to check
+        :rtype: int
+        """
+        parent = self.mapToSource(parent)
+        return self.sourceModel().rowCount(parent)
 
     def lessThan(self, sourceLeft, sourceRight):
         """Returns True if the value of the item referred to by the given


### PR DESCRIPTION
When using a proxy model, `hasChildren` and `rowCount` must be reimplemented, else the default behaviour is used and children are populated.

Closes #2017 