### PR TITLE
include requirements.txt in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 # List of silx development dependencies
 # Those ARE NOT required for installation, at runtime or to build from source (except for the doc)
 
-numpy >= 1.8
+-r requirements.txt
 setuptools        # Advanced packaging tools
 wheel             # To build wheels
 Cython >= 0.21.1  # To regenerate .c/.cpp files from .pyx


### PR DESCRIPTION
I also saw that `scipy` was on the requirements.txt but from my point of view it should be in requirements-dev.txt no ?