### PR TITLE
Add a silx.gui.qt.inspect module

### DIFF
--- a/silx/gui/qt/inspect.py
+++ b/silx/gui/qt/inspect.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This module provides functions to access Qt C++ object state:
+
+- :func:`isValid` to check whether a QObject C++ pointer is valid.
+- :func:`createdByPython` to check if a QObject was created from Python.
+- :func:`ownedByPython` to check if a QObject is currently owned by Python.
+"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "08/10/2018"
+
+
+from . import _qt as qt
+
+if qt.BINDING in ('PyQt4', 'PyQt5'):
+    from sip import isdeleted as _isdeleted  # noqa
+    from sip import ispycreated as createdByPython  # noqa
+    from sip import ispyowned as ownedByPython  # noqa
+
+    def isValid(obj):
+        """Returns True if underlying C++ object is valid.
+
+        :param QObject obj:
+        :rtype: bool
+        """
+        return not _isdeleted(obj)
+
+elif qt.BINDING == 'PySide2':
+    from PySide2.shiboken2 import isValid  # noqa
+    from PySide2.shiboken2 import createdByPython  # noqa
+    from PySide2.shiboken2 import ownedByPython  # noqa
+
+elif qt.BINDING == 'PySide':
+    try:  # Available through PySide
+        from PySide.shiboken import isValid  # noqa
+        from PySide.shiboken import createdByPython  # noqa
+        from PySide.shiboken import ownedByPython  # noqa
+    except ImportError:  # Available through standalone shiboken package
+        from Shiboken.shiboken import isValid  # noqa
+        from Shiboken.shiboken import createdByPython  # noqa
+        from Shiboken.shiboken import ownedByPython  # noqa
+
+else:
+    raise ImportError("Unsupported Qt binding %s" % qt.BINDING)
+
+__all__ = ['isValid', 'createdByPython', 'ownedByPython']

--- a/silx/gui/test/test_qt.py
+++ b/silx/gui/test/test_qt.py
@@ -36,6 +36,10 @@ from silx.test.utils import temp_dir
 from silx.gui.utils.testutils import TestCaseQt
 
 from silx.gui import qt
+try:
+    from silx.gui.qt import inspect as qt_inspect
+except ImportError:
+    qt_inspect = None
 
 
 class TestQtWrapper(unittest.TestCase):
@@ -159,9 +163,35 @@ class TestLoadUi(TestCaseQt):
             testMainWindow.close()
 
 
+class TestQtInspect(unittest.TestCase):
+    """Test functions of silx.gui.qt.inspect module"""
+
+    # shiboken module is not always available
+    @unittest.skipIf(qt.BINDING == 'PySide' and qt_inspect is None,
+                     reason="shiboken module not available")
+    def test(self):
+        """Test functions of silx.gui.qt.inspect module"""
+        self.assertIsNotNone(qt_inspect)
+
+        parent = qt.QObject()
+
+        self.assertTrue(qt_inspect.isValid(parent))
+        self.assertTrue(qt_inspect.createdByPython(parent))
+        self.assertTrue(qt_inspect.ownedByPython(parent))
+
+        obj = qt.QObject(parent)
+
+        self.assertTrue(qt_inspect.isValid(obj))
+        self.assertTrue(qt_inspect.createdByPython(obj))
+        self.assertFalse(qt_inspect.ownedByPython(obj))
+
+        del parent
+        self.assertFalse(qt_inspect.isValid(obj))
+
+
 def suite():
     test_suite = unittest.TestSuite()
-    for TestCaseCls in (TestQtWrapper, TestLoadUi):
+    for TestCaseCls in (TestQtWrapper, TestLoadUi, TestQtInspect):
         test_suite.addTest(
             unittest.defaultTestLoader.loadTestsFromTestCase(TestCaseCls))
     return test_suite


### PR DESCRIPTION
This PR adds a `silx.gui.qt.inspect` module which provides 3 functions to check the state of a wrapped C++ QObject: `isValid`, `createdByPython` and `ownedByPython`.

It makes API consistent across PyQt* and PySide* by taking PySide2 names.
For PySide(1), it does its best to load shiboken... but it might not be available (I could not find it on Debian8).