### PR TITLE
Improve colordialog

### DIFF
--- a/examples/imageview.py
+++ b/examples/imageview.py
@@ -42,7 +42,7 @@ from __future__ import division
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "18/10/2016"
+__date__ = "08/11/2018"
 
 import logging
 from silx.gui.plot.ImageView import ImageViewMainWindow
@@ -118,8 +118,7 @@ def main(argv=None):
 
     if args.log:  # Use log normalization by default
         colormap = mainWindow.getDefaultColormap()
-        colormap['normalization'] = 'log'
-        mainWindow.setColormap(colormap)
+        colormap.setNormalization(colormap.LOGARITHM)
 
     mainWindow.setImage(data,
                         origin=args.origin,

--- a/silx/_config.py
+++ b/silx/_config.py
@@ -28,7 +28,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "08/11/2018"
+__date__ = "09/11/2018"
 
 
 class Config(object):
@@ -61,16 +61,6 @@ class Config(object):
     :module:`silx.gui.colors`.
 
     .. versionadded:: 0.8
-    """
-
-    PREFERRED_COLORMAPS = None
-    """List the preferred LUT names which have to be displayed by default
-    in widgets providing LUT selection.
-
-    The available list of names are availaible in the module
-    :module:`silx.gui.colors`.
-
-    .. versionadded:: 0.10
     """
 
     DEFAULT_PLOT_IMAGE_Y_AXIS_ORIENTATION = 'upward'

--- a/silx/_config.py
+++ b/silx/_config.py
@@ -119,4 +119,3 @@ class Config(object):
 
     .. versionadded:: 0.9
     """
-                                    

--- a/silx/_config.py
+++ b/silx/_config.py
@@ -28,7 +28,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "26/04/2018"
+__date__ = "08/11/2018"
 
 
 class Config(object):
@@ -61,6 +61,16 @@ class Config(object):
     :module:`silx.gui.colors`.
 
     .. versionadded:: 0.8
+    """
+
+    PREFERRED_COLORMAPS = None
+    """List the preferred LUT names which have to be displayed by default
+    in widgets providing LUT selection.
+
+    The available list of names are availaible in the module
+    :module:`silx.gui.colors`.
+
+    .. versionadded:: 0.10
     """
 
     DEFAULT_PLOT_IMAGE_Y_AXIS_ORIENTATION = 'upward'

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -105,6 +105,16 @@ _AVAILABLE_LUTS = collections.OrderedDict([
 DEFAULT_COLORMAPS = tuple([k for k in _AVAILABLE_LUTS.keys() if _AVAILABLE_LUTS[k].default])
 """Tuple of supported colormap names."""
 
+DEFAULT_MIN_LIN = 0
+"""Default min value if in linear normalization"""
+DEFAULT_MAX_LIN = 1
+"""Default max value if in linear normalization"""
+DEFAULT_MIN_LOG = 1
+"""Default min value if in log normalization"""
+DEFAULT_MAX_LOG = 10
+"""Default max value if in log normalization"""
+
+
 def rgba(color, colorDict=None):
     """Convert color code '#RRGGBB' and '#RRGGBBAA' to (R, G, B, A)
 
@@ -271,14 +281,6 @@ def _getColormap(name):
         lut = _createColormapLut(name)
         _COLORMAP_CACHE[name] = lut
     return _COLORMAP_CACHE[name]
-DEFAULT_MIN_LIN = 0
-"""Default min value if in linear normalization"""
-DEFAULT_MAX_LIN = 1
-"""Default max value if in linear normalization"""
-DEFAULT_MIN_LOG = 1
-"""Default min value if in log normalization"""
-DEFAULT_MAX_LOG = 10
-"""Default max value if in log normalization"""
 
 
 class Colormap(qt.QObject):

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import
 
 __authors__ = ["T. Vincent", "H.Payno"]
 __license__ = "MIT"
-__date__ = "08/11/2018"
+__date__ = "09/11/2018"
 
 import numpy
 import logging
@@ -868,15 +868,11 @@ def preferredColormaps():
     global _PREFERRED_COLORMAPS
     if _PREFERRED_COLORMAPS is None:
         # Initialize preferred colormaps
-        if config.PREFERRED_COLORMAPS is not None:
-            default_preferred = config.PREFERRED_COLORMAPS
-        else:
-            default_preferred = [k for k in _AVAILABLE_LUTS.keys() if _AVAILABLE_LUTS[k].preferred]
-        _setPreferredColormaps(default_preferred)
-    return _PREFERRED_COLORMAPS
+        default_preferred = [k for k in _AVAILABLE_LUTS.keys() if _AVAILABLE_LUTS[k].preferred]
+        setPreferredColormaps(default_preferred)
+    return tuple(_PREFERRED_COLORMAPS)
 
 
-@deprecation.deprecated(replacement="silx.config.PREFFERED_COLORMAPS", since_version="0.10")
 def setPreferredColormaps(colormaps):
     """Set the list of preferred colormap names.
 
@@ -887,13 +883,8 @@ def setPreferredColormaps(colormaps):
     :type colormaps: iterable of str
     :raise ValueError: if the list of available preferred colormaps is empty.
     """
-    _setPreferredColormaps(colormaps)
-
-
-def _setPreferredColormaps(colormaps):
     supportedColormaps = Colormap.getSupportedColormaps()
-    colormaps = tuple(
-        cmap for cmap in colormaps if cmap in supportedColormaps)
+    colormaps = [cmap for cmap in colormaps if cmap in supportedColormaps]
     if len(colormaps) == 0:
         raise ValueError("Cannot set preferred colormaps to an empty list")
 

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -887,7 +887,7 @@ def setPreferredColormaps(colormaps):
     _PREFERRED_COLORMAPS = colormaps
 
 
-def registerLUT(name, colors, cursor_color='black'):
+def registerLUT(name, colors, cursor_color='black', preferred=True):
     """Register a custom LUT to be used with `Colormap` objects.
 
     It can override existing LUT names.
@@ -896,11 +896,24 @@ def registerLUT(name, colors, cursor_color='black'):
     :param numpy.ndarray colors: The custom LUT to register.
             Nx3 or Nx4 numpy array of RGB(A) colors,
             either uint8 or float in [0, 1].
+    :param bool preferred: If true, this LUT will be displayed as part of the
+        preferred colormaps in dialogs.
     :param str cursor_color: Color used to display overlay over images using
         colormap with this LUT.
     """
-    description = _LUT_DESCRIPTION('user', cursor_color, True)
+    description = _LUT_DESCRIPTION('user', cursor_color, preferred=preferred)
     colors = _arrayToRgba8888(colors)
     _AVAILABLE_LUTS[name] = description
+
+    if preferred:
+        # Invalidate the preferred cache
+        global _PREFERRED_COLORMAPS
+        if _PREFERRED_COLORMAPS is not None:
+            if name not in _PREFERRED_COLORMAPS:
+                _PREFERRED_COLORMAPS.append(name)
+        else:
+            # The cache is not yet loaded, it's fine
+            pass
+
     # Register the cache as the LUT was already loaded
     _COLORMAP_CACHE[name] = colors

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -103,11 +103,6 @@ _AVAILABLE_LUTS = collections.OrderedDict([
 ])
 """Description for internal porpose of all the default LUT provided by the library."""
 
-DEFAULT_COLORMAPS = tuple(_AVAILABLE_LUTS.keys())
-"""Tuple of supported colormap names.
-
-This attribute should not be used as has it could be unsynchronized.
-"""
 
 DEFAULT_MIN_LIN = 0
 """Default min value if in linear normalization"""

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -35,6 +35,7 @@ import numpy
 import logging
 import collections
 from silx.gui import qt
+from silx import config
 from silx.math.combo import min_max
 from silx.math.colormap import cmap as _cmap
 from silx.utils.exceptions import NotEditableError
@@ -859,7 +860,10 @@ def preferredColormaps():
     global _PREFERRED_COLORMAPS
     if _PREFERRED_COLORMAPS is None:
         # Initialize preferred colormaps
-        default_preferred = [k for k in _AVAILABLE_LUTS.keys() if _AVAILABLE_LUTS[k].preferred]
+        if config.PREFERRED_COLORMAPS is not None:
+            default_preferred = config.PREFERRED_COLORMAPS
+        else:
+            default_preferred = [k for k in _AVAILABLE_LUTS.keys() if _AVAILABLE_LUTS[k].preferred]
         setPreferredColormaps(default_preferred)
     return _PREFERRED_COLORMAPS
 

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -864,10 +864,11 @@ def preferredColormaps():
             default_preferred = config.PREFERRED_COLORMAPS
         else:
             default_preferred = [k for k in _AVAILABLE_LUTS.keys() if _AVAILABLE_LUTS[k].preferred]
-        setPreferredColormaps(default_preferred)
+        _setPreferredColormaps(default_preferred)
     return _PREFERRED_COLORMAPS
 
 
+@deprecation.deprecated(replacement="silx.config.PREFFERED_COLORMAPS", since_version="0.10")
 def setPreferredColormaps(colormaps):
     """Set the list of preferred colormap names.
 
@@ -878,6 +879,10 @@ def setPreferredColormaps(colormaps):
     :type colormaps: iterable of str
     :raise ValueError: if the list of available preferred colormaps is empty.
     """
+    _setPreferredColormaps(colormaps)
+
+
+def _setPreferredColormaps(colormaps):
     supportedColormaps = Colormap.getSupportedColormaps()
     colormaps = tuple(
         cmap for cmap in colormaps if cmap in supportedColormaps)

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -916,4 +916,5 @@ def registerLUT(name, colors, cursor_color='black'):
     description = _LUT_DESCRIPTION('user', cursor_color, True)
     colors = _arrayToRgba8888(colors)
     _AVAILABLE_LUTS[name] = description
+    # Register the cache as the LUT was already loaded
     _COLORMAP_CACHE[name] = colors

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -907,3 +907,21 @@ def _setPreferredColormaps(colormaps):
 
     global _PREFERRED_COLORMAPS
     _PREFERRED_COLORMAPS = colormaps
+
+
+def registerLUT(name, colors, cursor_color='black'):
+    """Register a custom LUT to be used with `Colormap` objects.
+
+    It can override existing LUT names.
+
+    :param str name: Name of the LUT as defined to configure colormaps
+    :param numpy.ndarray colors: The custom LUT to register.
+            Nx3 or Nx4 numpy array of RGB(A) colors,
+            either uint8 or float in [0, 1].
+    :param str cursor_color: Color used to display overlay over images using
+        colormap with this LUT.
+    """
+    description = _LUT_DESCRIPTION('user', cursor_color, True)
+    colors = _arrayToRgba8888(colors)
+    _AVAILABLE_LUTS[name] = description
+    _COLORMAP_CACHE[name] = colors

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -82,28 +82,31 @@ _COLORDICT['darkMagenta'] = '#800080'
 COLORDICT = _COLORDICT
 
 
-_LUT_DESCRIPTION = collections.namedtuple("_LUT_DESCRIPTION", ["source", "cursor_color", "default", "preferred"])
+_LUT_DESCRIPTION = collections.namedtuple("_LUT_DESCRIPTION", ["source", "cursor_color", "preferred"])
 """Description of a LUT for internal purpose."""
 
 
 _AVAILABLE_LUTS = collections.OrderedDict([
-    ('gray', _LUT_DESCRIPTION('builtin', 'pink', True, True)),
-    ('reversed gray', _LUT_DESCRIPTION('builtin', 'pink', True, True)),
-    ('temperature', _LUT_DESCRIPTION('builtin', 'pink', True, True)),
-    ('red', _LUT_DESCRIPTION('builtin', 'green', True, True)),
-    ('green', _LUT_DESCRIPTION('builtin', 'pink', True, True)),
-    ('blue', _LUT_DESCRIPTION('builtin', 'yellow', True, True)),
-    ('jet', _LUT_DESCRIPTION('matplotlib', 'pink', True, True)),
-    ('viridis', _LUT_DESCRIPTION('resource', 'pink', True, True)),
-    ('magma', _LUT_DESCRIPTION('resource', 'green', True, True)),
-    ('inferno', _LUT_DESCRIPTION('resource', 'green', True, True)),
-    ('plasma', _LUT_DESCRIPTION('resource', 'green', True, True)),
-    ('hsv', _LUT_DESCRIPTION('matplotlib', 'black', False, True)),
+    ('gray', _LUT_DESCRIPTION('builtin', 'pink', True)),
+    ('reversed gray', _LUT_DESCRIPTION('builtin', 'pink', True)),
+    ('temperature', _LUT_DESCRIPTION('builtin', 'pink', True)),
+    ('red', _LUT_DESCRIPTION('builtin', 'green', True)),
+    ('green', _LUT_DESCRIPTION('builtin', 'pink', True)),
+    ('blue', _LUT_DESCRIPTION('builtin', 'yellow', True)),
+    ('jet', _LUT_DESCRIPTION('matplotlib', 'pink', True)),
+    ('viridis', _LUT_DESCRIPTION('resource', 'pink', True)),
+    ('magma', _LUT_DESCRIPTION('resource', 'green', True)),
+    ('inferno', _LUT_DESCRIPTION('resource', 'green', True)),
+    ('plasma', _LUT_DESCRIPTION('resource', 'green', True)),
+    ('hsv', _LUT_DESCRIPTION('matplotlib', 'black', True)),
 ])
 """Description for internal porpose of all the default LUT provided by the library."""
 
-DEFAULT_COLORMAPS = tuple([k for k in _AVAILABLE_LUTS.keys() if _AVAILABLE_LUTS[k].default])
-"""Tuple of supported colormap names."""
+DEFAULT_COLORMAPS = tuple(_AVAILABLE_LUTS.keys())
+"""Tuple of supported colormap names.
+
+This attribute should not be used as has it could be unsynchronized.
+"""
 
 DEFAULT_MIN_LIN = 0
 """Default min value if in linear normalization"""
@@ -743,9 +746,9 @@ class Colormap(qt.QObject):
         colormaps.update(_AVAILABLE_LUTS.keys())
 
         colormaps = tuple(cmap for cmap in sorted(colormaps)
-                          if cmap not in DEFAULT_COLORMAPS)
+                          if cmap not in _AVAILABLE_LUTS.keys())
 
