### PR TITLE
Stop testing PySide with CI

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -34,10 +34,6 @@ environment:
           QT_BINDING: "PyQt4"
           WITH_GL_TEST: False
 
-        - PYTHON_DIR: "C:\\Python27-x64"
-          QT_BINDING: "PySide"
-          WITH_GL_TEST: False
-
 install:
     # Add Python to PATH
     - "SET PATH=%PYTHON_DIR%;%PYTHON_DIR%\\Scripts;%PATH%"


### PR DESCRIPTION
Stop testing PySide as it is no more a target and this should speed-up appveyor builds.