### PR TITLE
Add alpha channel to ScatterView

### DIFF
--- a/silx/gui/plot/ScatterView.py
+++ b/silx/gui/plot/ScatterView.py
@@ -273,7 +273,7 @@ class ScatterView(qt.QMainWindow):
         :return: Colormap currently in use
         :rtype: ~silx.gui.colors.Colormap
         """
-        self.getScatterItem().getColormap()
+        return self.getScatterItem().getColormap()
 
     # Control displayed scatter plot
 

--- a/silx/gui/plot/ScatterView.py
+++ b/silx/gui/plot/ScatterView.py
@@ -277,7 +277,7 @@ class ScatterView(qt.QMainWindow):
 
     # Control displayed scatter plot
 
-    def setData(self, x, y, value, xerror=None, yerror=None, copy=True):
+    def setData(self, x, y, value, xerror=None, yerror=None, alpha=None, copy=True):
         """Set the data of the scatter plot.
 
         To reset the scatter plot, set x, y and value to None.
@@ -295,6 +295,8 @@ class ScatterView(qt.QMainWindow):
 
         :param yerror: Values with the uncertainties on the y values
         :type yerror: A float, or a numpy.ndarray of float32. See xerror.
+        :param alpha: Values with the transparency (between 0 and 1)
+        :type alpha: A float, or a numpy.ndarray of float32 
         :param bool copy: True make a copy of the data (default),
                           False to use provided arrays.
         """
@@ -303,7 +305,7 @@ class ScatterView(qt.QMainWindow):
         value = () if value is None else value
 
         self.getScatterItem().setData(
-            x=x, y=y, value=value, xerror=xerror, yerror=yerror, copy=copy)
+            x=x, y=y, value=value, xerror=xerror, yerror=yerror, alpha=alpha, copy=copy)
 
     def getData(self, *args, **kwargs):
         return self.getScatterItem().getData(*args, **kwargs)

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -166,6 +166,7 @@ class Scatter(Points, ColormapMixIn):
         :param yerror: Values with the uncertainties on the y values
         :type yerror: A float, or a numpy.ndarray of float32. See xerror.
         :param alpha: Values with the transparency (between 0 and 1)
+        :type alpha: A float, or a numpy.ndarray of float32 
         :param bool copy: True make a copy of the data (default),
                           False to use provided arrays.
         """

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -53,7 +53,8 @@ class Scatter(Points, ColormapMixIn):
         Points.__init__(self)
         ColormapMixIn.__init__(self)
         self._value = ()
-
+        self._alpha = None
+        
     def _addBackendRenderer(self, backend):
         """Update backend renderer"""
         # Filter-out values <= 0
@@ -65,6 +66,9 @@ class Scatter(Points, ColormapMixIn):
 
         cmap = self.getColormap()
         rgbacolors = cmap.applyToData(self._value)
+
+        if self._alpha is not None:
+            rgbacolors[:, -1] *= numpy.clip(self._alpha*255, 0, 255).astype(numpy.uint8)
 
         return backend.addCurve(xFiltered, yFiltered, self.getLegend(),
                                 color=rgbacolors,
@@ -112,6 +116,15 @@ class Scatter(Points, ColormapMixIn):
         """
         return numpy.array(self._value, copy=copy)
 
+    def getAlphaData(self, copy=True):
+        """Returns the alpha (transparency) assigned to the scatter data points.
+
+        :param copy: True (Default) to get a copy,
+                     False to use internal representation (do not modify!)
+        :rtype: numpy.ndarray
+        """
+        return numpy.array(self._alpha, copy=copy)
+
     def getData(self, copy=True, displayed=False):
         """Returns the x, y coordinates and the value of the data points
 
@@ -137,7 +150,7 @@ class Scatter(Points, ColormapMixIn):
                 self.getYErrorData(copy))
 
     # reimplemented from Points to handle `value`
-    def setData(self, x, y, value, xerror=None, yerror=None, copy=True):
+    def setData(self, x, y, value, xerror=None, yerror=None, alpha=None, copy=True):
         """Set the data of the scatter.
 
         :param numpy.ndarray x: The data corresponding to the x coordinates.
@@ -152,6 +165,7 @@ class Scatter(Points, ColormapMixIn):
                       row 1 for negative errors.
         :param yerror: Values with the uncertainties on the y values
         :type yerror: A float, or a numpy.ndarray of float32. See xerror.
+        :param alpha: Values with the transparency (between 0 and 1)
         :param bool copy: True make a copy of the data (default),
                           False to use provided arrays.
         """
