### PR TITLE
Improve drawmask selection2

### DIFF
--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import
 
 __authors__ = ["T. Vincent", "H.Payno"]
 __license__ = "MIT"
-__date__ = "19/11/2018"
+__date__ = "30/11/2018"
 
 import numpy
 import logging
@@ -161,6 +161,23 @@ def rgba(color, colorDict=None):
     b = int(color[5:7], 16) / 255.
     a = int(color[7:9], 16) / 255. if len(color) == 9 else 1.
     return r, g, b, a
+
+
+def greyed(color, colorDict=None):
+    """Convert color code '#RRGGBB' and '#RRGGBBAA' to a grey color
+    (R, G, B, A).
+
+    It also convert RGB(A) values from uint8 to float in [0, 1] and
+    accept a QColor as color argument.
+
+    :param str color: The color to convert
+    :param dict colorDict: A dictionary of color name conversion to color code
+    :returns: RGBA colors as floats in [0., 1.]
+    :rtype: tuple
+    """
+    r, g, b, a = rgba(color=color, colorDict=colorDict)
+    g = 0.21 * r + 0.72 * g + 0.07 * b
+    return g, g, g, a
 
 
 def cursorColorForColormap(colormapName):

--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -96,10 +96,18 @@ class _PlotInteraction(object):
 
         fill = fill != 'none'  # TODO not very nice either
 
+        greyed = colors.greyed(color)[0]
+        if greyed < 0.5:
+            color2 = "white"
+        else:
+            color2 = "black"
+
         self.plot.addItem(points[:, 0], points[:, 1], legend=legend,
                           replace=False,
-                          shape=shape, color=color, fill=fill,
+                          shape=shape, fill=fill,
+                          color=color, linebgcolor=color2, linestyle="--",
                           overlay=True)
+
         self._selectionAreas.add(legend)
 
     def resetSelectionArea(self):

--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "30/11/2018"
+__date__ = "21/12/2018"
 
 
 import math
@@ -553,7 +553,6 @@ class SelectPolygon(Select):
         if qt.BINDING in ('PyQt5', 'PySide2'):
             ratio = self.plot.window().windowHandle().devicePixelRatio()
         return self.DRAG_THRESHOLD_DIST * ratio
-
 
 
 class Select2Points(Select):

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -1179,6 +1179,7 @@ class PlotWidget(qt.QMainWindow):
         item.setPoints(numpy.array((xdata, ydata)).T)
         item.setLineStyle(linestyle)
         item.setLineWidth(linewidth)
+        item.setLineBgColor(linebgcolor)
 
         self._add(item)
 

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -31,7 +31,7 @@ from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent"]
 __license__ = "MIT"
-__date__ = "26/11/2018"
+__date__ = "21/12/2018"
 
 
 from collections import OrderedDict, namedtuple
@@ -1118,7 +1118,8 @@ class PlotWidget(qt.QMainWindow):
     def addItem(self, xdata, ydata, legend=None, info=None,
                 replace=False,
                 shape="polygon", color='black', fill=True,
-                overlay=False, z=None):
+                overlay=False, z=None, linestyle="-", linewidth=1.0,
+                linebgcolor=None):
         """Add an item (i.e. a shape) to the plot.
 
         Items are uniquely identified by their legend.
@@ -1142,6 +1143,19 @@ class PlotWidget(qt.QMainWindow):
                              This allows for rendering optimization if this
                              item is changed often.
         :param int z: Layer on which to draw the item (default: 2)
+        :param str linestyle: Style of the line.
+            Only relevant for line markers where X or Y is None.
+            Value in:
+
+            - ' '  no line
+            - '-'  solid line
+            - '--' dashed line
+            - '-.' dash-dot line
+            - ':'  dotted line
+        :param float linewidth: Width of the line.
+            Only relevant for line markers where X or Y is None.
+        :param str linebgcolor: Background color of the line, e.g., 'blue', 'b',
+            '#FF0000'. It is used to draw dotted line using a second color.
         :returns: The key string identify this item
         """
         # expected to receive the same parameters as the signal
@@ -1163,6 +1177,8 @@ class PlotWidget(qt.QMainWindow):
         item.setOverlay(overlay)
         item.setZValue(z)
         item.setPoints(numpy.array((xdata, ydata)).T)
