### PR TITLE
Robustness on colormap

### DIFF
--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -31,9 +31,10 @@ __authors__ = ["T. Vincent", "H.Payno"]
 __license__ = "MIT"
 __date__ = "06/11/2018"
 
-from silx.gui import qt
 import numpy
 import logging
+
+from silx.gui import qt
 from silx.math.combo import min_max
 from silx.math.colormap import cmap as _cmap
 from silx.utils.exceptions import NotEditableError

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -38,6 +38,7 @@ from silx.gui import qt
 from silx.math.combo import min_max
 from silx.math.colormap import cmap as _cmap
 from silx.utils.exceptions import NotEditableError
+from silx.utils import deprecation
 from silx.resources import resource_filename as _resource_filename
 
 
@@ -300,6 +301,12 @@ class Colormap(qt.QObject):
         self._colors = None
 
         if colors is not None and name is not None:
+            deprecation.deprecated_warning("Argument",
+                                           name="silx.gui.plot.Colors",
+                                           reason="name and colors can't be used at the same time",
+                                           since_version="0.10.0",
+                                           skip_backtrace_count=1)
+
             colors = None
 
         if name is not None:

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -710,6 +710,10 @@ class Colormap(qt.QObject):
 
     def __eq__(self, other):
         """Compare colormap values and not pointers"""