@@ -160,7 +174,8 @@ class Scatter(Points, ColormapMixIn):
         assert len(x) == len(value)
 
         self._value = value
-
+        self._alpha = alpha
+        
         # set x, y, xerror, yerror
 
         # call self._updated + plot._invalidateDataRange()

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -53,7 +53,7 @@ class Scatter(Points, ColormapMixIn):
         Points.__init__(self)
         ColormapMixIn.__init__(self)
         self._value = ()
-        self._alpha = None
+        self.__alpha = None
         
     def _addBackendRenderer(self, backend):
         """Update backend renderer"""
@@ -67,8 +67,8 @@ class Scatter(Points, ColormapMixIn):
         cmap = self.getColormap()
         rgbacolors = cmap.applyToData(self._value)
 
-        if self._alpha is not None:
-            rgbacolors[:, -1] *= numpy.clip(self._alpha*255, 0, 255).astype(numpy.uint8)
+        if self.__alpha is not None:
+            rgbacolors[:, -1] = numpy.clip(self.__alpha*255, 0, 255).astype(numpy.uint8)
 
         return backend.addCurve(xFiltered, yFiltered, self.getLegend(),
                                 color=rgbacolors,
@@ -123,7 +123,7 @@ class Scatter(Points, ColormapMixIn):
                      False to use internal representation (do not modify!)
         :rtype: numpy.ndarray
         """
-        return numpy.array(self._alpha, copy=copy)
+        return numpy.array(self.__alpha, copy=copy)
 
     def getData(self, copy=True, displayed=False):
         """Returns the x, y coordinates and the value of the data points
@@ -174,7 +174,7 @@ class Scatter(Points, ColormapMixIn):
         assert len(x) == len(value)
 
         self._value = value
-        self._alpha = alpha
+        self.__alpha = alpha
         
         # set x, y, xerror, yerror
 

--- a/silx/gui/plot/test/testScatterView.py
+++ b/silx/gui/plot/test/testScatterView.py
@@ -103,6 +103,24 @@ class TestScatterView(PlotWidgetTestCase):
         self.assertIsNone(data[3])  # xerror
         self.assertIsNone(data[4])  # yerror
 
+    def testAlpha(self):
+        """Test alpha transparency in setData"""
+        _pts = 100
+        _levels = 100
+        _fwhm = 50
+        x = numpy.random.rand(_pts)*_levels
+        y = numpy.random.rand(_pts)*_levels
+        value = numpy.random.rand(_pts)*_levels
+        x0 = x[int(_pts/2)]
+        y0 = x[int(_pts/2)]
+        #2D Gaussian kernel
+        alpha = numpy.exp(-4*numpy.log(2) * ((x-x0)**2 + (y-y0)**2) / _fwhm**2)
+
+        self.plot.setData(x, y, value, alpha=alpha)
+        self.qapp.processEvents()
+
+        alphaData = self.plot.getAlphaData()
+        self.assertTrue(numpy.all(numpy.equal(alpha, alphaData)))
 
 def suite():
     test_suite = unittest.TestSuite()


### PR DESCRIPTION
It adds the possibility to give a transparency channel in addition to the value.

A minimal example to see its behaviour:

```
import numpy as np
from silx import config
from silx import sx
from silx.gui.plot.ScatterView import ScatterView

samps = 1000
levels = 100
fwhm = 50
cen = 500

x = np.random.rand(samps)*levels
y = np.random.rand(samps)*levels
v = np.random.rand(samps)*levels
x0, y0 = x[cen], y[cen]
a = np.exp(-4*np.log(2) * ((x-x0)**2 + (y-y0)**2) / fwhm**2)

config.DEFAULT_COLORMAP_NAME = 'viridis'

#without transparency
s1 = ScatterView()                                                
s1.setData(x, y, v)
s1.show()
#with transparency
s2 = ScatterView()
s2.setData(x, y, v, alpha=a)
s2.show()

```