-        return DEFAULT_COLORMAPS + colormaps
+        return tuple(_AVAILABLE_LUTS.keys()) + colormaps
 
     def __str__(self):
         return str(self._toDict())

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -465,16 +465,8 @@ class Colormap(qt.QObject):
             raise TypeError("An array is expected for 'colors' argument. '%s' was found." % type(colors))
         assert len(colors) != 0
         assert colors.ndim >= 2
-        assert colors.shape[-1] <= 4  # Provide up to 4 channels (RGBA)
         colors.shape = -1, colors.shape[-1]
-        if colors.dtype.kind == 'f':
-            colors = _arrayToRgba8888(colors)
-
-        # Makes sure it is RGBA8888
-        self._colors = numpy.zeros((len(colors), 4), dtype=numpy.uint8)
-        self._colors[:, 3] = 255  # Alpha channel
-        self._colors[:, :colors.shape[1]] = colors  # Copy colors
-
+        self._colors = _arrayToRgba8888(colors)
         self._name = None
         self.sigChanged.emit()
 

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -354,7 +354,7 @@ class ColormapDialog(qt.QDialog):
         normButtonGroup.setExclusive(True)
         normButtonGroup.addButton(self._normButtonLinear)
         normButtonGroup.addButton(self._normButtonLog)
