### PR TITLE
Support background color

### DIFF
--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import
 
 __authors__ = ["T. Vincent", "H.Payno"]
 __license__ = "MIT"
-__date__ = "09/11/2018"
+__date__ = "19/11/2018"
 
 import numpy
 import logging
@@ -77,6 +77,7 @@ _COLORDICT['darkBrown'] = '#660000'
 _COLORDICT['darkCyan'] = '#008080'
 _COLORDICT['darkYellow'] = '#808000'
 _COLORDICT['darkMagenta'] = '#800080'
+_COLORDICT['transparent'] = '#00000000'
 
 
 # FIXME: It could be nice to expose a functional API instead of that attribute

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -229,6 +229,9 @@ class PlotWidget(qt.QMainWindow):
         self._activeLegend = {'curve': None, 'image': None,
                               'scatter': None}
 
+        self._backgroundColor = None
+        self._dataBackgroundColor = None
+
         # default properties
         self._cursorConfiguration = None
 
@@ -347,6 +350,59 @@ class PlotWidget(qt.QMainWindow):
 
         if self._autoreplot and not wasDirty and self.isVisible():
             self._backend.postRedisplay()
+
+    def getBackgroundColor(self):
+        """Returns the RGBA colors used to display the background of this widget
+
+        The default value is an invalid `QColor`.
+
+        :rtype: qt.QColor
+        """
+        if self._backgroundColor is None:
+            # An invalid color
+            return qt.QColor()
+        rgba = self._backgroundColor
+        return qt.QColor(*rgba)
+
+    def setBackgroundColor(self, color):
+        """Set the background color of this widget.
+
+        :param color: The new color. It can be farious formats (tuple,
+            numpy array, QColor)
+        """
+        if color is not None:
+            color = colors.rgba(color)
+        if self._backgroundColor == color:
+            return
+        self._backgroundColor = color
+        self._backend.setBackgroundColors(self._backgroundColor, self._dataBackgroundColor)
+
+    def getDataBackgroundColor(self):
+        """Returns the RGBA colors used to display the background of the plot
+        view displaying the data.
+
+        The default value is an invalid `QColor`.
+
+        :rtype: qt.QColor
+        """
+        if self._dataBackgroundColor is None:
+            # An invalid color
+            return qt.QColor()
+        rgba = self._dataBackgroundColor
+        return qt.QColor(*rgba)
+
+    def setDataBackgroundColor(self, color):
+        """Set the background color of this widget.
+
+        :param color: The new color. It can be farious formats (tuple,
+            numpy array, QColor)
+        """
+        if color is not None:
+            color = colors.rgba(color)
+        if self._dataBackgroundColor == color:
+            return
+        self._dataBackgroundColor = color
+        self._backend.setBackgroundColors(self._backgroundColor, self._dataBackgroundColor)
 
     def showEvent(self, event):
         if self._autoreplot and self._dirty:

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -31,7 +31,7 @@ from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent"]
 __license__ = "MIT"
-__date__ = "12/10/2018"
+__date__ = "19/11/2018"
 
 
 from collections import OrderedDict, namedtuple
@@ -208,27 +208,8 @@ class PlotWidget(qt.QMainWindow):
         else:
             self.setWindowTitle('PlotWidget')
 
-        if backend is None:
-            backend = silx.config.DEFAULT_PLOT_BACKEND
-
-        if hasattr(backend, "__call__"):
-            self._backend = backend(self, parent)
-
-        elif hasattr(backend, "lower"):
-            lowerCaseString = backend.lower()
-            if lowerCaseString in ("matplotlib", "mpl"):
-                backendClass = BackendMatplotlibQt
-            elif lowerCaseString in ('gl', 'opengl'):
-                from .backends.BackendOpenGL import BackendOpenGL
-                backendClass = BackendOpenGL
-            elif lowerCaseString == 'none':
-                from .backends.BackendBase import BackendBase as backendClass
-            else:
-                raise ValueError("Backend not supported %s" % backend)
-            self._backend = backendClass(self, parent)
-
-        else:
-            raise ValueError("Backend not supported %s" % str(backend))
+        self._backend = None
+        self._setBackend(backend)
 
         self.setCallback()  # set _callback
 
