### PR TITLE
(hopefully) fixes travis macos tests

### DIFF
--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -118,6 +118,7 @@ class TestPlotWidget(PlotWidgetTestCase, ParametricTestCase):
         """Test resizing the widget and receiving limitsChanged events"""
         self.plot.resize(200, 200)
         self.qapp.processEvents()
+        self.qWait(100)
 
         xlim = self.plot.getXAxis().getLimits()
         ylim = self.plot.getYAxis().getLimits()
@@ -129,6 +130,7 @@ class TestPlotWidget(PlotWidgetTestCase, ParametricTestCase):
         # Resize without aspect ratio
         self.plot.resize(200, 300)
         self.qapp.processEvents()
+        self.qWait(100)
         self._checkLimits(expectedXLim=xlim, expectedYLim=ylim)
         self.assertEqual(listener.callCount(), 0)
 
@@ -139,6 +141,7 @@ class TestPlotWidget(PlotWidgetTestCase, ParametricTestCase):
 
         self.plot.resize(200, 200)
         self.qapp.processEvents()
+        self.qWait(100)
         self.assertNotEqual(listener.callCount(), 0)
 
     def testAddRemoveItemSignals(self):

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -137,6 +137,7 @@ class TestPlotWidget(PlotWidgetTestCase, ParametricTestCase):
         # Resize with aspect ratio
         self.plot.setKeepDataAspectRatio(True)
         self.qapp.processEvents()
+        self.qWait(1000)
         listener.clear()  # Clean-up received signal
 
         self.plot.resize(200, 200)


### PR DESCRIPTION
This PR adds some `qWait` in the resize/change aspect ratio test of the PlotWidget which leaded to random seg fault when running the tests with the OpenGL backend on macos on travis (I could not reproduce locally).

Hopefully closes #2134