### PR TITLE
Avoid iterate uncertainties if not enough names are provided

### DIFF
--- a/silx/io/nxdata/parse.py
+++ b/silx/io/nxdata/parse.py
@@ -52,7 +52,7 @@ from silx.third_party import six
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "17/04/2018"
+__date__ = "06/11/2018"
 
 
 class InvalidNXdataError(Exception):
@@ -181,8 +181,14 @@ class NXdata(object):
             uncertainties_names = get_uncertainties_names(self.group, signal_name)
             if uncertainties_names is not None:
                 if len(uncertainties_names) != len(axes_names):
-                    self.issues.append("@uncertainties does not define the same " +
-                                       "number of fields than @axes")
+                    if len(uncertainties_names) < len(axes_names):
+                        # ignore the field to avoid index error in the axes loop
+                        uncertainties_names = None
+                        self.issues.append("@uncertainties does not define the same " +
+                                           "number of fields than @axes. Field ignored")
+                    else:
+                        self.issues.append("@uncertainties does not define the same " +
+                                           "number of fields than @axes")
 
             # Test individual axes
             is_scatter = True  # true if all axes have the same size as the signal


### PR DESCRIPTION
Avoid IndexError if axes names and uncertainties names do not have the same size

```
ERROR:silx.gui.qt._qt:<class 'IndexError'> list index out of range   File "/workspace/valls/silx.git/build/lib.linux-x86_64-3.5/silx/app/view/Viewer.py", line 749, in displaySelectedData
    self.__dataPanel.setData(data)
  File "/workspace/valls/silx.git/build/lib.linux-x86_64-3.5/silx/app/view/DataPanel.py", line 119, in setData
    self.__dataViewer.setData(data)
  File "/workspace/valls/silx.git/build/lib.linux-x86_64-3.5/silx/gui/data/DataViewerFrame.py", line 173, in setData
    self.__dataViewer.setData(data)
  File "/workspace/valls/silx.git/build/lib.linux-x86_64-3.5/silx/gui/data/DataViewer.py", line 508, in setData
    self.__updateView()
  File "/workspace/valls/silx.git/build/lib.linux-x86_64-3.5/silx/gui/data/DataViewer.py", line 426, in __updateView
    self.__updateAvailableViews()
  File "/workspace/valls/silx.git/build/lib.linux-x86_64-3.5/silx/gui/data/DataViewer.py", line 406, in __updateAvailableViews
    info = self._getInfo()
  File "/workspace/valls/silx.git/build/lib.linux-x86_64-3.5/silx/gui/data/DataViewer.py", line 541, in _getInfo
    self.__info = DataViews.DataInfo(self.__data)
  File "/workspace/valls/silx.git/build/lib.linux-x86_64-3.5/silx/gui/data/DataViews.py", line 121, in __init__
    nxd = nxdata.get_default(data)
  File "/workspace/valls/silx.git/build/lib.linux-x86_64-3.5/silx/io/nxdata/parse.py", line 862, in get_default
    elif not validate or is_valid_nxdata(group):
  File "/workspace/valls/silx.git/build/lib.linux-x86_64-3.5/silx/io/nxdata/parse.py", line 751, in is_valid_nxdata
    nxd = NXdata(group)
  File "/workspace/valls/silx.git/build/lib.linux-x86_64-3.5/silx/io/nxdata/parse.py", line 87, in __init__
    self._validate()
  File "/workspace/valls/silx.git/build/lib.linux-x86_64-3.5/silx/io/nxdata/parse.py", line 238, in _validate
    errors_name = uncertainties_names[i]
```