### PR TITLE
[NXdataWidgets]Improve sliders location for data selection 

### DIFF
--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -72,21 +72,16 @@ class ArrayCurvePlot(qt.QWidget):
 
         self._plot = Plot1D(self)
 
-        self.selectorDock = qt.QDockWidget("Data selector", self._plot)
-        # not closable
-        self.selectorDock.setFeatures(qt.QDockWidget.DockWidgetMovable |
-                                      qt.QDockWidget.DockWidgetFloatable)
-        self._selector = NumpyAxesSelector(self.selectorDock)
+        self._selector = NumpyAxesSelector(self)
         self._selector.setNamedAxesSelectorVisibility(False)
         self.__selector_is_connected = False
-        self.selectorDock.setWidget(self._selector)
-        self._plot.addTabbedDockWidget(self.selectorDock)
 
         self._plot.sigActiveCurveChanged.connect(self._setYLabelFromActiveLegend)
 
-        layout = qt.QGridLayout()
+        layout = qt.QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
-        layout.addWidget(self._plot, 0, 0)
+        layout.addWidget(self._plot)
+        layout.addWidget(self._selector)
 
         self.setLayout(layout)
 
@@ -130,9 +125,9 @@ class ArrayCurvePlot(qt.QWidget):
         self._selector.setAxisNames(["Y"])
 
         if len(ys[0].shape) < 2:
-            self.selectorDock.hide()
+            self._selector.hide()
         else:
-            self.selectorDock.show()
+            self._selector.show()
 
         self._plot.setGraphTitle(title or "")
         self._updateCurve()
@@ -339,11 +334,8 @@ class ArrayImagePlot(qt.QWidget):
                                                normalization=Colormap.LINEAR))
         self._plot.getIntensityHistogramAction().setVisible(True)
 
-        self.selectorDock = qt.QDockWidget("Data selector", self._plot)
         # not closable
-        self.selectorDock.setFeatures(qt.QDockWidget.DockWidgetMovable |
-                                      qt.QDockWidget.DockWidgetFloatable)
-        self._selector = NumpyAxesSelector(self.selectorDock)
+        self._selector = NumpyAxesSelector(self)
         self._selector.setNamedAxesSelectorVisibility(False)
         self._selector.selectionChanged.connect(self._updateImage)
 
@@ -355,9 +347,8 @@ class ArrayImagePlot(qt.QWidget):
 
         layout = qt.QVBoxLayout()
         layout.addWidget(self._plot)
+        layout.addWidget(self._selector)
         layout.addWidget(self._auxSigSlider)
-        self.selectorDock.setWidget(self._selector)
-        self._plot.addTabbedDockWidget(self.selectorDock)
 
         self.setLayout(layout)
 
@@ -413,9 +404,9 @@ class ArrayImagePlot(qt.QWidget):
         self._selector.setData(signals[0])
 
         if len(signals[0].shape) <= img_ndim:
-            self.selectorDock.hide()
+            self._selector.hide()
         else:
-            self.selectorDock.show()
+            self._selector.show()
 
         self._auxSigSlider.setMaximum(len(signals) - 1)
         if len(signals) > 1:


### PR DESCRIPTION
Improves upon #2213 

The PR only fixes the issue for NXdata widgets, by not putting the sliders in a dock widget (this was asking for trouble).

It does not address the general question of the dock widget position and how to let applications specify a preferred initial location.