+        item.setLineStyle(linestyle)
+        item.setLineWidth(linewidth)
 
         self._add(item)
 

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -31,7 +31,7 @@ This API is a simplified version of PyMca PlotBackend API.
 
 __authors__ = ["V.A. Sole", "T. Vincent"]
 __license__ = "MIT"
-__date__ = "19/11/2018"
+__date__ = "21/12/2018"
 
 import weakref
 from ... import qt
@@ -171,7 +171,7 @@ class BackendBase(object):
         return legend
 
     def addItem(self, x, y, legend, shape, color, fill, overlay, z,
-                linestyle, linewidth):
+                linestyle, linewidth, linebgcolor):
         """Add an item (i.e. a shape) to the plot.
 
         :param numpy.ndarray x: The X coords of the points of the shape
@@ -194,6 +194,8 @@ class BackendBase(object):
             - ':'  dotted line
         :param float linewidth: Width of the line.
             Only relevant for line markers where X or Y is None.
+        :param str linebgcolor: Background color of the line, e.g., 'blue', 'b',
+            '#FF0000'. It is used to draw dotted line using a second color.
         :returns: The handle used by the backend to univocally access the item
         """
         return legend

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -467,7 +467,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
         return image
 
     def addItem(self, x, y, legend, shape, color, fill, overlay, z,
-                linestyle, linewidth):
+                linestyle, linewidth, linebgcolor):
         xView = numpy.array(x, copy=False)
         yView = numpy.array(y, copy=False)
 

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -28,7 +28,7 @@ from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent, H. Payno"]
 __license__ = "MIT"
-__date__ = "19/12/2018"
+__date__ = "21/12/2018"
 
 
 import logging
@@ -60,6 +60,22 @@ from ....third_party.modest_image import ModestImage
 from . import BackendBase
 from .._utils import FLOAT32_MINPOS
 from .._utils.dtime_ticklayout import calcTicks, bestFormatString, timestamp
+
+
+_PATCH_LINESTYLE = {
+    "-": 'solid',
+    "--": 'dashed',
+    '-.': 'dashdot',
+    ':': 'dotted',
+    '': "solid",
+    None: "solid",
+}
+"""Patches do not uses the same matplotlib syntax"""
+
+
+def normalize_linestyle(linestyle):
+    """Normalize known old-style linestyle, else return the provided value."""
+    return _PATCH_LINESTYLE.get(linestyle, linestyle)
 
 
 class NiceDateLocator(Locator):
@@ -454,6 +470,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
                 linestyle, linewidth):
         xView = numpy.array(x, copy=False)
         yView = numpy.array(y, copy=False)
+
+        linestyle = normalize_linestyle(linestyle)
 
         if shape == "line":
             item = self.ax.plot(x, y, label=legend, color=color,

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -28,7 +28,7 @@ from __future__ import division
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "19/11/2018"
+__date__ = "21/12/2018"
 
 from collections import OrderedDict, namedtuple
 from ctypes import c_void_p
@@ -1025,7 +1025,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         return legend, 'image'
 
     def addItem(self, x, y, legend, shape, color, fill, overlay, z,
-                linestyle, linewidth):
+                linestyle, linewidth, linebgcolor):
         # TODO handle overlay
         if shape not in ('polygon', 'rectangle', 'line',
                          'vline', 'hline', 'polylines'):

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1026,6 +1026,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
     def addItem(self, x, y, legend, shape, color, fill, overlay, z,
                 linestyle, linewidth, linebgcolor):
+        # FIXME: implement lineStyle and lineBgColor
         # TODO handle overlay
         if shape not in ('polygon', 'rectangle', 'line',
                          'vline', 'hline', 'polylines'):

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -84,6 +84,9 @@ class ItemChangedType(enum.Enum):
     COLOR = 'colorChanged'
     """Item's color changed flag."""
 
+    LINE_BG_COLOR = 'lineBgColorChanged'
+    """Item's line background color changed flag."""
+
     YAXIS = 'yAxisChanged'
     """Item's Y axis binding changed flag."""
 
