### PR TITLE
Fix dialogs directory enabled for macOS/pyqt4

### DIFF
--- a/silx/gui/dialog/SafeFileSystemModel.py
+++ b/silx/gui/dialog/SafeFileSystemModel.py
@@ -749,7 +749,7 @@ class SafeFileSystemModel(qt.QSortFilterProxyModel):
         index = self.mapToSource(index)
         filters = sourceModel.flags(index)
 
-        if self.__nameFilterDisables:
+        if self.__nameFilterDisables and not sourceModel.isDir(index):
             item = sourceModel._item(index)
             if not self.__nameFiltersAccepted(item):
                 filters &= ~qt.Qt.ItemIsEnabled


### PR DESCRIPTION
This PR makes directory enabled in dialogs with PyQt4 on macOS and avoids the following test errors:

```
======================================================================
FAIL: testFilterExtensions (silx.gui.dialog.test.test_datafiledialog.TestDataFileDialogInteraction)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/tvincent/venv/silx-release-py27/lib/python2.7/site-packages/silx/gui/dialog/test/test_datafiledialog.py", line 547, in testFilterExtensions
    self.assertEqual(self._countSelectableItems(browser.model(), browser.rootIndex()), 4)
AssertionError: 3 != 4

======================================================================
FAIL: testFilterExtensions (silx.gui.dialog.test.test_imagefiledialog.TestImageFileDialogInteraction)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/tvincent/venv/silx-release-py27/lib/python2.7/site-packages/silx/gui/dialog/test/test_imagefiledialog.py", line 555, in testFilterExtensions
    self.assertEqual(self._countSelectableItems(browser.model(), browser.rootIndex()), 6)
AssertionError: 5 != 6
```