### PR TITLE
Fixes AttributeError in Colorbar.getLegend

### DIFF
--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -205,7 +205,7 @@ class ColorBarWidget(qt.QWidget):
         :return: return the legend displayed along the colorbar
         :rtype: str
         """
-        return self.legend.getText()
+        return self.legend.text()
 
     def _activeScatterChanged(self, previous, legend):
         """Handle plot active scatter changed"""


### PR DESCRIPTION
There is a small bug in the `Colorbar.getLegend`. You can reproduce it with the following example.

```
from PyQt5.QtWidgets import QApplication
from silx.gui.plot.ColorBar import ColorBarWidget

app = QApplication([])
colorbar = ColorBarWidget()
colorbar.setLegend('Hi there')
print(colorbar.getLegend())
```

This PR fixes the bug.