-        self._normButtonLinear.toggled[bool].connect(self._updateLinearNorm)
+        self._normButtonLinear.toggled[bool].connect(self._updateNormalization)
 
         normLayout = qt.QHBoxLayout()
         normLayout.setContentsMargins(0, 0, 0, 0)
@@ -984,14 +984,15 @@ class ColormapDialog(qt.QDialog):
                 colormap.setColormapLUT(lut)
             self._ignoreColormapChange = False
 
-    def _updateLinearNorm(self, isNormLinear):
+    def _updateNormalization(self, isNormLinear):
         if self._ignoreColormapChange is True:
             return
 
-        if self._colormap():
+        colormap = self.getColormap()
+        if colormap is not None:
             self._ignoreColormapChange = True
             norm = Colormap.LINEAR if isNormLinear else Colormap.LOGARITHM
-            self._colormap().setNormalization(norm)
+            colormap.setNormalization(norm)
             self._ignoreColormapChange = False
 
     def _minMaxTextEdited(self, text):

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -829,12 +829,18 @@ class ColormapDialog(qt.QDialog):
         :param float positiveMin: The positive minimum of the data
         :param float maximum: The maximum of the data
         """
-        if minimum is None or positiveMin is None or maximum is None:
+        scale = self._plot.getXAxis().getScale()
+        if scale == Axis.LOGARITHMIC:
+            dataMin, dataMax = positiveMin, maximum
+        else:
+            dataMin, dataMax = minimum, maximum
+
+        if dataMin is None or dataMax is None:
             self._dataRange = None
             self._plot.remove(legend='Range', kind='histogram')
         else:
             hist = numpy.array([1])
-            bin_edges = numpy.array([minimum, maximum])
+            bin_edges = numpy.array([dataMin, dataMax])
             self._plot.addHistogram(hist,
                                     bin_edges,
                                     legend="Range",

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -940,6 +940,7 @@ class ColormapDialog(qt.QDialog):
         if self.isVisible():
             self._applyColormap()
         else:
+            self._updateResetButton()
             self._displayLater()
 
     def _updateResetButton(self):

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -63,7 +63,7 @@ from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent", "H. Payno"]
 __license__ = "MIT"
-__date__ = "08/11/2018"
+__date__ = "09/11/2018"
 
 
 import logging
@@ -149,22 +149,6 @@ class _BoundaryWidget(qt.QWidget):
         self._updateDisplayedText()
 
 
-class _HashableNumpyArray(object):
-    """Holster of numpy array to provide hashable and comparable objects"""
-
-    def __init__(self, array):
-        self.__array = array
-
-    def __eq__(self, other):
-        if not isinstance(other, _HashableNumpyArray):
-            return False
-        return numpy.array_equal(self.__array, other.__array)
-
-    def __hash__(self):
-        # str only uses head and tail of the numpy array
-        return hash(str(self.__array))
-
-
 class _ColormapNameCombox(qt.QComboBox):
     def __init__(self, parent=None):
         qt.QComboBox.__init__(self, parent)
@@ -189,11 +173,14 @@ class _ColormapNameCombox(qt.QComboBox):
         :param numpy.ndarray colors: Colors identify the LUT
         :rtype: qt.QIcon
         """
