### PR TITLE
Make QImage<->array conversion public

### DIFF
--- a/doc/source/modules/gui/utils.rst
+++ b/doc/source/modules/gui/utils.rst
@@ -10,3 +10,9 @@
 
 .. automodule:: silx.gui.utils.concurrent
    :members:
+
+:mod:`~silx.gui.utils.image`
+----------------------------
+
+.. automodule:: silx.gui.utils.image
+   :members:

--- a/silx/gui/_glutils/font.py
+++ b/silx/gui/_glutils/font.py
@@ -32,7 +32,7 @@ __date__ = "13/10/2016"
 import logging
 import numpy
 
-from ..utils._image import convertQImageToArray
+from ..utils.image import convertQImageToArray
 from .. import qt
 
 _logger = logging.getLogger(__name__)

--- a/silx/gui/plot/actions/io.py
+++ b/silx/gui/plot/actions/io.py
@@ -53,7 +53,7 @@ from silx.gui import qt, printer
 from silx.gui.dialog.GroupDialog import GroupDialog
 from silx.third_party.EdfFile import EdfFile
 from silx.third_party.TiffIO import TiffIO
-from ...utils._image import convertArrayToQImage
+from ...utils.image import convertArrayToQImage
 if sys.version_info[0] == 3:
     from io import BytesIO
 else:

--- a/silx/gui/plot/test/testStats.py
+++ b/silx/gui/plot/test/testStats.py
@@ -361,6 +361,7 @@ class TestStatsWidgetWithCurves(TestCaseQt):
     def setUp(self):
         TestCaseQt.setUp(self)
         self.plot = Plot1D()
+        self.plot.show()
         x = range(20)
         y = range(20)
         self.plot.addCurve(x, y, legend='curve0')

--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -36,7 +36,7 @@ import logging
 from silx.gui import qt
 from silx.gui.colors import rgba
 from . import actions
-from ..utils._image import convertArrayToQImage
+from ..utils.image import convertArrayToQImage
 
 from .. import _glutils as glu
 from .scene import interaction, primitives, transform

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -41,7 +41,7 @@ import numpy
 
 from silx.third_party import six
 
-from ...utils._image import convertArrayToQImage
+from ...utils.image import convertArrayToQImage
 from ...colors import preferredColormaps
 from ... import qt, icons
 from .. import items

--- a/silx/gui/plot3d/actions/io.py
+++ b/silx/gui/plot3d/actions/io.py
@@ -43,7 +43,7 @@ from silx.gui import qt, printer
 from silx.gui.icons import getQIcon
 from .Plot3DAction import Plot3DAction
 from ..utils import mng
-from ...utils._image import convertQImageToArray
+from ...utils.image import convertQImageToArray
 
 
 _logger = logging.getLogger(__name__)

--- a/silx/gui/utils/image.py
+++ b/silx/gui/utils/image.py
@@ -96,8 +96,9 @@ def convertQImageToArray(image):
     The created numpy array is using a copy of the QImage data.
 
     :param QImage image: The QImage to convert.
-    :return: The image array of RGB or RGBA channels
-    :rtype: numpy.ndarray of uint8 of shape (height, width, channels (3 or 4))
+    :return: The image array of RGB or RGBA channels of shape
+        (height, width, channels (3 or 4))
+    :rtype: numpy.ndarray of uint8
     """
     rgba8888 = getattr(qt.QImage, 'Format_RGBA8888', None)  # Only in Qt5
 

--- a/silx/gui/utils/image.py
+++ b/silx/gui/utils/image.py
@@ -43,44 +43,44 @@ from numpy.lib.stride_tricks import as_strided as _as_strided
 from .. import qt
 
 
-def convertArrayToQImage(image):
+def convertArrayToQImage(array):
     """Convert an array-like image to a QImage.
 
     The created QImage is using a copy of the array data.
 
     Limitation: Only RGB or RGBA images with 8 bits per channel are supported.
 
-    :param image: Array-like image data of shape (height, width, channels)
+    :param array: Array-like image data of shape (height, width, channels)
        Channels are expected to be either RGB or RGBA.
