### PR TITLE
Update dependencies warning

### DIFF
--- a/silx/gui/plot/CompareImages.py
+++ b/silx/gui/plot/CompareImages.py
@@ -46,11 +46,10 @@ from silx.third_party import enum
 
 _logger = logging.getLogger(__name__)
 
-try:
-    from silx.image import sift
-except ImportError as e:
-    _logger.warning("Error while importing sift: %s", str(e))
-    _logger.debug("Backtrace", exc_info=True)
+from silx.opencl import ocl
+if ocl is not None:
+    from silx.opencl import sift
+else:  # No OpenCL device or no pyopencl
     sift = None
 
 

--- a/silx/image/medianfilter.py
+++ b/silx/image/medianfilter.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2017 European Synchrotron Radiation Facility
+# Copyright (C) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -31,12 +31,15 @@ __authors__ = ["H. Payno"]
 __license__ = "MIT"
 __date__ = "04/05/2017"
 
-from silx.math import medianfilter as medianfilter_cpp
-try:
-    from silx.opencl import medfilt as medfilt_opencl
-except ImportError:
-    medfilt_opencl = None
+
 import logging
+
+from silx.math import medianfilter as medianfilter_cpp
+from silx.opencl import ocl as _ocl
+if _ocl is not None:
+    from silx.opencl import medfilt as medfilt_opencl
+else:  # No OpenCL device or pyopencl not installed
+    medfilt_opencl = None
 
 
 _logger = logging.getLogger(__name__)
@@ -84,7 +87,7 @@ def medfilt2d(image, kernel_size=3, engine='cpp'):
                                         conditional=False)
     elif engine == 'opencl':
         if medfilt_opencl is None:
-            wrn = 'opencl median filter module import failed'
+            wrn = 'opencl median filter not available. '
             wrn += 'Launching cpp implementation.'
             _logger.warning(wrn)
             # instead call the cpp implementation

--- a/silx/opencl/sift/alignment.py
+++ b/silx/opencl/sift/alignment.py
@@ -4,7 +4,7 @@
 #    Project: Sift implementation in Python + OpenCL
 #             https://github.com/silx-kit/silx
 #
-#    Copyright (C) 2013-2017  European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2013-2018  European Synchrotron Radiation Facility, Grenoble, France
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -51,8 +51,6 @@ from ..utils import calc_size, get_opencl_code
 from .utils import matching_correction
 import logging
 logger = logging.getLogger(__name__)
-if not pyopencl:
-    logger.warning("No PyOpenCL, no sift")
 
 from .match import MatchPlan
 from .plan import SiftPlan

--- a/silx/opencl/sift/match.py
+++ b/silx/opencl/sift/match.py
@@ -50,8 +50,6 @@ from ..common import pyopencl, kernel_workgroup_size
 from .utils import calc_size
 from ..processing import OpenclProcessing, BufferDescription
 logger = logging.getLogger(__name__)
-if not pyopencl:
-    logger.warning("No PyOpenCL, no sift")
 
 
 class MatchPlan(OpenclProcessing):


### PR DESCRIPTION
This PR removes duplicated warnings about `pyopencl` not being available.

The only remaining warning about a missing dependency in silx is when importing `silx.opencl` when `pyopencl` is missing... which makes sense to me (To me it should even raise an `ImportError`).

This PR also reworks the way `CompareWidgets` and `silx.image.medianfilter` are probing the availability of OpenCL as `ImportError` is not raised.

To me it closes #2023