### PR TITLE
[plot3d] Add picking of Mesh, Box, Cylinder and Hexagon items

### DIFF
--- a/silx/gui/plot3d/items/mesh.py
+++ b/silx/gui/plot3d/items/mesh.py
@@ -371,10 +371,19 @@ class _CylindricalVolume(DataItem3D):
         if len(trianglesIndices) == 0:
             return None
 
-        points = t.reshape(-1, 1) * (rayObject[1] - rayObject[0]) + rayObject[0]
-
         # Get object index from triangle index
         indices = trianglesIndices // (4 * self._nbFaces)
+
+        # Select closest intersection point for each primitive
+        indices, firstIndices = numpy.unique(indices, return_index=True)
+        t = t[firstIndices]
+
+        # Resort along t as result of numpy.unique is not sorted by t
+        sortedIndices = numpy.argsort(t)
+        t = t[sortedIndices]
+        indices = indices[sortedIndices]
+
+        points = t.reshape(-1, 1) * (rayObject[1] - rayObject[0]) + rayObject[0]
 
         return PickingResult(self,
                              positions=points,

--- a/silx/gui/plot3d/items/mesh.py
+++ b/silx/gui/plot3d/items/mesh.py
@@ -31,11 +31,17 @@ __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "17/07/2018"
 
+
+import logging
 import numpy
 
-from ..scene import primitives
-from .core import DataItem3D, ItemChangedType
+from ..scene import primitives, utils
 from ..scene.transform import Rotate
+from .core import DataItem3D, ItemChangedType
+from ._pick import PickingResult
+
+
+_logger = logging.getLogger(__name__)
 
 
 class Mesh(DataItem3D):
@@ -56,11 +62,7 @@ class Mesh(DataItem3D):
                 copy=True):
         """Set mesh geometry data.
 
-        Supported drawing modes are:
-
-        - For points: 'points'
-        - For lines: 'lines', 'line_strip', 'loop'
-        - For triangles: 'triangles', 'triangle_strip', 'fan'
+        Supported drawing modes are: 'triangles', 'triangle_strip', 'fan'
 
         :param numpy.ndarray position:
             Position (x, y, z) of each vertex as a (N, 3) array
@@ -73,7 +75,7 @@ class Mesh(DataItem3D):
         self._getScenePrimitive().children = []  # Remove any previous mesh
 
         if position is None or len(position) == 0:
-            self._mesh = 0
+            self._mesh = None
         else:
             self._mesh = primitives.Mesh3D(
                 position, color, normal, mode=mode, copy=copy)
@@ -144,6 +146,72 @@ class Mesh(DataItem3D):
         :rtype: str
         """
         return self._mesh.drawMode
+
+    def _pickFull(self, context):
+        """Perform precise picking in this item at given widget position.
+
+        :param PickContext context: Current picking context
+        :return: Object holding the results or None
+        :rtype: Union[None,PickingResult]
+        """
+        rayObject = context.getPickingSegment(frame=self._getScenePrimitive())
+        if rayObject is None:  # No picking outside viewport
+            return None
+        rayObject = rayObject[:, :3]
+
+        positions = self.getPositionData(copy=False)
+        if positions.size == 0:
+            return None
+
+        mode = self.getDrawMode()
+        if mode == 'triangles':
+            triangles = positions.reshape(-1, 3, 3)
+
+        elif mode == 'triangle_strip':
+            # Expand strip
+            triangles = numpy.empty((len(positions) - 2, 3, 3),
+                                    dtype=positions.dtype)
+            triangles[:, 0] = positions[:-2]
+            triangles[:, 1] = positions[1:-1]
+            triangles[:, 2] = positions[2:]
+
+        elif mode == 'fan':
+            # Expand fan
+            triangles = numpy.empty((len(positions) - 2, 3, 3),
+                                    dtype=positions.dtype)
+            triangles[:, 0] = positions[0]
+            triangles[:, 1] = positions[1:-1]
+            triangles[:, 2] = positions[2:]
+
+        else:
+            _logger.warning("Unsupported draw mode: %s" % mode)
+            return None
+
+        trianglesIndices, t, barycentric = utils.segmentTrianglesIntersection(
+            rayObject, triangles)
+
+        if len(trianglesIndices) == 0:
+            return None
+
+        points = t.reshape(-1, 1) * (rayObject[1] - rayObject[0]) + rayObject[0]
+
+        # Get vertex index from triangle index and closest point in triangle
+        closest = numpy.argmax(barycentric, axis=1)
+
+        if mode == 'triangles':
+            indices = trianglesIndices * 3 + closest
+
+        elif mode == 'triangle_strip':
+            indices = trianglesIndices + closest
+
+        elif mode == 'fan':
+            indices = trianglesIndices + closest  # For corners 1 and 2
+            indices[closest == 0] = 0  # For first corner (common)
+
+        return PickingResult(self,
+                             positions=points,
+                             indices=indices,
+                             fetchdata=self.getPositionData)
 
 
 class _CylindricalVolume(DataItem3D):

--- a/silx/gui/plot3d/test/testSceneWidgetPicking.py
+++ b/silx/gui/plot3d/test/testSceneWidgetPicking.py
@@ -173,6 +173,51 @@ class TestSceneWidgetPicking(TestCaseQt, ParametricTestCase):
         picking = list(self.widget.pickItems(1, 1))
         self.assertEqual(len(picking), 0)
 