-    :type image: numpy.ndarray of uint8
+    :type array: numpy.ndarray of uint8
     :return: Corresponding Qt image with RGB888 or ARGB32 format.
     :rtype: QImage
     """
-    image = numpy.array(image, copy=False, order='C', dtype=numpy.uint8)
+    array = numpy.array(array, copy=False, order='C', dtype=numpy.uint8)
 
-    if image.ndim != 3 or image.shape[2] not in (3, 4):
+    if array.ndim != 3 or array.shape[2] not in (3, 4):
         raise ValueError(
             'Image must be a 3D array with 3 or 4 channels per pixel')
 
-    if image.shape[2] == 4:
+    if array.shape[2] == 4:
         format_ = qt.QImage.Format_ARGB32
         # RGBA -> ARGB + take care of endianness
         if sys.byteorder == 'little':  # RGBA -> BGRA
-            image = image[:, :, (2, 1, 0, 3)]
+            array = array[:, :, (2, 1, 0, 3)]
         else:  # big endian: RGBA -> ARGB
-            image = image[:, :, (3, 0, 1, 2)]
+            array = array[:, :, (3, 0, 1, 2)]
 
-        image = numpy.array(image, order='C')  # Make a contiguous array
+        array = numpy.array(array, order='C')  # Make a contiguous array
 
-    else:  # image.shape[2] == 3
+    else:  # array.shape[2] == 3
         format_ = qt.QImage.Format_RGB888
 
-    height, width, depth = image.shape
+    height, width, depth = array.shape
     qimage = qt.QImage(
-        image.data,
+        array.data,
         width,
         height,
-        image.strides[0],  # bytesPerLine
+        array.strides[0],  # bytesPerLine
         format_)
 
     return qimage.copy()  # Making a copy of the image and its data

--- a/silx/gui/utils/image.py
+++ b/silx/gui/utils/image.py
@@ -22,11 +22,10 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-"""This module provides convenient functions to use with Qt objects.
+"""This module provides conversions between numpy.ndarray and QImage
 
-It provides:
-- conversion between numpy and QImage:
-  :func:`convertArrayToQImage`, :func:`convertQImageToArray`
+- :func:`convertArrayToQImage`
+- :func:`convertQImageToArray`
 """
 
 from __future__ import division
@@ -34,7 +33,7 @@ from __future__ import division
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "16/01/2017"
+__date__ = "04/09/2018"
 
 
 import sys

--- a/silx/gui/utils/test/test_image.py
+++ b/silx/gui/utils/test/test_image.py
@@ -33,7 +33,7 @@ import unittest
 
 from silx.gui import qt
 from silx.gui.test.utils import TestCaseQt
-from silx.gui.utils import image
+from silx.gui.utils.image import convertArrayToQImage, convertQImageToArray
 
 
 class TestQImageConversion(TestCaseQt):
@@ -42,7 +42,7 @@ class TestQImageConversion(TestCaseQt):
     def testConvertArrayToQImage(self):
         """Test conversion of numpy array to QImage"""
         image = numpy.ones((3, 3, 3), dtype=numpy.uint8)
-        qimage = image.convertArrayToQImage(image)
+        qimage = convertArrayToQImage(image)
 
         self.assertEqual(qimage.height(), image.shape[0])
         self.assertEqual(qimage.width(), image.shape[1])
@@ -55,7 +55,7 @@ class TestQImageConversion(TestCaseQt):
         """Test conversion of QImage to numpy array"""
         qimage = qt.QImage(3, 3, qt.QImage.Format_RGB888)
         qimage.fill(0x010101)
-        image = image.convertQImageToArray(qimage)
+        image = convertQImageToArray(qimage)
 
         self.assertEqual(qimage.height(), image.shape[0])
         self.assertEqual(qimage.width(), image.shape[1])

--- a/silx/gui/utils/test/test_image.py
+++ b/silx/gui/utils/test/test_image.py
@@ -33,7 +33,7 @@ import unittest
 
 from silx.gui import qt
 from silx.gui.test.utils import TestCaseQt
-from silx.gui.utils import _image
+from silx.gui.utils import image
 
 
 class TestQImageConversion(TestCaseQt):
@@ -42,7 +42,7 @@ class TestQImageConversion(TestCaseQt):
     def testConvertArrayToQImage(self):
         """Test conversion of numpy array to QImage"""
         image = numpy.ones((3, 3, 3), dtype=numpy.uint8)
-        qimage = _image.convertArrayToQImage(image)
+        qimage = image.convertArrayToQImage(image)
 
         self.assertEqual(qimage.height(), image.shape[0])
         self.assertEqual(qimage.width(), image.shape[1])
@@ -55,7 +55,7 @@ class TestQImageConversion(TestCaseQt):
         """Test conversion of QImage to numpy array"""
         qimage = qt.QImage(3, 3, qt.QImage.Format_RGB888)
         qimage.fill(0x010101)
-        image = _image.convertQImageToArray(qimage)
+        image = image.convertQImageToArray(qimage)
 
         self.assertEqual(qimage.height(), image.shape[0])
         self.assertEqual(qimage.width(), image.shape[1])

--- a/silx/gui/widgets/RangeSlider.py
+++ b/silx/gui/widgets/RangeSlider.py
@@ -37,7 +37,7 @@ __date__ = "02/08/2018"
 import numpy as numpy
 
 from silx.gui import qt, icons, colors
-from silx.gui.utils._image import convertArrayToQImage
+from silx.gui.utils.image import convertArrayToQImage
 
 
 class RangeSlider(qt.QWidget):


### PR DESCRIPTION
This PR makes QImage <-> array conversion available in the public API and add support for RGBA data/ARGB32 and RGBA8888 QImage format.

closes  #2082