### PR TITLE
Sync center of axis

### DIFF
--- a/examples/syncPlotLocation.py
+++ b/examples/syncPlotLocation.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This script is an example to illustrate how to use axis synchronization
+tool.
+"""
+
+from silx.gui import qt
+from silx.gui.plot import Plot2D
+import numpy
+import silx.test.utils
+from silx.gui.plot.utils.axis import SyncAxes
+from silx.gui.colors import Colormap
+
+
+class SyncPlot(qt.QMainWindow):
+
+    def __init__(self):
+        qt.QMainWindow.__init__(self)
+        self.setWindowTitle("Plot with synchronized axes")
+        widget = qt.QWidget(self)
+        self.setCentralWidget(widget)
+
+        layout = qt.QGridLayout()
+        widget.setLayout(layout)
+
+        backend = "gl"
+        plots = []
+
+        data = numpy.arange(100 * 100)
+        data = (data % 100) / 5.0
+        data = numpy.sin(data)
+        data.shape = 100, 100
+
+        colormaps = ["gray", "red", "green", "blue"]
+        for i in range(2 * 2):
+            plot = Plot2D(parent=widget, backend=backend)
+            plot.setInteractiveMode('pan')
+            plot.setDefaultColormap(Colormap(colormaps[i]))
+            noisyData = silx.test.utils.add_gaussian_noise(data, mean=i / 10.0)
+            plot.addImage(noisyData)
+            plots.append(plot)
+
+        xAxis = [p.getXAxis() for p in plots]
+        yAxis = [p.getYAxis() for p in plots]
+
+        self.constraint1 = SyncAxes(xAxis,
+                                    syncLimits=False,
+                                    syncScale=True,
+                                    syncDirection=True,
+                                    syncCenter=True,
+                                    syncZoom=True)
+        self.constraint2 = SyncAxes(yAxis,
+                                    syncLimits=False,
+                                    syncScale=True,
+                                    syncDirection=True,
+                                    syncCenter=True,
+                                    syncZoom=True)
+
+        for i, plot in enumerate(plots):
+            if i % 2 == 0:
+                plot.setFixedWidth(400)
+            else:
+                plot.setFixedWidth(500)
+            if i // 2 == 0:
+                plot.setFixedHeight(400)
+            else:
+                plot.setFixedHeight(500)
+            layout.addWidget(plot, i // 2, i % 2)
+
+    def createCenteredLabel(self, text):
+        label = qt.QLabel(self)
+        label.setAlignment(qt.Qt.AlignCenter)
+        label.setText(text)
+        return label
+
+
+if __name__ == "__main__":
+    app = qt.QApplication([])
+    window = SyncPlot()
+    window.setAttribute(qt.Qt.WA_DeleteOnClose, True)
+    window.setVisible(True)
+    app.exec_()

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -423,7 +423,8 @@ class Colormap(qt.QObject):
         """
         if self.isEditable() is False:
             raise NotEditableError('Colormap is not editable')
-        assert name in self.getSupportedColormaps()
+        if name not in self.getSupportedColormaps():
+            raise ValueError("Colormap name '%s' is not supported" % name)
         self._name = str(name)
         self._colors = _getColormap(self._name)
         self.sigChanged.emit()

--- a/silx/gui/plot/test/testUtilsAxis.py
+++ b/silx/gui/plot/test/testUtilsAxis.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "14/02/2018"
+__date__ = "19/11/2018"
 
 
 import unittest
@@ -154,6 +154,33 @@ class TestAxisSync(TestCaseQt):
         self.assertEqual(self.plot1.getYAxis().isInverted(), True)
         self.assertEqual(self.plot2.getYAxis().isInverted(), True)
         self.assertEqual(self.plot3.getYAxis().isInverted(), True)
+
+    def testSyncCenter(self):
+        """Test direction change"""
+        # Not the same scale
+        self.plot1.getXAxis().setLimits(0, 200)
+        self.plot2.getXAxis().setLimits(0, 20)
+        self.plot3.getXAxis().setLimits(0, 2)
+        _sync = SyncAxes([self.plot1.getXAxis(), self.plot2.getXAxis(), self.plot3.getXAxis()],
+                         syncLimits=False, syncCenter=True)
+
+        self.assertEqual(self.plot1.getXAxis().getLimits(), (0, 200))
+        self.assertEqual(self.plot2.getXAxis().getLimits(), (100 - 10, 100 + 10))
+        self.assertEqual(self.plot3.getXAxis().getLimits(), (100 - 1, 100 + 1))
+
+    def testSyncCenterAndZoom(self):
+        """Test direction change"""
+        # Not the same scale
+        self.plot1.getXAxis().setLimits(0, 200)
+        self.plot2.getXAxis().setLimits(0, 20)
+        self.plot3.getXAxis().setLimits(0, 2)
+        _sync = SyncAxes([self.plot1.getXAxis(), self.plot2.getXAxis(), self.plot3.getXAxis()],
+                         syncLimits=False, syncCenter=True, syncZoom=True)
+
+        # Supposing all the plots use the same size
+        self.assertEqual(self.plot1.getXAxis().getLimits(), (0, 200))
+        self.assertEqual(self.plot2.getXAxis().getLimits(), (0, 200))
+        self.assertEqual(self.plot3.getXAxis().getLimits(), (0, 200))
 
 
 def suite():