-        iconHash = (name, _HashableNumpyArray(colors))
-        icon = _colormapIconPreview.get(iconHash, None)
+        if name is not None:
+            iconKey = name
+        else:
+            iconKey = tuple(colors)
+        icon = _colormapIconPreview.get(iconKey, None)
         if icon is None:
             icon = self.createIconPreview(name, colors)
-            _colormapIconPreview[iconHash] = icon
+            _colormapIconPreview[iconKey] = icon
         return icon
 
     def createIconPreview(self, name=None, colors=None):

--- a/silx/gui/dialog/test/test_colormapdialog.py
+++ b/silx/gui/dialog/test/test_colormapdialog.py
@@ -26,12 +26,11 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "23/05/2018"
+__date__ = "08/11/2018"
 
 
 import unittest
 
-from silx.gui.utils.testutils import qWaitForWindowExposedAndActivate
 from silx.gui import qt
 from silx.gui.dialog import ColormapDialog
 from silx.gui.utils.testutils import TestCaseQt

--- a/silx/gui/dialog/test/test_colormapdialog.py
+++ b/silx/gui/dialog/test/test_colormapdialog.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "08/11/2018"
+__date__ = "09/11/2018"
 
 
 import unittest
@@ -67,10 +67,12 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         editing the same colormap"""
         colormapDiag2 = ColormapDialog.ColormapDialog()
         colormapDiag2.setColormap(self.colormap)
+        colormapDiag2.show()
         self.colormapDiag.setColormap(self.colormap)
+        self.colormapDiag.show()
 
         self.colormapDiag._comboBoxColormap._setCurrentName('red')
-        self.colormapDiag._normButtonLog.setChecked(True)
+        self.colormapDiag._normButtonLog.click()
         self.assertTrue(self.colormap.getName() == 'red')
         self.assertTrue(self.colormapDiag.getColormap().getName() == 'red')
         self.assertTrue(self.colormap.getNormalization() == 'log')
@@ -159,6 +161,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
     def testSetColormapIsCorrect(self):
         """Make sure the interface fir the colormap when set a new colormap"""
         self.colormap.setName('red')
+        self.colormapDiag.show()
         for norm in (Colormap.NORMALIZATIONS):
             for autoscale in (True, False):
                 if autoscale is True:
@@ -264,6 +267,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         """Test that the colormapDialog is correctly updated when changing the
         colormap editable status"""
         colormap = Colormap(normalization='linear', vmin=1.0, vmax=10.0)
+        self.colormapDiag.show()
         self.colormapDiag.setColormap(colormap)
         for editable in (True, False):
             with self.subTest(editable=editable):
@@ -283,7 +287,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         # False
         self.colormapDiag.setModal(False)
         colormap.setEditable(True)
-        self.colormapDiag._normButtonLog.setChecked(True)
+        self.colormapDiag._normButtonLog.click()
         resetButton = self.colormapDiag._buttonsNonModal.button(qt.QDialogButtonBox.Reset)
         self.assertTrue(resetButton.isEnabled())
         colormap.setEditable(False)

--- a/silx/gui/dialog/test/test_colormapdialog.py
+++ b/silx/gui/dialog/test/test_colormapdialog.py
@@ -70,7 +70,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         colormapDiag2.setColormap(self.colormap)
         self.colormapDiag.setColormap(self.colormap)
 
-        self.colormapDiag._comboBoxColormap.setCurrentName('red')
+        self.colormapDiag._comboBoxColormap._setCurrentName('red')
         self.colormapDiag._normButtonLog.setChecked(True)
         self.assertTrue(self.colormap.getName() == 'red')
         self.assertTrue(self.colormapDiag.getColormap().getName() == 'red')
@@ -193,7 +193,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.colormapDiag.show()
         del self.colormap
         self.assertTrue(self.colormapDiag.getColormap() is None)
-        self.colormapDiag._comboBoxColormap.setCurrentName('blue')
+        self.colormapDiag._comboBoxColormap._setCurrentName('blue')
 
     def testColormapEditedOutside(self):
         """Make sure the GUI is still up to date if the colormap is modified
