### PR TITLE
Clean up the icon cache

### DIFF
--- a/silx/gui/icons.py
+++ b/silx/gui/icons.py
@@ -50,10 +50,23 @@ _cached_icons = None
 
 
 def getIconCache():
+    """Get access to all cached icons
+
+    :rtype: dict
+    """
     global _cached_icons
     if _cached_icons is None:
         _cached_icons = weakref.WeakValueDictionary()
+        # Clean up the cache before leaving the application
+        # See https://github.com/silx-kit/silx/issues/1771
+        qt.QApplication.instance().aboutToQuit.connect(cleanIconCache)
     return _cached_icons
+
+
+def cleanIconCache():
+    """Clean up the icon cache"""
+    _logger.debug("Clean up icon cache")
+    _cached_icons.clear()
 
 
 _supported_formats = None

--- a/silx/gui/icons.py
+++ b/silx/gui/icons.py
@@ -29,7 +29,7 @@ Use :func:`getQIcon` to create Qt QIcon from the name identifying an icon.
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "19/06/2018"
+__date__ = "05/10/2018"
 
 
 import os
@@ -45,8 +45,15 @@ _logger = logging.getLogger(__name__)
 """Module logger"""
 
 
-_cached_icons = weakref.WeakValueDictionary()
+_cached_icons = None
 """Cache loaded icons in a weak structure"""
+
+
+def getIconCache():
+    global _cached_icons
+    if _cached_icons is None:
+        _cached_icons = weakref.WeakValueDictionary()
+    return _cached_icons
 
 
 _supported_formats = None
@@ -285,7 +292,8 @@ def getAnimatedIcon(name):
     :raises: ValueError when name is not known
     """
     key = name + "__anim"
-    if key not in _cached_icons:
+    cached_icons = getIconCache()
+    if key not in cached_icons:
 
         qtMajorVersion = int(qt.qVersion().split(".")[0])
         icon = None
@@ -306,9 +314,9 @@ def getAnimatedIcon(name):
         if icon is None:
             raise ValueError("Not an animated icon name: %s", name)
 
-        _cached_icons[key] = icon
+        cached_icons[key] = icon
     else:
-        icon = _cached_icons[key]
+        icon = cached_icons[key]
     return icon
 
 
@@ -329,12 +337,13 @@ def getQIcon(name):
     :return: Corresponding QIcon
     :raises: ValueError when name is not known
     """
-    if name not in _cached_icons:
+    cached_icons = getIconCache()
+    if name not in cached_icons:
         qfile = getQFile(name)
         icon = qt.QIcon(qfile.fileName())
-        _cached_icons[name] = icon
+        cached_icons[name] = icon
     else:
-        icon = _cached_icons[name]
+        icon = cached_icons[name]
     return icon
 
 


### PR DESCRIPTION
The idea is to release on our own Python object binding before Qt release itself C++ objects.


The  bug was occurring 1 time every 10 launchs.
This patch looks to fix the problem. No bugs through about 30 launchs.



Closes #1771