### PR TITLE
[plot] Add ColorBarWidget to ImageView

### DIFF
--- a/silx/gui/plot/ImageView.py
+++ b/silx/gui/plot/ImageView.py
@@ -345,7 +345,8 @@ class ImageView(PlotWindow):
         layout.addWidget(self.getWidgetHandle(), 0, 0)
         layout.addWidget(self._histoVPlot.getWidgetHandle(), 0, 1)
         layout.addWidget(self._histoHPlot.getWidgetHandle(), 1, 0)
-        layout.addWidget(self._radarView, 1, 1)
+        layout.addWidget(self._radarView, 1, 1, 1, 2)
+        layout.addWidget(self.getColorBarWidget(), 0, 2)
 
         layout.setColumnMinimumWidth(0, self.IMAGE_MIN_SIZE)
         layout.setColumnStretch(0, 1)


### PR DESCRIPTION
This PR adds `PlotWindow`'s `ColorBarWidget` to `ImageView` central widget layout, otherwise it is deleted as `ImageView` changes the content of the `PlotWindow` central widget

This is probably the cause of #2202 and anyway makes the colorbar available in the `ImageView` widget (disabled by default).

If this is solving #2202, I would be in favor of integrating in 0.9.