### PR TITLE
[plot] add/remove item signals in PlotWidget

### DIFF
--- a/doc/source/modules/gui/plot/plotsignal.rst
+++ b/doc/source/modules/gui/plot/plotsignal.rst
@@ -132,6 +132,7 @@ Plot state change events
     These events are deprecated.  
     Use :attr:`PlotWidget.sigSetKeepDataAspectRatio`,
     :attr:`PlotWidget.sigSetGraphGrid`, :attr:`PlotWidget.sigSetGraphCursor`,
+    :attr:`PlotWidget.sigItemAdded`,:attr:`PlotWidget.sigItemAboutToBeRemoved`,
     :attr:`PlotWidget.sigContentChanged`, :attr:`PlotWidget.sigActiveCurveChanged`,
     :attr:`PlotWidget.sigActiveImageChanged` and
     :attr:`PlotWidget.sigInteractiveModeChanged` instead.

--- a/doc/source/modules/gui/plot/plotwidget.rst
+++ b/doc/source/modules/gui/plot/plotwidget.rst
@@ -159,6 +159,8 @@ The :class:`PlotWidget` provides the following Qt signals:
 .. autoattribute:: PlotWidget.sigSetGraphGrid
 .. autoattribute:: PlotWidget.sigSetGraphCursor
 .. autoattribute:: PlotWidget.sigSetPanWithArrowKeys
+.. autoattribute:: PlotWidget.sigItemAdded
+.. autoattribute:: PlotWidget.sigItemAboutToBeRemoved
 .. autoattribute:: PlotWidget.sigContentChanged
 .. autoattribute:: PlotWidget.sigActiveCurveChanged
 .. autoattribute:: PlotWidget.sigActiveImageChanged

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -193,6 +193,18 @@ class PlotWidget(qt.QMainWindow):
     It provides the source as passed to :meth:`setInteractiveMode`.
     """
 
+    sigItemAdded = qt.Signal(items.Item)
+    """Signal emitted when an item was just added to the plot
+
+    It provides the added item.
+    """
+
+    sigItemAboutToBeRemoved = qt.Signal(items.Item)
+    """Signal emitted right before an item is removed from the plot.
+
+    It provides the item that will be removed.
+    """
+
     def __init__(self, parent=None, backend=None,
                  legends=False, callback=None, **kw):
         self._autoreplot = False
@@ -452,6 +464,7 @@ class PlotWidget(qt.QMainWindow):
             self._invalidateDataRange()  # TODO handle this automatically
 
         self._notifyContentChanged(item)
+        self.sigItemAdded.emit(item)
 
     def _notifyContentChanged(self, item):
         legend, kind = self._itemKey(item)
@@ -465,6 +478,8 @@ class PlotWidget(qt.QMainWindow):
         key = self._itemKey(item)
         if key not in self._content:
             raise RuntimeError('Item not in the plot')
+
+        self.sigItemAboutToBeRemoved.emit(item)
 
         legend, kind = key
 

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -141,6 +141,21 @@ class TestPlotWidget(PlotWidgetTestCase, ParametricTestCase):
         self.qapp.processEvents()
         self.assertNotEqual(listener.callCount(), 0)
 
+    def testAddRemoveItemSignals(self):
+        """Test sigItemAdded and sigItemAboutToBeRemoved"""
+        listener = SignalListener()
+        self.plot.sigItemAdded.connect(listener.partial('add'))
+        self.plot.sigItemAboutToBeRemoved.connect(listener.partial('remove'))
+
+        self.plot.addCurve((1, 2, 3), (3, 2, 1), legend='curve')
+        self.assertEqual(listener.callCount(), 1)
+
+        curve = self.plot.getCurve('curve')
+        self.plot.remove('curve')
+        self.assertEqual(listener.callCount(), 2)
+        self.assertEqual(listener.arguments(callIndex=0), ('add', curve))
+        self.assertEqual(listener.arguments(callIndex=1), ('remove', curve))
+
 
 class TestPlotImage(PlotWidgetTestCase, ParametricTestCase):
     """Basic tests for addImage"""


### PR DESCRIPTION
This PR adds `sigItemAdded` and `sigItemAboutToBeRemoved` to `PlotWidget`.
I replaced usage of `sigContentChanged` where it was "easy".
For other usage, a `_getKind` method in plot Item is probably needed... (at least transitively).

closes #1908