### PR TITLE
Improve silx view loading

### DIFF
--- a/silx/app/view/Viewer.py
+++ b/silx/app/view/Viewer.py
@@ -829,7 +829,7 @@ class Viewer(qt.QMainWindow):
                 menu.addAction(action)
 
             if silx.io.is_file(h5):
-                action = qt.QAction("Remove %s" % obj.local_filename, event.source())
+                action = qt.QAction("Close %s" % obj.local_filename, event.source())
                 action.triggered.connect(lambda: self.__treeview.findHdf5TreeModel().removeH5pyObject(h5))
                 menu.addAction(action)
                 action = qt.QAction("Synchronize %s" % obj.local_filename, event.source())

--- a/silx/app/view/Viewer.py
+++ b/silx/app/view/Viewer.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "08/10/2018"
+__date__ = "09/11/2018"
 
 
 import os
@@ -74,6 +74,7 @@ class Viewer(qt.QMainWindow):
         rightPanel.setOrientation(qt.Qt.Vertical)
         self.__splitter2 = rightPanel
 
+        self.__displayIt = None
         self.__treeWindow = self.__createTreeWindow(self.__treeview)
 
         # Custom the model to be able to manage the life cycle of the files
@@ -387,6 +388,8 @@ class Viewer(qt.QMainWindow):
 
     def __h5FileLoaded(self, loadedH5):
         self.__context.pushRecentFile(loadedH5.file.filename)
+        if loadedH5.file.filename == self.__displayIt:
+            self.displayData(loadedH5)
 
     def __h5FileRemoved(self, removedH5):
         self.__dataPanel.removeDatasetsFrom(removedH5)
@@ -737,6 +740,9 @@ class Viewer(qt.QMainWindow):
         silx.config.DEFAULT_PLOT_BACKEND = "opengl"
 
     def appendFile(self, filename):
+        if self.__displayIt is None:
+            # Store the file to display it (loading could be async)
+            self.__displayIt = filename
         self.__treeview.findHdf5TreeModel().appendFile(filename)
 
     def displaySelectedData(self):

--- a/silx/app/view/Viewer.py
+++ b/silx/app/view/Viewer.py
@@ -389,6 +389,7 @@ class Viewer(qt.QMainWindow):
     def __h5FileLoaded(self, loadedH5):
         self.__context.pushRecentFile(loadedH5.file.filename)
         if loadedH5.file.filename == self.__displayIt:
+            self.__displayIt = None
             self.displayData(loadedH5)
 
     def __h5FileRemoved(self, removedH5):

--- a/silx/app/view/Viewer.py
+++ b/silx/app/view/Viewer.py
@@ -406,10 +406,11 @@ class Viewer(qt.QMainWindow):
         self.__context.saveSettings()
 
         # Clean up as much as possible Python objects
-        model = self.__customNxdata.model()
-        model.clear()
-        model = self.__treeview.findHdf5TreeModel()
-        model.clear()
+        self.displayData(None)
+        customModel = self.__customNxdata.model()
+        customModel.clear()
+        hdf5Model = self.__treeview.findHdf5TreeModel()
+        hdf5Model.clear()
 
     def saveSettings(self, settings):
         """Save the window settings to this settings object

--- a/silx/app/view/main.py
+++ b/silx/app/view/main.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "07/06/2018"
+__date__ = "09/11/2018"
 
 import sys
 import argparse
@@ -35,17 +35,6 @@ import signal
 
 _logger = logging.getLogger(__name__)
 """Module logger"""
-
-if "silx.gui.qt" not in sys.modules:
-    # Try first PyQt5 and not the priority imposed by silx.gui.qt.
-    # To avoid problem with unittests we only do it if silx.gui.qt is not
-    # yet loaded.
-    # TODO: Can be removed for silx 0.8, as it should be the default binding
-    # of the silx library.
-    try:
-        import PyQt5.QtCore
-    except ImportError:
-        pass
 
 import silx
 from silx.gui import qt

--- a/silx/gui/data/DataViewer.py
+++ b/silx/gui/data/DataViewer.py
@@ -288,6 +288,7 @@ class DataViewer(qt.QFrame):
         else:
             self.__displayedData = self.__data
 
+        # TODO: would be good to avoid that, it should be synchonous
         qt.QTimer.singleShot(10, self.__setDataInView)
 
     def __setDataInView(self):

--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -26,7 +26,7 @@
 """
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "09/11/2018"
+__date__ = "12/11/2018"
 
 import numpy
 
@@ -177,7 +177,9 @@ class ArrayCurvePlot(qt.QWidget):
                 break
 
     def clear(self):
+        old = self._selector.blockSignals(True)
         self._selector.clear()
+        self._selector.blockSignals(old)
         self._plot.clear()
 
 
@@ -487,7 +489,9 @@ class ArrayImagePlot(qt.QWidget):
         self._plot.resetZoom()
 
     def clear(self):
+        old = self._selector.blockSignals(True)
         self._selector.clear()
+        self._selector.blockSignals(old)
         self._plot.clear()
 
 
@@ -658,5 +662,7 @@ class ArrayStackPlot(qt.QWidget):
                         self.__x_axis_name])
 
     def clear(self):
+        old = self._selector.blockSignals(True)
         self._selector.clear()
+        self._selector.blockSignals(old)
         self._stack_view.clear()

