### PR TITLE
Improve support of Qt designer with PySide2

### DIFF
--- a/silx/gui/test/test_qt.py
+++ b/silx/gui/test/test_qt.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -90,6 +90,32 @@ class TestLoadUi(TestCaseQt):
         </property>
         <property name="text">
          <string>Button 2</string>
+        </property>
+       </widget>
+       <widget class="Line" name="line">
+        <property name="geometry">
+         <rect>
+          <x>10</x>
+          <y>90</y>
+          <width>118</width>
+          <height>3</height>
+         </rect>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+       <widget class="Line" name="line_2">
+        <property name="geometry">
+         <rect>
+          <x>150</x>
+          <y>20</y>
+          <width>3</width>
+          <height>61</height>
+         </rect>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
         </property>
        </widget>
       </widget>

--- a/silx/gui/test/test_qt.py
+++ b/silx/gui/test/test_qt.py
@@ -136,6 +136,7 @@ class TestLoadUi(TestCaseQt):
     </ui>
     """
 
+    @unittest.skipIf(qt.BINDING == "PySide", "Not fully working with PySide")
     def testLoadUi(self):
         """Create a QMainWindow from an ui file"""
         with temp_dir() as tmp:


### PR DESCRIPTION
This PR adds the support of the `Line` class which is produced by the Qt designer but is not supported by PySide2 (it's not a Qt widget).
With this, one can use Line in the Qt designer and use PySide2