### PR TITLE
Add PlotWidget.getItems

### DIFF
--- a/doc/source/modules/gui/plot/plotwidget.rst
+++ b/doc/source/modules/gui/plot/plotwidget.rst
@@ -37,14 +37,12 @@ Get data
 
 Those methods return objects providing access to plotted data:
 
+.. automethod:: PlotWidget.getItems
+
 .. automethod:: PlotWidget.getCurve
 .. automethod:: PlotWidget.getImage
 .. automethod:: PlotWidget.getScatter
 .. automethod:: PlotWidget.getHistogram
-
-.. automethod:: PlotWidget.getAllCurves
-.. automethod:: PlotWidget.getAllImages
-
 
 Plot markers
 ............

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -1780,6 +1780,13 @@ class PlotWidget(qt.QMainWindow):
 
     # Getters
 
+    def getItems(self):
+        """Returns the list of items in the plot
+
+        :rtype: List[silx.gui.plot.items.Item]
+        """
+        return tuple(self._content.values())
+
     def getAllCurves(self, just_legend=False, withhidden=False):
         """Returns all curves legend or info and data.
 

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -156,6 +156,28 @@ class TestPlotWidget(PlotWidgetTestCase, ParametricTestCase):
         self.assertEqual(listener.arguments(callIndex=0), ('add', curve))
         self.assertEqual(listener.arguments(callIndex=1), ('remove', curve))
 
+    def testGetItems(self):
+        """Test getItems method"""
+        curve_x = 1, 2
+        self.plot.addCurve(curve_x, (3, 4))
+        image = (0, 1), (2, 3)
+        self.plot.addImage(image)
+        scatter_x = 10, 11
+        self.plot.addScatter(scatter_x, (12, 13), (0, 1))
+        marker_pos = 5, 5
+        self.plot.addMarker(*marker_pos)
+        marker_x = 6
+        self.plot.addXMarker(marker_x)
+        self.plot.addItem((0, 5), (2, 10), shape='rectangle')
+
+        items = self.plot.getItems()
+        self.assertEqual(len(items), 6)
+        self.assertTrue(numpy.all(numpy.equal(items[0].getXData(), curve_x)))
+        self.assertTrue(numpy.all(numpy.equal(items[1].getData(), image)))
+        self.assertTrue(numpy.all(numpy.equal(items[2].getXData(), scatter_x)))
+        self.assertTrue(numpy.all(numpy.equal(items[3].getPosition(), marker_pos)))
+        self.assertTrue(numpy.all(numpy.equal(items[4].getPosition()[0], marker_x)))
+        self.assertEqual(items[5].getType(), 'rectangle')
 
 class TestPlotImage(PlotWidgetTestCase, ParametricTestCase):
     """Basic tests for addImage"""


### PR DESCRIPTION
This PR adds a `PlotWidget.getItems` method which returns all items of the plot.

In the long term, this is a replacement for `getAllCurves`, `getAllImage` and any missing `getAll*` methods.
One can then filter out what he wants from the returned tuple.

Use case: PR #2112 add some methods to marker items, but there is no way from the public API to retrieve the marker items....