@@ -256,7 +256,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         cb = self.colormapDiag._comboBoxColormap
         self.assertTrue(cb.getCurrentName() == colormapName)
         cb.setCurrentIndex(0)
-        index = cb.findColormap(colormapName)
+        index = cb.findLutName(colormapName)
         assert index is not 0  # if 0 then the rest of the test has no sense
         cb.setCurrentIndex(index)
         self.assertTrue(cb.getCurrentName() == colormapName)

--- a/silx/gui/test/test_colors.py
+++ b/silx/gui/test/test_colors.py
@@ -29,14 +29,13 @@ from __future__ import absolute_import
 
 __authors__ = ["H.Payno"]
 __license__ = "MIT"
-__date__ = "06/11/2018"
+__date__ = "08/11/2018"
 
 import unittest
 import numpy
 from silx.utils.testutils import ParametricTestCase
 from silx.gui import colors
 from silx.gui.colors import Colormap
-from silx.gui.colors import preferredColormaps, setPreferredColormaps
 from silx.utils.exceptions import NotEditableError
 
 
@@ -402,27 +401,27 @@ class TestPreferredColormaps(unittest.TestCase):
 
     def setUp(self):
         # Save preferred colormaps
-        self._colormaps = preferredColormaps()
+        self._colormaps = colors.preferredColormaps()
 
     def tearDown(self):
         # Restore saved preferred colormaps
