### PR TITLE
devscripts is needed on debian for automatic packaging

### DIFF
--- a/package/debian8/control
+++ b/package/debian8/control
@@ -65,7 +65,8 @@ Build-Depends: cython,
                python3-scipy-dbg,
                python3-sphinx,
                python3-sphinxcontrib.programoutput,
-               help2man
+               help2man,
+               devscripts
 Standards-Version: 3.9.6
 Vcs-Browser: https://anonscm.debian.org/cgit/debian-science/packages/silx.git
 Vcs-Git: git://anonscm.debian.org/debian-science/packages/silx.git

--- a/package/debian9/control
+++ b/package/debian9/control
@@ -45,7 +45,8 @@ Build-Depends: cython,
                python3-sphinxcontrib.programoutput,
                openstack-pkg-tools,
                help2man,
-               locales
+               locales,
+               devscripts
 Standards-Version: 3.9.8
 Vcs-Browser: https://anonscm.debian.org/cgit/debian-science/packages/silx.git
 Vcs-Git: git://anonscm.debian.org/debian-science/packages/silx.git


### PR DESCRIPTION
missing dependency in debian