### PR TITLE
Refactor colormap

### DIFF
--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -154,23 +154,9 @@ def cursorColorForColormap(colormapName):
     return _COLORMAP_CURSOR_COLORS.get(colormapName, 'black')
 
 
-DEFAULT_COLORMAPS = (
-    'gray', 'reversed gray', 'temperature', 'red', 'green', 'blue')
-"""Tuple of supported colormap names."""
-
-DEFAULT_MIN_LIN = 0
-"""Default min value if in linear normalization"""
-DEFAULT_MAX_LIN = 1
-"""Default max value if in linear normalization"""
-DEFAULT_MIN_LOG = 1
-"""Default min value if in log normalization"""
-DEFAULT_MAX_LOG = 10
-"""Default max value if in log normalization"""
-
-
 # Colormap loader
 
-_AVAILABLE_AS_RESOURCE = ('magma', 'inferno', 'plasma', 'viridis')
+_AVAILABLE_AS_RESOURCE = 'viridis', 'magma', 'inferno', 'plasma'
 """List available colormap name as resources"""
 
 
@@ -253,6 +239,19 @@ def _getColormap(name):
         _COLORMAP_CACHE[name] = lut
 
     return _COLORMAP_CACHE[name]
+
+
+DEFAULT_COLORMAPS = _AVAILABLE_AS_BUILTINS + _AVAILABLE_AS_RESOURCE
+"""Tuple of supported colormap names."""
+
+DEFAULT_MIN_LIN = 0
+"""Default min value if in linear normalization"""
+DEFAULT_MAX_LIN = 1
+"""Default max value if in linear normalization"""
+DEFAULT_MIN_LOG = 1
+"""Default min value if in log normalization"""
+DEFAULT_MAX_LOG = 10
+"""Default max value if in log normalization"""
 
 
 class Colormap(qt.QObject):
@@ -676,7 +675,8 @@ class Colormap(qt.QObject):
         """Get the supported colormap names as a tuple of str.
 
         The list should at least contain and start by:
-        ('gray', 'reversed gray', 'temperature', 'red', 'green', 'blue')
+        ('gray', 'reversed gray', 'temperature', 'red', 'green', 'blue',
+         'viridis', 'magma', 'inferno', 'plasma')
         :rtype: tuple
         """
         if _matplotlib_cm is not None:
@@ -685,7 +685,9 @@ class Colormap(qt.QObject):
             colormaps = set()
         colormaps.update(_AVAILABLE_AS_BUILTINS)
         colormaps.update(_AVAILABLE_AS_RESOURCE)
-        colormaps = tuple(sorted(colormaps))
+
+        colormaps = tuple(cmap for cmap in sorted(colormaps)
+                      if cmap not in DEFAULT_COLORMAPS)
 
         return DEFAULT_COLORMAPS + colormaps
 
@@ -793,7 +795,6 @@ def preferredColormaps():
     """
     global _PREFERRED_COLORMAPS
     if _PREFERRED_COLORMAPS is None:
-        _PREFERRED_COLORMAPS = DEFAULT_COLORMAPS
         # Initialize preferred colormaps
         setPreferredColormaps(('gray', 'reversed gray',
                                'temperature', 'red', 'green', 'blue', 'jet',

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -635,7 +635,7 @@ class Colormap(qt.QObject):
 
     @staticmethod
     def _fromDict(dic):
-        colormap = Colormap(name="")
+        colormap = Colormap()
         colormap._setFromDict(dic)
         return colormap
 

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -32,7 +32,6 @@ __license__ = "MIT"
 __date__ = "05/10/2018"
 
 from silx.gui import qt
-import copy as copy_mdl
 import numpy
 import logging
 from silx.math.combo import min_max
@@ -294,6 +293,8 @@ class Colormap(qt.QObject):
                 vmin = None
                 vmax = None
 
+        self._name = None
+        self._colors = None
         if name is not None:  # Ignores colors
             self.setName(name)
         else:

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -295,10 +295,12 @@ class Colormap(qt.QObject):
 
         self._name = None
         self._colors = None
-        if name is not None:  # Ignores colors
-            self.setName(name)
-        else:
+
+        if colors is not None:
             self.setColormapLUT(colors)
+
+        if name is not None:
+            self.setName(name)  # And resets colormap LUT
 
         self._normalization = str(normalization)
         self._vmin = float(vmin) if vmin is not None else None
@@ -377,6 +379,8 @@ class Colormap(qt.QObject):
         if colors.shape == ():
             raise TypeError("An array is expected for 'colors' argument. '%s' was found." % type(colors))
         assert len(colors) != 0
+        assert colors.ndim >= 2
+        assert colors.shape[-1] <= 4  # Provide up to 4 channels (RGBA)
         colors.shape = -1, colors.shape[-1]
         if colors.dtype.kind == 'f':
             colors = _convertColorsFromFloatToUint8(colors)

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -376,13 +376,11 @@ class BaseMaskToolsWidget(qt.QWidget):
         self._plotRef = weakref.ref(plot)
         self._maskName = '__MASK_TOOLS_%d' % id(self)  # Legend of the mask
 
-        self._colormap = Colormap(name="",
-                                  normalization='linear',
+        self._colormap = Colormap(normalization='linear',
                                   vmin=0,
-                                  vmax=self._maxLevelNumber,
-                                  colors=None)
+                                  vmax=self._maxLevelNumber)
         self._defaultOverlayColor = rgba('gray')  # Color of the mask
-        self._setMaskColors(1, 0.5)
+        self._setMaskColors(1, 0.5)  # Set the colormap LUT
 
         if not isinstance(mask, BaseMask):
             raise TypeError("mask is not an instance of BaseMask")

--- a/silx/gui/plot/matplotlib/Colormap.py
+++ b/silx/gui/plot/matplotlib/Colormap.py
@@ -29,7 +29,13 @@ from matplotlib.colors import ListedColormap
 import matplotlib.colors
 import matplotlib.cm
 import silx.resources
-from silx.utils.deprecation import deprecated
+from silx.utils.deprecation import deprecated, deprecated_warning
+
+
+deprecated_warning(type_='module',
+                   name=__file__,
+                   replacement='silx.gui.colors.Colormap',
+                   since_version='0.10.0')
 
 
 _logger = logging.getLogger(__name__)
@@ -46,25 +52,30 @@ _CMAPS = {}
 
 
 @property
+@deprecated(since_version='0.10.0')
 def magma():
     return getColormap('magma')
 
 
 @property
+@deprecated(since_version='0.10.0')
 def inferno():
     return getColormap('inferno')
 
 
 @property
+@deprecated(since_version='0.10.0')
 def plasma():
     return getColormap('plasma')
 
 
 @property
+@deprecated(since_version='0.10.0')
 def viridis():
     return getColormap('viridis')
 
 
+@deprecated(since_version='0.10.0')
 def getColormap(name):
     """Returns matplotlib colormap corresponding to given name
 