--- a/silx/gui/plot/test/testUtilsAxis.py
+++ b/silx/gui/plot/test/testUtilsAxis.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "19/11/2018"
+__date__ = "20/11/2018"
 
 
 import unittest
@@ -181,6 +181,26 @@ class TestAxisSync(TestCaseQt):
         self.assertEqual(self.plot1.getXAxis().getLimits(), (0, 200))
         self.assertEqual(self.plot2.getXAxis().getLimits(), (0, 200))
         self.assertEqual(self.plot3.getXAxis().getLimits(), (0, 200))
+
+    def testAddAxis(self):
+        """Test synchronization after construction"""
+        sync = SyncAxes([self.plot1.getXAxis(), self.plot2.getXAxis()])
+        sync.addAxis(self.plot3.getXAxis())
+
+        self.plot1.getXAxis().setLimits(10, 500)
+        self.assertEqual(self.plot1.getXAxis().getLimits(), (10, 500))
+        self.assertEqual(self.plot2.getXAxis().getLimits(), (10, 500))
+        self.assertEqual(self.plot3.getXAxis().getLimits(), (10, 500))
+
+    def testRemoveAxis(self):
+        """Test synchronization after construction"""
+        sync = SyncAxes([self.plot1.getXAxis(), self.plot2.getXAxis(), self.plot3.getXAxis()])
+        sync.removeAxis(self.plot3.getXAxis())
+
+        self.plot1.getXAxis().setLimits(10, 500)
+        self.assertEqual(self.plot1.getXAxis().getLimits(), (10, 500))
+        self.assertEqual(self.plot2.getXAxis().getLimits(), (10, 500))
+        self.assertNotEqual(self.plot3.getXAxis().getLimits(), (10, 500))
 
 
 def suite():

--- a/silx/gui/plot/utils/axis.py
+++ b/silx/gui/plot/utils/axis.py
@@ -80,6 +80,8 @@ class SyncAxes(object):
         :param bool syncCenter: Synchronize the center of the axes in the center
             of the plots
         :param bool syncZoom: Synchronize the zoom of the plot
+        :param bool filterHiddenPlots: True to avoid updating hidden plots.
+            Default: False.
         """
         object.__init__(self)
 
@@ -125,8 +127,8 @@ class SyncAxes(object):
         self.synchronize()
 
     def isSynchronizing(self):
-        """Returns true of event are connected to the axis to synchronize them
-        altogether
+        """Returns true if events are connected to the axes to synchronize them
+        all together
 
         :rtype: bool
         """
@@ -197,7 +199,10 @@ class SyncAxes(object):
                     sig.disconnect(callback)
 
     def addAxis(self, axis):
-        """Add a new axes to synchronize."""
+        """Add a new axes to synchronize.
+
+        :param ~silx.gui.plot.items.Axis axis: The axis to synchronize
+        """
         self.__axisRefs.append(weakref.ref(axis))
         if self.isSynchronizing():
             self.__connectAxes(axis)
@@ -205,13 +210,21 @@ class SyncAxes(object):
             self.synchronize()
 
     def removeAxis(self, axis):
+        """Remove an axis from the synchronized axes.
+
+        :param ~silx.gui.plot.items.Axis axis: The axis to remove
+        """
         ref = weakref.ref(axis)
         self.__axisRefs.remove(ref)
         if self.isSynchronizing():
             self.__disconnectAxes(axis)
 
     def synchronize(self, mainAxis=None):
-        """Synchronize programatically all the axes"""
+        """Synchronize programatically all the axes.
+
+        :param ~silx.gui.plot.items.Axis mainAxis:
+            The axis to take as reference (Default: the first axis).
+        """
         # sync the current state
         axes = self.__getAxes()
         if len(axes) == 0:

--- a/silx/gui/plot/utils/axis.py
+++ b/silx/gui/plot/utils/axis.py
@@ -353,6 +353,8 @@ class SyncAxes(object):
         with self.__inhibitSignals():
             center = self.__getAxesCenter(changedAxis, vmin, vmax)
             pixelRange = self.__getRangeInPixel(changedAxis)
+            if pixelRange == 0:
+                return
             pixelSize = (vmax - vmin) / pixelRange
             for axis in self.__axesToUpdate(changedAxis):
                 vmin, vmax = self.__getLimitsFromCenter(axis, center, pixelSize)


### PR DESCRIPTION
This PR add another way to sync axes.

- `syncCenter` allow to synchronize axes to the value displayed in there center
- `syncZoom` allow to sync the pixel size of axes, reaching displayed pixels used to display the axes

As result `limits` of all axes can be different according to the size of the widget. Fixed limits was creating a lot of inconsistencies in case of use of fixed aspect ratio, or in case a lot of widgets are synchronized (widget size could not always match). Both constrains are still useful, depending on the context.

As it is mostly designed to sync Plot2D (displaying images), only a subset was implemented.

- Can only be used with linear axes
- Can be used to constrains `center` or `center+zoon`, but not `zoom` only

Closes #2243