### PR TITLE
Unpin pyopengl and pyopencl versions

### DIFF
--- a/ci/info_platform.py
+++ b/ci/info_platform.py
@@ -8,10 +8,14 @@ __license__ = "MIT"
 
 
 import sys
+import platform
 
 print("Python %s bits" % (tuple.__itemsize__ * 8))
 print("       maxsize: %s\t maxunicode: %s" % (sys.maxsize, sys.maxunicode))
 print(sys.version)
+print(" ")
+
+print("Platform: " + platform.platform())
 print(" ")
 
 try:

--- a/ci/info_platform.py
+++ b/ci/info_platform.py
@@ -16,6 +16,7 @@ print(sys.version)
 print(" ")
 
 print("Platform: " + platform.platform())
+print("- Machine: " + platform.machine())
 print(" ")
 
 try:

--- a/ci/requirements-pinned.txt
+++ b/ci/requirements-pinned.txt
@@ -1,6 +1,1 @@
-# To use pyopencl wheels on Windows
---trusted-host www.silx.org
---find-links http://www.silx.org/pub/wheelhouse/
 
-PyOpenGL               # PyOpenGL pre-release broken on Windows (#2074)
-pyopencl==2018.1.1     # Until pyopencl 2018.2 issue is fixed

--- a/ci/requirements-pinned.txt
+++ b/ci/requirements-pinned.txt
@@ -1,1 +1,1 @@
-
+pybind11  # Required to build pyopencl

--- a/ci/requirements-pinned.txt
+++ b/ci/requirements-pinned.txt
@@ -1,3 +1,7 @@
+# To use pyopencl wheels on Windows
+--trusted-host www.silx.org
+--find-links http://www.silx.org/pub/wheelhouse/
+
 pybind11  # Required to build pyopencl
 
 # Pinpoint pyopencl on Windows to latest wheel available for python 2.7

--- a/ci/requirements-pinned.txt
+++ b/ci/requirements-pinned.txt
@@ -1,1 +1,6 @@
 pybind11  # Required to build pyopencl
+
+# Pinpoint pyopencl on Windows to latest wheel available for python 2.7
+# on https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyopencl
+# Anyway, we don't test OpenCL on appveyor
+pyopencl == 2018.1.1; sys_platform == 'win32'

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ enum34; python_version == '2.7'
 futures; python_version == '2.7'
 
 # Extra dependencies (from setup.py extra_requires 'full' target)
-pyopencl; platform_machine in "i386, x86_64"  # For silx.opencl
+pyopencl; platform_machine in "i386, x86_64, AMD64"  # For silx.opencl
 Mako                      # For pyopencl reduction
 qtconsole                 # For silx.gui.console
 matplotlib >= 1.2.0       # For silx.gui.plot


### PR DESCRIPTION
This PR removes version pin-pointing for pyopengl and pyopengl as new versions are available.