### PR TITLE
[MaskWidget] Save mask as hdf5

### DIFF
--- a/silx/gui/dialog/DatasetDialog.py
+++ b/silx/gui/dialog/DatasetDialog.py
@@ -1,0 +1,105 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This module provides a dialog widget to select a HDF5 dataset in a
+tree.
+
+.. autoclass:: DatasetDialog
+   :members:
+   :inherited-members:
+
+
+"""
+from .GroupDialog import _Hdf5ItemSelectionDialog
+import silx.io
+from silx.io.url import DataUrl
+
+
+__authors__ = ["P. Knobel"]
+__license__ = "MIT"
+__date__ = "05/09/2018"
+
+
+class DatasetDialog(_Hdf5ItemSelectionDialog):
+    """This :class:`QDialog` uses a :class:`silx.gui.hdf5.Hdf5TreeView` to
+    provide a HDF5 dataset selection dialog.
+
+    The information identifying the selected node is provided as a
+    :class:`silx.io.url.DataUrl`.
+
+    Example:
+
+    .. code-block:: python
+
+        dialog = DatasetDialog()
+        dialog.addFile(filepath1)
+        dialog.addFile(filepath2)
+
+        if dialog.exec_():
+            print("File path: %s" % dialog.getSelectedDataUrl().file_path())
+            print("HDF5 dataset path : %s " % dialog.getSelectedDataUrl().data_path())
+        else:
+            print("Operation cancelled :(")
+
+    """
+    def __init__(self, parent=None):
+        _Hdf5ItemSelectionDialog.__init__(self, parent)
+
+        # customization for groups
+        self.setWindowTitle("HDF5 dataset selection")
+
+        self._header.setSections([self._model.NAME_COLUMN,
+                                  self._model.NODE_COLUMN,
+                                  self._model.LINK_COLUMN,
+                                  self._model.TYPE_COLUMN,
+                                  self._model.SHAPE_COLUMN])
+
+    def _onActivation(self, idx):
+        # double-click or enter press: filter for datasets
+        nodes = list(self._tree.selectedH5Nodes())
+        node = nodes[0]
+        if silx.io.is_dataset(node.h5py_object):
+            self.accept()
+
+    def _updateUrl(self):
+        # overloaded to filter for datasets
+        nodes = list(self._tree.selectedH5Nodes())
+        subgroupName = self._lineEditNewItem.text()
+        if nodes:
+            node = nodes[0]
+            if silx.io.is_dataset(node.h5py_object):
+                data_path = node.local_name
+                if subgroupName.lstrip("/"):
+                    if not data_path.endswith("/"):
+                        data_path += "/"
+                    data_path += subgroupName.lstrip("/")
+                self._selectedUrl = DataUrl(file_path=node.local_filename,
+                                            data_path=data_path)
+                self._okButton.setEnabled(True)
+                self._labelSelection.setText(
+                        self._selectedUrl.path())
+            else:
+                self._selectedUrl = None
+                self._okButton.setEnabled(False)
+                self._labelSelection.setText("Select a dataset")

--- a/silx/gui/dialog/GroupDialog.py
+++ b/silx/gui/dialog/GroupDialog.py
@@ -26,8 +26,8 @@
 tree.
 
 .. autoclass:: GroupDialog
-   :show-inheritance:
    :members:
+   :inherited-members:
 
 
 """

--- a/silx/gui/plot/actions/io.py
+++ b/silx/gui/plot/actions/io.py
@@ -40,7 +40,7 @@ __license__ = "MIT"
 __date__ = "12/07/2018"
 
 from . import PlotAction
-from silx.io.utils import save1D, savespec
+from silx.io.utils import save1D, savespec, NEXUS_HDF5_EXT
 from silx.io.nxdata import save_NXdata
 import logging
 import sys
@@ -62,9 +62,7 @@ else:
 
 _logger = logging.getLogger(__name__)
 
-
-_NEXUS_HDF5_EXT = [".h5", ".nx5", ".nxs",  ".hdf", ".hdf5", ".cxi"]
-_NEXUS_HDF5_EXT_STR = ' '.join(['*' + ext for ext in _NEXUS_HDF5_EXT])
+_NEXUS_HDF5_EXT_STR = ' '.join(['*' + ext for ext in NEXUS_HDF5_EXT])
 
 
 def selectOutputGroup(h5filename):

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -55,6 +55,10 @@ except ImportError as e:
 logger = logging.getLogger(__name__)
 
 
+NEXUS_HDF5_EXT = [".h5", ".nx5", ".nxs",  ".hdf", ".hdf5", ".cxi"]
+"""List of possible extensions for HDF5 file formats."""
+
+
 class H5Type(enum.Enum):
     """Identify a set of HDF5 concepts"""
     DATASET = 1


### PR DESCRIPTION
Support for hdf5 for loading and saving masks.

Closes #1945 

A new dialog is needed to select a dataset (existing or new) in a HDF5 file. The code can be reused from existing GroupDialog used to save plots as NXdata. But it needs to be improved in order to support a *read/open* mode, and to select a group while specifying a new dataset name in *write/save* mode.
