### PR TITLE
[doc]Fix sphinx errors and warnings 

### DIFF
--- a/doc/source/modules/gui/plot/items.rst
+++ b/doc/source/modules/gui/plot/items.rst
@@ -32,7 +32,7 @@ Curve
              isHighlighted, setHighlighted, getHighlightedStyle, setHighlightedStyle,
              getCurrentStyle
 
-.. autoclass:: CurveStyle
+.. autoclass:: silx.gui.plot.items.curve.CurveStyle
    :members: getColor, getLineStyle, getLineWidth, getSymbol, getSymbolSize
 
 Images

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -741,8 +741,10 @@ class Colormap(qt.QObject):
         """Get the supported colormap names as a tuple of str.
 
         The list should at least contain and start by:
-        ('gray', 'reversed gray', 'temperature', 'red', 'green', 'blue',
+
+         ('gray', 'reversed gray', 'temperature', 'red', 'green', 'blue',
          'viridis', 'magma', 'inferno', 'plasma')
+
         :rtype: tuple
         """
         colormaps = set()

--- a/silx/gui/plot3d/SceneWidget.py
+++ b/silx/gui/plot3d/SceneWidget.py
@@ -488,7 +488,8 @@ class SceneWidget(Plot3DWidget):
         :param int index: The index at which to place the item.
                           By default it is appended to the end of the list.
         :return: The newly created scalar volume item
-        :rtype: items.ScalarField3D
+        :rtype: ~silx.gui.plot3d.items.volume.ScalarField3D
+
         """
         volume = items.ScalarField3D()
         volume.setData(data, copy=copy)
@@ -508,7 +509,7 @@ class SceneWidget(Plot3DWidget):
         :param int index: The index at which to place the item.
                           By default it is appended to the end of the list.
         :return: The newly created 3D scatter item
-        :rtype: items.Scatter3D
+        :rtype: ~silx.gui.plot3d.items.scatter.Scatter3D
         """
         scatter3d = items.Scatter3D()
         scatter3d.setData(x=x, y=y, z=z, value=value, copy=copy)
@@ -528,7 +529,7 @@ class SceneWidget(Plot3DWidget):
         :param int index: The index at which to place the item.
                           By default it is appended to the end of the list.
         :return: The newly created 2D scatter item
-        :rtype: items.Scatter2D
+        :rtype: ~silx.gui.plot3d.items.scatter.Scatter2D
         """
         scatter2d = items.Scatter2D()
         scatter2d.setData(x=x, y=y, value=value, copy=copy)
@@ -548,7 +549,7 @@ class SceneWidget(Plot3DWidget):
         :param int index: The index at which to place the item.
                           By default it is appended to the end of the list.
         :return: The newly created image item
-        :rtype: items.ImageData or items.ImageRgba
+        :rtype: ~silx.gui.plot3d.items.image.ImageData or ~silx.gui.plot3d.items.image.ImageRgba
         :raise ValueError: For arrays of unsupported dimensions
         """
         data = numpy.array(data, copy=False)


### PR DESCRIPTION
Sphinx was unable to create link to `plot3d.items` without the full path (confusion with `plot.items`)

@t20100 : I'm not sure about https://github.com/silx-kit/silx/commit/9c82c19e929930e645161462804a79207e0c7b89 . Maybe it would be better to import/expose `CurveStyle` also in `silx/gui/plot/items/__init__.py` instead of providing the correct path in the incorrect doc page.