### PR TITLE
HDF5 tree nexus class format issue

### DIFF
--- a/silx/gui/hdf5/Hdf5Item.py
+++ b/silx/gui/hdf5/Hdf5Item.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -354,7 +354,7 @@ class Hdf5Item(Hdf5Node):
                 else:
                     if six.PY2:
                         self.__nx_class = self.__nx_class.decode()
-                    else:
+                    elif not isinstance(self.__nx_class, str):
                         self.__nx_class = str(self.__nx_class, "UTF-8")
         return self.__nx_class
 


### PR DESCRIPTION
This PR fixes an issue I got with python 3.4, h5py 2.7.1, PyQt5, where `__nx_class` was already a `str`. 