@@ -295,6 +276,34 @@ class PlotWidget(qt.QMainWindow):
         self.setGraphXLimits(0., 100.)
         self.setGraphYLimits(0., 100., axis='right')
         self.setGraphYLimits(0., 100., axis='left')
+
+    def _setBackend(self, backend):
+        """Setup a new backend"""
+        assert(self._backend is None)
+
+        if backend is None:
+            backend = silx.config.DEFAULT_PLOT_BACKEND
+
+        if hasattr(backend, "__call__"):
+            backend = backend(self, self)
+
+        elif hasattr(backend, "lower"):
+            lowerCaseString = backend.lower()
+            if lowerCaseString in ("matplotlib", "mpl"):
+                backendClass = BackendMatplotlibQt
+            elif lowerCaseString in ('gl', 'opengl'):
+                from .backends.BackendOpenGL import BackendOpenGL
+                backendClass = BackendOpenGL
+            elif lowerCaseString == 'none':
+                from .backends.BackendBase import BackendBase as backendClass
+            else:
+                raise ValueError("Backend not supported %s" % backend)
+            backend = backendClass(self, self)
+
+        else:
+            raise ValueError("Backend not supported %s" % str(backend))
+
+        self._backend = backend
 
     # TODO: Can be removed for silx 0.10
     @staticmethod

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -31,7 +31,7 @@ This API is a simplified version of PyMca PlotBackend API.
 
 __authors__ = ["V.A. Sole", "T. Vincent"]
 __license__ = "MIT"
-__date__ = "24/04/2018"
+__date__ = "19/11/2018"
 
 import weakref
 from ... import qt
@@ -546,3 +546,21 @@ class BackendBase(object):
         This only check status set to axes from the public API
         """
         return self._axesDisplayed
+
+    def setBackgroundColors(self, backgroundColor, dataBackgroundColor=None):
+        """
+        Set background colors used to display this widget.
+
+        If a `backgroundColor` is set, it is used for all the background of the
+        widget, while no `dataBackgroundColor` is used.
+
+        If a `dataBackgroundColor` is set, it is used to set the background
+        of the view displayed the data only. The widget outside the axes will
+        still use the `backgroundColor` as background.
+
+        :param Union[Tuple[float],None] backgroundColor: Background of the
+            widget
+        :param Union[Tuple[float],None] dataBackgroundColor: Background of the
+            data view
+        """
+        pass

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -28,7 +28,7 @@ from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent, H. Payno"]
 __license__ = "MIT"
-__date__ = "01/08/2018"
+__date__ = "19/11/2018"
 
 
 import logging
@@ -60,7 +60,6 @@ from ....third_party.modest_image import ModestImage
 from . import BackendBase
 from .._utils import FLOAT32_MINPOS
 from .._utils.dtime_ticklayout import calcTicks, bestFormatString, timestamp
-
 
 
 class NiceDateLocator(Locator):
@@ -115,7 +114,6 @@ class NiceDateLocator(Locator):
         return ticks
 
 
-
 class NiceAutoDateFormatter(Formatter):
     """
     Matplotlib FuncFormatter that is linked to a NiceDateLocator and gives the
@@ -139,7 +137,6 @@ class NiceAutoDateFormatter(Formatter):
         else:
             return bestFormatString(self.locator.spacing, self.locator.unit)
 