@@ -559,6 +562,7 @@ class LineMixIn(ItemMixInBase):
     def __init__(self):
         self._linewidth = self._DEFAULT_LINEWIDTH
         self._linestyle = self._DEFAULT_LINESTYLE
+        self._lineBgColor = None
 
     @classmethod
     def getSupportedLineStyles(cls):
@@ -616,6 +620,34 @@ class LineMixIn(ItemMixInBase):
         if style != self._linestyle:
             self._linestyle = style
             self._updated(ItemChangedType.LINE_STYLE)
+
+    def getLineBgColor(self):
+        """Returns the RGBA color of the item
+        :rtype: 4-tuple of float in [0, 1] or array of colors
+        """
+        return self._lineBgColor
+
+    def setLineBgColor(self, color, copy=True):
+        """Set item color
+        :param color: color(s) to be used
+        :type color: str ("#RRGGBB") or (npoints, 4) unsigned byte array or
+                     one of the predefined color names defined in colors.py
+        :param bool copy: True (Default) to get a copy,
+                         False to use internal representation (do not modify!)
+        """
+        if color is not None:
+            if isinstance(color, six.string_types):
+                color = colors.rgba(color)
+            else:
+                color = numpy.array(color, copy=copy)
+                # TODO more checks + improve color array support
+                if color.ndim == 1:  # Single RGBA color
+                    color = colors.rgba(color)
+                else:  # Array of colors
+                    assert color.ndim == 2
+
+        self._lineBgColor = color
+        self._updated(ItemChangedType.LINE_BG_COLOR)
 
 
 class ColorMixIn(ItemMixInBase):

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -27,7 +27,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "14/06/2018"
+__date__ = "21/12/2018"
 
 import collections
 from copy import deepcopy
@@ -894,14 +894,14 @@ class Points(Item, SymbolMixIn, AlphaMixIn):
             # use the getData class method because instance method can be
             # overloaded to return additional arrays
             data = Points.getData(self, copy=False,
-                                 displayed=True)
+                                  displayed=True)
             if len(data) == 5:
                 # hack to avoid duplicating caching mechanism in Scatter
                 # (happens when cached data is used, caching done using
                 # Scatter._logFilterData)
-                x, y, xerror, yerror = data[0], data[1], data[3], data[4]
+                x, y, _xerror, _yerror = data[0], data[1], data[3], data[4]
             else:
-                x, y, xerror, yerror = data
+                x, y, _xerror, _yerror = data
 
             self._boundsCache[(xPositive, yPositive)] = (
                 numpy.nanmin(x),

--- a/silx/gui/plot/items/shape.py
+++ b/silx/gui/plot/items/shape.py
@@ -75,7 +75,7 @@ class Shape(Item, ColorMixIn, FillMixIn, LineMixIn):
                                z=self.getZValue(),
                                linestyle=self.getLineStyle(),
                                linewidth=self.getLineWidth(),
-                               linebgcolor=None)
+                               linebgcolor=self.getLineBgColor())
 
     def isOverlay(self):
         """Return true if shape is drawn as an overlay

--- a/silx/gui/plot/items/shape.py
+++ b/silx/gui/plot/items/shape.py
@@ -27,7 +27,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "17/05/2017"
+__date__ = "21/12/2018"
 
 
 import logging
@@ -74,7 +74,8 @@ class Shape(Item, ColorMixIn, FillMixIn, LineMixIn):
                                overlay=self.isOverlay(),
                                z=self.getZValue(),
                                linestyle=self.getLineStyle(),
-                               linewidth=self.getLineWidth())
+                               linewidth=self.getLineWidth(),
+                               linebgcolor=None)
 
     def isOverlay(self):
         """Return true if shape is drawn as an overlay


### PR DESCRIPTION
Here is a patch to allow to display dotted lines in 2 colors.

- The Matplotlib backend is based on a custom `_DoubleColoredLinePatch` customing the rendering method. And other expected methods.
- Tested only on matplotlib 3.0.2, and Debian8 one
- There is no OpenGL backend
- `line`/`vline`/`hline` do not uses patches, then there is no special rendering for this.
    - It could be fixed

![screenshot from 2018-11-30 18-44-22](https://user-images.githubusercontent.com/7579321/49306387-51f32980-f4d2-11e8-9002-80c85bf4af59.png)

Closes #1270 