@@ -143,6 +154,7 @@ def getColormap(name):
         return matplotlib.cm.get_cmap(name)
 
 
+@deprecated(since_version='0.10.0')
 def getScalarMappable(colormap, data=None):
     """Returns matplotlib ScalarMappable corresponding to colormap
 
@@ -223,6 +235,8 @@ def applyColormapToData(data, colormap):
     return rgbaImage
 
 
+@deprecated(replacement='silx.colors.Colormap.getSupportedColormaps',
+            since_version='0.10.0')
 def getSupportedColormaps():
     """Get the supported colormap names as a tuple of str.
     """

--- a/silx/gui/test/test_colors.py
+++ b/silx/gui/test/test_colors.py
@@ -228,14 +228,16 @@ class TestObjectAPI(ParametricTestCase):
         """Make sure the copy function is correctly processing
         """
         colormapObject = Colormap(name='red',
-                                  colors=numpy.array([12, 13, 14]),
+                                  colors=numpy.array([[1., 0., 0.],
+                                                      [0., 1., 0.],
+                                                      [0., 0., 1.]]),
                                   vmin=None,
                                   vmax=None,
                                   normalization=Colormap.LOGARITHM)
 
         colormapObject2 = colormapObject.copy()
         self.assertTrue(colormapObject == colormapObject2)
-        colormapObject.setColormapLUT(numpy.array([0, 1]))
+        colormapObject.setColormapLUT([[0, 0, 0], [255, 255, 255]])
         self.assertFalse(colormapObject == colormapObject2)
 
         colormapObject2 = colormapObject.copy()
@@ -361,7 +363,7 @@ class TestObjectAPI(ParametricTestCase):
         with self.assertRaises(NotEditableError):
             colormap.setName('magma')
         with self.assertRaises(NotEditableError):
-            colormap.setColormapLUT(numpy.array([0, 1]))
+            colormap.setColormapLUT([[0., 0., 0.], [1., 1., 1.]])
         with self.assertRaises(NotEditableError):
             colormap._setFromDict(colormap._toDict())
         state = colormap.saveState()

--- a/silx/gui/test/test_colors.py
+++ b/silx/gui/test/test_colors.py
@@ -158,12 +158,12 @@ class TestDictAPI(unittest.TestCase):
         self.assertFalse(colormapObject.isAutoscale() == clm_dict['autoscale'])
 
     def testMissingKeysFromDict(self):
-        """Make sure we can create a Colormap object from a dictionnary even if
-        there is missing keys excepts if those keys are 'colors' or 'name'
+        """Make sure we can create a Colormap object from a dictionary even if
+        there is missing keys except if those keys are 'colors' or 'name'
         """
-        colormap = Colormap._fromDict({'name': 'toto'})
+        colormap = Colormap._fromDict({'name': 'blue'})
         self.assertTrue(colormap.getVMin() is None)
-        colormap = Colormap._fromDict({'colors': numpy.zeros(10)})
+        colormap = Colormap._fromDict({'colors': numpy.zeros((5, 3))})
         self.assertTrue(colormap.getName() is None)
 
         with self.assertRaises(ValueError):
@@ -227,7 +227,7 @@ class TestObjectAPI(ParametricTestCase):
     def testCopy(self):
         """Make sure the copy function is correctly processing
         """
-        colormapObject = Colormap(name='toto',
+        colormapObject = Colormap(name='red',
                                   colors=numpy.array([12, 13, 14]),
                                   vmin=None,
                                   vmax=None,


### PR DESCRIPTION
This PR reworks `silx.gui.colors.Colormap` implementation and deprecates `silx.gui.plot.matplotlib.Colormap` (which is no longer used within silx).
It:
- Removes the strong dependency to matplotlib in `silx.gui.colors`: closes #1859
- Improves `Colormap.getNColors`  to return the same number of colors as the LUT (and not a hard-coded 256): closes #2217