+    def testPickMesh(self):
+        """Test picking of Mesh items"""
+
+        triangles = items.Mesh()
+        triangles.setData(
+            position=((0, 0, 0), (1, 0, 0), (1, 1, 0),
+                      (0, 0, 0), (1, 1, 0), (0, 1, 0)),
+            color=(1, 0, 0, 1),
+            mode='triangles')
+        triangleStrip = items.Mesh()
+        triangleStrip.setData(
+            position=(((1, 0, 0), (0, 0, 0), (1, 1, 0), (0, 1, 0))),
+            color=(0, 1, 0, 1),
+            mode='triangle_strip')
+        triangleFan = items.Mesh()
+        triangleFan.setData(
+            position=((0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)),
+            color=(0, 0, 1, 1),
+            mode='fan')
+
+        for item in (triangles, triangleStrip, triangleFan):
+            with self.subTest(mode=item.getDrawMode()):
+                # Add item
+                self.widget.clearItems()
+                self.widget.addItem(item)
+                self.widget.resetZoom('front')
+                self.qapp.processEvents()
+                self.qWait(2000)
+
+                # Picking on data (at widget center)
+                picking = list(self.widget.pickItems(*self._widgetCenter()))
+
+                self.assertEqual(len(picking), 1)
+                self.assertIs(picking[0].getItem(), item)
+                nbPos = len(picking[0].getPositions())
+                data = picking[0].getData()
+                self.assertEqual(nbPos, len(data))
+                self.assertTrue(numpy.array_equal(
+                    data,
+                    item.getPositionData()[picking[0].getIndices()]))
+
+                # Picking outside data
+                picking = list(self.widget.pickItems(1, 1))
+                self.assertEqual(len(picking), 0)
+
 
 def suite():
     testsuite = unittest.TestSuite()

--- a/silx/gui/plot3d/test/testSceneWidgetPicking.py
+++ b/silx/gui/plot3d/test/testSceneWidgetPicking.py
@@ -200,7 +200,6 @@ class TestSceneWidgetPicking(TestCaseQt, ParametricTestCase):
                 self.widget.addItem(item)
                 self.widget.resetZoom('front')
                 self.qapp.processEvents()
-                self.qWait(2000)
 
                 # Picking on data (at widget center)
                 picking = list(self.widget.pickItems(*self._widgetCenter()))
@@ -213,6 +212,43 @@ class TestSceneWidgetPicking(TestCaseQt, ParametricTestCase):
                 self.assertTrue(numpy.array_equal(
                     data,
                     item.getPositionData()[picking[0].getIndices()]))
+
+                # Picking outside data
+                picking = list(self.widget.pickItems(1, 1))
+                self.assertEqual(len(picking), 0)
+
+    def testPickCylindricalMesh(self):
+        """Test picking of Box, Cylinder and Hexagon items"""
+
+        positions = numpy.array(((0., 0., 0.), (1., 1., 0.), (2., 2., 0.)))
+        box = items.Box()
+        box.setData(position=positions)
+        cylinder = items.Cylinder()
+        cylinder.setData(position=positions)
+        hexagon = items.Hexagon()
+        hexagon.setData(position=positions)
+
+        for item in (box, cylinder, hexagon):
+            with self.subTest(item=item.__class__.__name__):
+                # Add item
+                self.widget.clearItems()
+                self.widget.addItem(item)
+                self.widget.resetZoom('front')
+                self.qapp.processEvents()
+
+                # Picking on data (at widget center)
+                picking = list(self.widget.pickItems(*self._widgetCenter()))
+
+                self.assertEqual(len(picking), 1)
+                self.assertIs(picking[0].getItem(), item)
+                nbPos = len(picking[0].getPositions())
+                data = picking[0].getData()
+                print(item.__class__.__name__, [positions[1]], data)
+                self.assertTrue(numpy.all(numpy.equal(positions[1], data)))
+                self.assertEqual(nbPos, len(data))
+                self.assertTrue(numpy.array_equal(
+                    data,
+                    item.getPosition()[picking[0].getIndices()]))
 
                 # Picking outside data
                 picking = list(self.widget.pickItems(1, 1))

--- a/silx/gui/plot3d/tools/PositionInfoWidget.py
+++ b/silx/gui/plot3d/tools/PositionInfoWidget.py
@@ -137,6 +137,9 @@ class PositionInfoWidget(qt.QWidget):
                         items.ImageData,
                         items.ImageRgba,
                         items.Mesh,
+                        items.Box,
+                        items.Cylinder,
+                        items.Hexagon,
                         volume.CutPlane,
                         volume.Isosurface)
     """Type of items that are picked"""

--- a/silx/gui/plot3d/tools/PositionInfoWidget.py
+++ b/silx/gui/plot3d/tools/PositionInfoWidget.py
@@ -136,6 +136,7 @@ class PositionInfoWidget(qt.QWidget):
                         items.Scatter2D,
                         items.ImageData,
                         items.ImageRgba,
+                        items.Mesh,
                         volume.CutPlane,
                         volume.Isosurface)
     """Type of items that are picked"""


### PR DESCRIPTION
Merge PR #2129 first!

This PR adds support of Mesh, Box, Cylinder and Hexagon items + some associated tests.
It provides the indices of the picked triangles for Mesh and the indices of the picked elements for Cylinder and Hexagon + a single position (the closest) for each elements.

closes #2135