### PR TITLE
Fix void reader when using numpy 1.15.0

### DIFF
--- a/silx/gui/data/TextFormatter.py
+++ b/silx/gui/data/TextFormatter.py
@@ -27,7 +27,7 @@ data module to format data as text in the same way."""
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "25/06/2018"
+__date__ = "24/07/2018"
 
 import numpy
 import numbers
@@ -206,7 +206,13 @@ class TextFormatter(qt.QObject):
             if six.PY2:
                 data = [ord(d) for d in data.data]
             else:
-                data = data.item().astype(numpy.uint8)
+                data = data.item()
+                if isinstance(data, numpy.ndarray):
+                    # Before numpy 1.15.0 the item API was returning a numpy array
+                    data = data.astype(numpy.uint8)
+                else:
+                    # Now it is supposed to be a bytes type
+                    pass
         elif six.PY2:
             data = [ord(d) for d in data]
             # In python3 data is already a bytes array


### PR DESCRIPTION
Unittest was not working anymore with Python3 and numpy 1.15.0.