-        setPreferredColormaps(self._colormaps)
+        colors._setPreferredColormaps(self._colormaps)
 
     def test(self):
         colormaps = 'viridis', 'magma'
 
-        setPreferredColormaps(colormaps)
-        self.assertEqual(preferredColormaps(), colormaps)
+        colors._setPreferredColormaps(colormaps)
+        self.assertEqual(colors.preferredColormaps(), colormaps)
 
         with self.assertRaises(ValueError):
-            setPreferredColormaps(())
+            colors._setPreferredColormaps(())
 
         with self.assertRaises(ValueError):
-            setPreferredColormaps(('This is not a colormap',))
+            colors._setPreferredColormaps(('This is not a colormap',))
 
         colormaps = 'red', 'green'
-        setPreferredColormaps(('This is not a colormap',) + colormaps)
-        self.assertEqual(preferredColormaps(), colormaps)
+        colors._setPreferredColormaps(('This is not a colormap',) + colormaps)
+        self.assertEqual(colors.preferredColormaps(), colormaps)
 
 
 def suite():

--- a/silx/gui/test/test_colors.py
+++ b/silx/gui/test/test_colors.py
@@ -424,6 +424,55 @@ class TestPreferredColormaps(unittest.TestCase):
         self.assertEqual(colors.preferredColormaps(), colormaps)
 
 