+        if other is None:
+            return False
+        if not isinstance(other, Colormap):
+            return False
         return (self.getName() == other.getName() and
                 self.getNormalization() == other.getNormalization() and
                 self.getVMin() == other.getVMin() and

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import
 
 __authors__ = ["T. Vincent", "H.Payno"]
 __license__ = "MIT"
-__date__ = "05/10/2018"
+__date__ = "06/11/2018"
 
 from silx.gui import qt
 import numpy
@@ -255,6 +255,8 @@ DEFAULT_MAX_LOG = 10
 class Colormap(qt.QObject):
     """Description of a colormap
 
+    If no `name` nor `colors` are provided, a default gray LUT is used.
+
     :param str name: Name of the colormap
     :param tuple colors: optional, custom colormap.
             Nx3 or Nx4 numpy array of RGB(A) colors,
@@ -279,7 +281,7 @@ class Colormap(qt.QObject):
     sigChanged = qt.Signal()
     """Signal emitted when the colormap has changed."""
 
-    def __init__(self, name='gray', colors=None, normalization=LINEAR, vmin=None, vmax=None):
+    def __init__(self, name=None, colors=None, normalization=LINEAR, vmin=None, vmax=None):
         qt.QObject.__init__(self)
         self._editable = True
 
@@ -296,11 +298,16 @@ class Colormap(qt.QObject):
         self._name = None
         self._colors = None
 
-        if colors is not None:
-            self.setColormapLUT(colors)
+        if colors is not None and name is not None:
+            colors = None
 
         if name is not None:
             self.setName(name)  # And resets colormap LUT
+        elif colors is not None:
+            self.setColormapLUT(colors)
+        else:
+            # Default colormap is grey
+            self.setName("gray")
 
         self._normalization = str(normalization)
         self._vmin = float(vmin) if vmin is not None else None

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -321,6 +321,26 @@ class Colormap(qt.QObject):
         self._vmin = float(vmin) if vmin is not None else None
         self._vmax = float(vmax) if vmax is not None else None
 
+    def setFromColormap(self, other):
+        """Set this colormap using information from the `other` colormap.
+
+        :param Colormap other: Colormap to use as reference.
+        """
+        if not self.isEditable():
+            raise NotEditableError('Colormap is not editable')
+        if self == other:
+            return
+        old = self.blockSignals(True)
+        name = other.getName()
+        if name is not None:
+            self.setName(name)
+        else:
+            self.setColormapLUT(other.getColormapLUT())
+        self.setNormalization(other.getNormalization())
+        self.setVRange(other.getVMin(), other.getVMax())
+        self.blockSignals(old)
+        self.sigChanged.emit()
+
     def getNColors(self, nbColors=None):
         """Returns N colors computed by sampling the colormap regularly.
 

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -335,7 +335,7 @@ class Colormap(qt.QObject):
         if name is not None:
             self.setName(name)
         else:
-            self.setColormapLUT(other.getColormapLUT())
+            self.setColormapLUT(other.getColormapLUT(copy=False))
         self.setNormalization(other.getNormalization())
         self.setVRange(other.getVMin(), other.getVMax())
         self.blockSignals(old)
@@ -383,17 +383,18 @@ class Colormap(qt.QObject):
         self._colors = _getColormap(self._name)
         self.sigChanged.emit()
 
-    def getColormapLUT(self):
+    def getColormapLUT(self, copy=True):
         """Return the list of colors for the colormap or None if not set.
 
         This returns None if the colormap was set with :meth:`setName`.
         Use :meth:`getNColors` to get the colormap LUT for any colormap.
 
+        :param bool copy: If true a copy of the numpy array is provided
         :return: the list of colors for the colormap or None if not set
         :rtype: numpy.ndarray or None
         """
         if self._name is None:
-            return numpy.array(self._colors, copy=True)
+            return numpy.array(self._colors, copy=copy)
         else:
             return None
 
@@ -684,7 +685,7 @@ class Colormap(qt.QObject):
         :rtype: silx.gui.colors.Colormap
         """
         return Colormap(name=self._name,
-                        colors=self.getColormapLUT(),
+                        colors=self.getColormapLUT(copy=False),
                         vmin=self._vmin,
                         vmax=self._vmax,
                         normalization=self._normalization)

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import
 
 __authors__ = ["T. Vincent", "H.Payno"]
 __license__ = "MIT"
-__date__ = "06/11/2018"
+__date__ = "07/11/2018"
 
 import numpy
 import logging
@@ -335,7 +335,7 @@ class Colormap(qt.QObject):
         if name is not None:
             self.setName(name)
         else:
-            self.setColormapLUT(other.getColormapLUT(copy=False))
+            self.setColormapLUT(other.getColormapLUT())
         self.setNormalization(other.getNormalization())
         self.setVRange(other.getVMin(), other.getVMax())
         self.blockSignals(old)
@@ -681,19 +681,6 @@ class Colormap(qt.QObject):
 
     def copy(self):
         """Return a copy of the Colormap.
-
-        :rtype: silx.gui.colors.Colormap
-        """
-        return Colormap(name=self._name,
-                        colors=self.getColormapLUT(copy=False),
-                        vmin=self._vmin,
-                        vmax=self._vmax,
-                        normalization=self._normalization)
-
-    def deepcopy(self):
-        """Return a copy of the Colormap.
-
-        If a LUT is provided the numpy array data is also copyed.
 
         :rtype: silx.gui.colors.Colormap
         """

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -690,6 +690,19 @@ class Colormap(qt.QObject):
                         vmax=self._vmax,
                         normalization=self._normalization)
 
+    def deepcopy(self):
+        """Return a copy of the Colormap.
+
+        If a LUT is provided the numpy array data is also copyed.
+
+        :rtype: silx.gui.colors.Colormap
+        """
+        return Colormap(name=self._name,
+                        colors=self.getColormapLUT(),
+                        vmin=self._vmin,
+                        vmax=self._vmax,
+                        normalization=self._normalization)
+
     def applyToData(self, data):
         """Apply the colormap to the data
 

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -63,7 +63,7 @@ from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent", "H. Payno"]
 __license__ = "MIT"
-__date__ = "23/05/2018"
+__date__ = "06/11/2018"
 
 
 import logging
@@ -727,9 +727,9 @@ class ColormapDialog(qt.QDialog):
         """
         colormap = self.getColormap()
         if colormap is not None and self._colormapStoredState is not None:
-            if self._colormap()._toDict() != self._colormapStoredState:
+            if colormap != self._colormapStoredState:
                 self._ignoreColormapChange = True
-                colormap._setFromDict(self._colormapStoredState)
+                colormap.setFromColormap(self._colormapStoredState)
                 self._ignoreColormapChange = False
                 self._applyColormap()
 
@@ -801,7 +801,7 @@ class ColormapDialog(qt.QDialog):
         """
         colormap = self.getColormap()
         if colormap is not None:
-            self._colormapStoredState = colormap._toDict()
+            self._colormapStoredState = colormap.copy()
         else:
             self._colormapStoredState = None
 
@@ -839,7 +839,7 @@ class ColormapDialog(qt.QDialog):
         colormap = self.getColormap()
         if colormap is not None and colormap.isEditable():
             # can reset only in the case the colormap changed
-            rStateEnabled = colormap._toDict() != self._colormapStoredState
+            rStateEnabled = colormap != self._colormapStoredState
         resetButton.setEnabled(rStateEnabled)
 
     def _applyColormap(self):

--- a/silx/gui/test/test_colors.py
+++ b/silx/gui/test/test_colors.py
@@ -388,6 +388,14 @@ class TestObjectAPI(ParametricTestCase):
         colormap = Colormap()
         self.assertNotEqual(colormap, None)
 
+    def testSet(self):
+        colormap = Colormap()
+        other = Colormap(name="viridis", vmin=1, vmax=2, normalization=Colormap.LOGARITHM)
+        self.assertNotEqual(colormap, other)
+        colormap.setFromColormap(other)
+        self.assertIsNot(colormap, other)
+        self.assertEqual(colormap, other)
+
 
 class TestPreferredColormaps(unittest.TestCase):
     """Test get|setPreferredColormaps functions"""

--- a/silx/gui/test/test_colors.py
+++ b/silx/gui/test/test_colors.py
@@ -375,6 +375,19 @@ class TestObjectAPI(ParametricTestCase):
         with self.assertRaises(TypeError):
             Colormap(colors=256)
 
+    def testEqual(self):
+        colormap1 = Colormap()
+        colormap2 = Colormap()
+        self.assertEqual(colormap1, colormap2)
+
+    def testCompareString(self):
+        colormap = Colormap()
+        self.assertNotEqual(colormap, "a")
+
+    def testCompareNone(self):
+        colormap = Colormap()
+        self.assertNotEqual(colormap, None)
+
 
 class TestPreferredColormaps(unittest.TestCase):
     """Test get|setPreferredColormaps functions"""

--- a/silx/gui/test/test_colors.py
+++ b/silx/gui/test/test_colors.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import
 
 __authors__ = ["H.Payno"]
 __license__ = "MIT"
-__date__ = "05/10/2018"
+__date__ = "06/11/2018"
 
 import unittest
 import numpy
@@ -373,7 +373,7 @@ class TestObjectAPI(ParametricTestCase):
     def testBadColorsType(self):
         """Make sure colors can't be something else than an array"""
         with self.assertRaises(TypeError):
-            Colormap(name='temperature', colors=256)
+            Colormap(colors=256)
 
 
 class TestPreferredColormaps(unittest.TestCase):

--- a/silx/sx/_plot.py
+++ b/silx/sx/_plot.py
@@ -27,7 +27,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "28/06/2018"
+__date__ = "06/11/2018"
 
 
 import collections
@@ -263,7 +263,6 @@ def imshow(data=None, cmap=None, norm=Colormap.LINEAR,
     colormap.setNormalization(norm)
     colormap.setVMin(vmin)
     colormap.setVMax(vmax)
-    plt.setDefaultColormap(colormap)
 
     # Handle aspect
     if aspect in (None, False, 'auto', 'normal'):

--- a/silx/sx/_plot.py
+++ b/silx/sx/_plot.py
@@ -39,8 +39,7 @@ import numpy
 from ..utils.weakref import WeakList
 from ..gui import qt
 from ..gui.plot import Plot1D, Plot2D, ScatterView
-from ..gui.colors import COLORDICT
-from ..gui.colors import Colormap
+from ..gui import colors
 from ..gui.plot.tools import roi
 from ..gui.plot.items import roi as roi_items
 from ..gui.plot.tools.toolbars import InteractiveModeToolBar
@@ -165,7 +164,7 @@ def plot(*args, **kwargs):
         # Parse style
         if style:
             # Handle color first
-            possible_colors = [c for c in COLORDICT if style.startswith(c)]
+            possible_colors = [c for c in colors.COLORDICT if style.startswith(c)]
             if possible_colors:  # Take the longest string matching a color name
                 curve_color = possible_colors[0]
                 for c in possible_colors[1:]:
@@ -203,7 +202,7 @@ def plot(*args, **kwargs):
     return plt
 
 
-def imshow(data=None, cmap=None, norm=Colormap.LINEAR,
+def imshow(data=None, cmap=None, norm=colors.Colormap.LINEAR,
            vmin=None, vmax=None,
            aspect=False,
            origin='upper', scale=(1., 1.),
@@ -259,7 +258,7 @@ def imshow(data=None, cmap=None, norm=Colormap.LINEAR,
     colormap = plt.getDefaultColormap()
     if cmap is not None:
         colormap.setName(cmap)
-    assert norm in Colormap.NORMALIZATIONS
+    assert norm in colors.Colormap.NORMALIZATIONS
     colormap.setNormalization(norm)
     colormap.setVMin(vmin)
     colormap.setVMax(vmax)
@@ -294,7 +293,7 @@ def imshow(data=None, cmap=None, norm=Colormap.LINEAR,
 
 def scatter(x=None, y=None, value=None, size=None,
             marker='o',
-            cmap=None, norm=Colormap.LINEAR,
+            cmap=None, norm=colors.Colormap.LINEAR,
             vmin=None, vmax=None):
     """
     Plot scattered data in a :class:`~silx.gui.plot.ScatterView` widget.
@@ -342,7 +341,7 @@ def scatter(x=None, y=None, value=None, size=None,
     colormap = plt.getPlotWidget().getDefaultColormap()
     if cmap is not None:
         colormap.setName(cmap)
-    assert norm in Colormap.NORMALIZATIONS
+    assert norm in colors.Colormap.NORMALIZATIONS
     colormap.setNormalization(norm)
     colormap.setVMin(vmin)
     colormap.setVMax(vmax)

--- a/silx/sx/_plot.py
+++ b/silx/sx/_plot.py
@@ -230,7 +230,9 @@ def imshow(data=None, cmap=None, norm=colors.Colormap.LINEAR,
 
     :param data: data to plot as an image
     :type data: numpy.ndarray-like with 2 dimensions
-    :param str cmap: The name of the colormap to use for the plot.
+    :param str cmap: The name of the colormap to use for the plot. It also
+        supports a numpy array containing a RGB LUT, or a `colors.Colormap`
+        instance.
     :param str norm: The normalization of the colormap:
                      'linear' (default) or 'log'
     :param float vmin: The value to use for the min of the colormap
@@ -256,7 +258,12 @@ def imshow(data=None, cmap=None, norm=colors.Colormap.LINEAR,
 
     # Update default colormap with input parameters
     colormap = plt.getDefaultColormap()
-    if cmap is not None:
+    if isinstance(cmap, colors.Colormap):
+        colormap = cmap
+        plt.setDefaultColormap(colormap)
+    elif isinstance(cmap, numpy.ndarray):
+        colormap.setColors(cmap)
+    elif cmap is not None:
         colormap.setName(cmap)
     assert norm in colors.Colormap.NORMALIZATIONS
     colormap.setNormalization(norm)

--- a/silx/sx/test/test_sx.py
+++ b/silx/sx/test/test_sx.py
@@ -38,6 +38,7 @@ from silx.gui import qt
 # load TestCaseQt before sx
 from silx.gui.utils.testutils import TestCaseQt
 from silx.gui.colors import rgba
+from silx.gui.colors import Colormap
 from silx import sx
 
 
@@ -111,6 +112,10 @@ class SXTest(TestCaseQt, ParametricTestCase):
 
         # image, named cmap
         plt = sx.imshow(img, cmap='jet', title='jet cmap')
+        self._expose_and_close(plt)
+
+        # image, custom colormap
+        plt = sx.imshow(img, cmap=Colormap(), title='custom colormap')
         self._expose_and_close(plt)
 
         # image, log cmap

--- a/silx/sx/test/test_sx.py
+++ b/silx/sx/test/test_sx.py
@@ -24,7 +24,7 @@
 # ###########################################################################*/
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "05/10/2018"
+__date__ = "06/11/2018"
 
 
 import logging
@@ -109,7 +109,7 @@ class SXTest(TestCaseQt, ParametricTestCase):
         plt = sx.imshow(img)
         self._expose_and_close(plt)
 
-        # image, gray cmap
+        # image, named cmap
         plt = sx.imshow(img, cmap='jet', title='jet cmap')
         self._expose_and_close(plt)
 


### PR DESCRIPTION
- Avoid to to use both `name` and `colors` in the constructor (`colors` is ignored + deprecation warning)
- Now `Colormap(colors=ndarray)` do not create anymore a default gray LUT
- `imshow` supports `Colormap` inside the argument `cmap`
- Improve the `Colormap` object API (`copy`, `__eq__`, `setFromColormap`)
- Get ride of dict in `ColormapDialog` to avoid exception when using colormap with custom LUT
- Some small clean up