--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -26,7 +26,7 @@
 """
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "10/10/2018"
+__date__ = "09/11/2018"
 
 import numpy
 
@@ -177,6 +177,7 @@ class ArrayCurvePlot(qt.QWidget):
                 break
 
     def clear(self):
+        self._selector.clear()
         self._plot.clear()
 
 
@@ -486,6 +487,7 @@ class ArrayImagePlot(qt.QWidget):
         self._plot.resetZoom()
 
     def clear(self):
+        self._selector.clear()
         self._plot.clear()
 
 
@@ -656,4 +658,5 @@ class ArrayStackPlot(qt.QWidget):
                         self.__x_axis_name])
 
     def clear(self):
+        self._selector.clear()
         self._stack_view.clear()

--- a/silx/io/fabioh5.py
+++ b/silx/io/fabioh5.py
@@ -262,7 +262,7 @@ class ImageGroup(commonh5.LazyLoadableGroup):
         self.add_node(detector)
 
 
-class HxDataPreviewGroup(commonh5.LazyLoadableGroup):
+class NxDataPreviewGroup(commonh5.LazyLoadableGroup):
     """Define the NxData group which is used as the default NXdata to show the
     content of the file.
     """
@@ -960,7 +960,7 @@ class File(commonh5.File):
         :param FabioReader fabio_reader: A reader for the Fabio image
         :rtype: commonh5.Group
         """
-        nxdata = HxDataPreviewGroup("image", fabio_reader)
+        nxdata = NxDataPreviewGroup("image", fabio_reader)
         scan_attrs = {
             "NX_class": "NXentry",
             "default": nxdata.basename,

--- a/silx/io/fabioh5.py
+++ b/silx/io/fabioh5.py
@@ -403,10 +403,11 @@ class FabioReader(object):
         may fail.
         """
         if self.__must_be_closed:
-            # It looks like there is no close on FabioImage
-            # self.__fabio_image.close()
-            pass
-        self.__fabio_image = None
+            # Make sure the API of fabio provide it a 'close' method
+            # TODO the test can be removed if fabio version >= 0.8
+            if hasattr(self.__fabio_file, "close"):
+                self.__fabio_file.close()
+        self.__fabio_file = None
 
     def fabio_file(self):
         return self.__fabio_file

--- a/silx/io/fabioh5.py
+++ b/silx/io/fabioh5.py
@@ -262,6 +262,26 @@ class ImageGroup(commonh5.LazyLoadableGroup):
         self.add_node(detector)
 
 
+class HxDataPreviewGroup(commonh5.LazyLoadableGroup):
+    """Define the NxData group which is used as the default NXdata to show the
+    content of the file.
+    """
+
+    def __init__(self, name, fabio_reader, parent=None):
+        attrs = {
+            "NX_class": "NXdata",
+            "interpretation": "image",
+            "signal": "data",
+        }
+        commonh5.LazyLoadableGroup.__init__(self, name, parent, attrs)
+        self.__fabio_reader = fabio_reader
+
+    def _create_child(self):
+        basepath = self.parent.name
+        data = commonh5.SoftLink("data", path=basepath + "/instrument/detector_0/data")
+        self.add_node(data)
+
+
 class SampleGroup(commonh5.LazyLoadableGroup):
     """Define the image group (sub group of measurement) using Fabio data.
     """
@@ -917,14 +937,15 @@ class File(commonh5.File):
         self.__fabio_reader = self.create_fabio_reader(file_name, fabio_image, file_series)
         if fabio_image is not None:
             file_name = fabio_image.filename
+        scan = self.create_scan_group(self.__fabio_reader)
 
         attrs = {"NX_class": "NXroot",
                  "file_time": datetime.datetime.now().isoformat(),
-                 "creator": "silx %s" % silx_version}
+                 "creator": "silx %s" % silx_version,
+                 "default": scan.basename}
         if file_name is not None:
             attrs["file_name"] = file_name
         commonh5.File.__init__(self, name=file_name, attrs=attrs)
-        scan = self.create_scan_group(self.__fabio_reader)
         self.add_node(scan)
 
     def create_scan_group(self, fabio_reader):
@@ -934,8 +955,12 @@ class File(commonh5.File):
         :param FabioReader fabio_reader: A reader for the Fabio image
         :rtype: commonh5.Group
         """
-
-        scan = commonh5.Group("scan_0", attrs={"NX_class": "NXentry"})
+        nxdata = HxDataPreviewGroup("image", fabio_reader)
+        scan_attrs = {
+            "NX_class": "NXentry",
+            "default": nxdata.basename,
+        }
+        scan = commonh5.Group("scan_0", attrs=scan_attrs)
         instrument = commonh5.Group("instrument", attrs={"NX_class": "NXinstrument"})
         measurement = MeasurementGroup("measurement", fabio_reader, attrs={"NX_class": "NXcollection"})
         file_ = commonh5.Group("file", attrs={"NX_class": "NXcollection"})
@@ -949,6 +974,7 @@ class File(commonh5.File):
         instrument.add_node(detector)
         file_.add_node(raw_header)
         scan.add_node(measurement)
+        scan.add_node(nxdata)
 
         if fabio_reader.has_sample_information():
             sample = SampleGroup("sample", fabio_reader)

--- a/silx/io/fabioh5.py
+++ b/silx/io/fabioh5.py
@@ -268,9 +268,13 @@ class HxDataPreviewGroup(commonh5.LazyLoadableGroup):
     """
 
     def __init__(self, name, fabio_reader, parent=None):
+        if fabio_reader.is_spectrum():
+            interpretation = "spectrum"
+        else:
+            interpretation = "image"
         attrs = {
             "NX_class": "NXdata",
-            "interpretation": "image",
+            "interpretation": interpretation,
             "signal": "data",
         }
         commonh5.LazyLoadableGroup.__init__(self, name, parent, attrs)


### PR DESCRIPTION
- `silx view` now display the file opened on the data view (previously it was only displayed on the side tree)
- `fabioh5` provides an `NXdata` containing the image (this NXdata is defaulted by the root and the entry)
- As result loading an EDF file displays an image (sounds original)
- Fix bug, as some fabio files was not closed

Closes #2238 
Closes #2225 