+class TestRegisteredLut(unittest.TestCase):
+    """Test get|setPreferredColormaps functions"""
+
+    def setUp(self):
+        # Save preferred colormaps
+        lut = numpy.arange(8 * 3)
+        lut.shape = -1, 3
+        lut = lut / (8.0 * 3)
+        colors.registerLUT("test_8", colors=lut, cursor_color='blue')
+
+    def testColormap(self):
+        colormap = Colormap("test_8")
+        self.assertIsNotNone(colormap)
+
+    def testCursor(self):
+        color = colors.cursorColorForColormap("test_8")
+        self.assertEqual(color, 'blue')
+
+    def testLut(self):
+        colormap = Colormap("test_8")
+        colors = colormap.getNColors(8)
+        self.assertEquals(len(colors), 8)
+
+    def testUint8(self):
+        lut = numpy.array([[255, 0, 0], [200, 0, 0], [150, 0, 0]], dtype="uint")
+        colors.registerLUT("test_type", lut)
+        colormap = colors.Colormap(name="test_type")
+        lut = colormap.getNColors(3)
+        self.assertEqual(lut.shape, (3, 4))
+        self.assertEqual(lut[0, 0], 255)
+
+    def testFloatRGB(self):
+        lut = numpy.array([[1.0, 0, 0], [0.5, 0, 0], [0, 0, 0]], dtype="float")
+        colors.registerLUT("test_type", lut)
+        colormap = colors.Colormap(name="test_type")
+        lut = colormap.getNColors(3)
+        self.assertEqual(lut.shape, (3, 4))
+        self.assertEqual(lut[0, 0], 255)
+
+    def testFloatRGBA(self):
+        lut = numpy.array([[1.0, 0, 0, 128 / 256.0], [0.5, 0, 0, 1.0], [0.0, 0, 0, 1.0]], dtype="float")
+        colors.registerLUT("test_type", lut)
+        colormap = colors.Colormap(name="test_type")
+        lut = colormap.getNColors(3)
+        self.assertEqual(lut.shape, (3, 4))
+        self.assertEqual(lut[0, 0], 255)
+        self.assertEqual(lut[0, 3], 128)
+
+
 def suite():
     test_suite = unittest.TestSuite()
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
@@ -432,6 +481,7 @@ def suite():
     test_suite.addTest(loadTests(TestDictAPI))
     test_suite.addTest(loadTests(TestObjectAPI))
     test_suite.addTest(loadTests(TestPreferredColormaps))
+    test_suite.addTest(loadTests(TestRegisteredLut))
     return test_suite
 
 

--- a/silx/gui/test/test_colors.py
+++ b/silx/gui/test/test_colors.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import
 
 __authors__ = ["H.Payno"]
 __license__ = "MIT"
-__date__ = "08/11/2018"
+__date__ = "09/11/2018"
 
 import unittest
 import numpy
@@ -405,22 +405,22 @@ class TestPreferredColormaps(unittest.TestCase):
 
     def tearDown(self):
         # Restore saved preferred colormaps
-        colors._setPreferredColormaps(self._colormaps)
+        colors.setPreferredColormaps(self._colormaps)
 
     def test(self):
         colormaps = 'viridis', 'magma'
 
-        colors._setPreferredColormaps(colormaps)
+        colors.setPreferredColormaps(colormaps)
         self.assertEqual(colors.preferredColormaps(), colormaps)
 
         with self.assertRaises(ValueError):
-            colors._setPreferredColormaps(())
+            colors.setPreferredColormaps(())
 
         with self.assertRaises(ValueError):
-            colors._setPreferredColormaps(('This is not a colormap',))
+            colors.setPreferredColormaps(('This is not a colormap',))
 
         colormaps = 'red', 'green'
-        colors._setPreferredColormaps(('This is not a colormap',) + colormaps)
+        colors.setPreferredColormaps(('This is not a colormap',) + colormaps)
         self.assertEqual(colors.preferredColormaps(), colormaps)
 
 


### PR DESCRIPTION
Some clean up and improvement around `silx.gui.colors`

- Fix ColormapDialog
- Display plot in log in colormap uses log
- Avoid extra computation while the ColormapDialog is not displayed
- Merge LUT descriptions
- provide an API to register new LUTs

Closes #2231
Closes #2230
Closes #2235