### PR TITLE
Make sx tests works with PyQt4/python2.7 on Windows

### DIFF
--- a/silx/sx/test/test_sx.py
+++ b/silx/sx/test/test_sx.py
@@ -204,7 +204,6 @@ class SXTest(TestCaseQt, ParametricTestCase):
         isosurfaces = window.getIsosurfaces()
         self.assertEqual(len(isosurfaces), 1)
 
-        self._expose_and_close(window)
         if not window.getPlot3DWidget().isValid():
             self.skipTest("OpenGL context is not valid")
 
@@ -218,8 +217,6 @@ class SXTest(TestCaseQt, ParametricTestCase):
         for iso, color in zip(isosurfaces, colors):
             self.assertEqual(rgba(iso.getColor()), rgba(color))
 
-        self._expose_and_close(window)
-
         # by isolevel, single color
         contours = 0.2, 0.5
         window = sx.contour3d(data, copy=False, contours=contours,
@@ -232,8 +229,6 @@ class SXTest(TestCaseQt, ParametricTestCase):
             self.assertEqual(rgba(iso.getColor()),
                              rgba('yellow'))
 
-        self._expose_and_close(window)
-
         # Single isolevel, colormap
         window = sx.contour3d(data, copy=False, contours=0.5,
                               colormap='gray', vmin=0.6, opacity=0.4)
@@ -243,8 +238,6 @@ class SXTest(TestCaseQt, ParametricTestCase):
         self.assertEqual(isosurfaces[0].getLevel(), 0.5)
         self.assertEqual(rgba(isosurfaces[0].getColor()),
                          (0., 0., 0., 0.4))
-
-        self._expose_and_close(window)
 
     @unittest.skipUnless(test_options.WITH_GL_TEST,
                          test_options.WITH_GL_TEST_REASON)
@@ -258,23 +251,19 @@ class SXTest(TestCaseQt, ParametricTestCase):
         # 3D positions, no value
         window = sx.points3d(x, y, z)
 
-        self._expose_and_close(window)
         if not window.getSceneWidget().isValid():
             self.skipTest("OpenGL context is not valid")
 
         # 3D positions, values
         window = sx.points3d(x, y, z, values, mode='2dsquare',
                              colormap='magma', vmin=0.4, vmax=0.5)
-        self._expose_and_close(window)
 
         # 2D positions, no value
         window = sx.points3d(x, y)
-        self._expose_and_close(window)
 
         # 2D positions, values
         window = sx.points3d(x, y, values=values, mode=',',
                              colormap='magma', vmin=0.4, vmax=0.5)
-        self._expose_and_close(window)
 
 
 def suite():


### PR DESCRIPTION
This PR fixes tests on sx.contour3d with PyQt4 on Python2.7 on Windows.

closes #1699