### PR TITLE
Improve file synchronization

### DIFF
--- a/silx/app/view/Viewer.py
+++ b/silx/app/view/Viewer.py
@@ -202,10 +202,22 @@ class Viewer(qt.QMainWindow):
             if silx.io.is_file(h5):
                 h5files.append(h5)
 
+        model = self.__treeview.findHdf5TreeModel()
         for h5 in h5files:
-            self.__treeview.findHdf5TreeModel().synchronizeH5pyObject(h5)
+            self.__synchronizeH5pyObject(h5)
 
         qt.QApplication.restoreOverrideCursor()
+
+    def __synchronizeH5pyObject(self, h5):
+        model = self.__treeview.findHdf5TreeModel()
+        # This is buggy right now while h5py do not alloow to close a file
+        # while references are still used
+        # model.synchronizeH5pyObject(h5)
+
+        filename = h5.filename
+        row = model.h5pyObjectRow(h5)
+        model.removeH5pyObject(h5)
+        model.insertFile(filename, row)
 
     def __expandAllSelected(self):
         """Expand all selected items of the tree.
@@ -720,5 +732,5 @@ class Viewer(qt.QMainWindow):
                 action.triggered.connect(lambda: self.__treeview.findHdf5TreeModel().removeH5pyObject(h5))
                 menu.addAction(action)
                 action = qt.QAction("Synchronize %s" % obj.local_filename, event.source())
-                action.triggered.connect(lambda: self.__treeview.findHdf5TreeModel().synchronizeH5pyObject(h5))
+                action.triggered.connect(lambda: self.__synchronizeH5pyObject(h5))
                 menu.addAction(action)

--- a/silx/app/view/Viewer.py
+++ b/silx/app/view/Viewer.py
@@ -185,6 +185,8 @@ class Viewer(qt.QMainWindow):
         model = self.__treeview.model()
         while len(indexes) > 0:
             index = indexes.pop(0)
+            if index.column() != 0:
+                continue
             if isinstance(index, tuple):
                 index, depth = index
             else:
@@ -211,6 +213,8 @@ class Viewer(qt.QMainWindow):
         model = self.__treeview.model()
         while len(indexes) > 0:
             index = indexes.pop(0)
+            if index.column() != 0:
+                continue
             if isinstance(index, tuple):
                 index, depth = index
             else:

--- a/silx/app/view/Viewer.py
+++ b/silx/app/view/Viewer.py
@@ -192,19 +192,33 @@ class Viewer(qt.QMainWindow):
 
         selection = self.__treeview.selectionModel()
         indexes = selection.selectedIndexes()
+        selectedRows = []
         model = self.__treeview.model()
         h5files = []
         while len(indexes) > 0:
             index = indexes.pop(0)
             if index.column() != 0:
                 continue
+            selectedRows.append(index.row())
             h5 = model.data(index, role=silx.gui.hdf5.Hdf5TreeModel.H5PY_OBJECT_ROLE)
             if silx.io.is_file(h5):
                 h5files.append(h5)
 
+        if len(h5files) == 0:
+            qt.QApplication.restoreOverrideCursor()
+            return
+
         model = self.__treeview.findHdf5TreeModel()
         for h5 in h5files:
             self.__synchronizeH5pyObject(h5)
+
+        model = self.__treeview.model()
+        itemSelection = qt.QItemSelection()
+        for row in selectedRows:
+            index = model.index(row, 0, qt.QModelIndex())
+            indexEnd = model.index(row, model.columnCount() - 1, qt.QModelIndex())
+            itemSelection.select(index, indexEnd)
+        selection.select(itemSelection, qt.QItemSelectionModel.ClearAndSelect)
 
         qt.QApplication.restoreOverrideCursor()
 

--- a/silx/app/view/Viewer.py
+++ b/silx/app/view/Viewer.py
@@ -224,8 +224,9 @@ class Viewer(qt.QMainWindow):
 
     def __synchronizeH5pyObject(self, h5):
         model = self.__treeview.findHdf5TreeModel()
-        # This is buggy right now while h5py do not alloow to close a file
-        # while references are still used
+        # This is buggy right now while h5py do not allow to close a file
+        # while references are still used.
+        # FIXME: The architecture have to be reworked to support this feature.
         # model.synchronizeH5pyObject(h5)
 
         filename = h5.filename

--- a/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/silx/gui/hdf5/Hdf5TreeModel.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "05/10/2018"
+__date__ = "08/10/2018"
 
 
 import os
@@ -594,7 +594,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
     def h5pyObjectRow(self, h5pyObject):
         for row in range(self.__root.childCount()):
             item = self.__root.child(row)
-            if item.obj is h5pyObject:
+            if item.obj == h5pyObject:
                 return row
         return -1
 
@@ -609,7 +609,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         index = 0
         while index < self.__root.childCount():
             item = self.__root.child(index)
-            if item.obj is h5pyObject:
+            if item.obj == h5pyObject:
                 qindex = self.index(index, 0, qt.QModelIndex())
                 self.synchronizeIndex(qindex)
             index += 1
@@ -621,7 +621,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         :param qt.QModelIndex index: Index of the item to remove
         """
         node = self.nodeFromIndex(index)
-        if node.parent is not self.__root:
+        if node.parent != self.__root:
             return
         self._closeFileIfOwned(node)
         self.beginRemoveRows(qt.QModelIndex(), index.row(), index.row())
@@ -639,7 +639,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         index = 0
         while index < self.__root.childCount():
             item = self.__root.child(index)
-            if item.obj is h5pyObject:
+            if item.obj == h5pyObject:
                 qindex = self.index(index, 0, qt.QModelIndex())
                 self.removeIndex(qindex)
             else:

--- a/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/silx/gui/hdf5/Hdf5TreeModel.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "11/06/2018"
+__date__ = "05/10/2018"
 
 
 import os
@@ -590,6 +590,13 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
 
         filename = node.obj.filename
         self.insertFileAsync(filename, index.row(), synchronizingNode=node)
+
+    def h5pyObjectRow(self, h5pyObject):
+        for row in range(self.__root.childCount()):
+            item = self.__root.child(row)
+            if item.obj is h5pyObject:
+                return row
+        return -1
 
     def synchronizeH5pyObject(self, h5pyObject):
         """


### PR DESCRIPTION
- Close and reload files (hack allowing to synch file)
   - As result, virtual HDF5 or displayed data are not updated but removed
   - This issue needs a bigger understanding and rework to be fixed
- Returns expanded tree and selection
- Icon to sync a file (to work, the root of the tree have to be selected)

Closes #298 (not part of the treeview, but part of silx view)
Closes #2083 
Closes #2087 