-
     def __call__(self, x, pos=None):
         """Return the format for tick val *x* at position *pos*
            Expects x to be a POSIX timestamp (seconds since 1 Jan 1970)
@@ -147,8 +144,6 @@ class NiceAutoDateFormatter(Formatter):
         dateTime = dt.datetime.fromtimestamp(x, tz=self.tz)
         tickStr = dateTime.strftime(self.formatString)
         return tickStr
-
-
 
 
 class _MarkerContainer(Container):
@@ -239,9 +234,9 @@ class BackendMatplotlib(BackendBase.BackendBase):
             self.ax2.get_yaxis().get_major_formatter().set_useOffset(False)
             self.ax2.get_xaxis().get_major_formatter().set_useOffset(False)
         except:
-            _logger.warning('Cannot disabled axes offsets in %s ' \
+            _logger.warning('Cannot disabled axes offsets in %s '
                             % matplotlib.__version__)
-        
+
         # critical for picking!!!!
         self.ax2.set_zorder(0)
         self.ax2.set_autoscaley_on(True)

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1132,3 +1132,15 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
         else:
             cursor = self._QT_CURSORS[cursor]
             FigureCanvasQTAgg.setCursor(self, qt.QCursor(cursor))
+
+    def setBackgroundColors(self, backgroundColor, dataBackgroundColor=None):
+        if backgroundColor is None:
+            backgroundColor = 'w'
+        self.fig.patch.set_facecolor(backgroundColor)
+        if dataBackgroundColor is None:
+            dataBackgroundColor = backgroundColor
+
+        if self._matplotlibVersion < _parse_version('2'):
+            self.ax.set_axis_bgcolor(dataBackgroundColor)
+        else:
+            self.ax.set_facecolor(dataBackgroundColor)

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -28,7 +28,7 @@ from __future__ import division
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "01/08/2018"
+__date__ = "19/11/2018"
 
 from collections import OrderedDict, namedtuple
 from ctypes import c_void_p
@@ -1723,3 +1723,6 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
     def setAxesDisplayed(self, displayed):
         BackendBase.BackendBase.setAxesDisplayed(self, displayed)
         self._plotFrame.displayed = displayed
+
+    def setBackgroundColors(self, backgroundColor, dataBackgroundColor=None):
+        # TODO

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1725,4 +1725,5 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         self._plotFrame.displayed = displayed
 
     def setBackgroundColors(self, backgroundColor, dataBackgroundColor=None):
-        # TODO
+        # FIXME: Implement this
+        _logger.warning("Set background color to the OpenGL backend is not yet implemented")

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "21/09/2018"
+__date__ = "19/11/2018"
 
 
 import unittest
@@ -181,6 +181,37 @@ class TestPlotWidget(PlotWidgetTestCase, ParametricTestCase):
         self.assertTrue(numpy.all(numpy.equal(items[3].getPosition(), marker_pos)))
         self.assertTrue(numpy.all(numpy.equal(items[4].getPosition()[0], marker_x)))
         self.assertEqual(items[5].getType(), 'rectangle')
+
+    def testBackGroundColors(self):
+        self.plot.setVisible(True)
+        self.qWaitForWindowExposed(self.plot)
+        self.qapp.processEvents()
+
+        # Custom the full background
+        color = self.plot.getBackgroundColor()
+        self.assertFalse(color.isValid())
+        self.plot.setBackgroundColor("red")
+        color = self.plot.getBackgroundColor()
+        self.assertTrue(color.isValid())
+        self.qapp.processEvents()
+
+        # Custom the data background
+        color = self.plot.getDataBackgroundColor()
+        self.assertFalse(color.isValid())
+        self.plot.setDataBackgroundColor("red")
+        color = self.plot.getDataBackgroundColor()
+        self.assertTrue(color.isValid())
+        self.qapp.processEvents()
+
+        # Back to default
+        self.plot.setBackgroundColor(None)
+        self.plot.setDataBackgroundColor(None)
+        color = self.plot.getBackgroundColor()
+        self.assertFalse(color.isValid())
+        color = self.plot.getDataBackgroundColor()
+        self.assertFalse(color.isValid())
+        self.qapp.processEvents()
+
 
 class TestPlotImage(PlotWidgetTestCase, ParametricTestCase):
     """Basic tests for addImage"""


### PR DESCRIPTION
Add `setBackgroundColor` and `setDataBackgroundColor` to the plot API

- `setBackgroundColor` allow to custom the full background of the widget (including the background bellow the plot data)
- `setDataBackgroundColor` allow to custom the background bellow the plot data only

Closes #2220 

The OpenGL backend is not part of the PR