### PR TITLE
Multi-backend FFT

### DIFF
--- a/silx/math/fft/__init__.py
+++ b/silx/math/fft/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+__authors__ = ["P. Paleo"]
+__license__ = "MIT"
+__date__ = "12/12/2018"
+
+from .fft import FFT

--- a/silx/math/fft/basefft.py
+++ b/silx/math/fft/basefft.py
@@ -52,11 +52,11 @@ def check_version(package, required_version):
 
 
 class BaseFFT(object):
+    """
+    Base class for all FFT backends.
+    """
     def __init__(self, **kwargs):
-        """
-        Base class for all FFT backends.
-        """
-        self.get_args(**kwargs)
+        self.__get_args(**kwargs)
 
         if self.shape is None and self.dtype is None and self.data is None:
             raise ValueError("Please provide either (shape and dtype) or data")
@@ -65,12 +65,12 @@ class BaseFFT(object):
             self.dtype = self.data.dtype
         self.user_data = self.data
         self.data_allocated = False
-        self.calc_axes()
-        self.set_dtypes()
-        self.calc_shape()
+        self.__calc_axes()
+        self.__set_dtypes()
+        self.__calc_shape()
 
 
-    def get_args(self, **kwargs):
+    def __get_args(self, **kwargs):
         expected_args = {
             "shape": None,
             "dtype": None,
@@ -87,7 +87,7 @@ class BaseFFT(object):
         for arg_name, arg_val in kwargs.items():
             setattr(self, arg_name, arg_val)
 
-    def set_dtypes(self):
+    def __set_dtypes(self):
         dtypes_mapping = {
             np.dtype("float32"): np.complex64,
             np.dtype("float64"): np.complex128,
@@ -106,7 +106,7 @@ class BaseFFT(object):
         self.dtype_out = dtypes_mapping[self.dtype_in]
 
 
-    def calc_shape(self):
+    def __calc_shape(self):
         # TODO allow for C2C even for real input data (?)
         if self.dtype_in in [np.float32, np.float64]:
             last_dim = self.shape[-1]//2 + 1
@@ -115,7 +115,7 @@ class BaseFFT(object):
         else:
             self.shape_out = self.shape
 
-    def calc_axes(self):
+    def __calc_axes(self):
         default_axes = tuple(range(len(self.shape)))
         if self.axes is None:
             self.axes = default_axes
@@ -149,4 +149,9 @@ class BaseFFT(object):
         else:
             return self.set_data(self.data_out, data, self.shape_out, self.dtype_out, copy=copy, name="data_out")
 
+    def fft(self, array, **kwargs):
+        raise ValueError("This should be implemented by back-end FFT")
+
+    def ifft(self, array, **kwargs):
+        raise ValueError("This should be implemented by back-end FFT")
 

--- a/silx/math/fft/basefft.py
+++ b/silx/math/fft/basefft.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+import numpy as np
+
+
+
+def check_version(package, required_version):
+    """
+    Check whether a given package version is superior or equal to required_version.
+    """
+    def numeric_version_repr(ver):
+        """
+        Dummy numeric representation of a semantic version.
+        The version is in format "X.Y.Z" where it is assumed that
+        Y < 1000 and Z < 10000.
+        """
+        major, minor, patch = ver.split(".")
+        return int(major) * 1e3 + int(minor) + int(patch) * 1e-4
+    try:
+        ver = getattr(package, "__version__")
+    except AttributeError:
+        try:
+            ver = getattr(package, "version")
+        except Exception:
+            return False
+    req_num = numeric_version_repr(required_version)
+    ver_num = numeric_version_repr(ver)
+    return ver_num >= req_num
+
+
+class BaseFFT(object):
+    def __init__(self, **kwargs):
+        """
+        Base class for all FFT backends.
+        """
+        self.get_args(**kwargs)
+
+        if self.shape is None and self.dtype is None and self.data is None:
+            raise ValueError("Please provide either (shape and dtype) or data")
+        if self.data is not None:
+            self.shape = self.data.shape
+            self.dtype = self.data.dtype
+        self.user_data = self.data
+        self.data_allocated = False
+        self.calc_axes()
+        self.set_dtypes()
+        self.calc_shape()
+
+
+    def get_args(self, **kwargs):
+        expected_args = {
+            "shape": None,
+            "dtype": None,
+            "data": None,
+            "shape_out": None,
+            "axes": None,
+            "normalize": "rescale",
+        }
+        for arg_name, default_val in expected_args.items():
+            if arg_name not in kwargs:
+                # Base class was not instantiated properly
+                raise ValueError("Please provide argument %s" % arg_name)
+            setattr(self, arg_name, default_val)
+        for arg_name, arg_val in kwargs.items():
+            setattr(self, arg_name, arg_val)
+
+    def set_dtypes(self):
+        dtypes_mapping = {
+            np.dtype("float32"): np.complex64,
+            np.dtype("float64"): np.complex128,
+            np.dtype("complex64"): np.complex64,
+            np.dtype("complex128"): np.complex128
+        }
+        dp = {
+            np.dtype("float32"): np.float64,
+            np.dtype("complex64"): np.complex128
+        }
+        self.dtype_in = np.dtype(self.dtype)
+        if self.dtype_in not in dtypes_mapping:
+            raise ValueError("Invalid input data type: got %s" %
+                self.dtype_in
+            )
+        self.dtype_out = dtypes_mapping[self.dtype_in]
+
+
+    def calc_shape(self):
+        # TODO allow for C2C even for real input data (?)
+        if self.dtype_in in [np.float32, np.float64]:
+            last_dim = self.shape[-1]//2 + 1
+            # FFTW convention
+            self.shape_out = self.shape[:-1] + (self.shape[-1]//2 + 1,)
+        else:
+            self.shape_out = self.shape
+
+    def calc_axes(self):
+        default_axes = tuple(range(len(self.shape)))
+        if self.axes is None:
+            self.axes = default_axes
+            self.user_axes = None
+        else:
+            self.user_axes = self.axes
+            # Handle possibly negative axes
+            self.axes = tuple(np.array(default_axes)[np.array(self.user_axes)])
+
+    def _allocate(self, shape, dtype):
+        raise ValueError("This should be implemented by back-end FFT")
+
+    def set_data(self, dst, src, shape, dtype, copy=True):
+        raise ValueError("This should be implemented by back-end FFT")
+
+    def allocate_arrays(self):
+        if not(self.data_allocated):
+            self.data_in = self._allocate(self.shape, self.dtype_in)
+            self.data_out = self._allocate(self.shape_out, self.dtype_out)
+            self.data_allocated = True
+
+    def set_input_data(self, data, copy=True):
+        if data is None:
+            return self.data_in
+        else:
+            return self.set_data(self.data_in, data, self.shape, self.dtype_in, copy=copy, name="data_in")
+
+    def set_output_data(self, data, copy=True):
+        if data is None:
+            return self.data_out
+        else:
+            return self.set_data(self.data_out, data, self.shape_out, self.dtype_out, copy=copy, name="data_out")
+
+

--- a/silx/math/fft/basefft.py
+++ b/silx/math/fft/basefft.py
@@ -24,21 +24,13 @@
 #
 # ###########################################################################*/
 import numpy as np
-
+from pkg_resources import parse_version
 
 
 def check_version(package, required_version):
     """
     Check whether a given package version is superior or equal to required_version.
     """
-    def numeric_version_repr(ver):
-        """
-        Dummy numeric representation of a semantic version.
-        The version is in format "X.Y.Z" where it is assumed that
-        Y < 1000 and Z < 10000.
-        """
-        major, minor, patch = ver.split(".")
-        return int(major) * 1e3 + int(minor) + int(patch) * 1e-4
     try:
         ver = getattr(package, "__version__")
     except AttributeError:
@@ -46,9 +38,9 @@ def check_version(package, required_version):
             ver = getattr(package, "version")
         except Exception:
             return False
-    req_num = numeric_version_repr(required_version)
-    ver_num = numeric_version_repr(ver)
-    return ver_num >= req_num
+    req_v = parse_version(required_version)
+    ver_v = parse_version(ver)
+    return ver_v >= req_v
 
 
 class BaseFFT(object):

--- a/silx/math/fft/clfft.py
+++ b/silx/math/fft/clfft.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+import numpy as np
+
+from .basefft import BaseFFT, check_version
+try:
+    import pyopencl as cl
+    import pyopencl.array as parray
+    import gpyfft
+    from gpyfft.fft import FFT as cl_fft
+    __have_clfft__ = True
+except ImportError:
+    __have_clfft__ = False
+
+
+# Check gpyfft version
+__required_gpyfft_version__ = "0.3.0"
+if __have_clfft__:
+    __have_clfft__ = check_version(gpyfft, __required_gpyfft_version__)
+
+class CLFFT(BaseFFT):
+    def __init__(
+        self,
+        shape=None,
+        dtype=None,
+        data=None,
+        shape_out=None,
+        axes=None,
+        normalize="rescale",
+        ctx=None,
+        fast_math=False,
+    ):
+        """
+        Initialize a clfft plan.
+        Please see FFT class for parameters help.
+
+        CLFFT-specific parameters:
+        ctx: pyopencl.Context
+            If set to other than None, an existing pyopencl context is used.
+        fast_math: bool
+            If set to True, computations will be done with "fast math" mode,
+            i.e more speed but less accuracy.
+        """
+        if not(__have_clfft__) or not(__have_clfft__):
+            raise ImportError("Please install pyopencl and gpyfft >= %s to use the OpenCL back-end" % __required_gpyfft_version__)
+
+        super(CLFFT, self).__init__(
+            shape=shape,
+            dtype=dtype,
+            data=data,
+            shape_out=shape_out,
+            axes=axes,
+            normalize=normalize,
+        )
+        self.ctx = ctx
+        self.fast_math = fast_math
+        self.backend = "clfft"
+
+        self.fix_axes()
+        self.init_context_queue()
+        self.allocate_arrays()
+        self.real_transform = np.isrealobj(self.data_in)
+        self.compute_forward_plan()
+        self.compute_inverse_plan()
+        self.refs = {
+            "data_in": self.data_in,
+            "data_out": self.data_out,
+        }
+        # TODO
+        #  Either pyopencl ElementWiseKernel, or built-in clfft callbacks
+        if self.normalize != "rescale":
+            raise NotImplementedError(
+                "Normalization modes other than rescale are not implemented with OpenCL backend yet."
+            )
+
+
+    def fix_axes(self):
+        """
+        "Fix" axes. clfft does not have the same convention as FFTW/cuda/numpy.
+        """
+        self.axes = self.axes[::-1]
+
+    def _allocate(self, shape, dtype):
+        return parray.zeros(self.queue, shape, dtype=dtype)
+
+
+    def check_array(self, array, shape, dtype, copy=True):
+        if array.shape != shape:
+            raise ValueError("Invalid data shape: expected %s, got %s" %
+                (shape, array.shape)
+            )
+        if array.dtype != dtype:
+            raise ValueError("Invalid data type: expected %s, got %s" %
+                (dtype, array.dtype)
+            )
+
+
+    def set_data(self, dst, src, shape, dtype, copy=True, name=None):
+        """
+        dst is a device array owned by the current instance
+        (either self.data_in or self.data_out).
+
+        copy is ignored for device<-> arrays.
+        """
+        self.check_array(src, shape, dtype)
+        if isinstance(src, np.ndarray):
+            if name == "data_out":
+                # Makes little sense to provide output=numpy_array
+                return dst
+            if not(src.flags["C_CONTIGUOUS"]):
+                src = np.ascontiguousarray(src, dtype=dtype)
+            # working on underlying buffer is notably faster
+            #~ dst[:] = src[:]
+            evt = cl.enqueue_copy(self.queue, dst.data, src)
+            evt.wait()
+        elif isinstance(src, parray.Array):
+            # No copy, use the data as self.d_input or self.d_output
+            # (this prevents the use of in-place transforms, however).
+            # We have to keep their old references.
+            if name is None:
+                # This should not happen
+                raise ValueError("Please provide either copy=True or name != None")
+            assert id(self.refs[name]) == id(dst) # DEBUG
+            setattr(self, name, src)
+            return src
+        else:
+            raise ValueError(
+                "Invalid array type %s, expected numpy.ndarray or pyopencl.array" %
+                type(src)
+            )
+        return dst
+
+
+    def recover_array_references(self):
+        self.data_in = self.refs["data_in"]
+        self.data_out = self.refs["data_out"]
+
+
+    def init_context_queue(self):
+        if self.ctx is None:
+            self.ctx = cl.create_some_context()
+        self.queue = cl.CommandQueue(self.ctx)
+
+
+    def compute_forward_plan(self):
+        self.plan_forward = cl_fft(
+            self.ctx,
+            self.queue,
+            self.data_in,
+            out_array=self.data_out,
+            axes=self.axes,
+            fast_math=self.fast_math,
+            real=self.real_transform,
+        )
+
+
+    def compute_inverse_plan(self):
+        self.plan_inverse = cl_fft(
+            self.ctx,
+            self.queue,
+            self.data_out,
+            out_array=self.data_in,
+            axes=self.axes,
+            fast_math=self.fast_math,
+            real=self.real_transform,
+        )
+
+
+    def update_forward_plan_arrays(self):
+        self.plan_forward.data = self.data_in
+        self.plan_forward.result = self.data_out
+
+
+    def update_inverse_plan_arrays(self):
+        self.plan_inverse.data = self.data_out
+        self.plan_inverse.result = self.data_in
+
+
+    def copy_output_if_numpy(self, dst, src):
+        if isinstance(dst, parray.Array):
+            return
+        # working on underlying buffer is notably faster
+        #~ dst[:] = src[:]
+        evt = cl.enqueue_copy(self.queue, dst, src.data)
+        evt.wait()
+
+
+    def fft(self, array, output=None, async=False):
+        """
+        Perform a
+        (forward) Fast Fourier Transform.
+
+        Parameters
+        ----------
+        array: numpy.ndarray or pyopencl.array
+            Input data. Must be consistent with the current context.
+        output: numpy.ndarray or pyopencl.array, optional
+            Output data. By default, output is a numpy.ndarray.
+        async: bool, optional
+            Whether to perform operation in asynchronous mode. Default is False,
+            meaning that we wait for transform to complete.
+        """
+        data_in = self.set_input_data(array, copy=False)
+        data_out = self.set_output_data(output, copy=False)
+        self.update_forward_plan_arrays()
+        event, = self.plan_forward.enqueue()
+        if not(async):
+            event.wait()
+        if output is not None:
+            self.copy_output_if_numpy(output, self.data_out)
+            res = output
+        else:
+            res = self.data_out.get()
+        self.recover_array_references()
+        return res
+
+
+    def ifft(self, array, output=None, async=False):
+        """
+        Perform a
+        (inverse) Fast Fourier Transform.
+
+        Parameters
+        ----------
+        array: numpy.ndarray or pyopencl.array
+            Input data. Must be consistent with the current context.
+        output: numpy.ndarray or pyopencl.array, optional
+            Output data. By default, output is a numpy.ndarray.
+        async: bool, optional
+            Whether to perform operation in asynchronous mode. Default is False,
+            meaning that we wait for transform to complete.
+        """
+        data_in = self.set_output_data(array, copy=False)
+        data_out = self.set_input_data(output, copy=False)
+        self.update_inverse_plan_arrays()
+        event, = self.plan_inverse.enqueue(forward=False)
+        if not(async):
+            event.wait()
+        if output is not None:
+            self.copy_output_if_numpy(output, self.data_in)
+            res = output
+        else:
+            res = self.data_in.get()
+        self.recover_array_references()
+        return res
+
+
+    def __del__(self):
+        # It seems that gpyfft underlying clFFT destructors are not called.
+        # This results in the following warning:
+        #   Warning:  Program terminating, but clFFT resources not freed.
+        #   Please consider explicitly calling clfftTeardown( )
+        del self.plan_forward
+        del self.plan_inverse
+

--- a/silx/math/fft/clfft.py
+++ b/silx/math/fft/clfft.py
@@ -42,6 +42,19 @@ if __have_clfft__:
     __have_clfft__ = check_version(gpyfft, __required_gpyfft_version__)
 
 class CLFFT(BaseFFT):
+    """
+    Initialize a clfft plan.
+    Please see FFT class for parameters help.
+
+    CLFFT-specific parameters
+    --------------------------
+
+    :param ctx: pyopencl.Context
+        If set to other than None, an existing pyopencl context is used.
+    :param fast_math: bool
+        If set to True, computations will be done with "fast math" mode,
+        i.e more speed but less accuracy.
+    """
     def __init__(
         self,
         shape=None,
@@ -53,17 +66,6 @@ class CLFFT(BaseFFT):
         ctx=None,
         fast_math=False,
     ):
-        """
-        Initialize a clfft plan.
-        Please see FFT class for parameters help.
-
-        CLFFT-specific parameters:
-        ctx: pyopencl.Context
-            If set to other than None, an existing pyopencl context is used.
-        fast_math: bool
-            If set to True, computations will be done with "fast math" mode,
-            i.e more speed but less accuracy.
-        """
         if not(__have_clfft__) or not(__have_clfft__):
             raise ImportError("Please install pyopencl and gpyfft >= %s to use the OpenCL back-end" % __required_gpyfft_version__)
 
@@ -213,13 +215,11 @@ class CLFFT(BaseFFT):
         Perform a
         (forward) Fast Fourier Transform.
 
-        Parameters
-        ----------
-        array: numpy.ndarray or pyopencl.array
+        :param array: numpy.ndarray or pyopencl.array
             Input data. Must be consistent with the current context.
-        output: numpy.ndarray or pyopencl.array, optional
+        :param output: numpy.ndarray or pyopencl.array, optional
             Output data. By default, output is a numpy.ndarray.
-        do_async: bool, optional
+        :param do_async: bool, optional
             Whether to perform operation in asynchronous mode. Default is False,
             meaning that we wait for transform to complete.
         """
@@ -243,13 +243,11 @@ class CLFFT(BaseFFT):
         Perform a
         (inverse) Fast Fourier Transform.
 
-        Parameters
-        ----------
-        array: numpy.ndarray or pyopencl.array
+        :param array: numpy.ndarray or pyopencl.array
             Input data. Must be consistent with the current context.
-        output: numpy.ndarray or pyopencl.array, optional
+        :param output: numpy.ndarray or pyopencl.array, optional
             Output data. By default, output is a numpy.ndarray.
-        do_async: bool, optional
+        :param do_async: bool, optional
             Whether to perform operation in asynchronous mode. Default is False,
             meaning that we wait for transform to complete.
         """

--- a/silx/math/fft/clfft.py
+++ b/silx/math/fft/clfft.py
@@ -208,7 +208,7 @@ class CLFFT(BaseFFT):
         evt.wait()
 
 
-    def fft(self, array, output=None, async=False):
+    def fft(self, array, output=None, do_async=False):
         """
         Perform a
         (forward) Fast Fourier Transform.
@@ -219,7 +219,7 @@ class CLFFT(BaseFFT):
             Input data. Must be consistent with the current context.
         output: numpy.ndarray or pyopencl.array, optional
             Output data. By default, output is a numpy.ndarray.
-        async: bool, optional
+        do_async: bool, optional
             Whether to perform operation in asynchronous mode. Default is False,
             meaning that we wait for transform to complete.
         """
@@ -227,7 +227,7 @@ class CLFFT(BaseFFT):
         data_out = self.set_output_data(output, copy=False)
         self.update_forward_plan_arrays()
         event, = self.plan_forward.enqueue()
-        if not(async):
+        if not(do_async):
             event.wait()
         if output is not None:
             self.copy_output_if_numpy(output, self.data_out)
@@ -238,7 +238,7 @@ class CLFFT(BaseFFT):
         return res
 
 
-    def ifft(self, array, output=None, async=False):
+    def ifft(self, array, output=None, do_async=False):
         """
         Perform a
         (inverse) Fast Fourier Transform.
@@ -249,7 +249,7 @@ class CLFFT(BaseFFT):
             Input data. Must be consistent with the current context.
         output: numpy.ndarray or pyopencl.array, optional
             Output data. By default, output is a numpy.ndarray.
-        async: bool, optional
+        do_async: bool, optional
             Whether to perform operation in asynchronous mode. Default is False,
             meaning that we wait for transform to complete.
         """
@@ -257,7 +257,7 @@ class CLFFT(BaseFFT):
         data_out = self.set_input_data(output, copy=False)
         self.update_inverse_plan_arrays()
         event, = self.plan_inverse.enqueue(forward=False)
-        if not(async):
+        if not(do_async):
             event.wait()
         if output is not None:
             self.copy_output_if_numpy(output, self.data_in)

--- a/silx/math/fft/cufft.py
+++ b/silx/math/fft/cufft.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+import numpy as np
+
+from .basefft import BaseFFT
+try:
+    import pycuda
+    import pycuda.gpuarray as gpuarray
+    from skcuda.fft import Plan
+    from skcuda.fft import fft as cu_fft
+    from skcuda.fft import ifft as cu_ifft
+    __have_cufft__ = True
+except ImportError:
+    __have_cufft__ = False
+
+class CUFFT(BaseFFT):
+    def __init__(
+        self,
+        shape=None,
+        dtype=None,
+        data=None,
+        shape_out=None,
+        axes=None,
+        normalize="rescale",
+        stream=None,
+    ):
+        """
+        Initialize a cufft plan.
+        Please see FFT class for parameters help.
+
+        CUFFT-specific parameters:
+        stream: pycuda.driver.Stream
+          Stream with which to associate the plan. If no stream is specified,
+          the default stream is used.
+        """
+        if not(__have_cufft__) or not(__have_cufft__):
+            raise ImportError("Please install pycuda and scikit-cuda to use the CUDA back-end")
+
+        super(CUFFT, self).__init__(
+            shape=shape,
+            dtype=dtype,
+            data=data,
+            shape_out=shape_out,
+            axes=axes,
+            normalize=normalize,
+        )
+        self.cufft_stream = stream
+        self.backend = "cufft"
+
+        self.configure_batched_transform()
+        self.allocate_arrays()
+        self.real_transform = np.isrealobj(self.data_in)
+        self.compute_forward_plan()
+        self.compute_inverse_plan()
+        self.refs = {
+            "data_in": self.data_in,
+            "data_out": self.data_out,
+        }
+        self.configure_normalization()
+
+
+    def _allocate(self, shape, dtype):
+        return gpuarray.zeros(shape, dtype)
+
+
+    # TODO support batched transform where batch is other than dimension 0
+    def configure_batched_transform(self):
+        self.cufft_batch_size = 1
+        self.cufft_shape = self.shape
+        if (self.axes is not None) and (len(self.axes) < len(self.shape)):
+            # In the easiest batch mode, dimension 0 is equal to batch_size.
+            # Otherwise, we have to configure istride/idist.
+            dims = tuple(np.arange(len(self.shape)))
+            if self.axes != dims[1:]:
+                raise NotImplementedError(
+                    "With the CUDA backend, batched transform can currently be performed only with axes=%s" % dims[1:]
+                )
+            self.cufft_batch_size = self.shape[0]
+            self.cufft_shape = self.shape[1:]
+            if len(self.cufft_shape) == 1:
+                self.cufft_shape = self.cufft_shape[0]
+
+
+    def configure_normalization(self):
+        # TODO
+        if self.normalize == "ortho":
+            raise NotImplementedError(
+                "Normalization mode 'ortho' is not implemented with CUDA backend yet."
+            )
+        self.cufft_scale_inverse = (self.normalize == "rescale")
+
+
+    def check_array(self, array, shape, dtype, copy=True):
+        if array.shape != shape:
+            raise ValueError("Invalid data shape: expected %s, got %s" %
+                (shape, array.shape)
+            )
+        if array.dtype != dtype:
+            raise ValueError("Invalid data type: expected %s, got %s" %
+                (dtype, array.dtype)
+            )
+
+
+    def set_data(self, dst, src, shape, dtype, copy=True, name=None):
+        """
+        dst is a device array owned by the current instance
+        (either self.data_in or self.data_out).
+
+        copy is ignored for device<-> arrays.
+        """
+        self.check_array(src, shape, dtype)
+        if isinstance(src, np.ndarray):
+            if name == "data_out":
+                # Makes little sense to provide output=numpy_array
+                return dst
+            if not(src.flags["C_CONTIGUOUS"]):
+                src = np.ascontiguousarray(src, dtype=dtype)
+            dst[:] = src[:]
+        elif isinstance(src, gpuarray.GPUArray):
+            # No copy, use the data as self.d_input or self.d_output
+            # (this prevents the use of in-place transforms, however).
+            # We have to keep their old references.
+            if name is None:
+                # This should not happen
+                raise ValueError("Please provide either copy=True or name != None")
+            assert id(self.refs[name]) == id(dst) # DEBUG
+            setattr(self, name, src)
+            return src
+        else:
+            raise ValueError(
+                "Invalid array type %s, expected numpy.ndarray or pycuda.gpuarray" %
+                type(src)
+            )
+        return dst
+
+
+    def recover_array_references(self):
+        self.data_in = self.refs["data_in"]
+        self.data_out = self.refs["data_out"]
+
+
+    def compute_forward_plan(self):
+        self.plan_forward = Plan(
+            self.cufft_shape,
+            self.dtype,
+            self.dtype_out,
+            batch=self.cufft_batch_size,
+            stream=self.cufft_stream,
+            # cufft extensible plan API is only supported after 0.5.1
+            # (commit 65288d28ca0b93e1234133f8d460dc6becb65121)
+            # but there is still no official 0.5.2
+            #~ auto_allocate=True # cufft extensible plan API
+        )
+
+
+    def compute_inverse_plan(self):
+        self.plan_inverse = Plan(
+            self.cufft_shape, # not shape_out
+            self.dtype_out,
+            self.dtype,
+            batch=self.cufft_batch_size,
+            stream=self.cufft_stream,
+            # cufft extensible plan API is only supported after 0.5.1
+            # (commit 65288d28ca0b93e1234133f8d460dc6becb65121)
+            # but there is still no official 0.5.2
+            #~ auto_allocate=True
+        )
+
+
+    def copy_output_if_numpy(self, dst, src):
+        if isinstance(dst, gpuarray.GPUArray):
+            return
+        dst[:] = src[:]
+
+
+    def fft(self, array, output=None):
+        """
+        Perform a
+        (forward) Fast Fourier Transform.
+
+        Parameters
+        ----------
+        array: numpy.ndarray or pycuda.gpuarray
+            Input data. Must be consistent with the current context.
+        output: numpy.ndarray or pycuda.gpuarray, optional
+            Output data. By default, output is a numpy.ndarray.
+        """
+        data_in = self.set_input_data(array, copy=False)
+        data_out = self.set_output_data(output, copy=False)
+
+        cu_fft(
+            data_in,
+            data_out,
+            self.plan_forward,
+            scale=False
+        )
+
+        if output is not None:
+            self.copy_output_if_numpy(output, self.data_out)
+            res = output
+        else:
+            res = self.data_out.get()
+        self.recover_array_references()
+        return res
+
+
+    def ifft(self, array, output=None):
+        """
+        Perform a
+        (inverse) Fast Fourier Transform.
+
+        Parameters
+        ----------
+        array: numpy.ndarray or pycuda.gpuarray
+            Input data. Must be consistent with the current context.
+        output: numpy.ndarray or pycuda.gpuarray, optional
+            Output data. By default, output is a numpy.ndarray.
+        """
+        data_in = self.set_output_data(array, copy=False)
+        data_out = self.set_input_data(output, copy=False)
+
+        cu_ifft(
+            data_in,
+            data_out,
+            self.plan_inverse,
+            scale=self.cufft_scale_inverse,
+        )
+
+        if output is not None:
+            self.copy_output_if_numpy(output, self.data_in)
+            res = output
+        else:
+            res = self.data_in.get()
+        self.recover_array_references()
+        return res
+
+
+

--- a/silx/math/fft/cufft.py
+++ b/silx/math/fft/cufft.py
@@ -37,6 +37,17 @@ except ImportError:
     __have_cufft__ = False
 
 class CUFFT(BaseFFT):
+    """
+    Initialize a cufft plan.
+    Please see FFT class for parameters help.
+
+    CUFFT-specific parameters
+    --------------------------
+
+    :param stream: pycuda.driver.Stream
+      Stream with which to associate the plan. If no stream is specified,
+      the default stream is used.
+    """
     def __init__(
         self,
         shape=None,
@@ -47,15 +58,6 @@ class CUFFT(BaseFFT):
         normalize="rescale",
         stream=None,
     ):
-        """
-        Initialize a cufft plan.
-        Please see FFT class for parameters help.
-
-        CUFFT-specific parameters:
-        stream: pycuda.driver.Stream
-          Stream with which to associate the plan. If no stream is specified,
-          the default stream is used.
-        """
         if not(__have_cufft__) or not(__have_cufft__):
             raise ImportError("Please install pycuda and scikit-cuda to use the CUDA back-end")
 
@@ -201,11 +203,9 @@ class CUFFT(BaseFFT):
         Perform a
         (forward) Fast Fourier Transform.
 
-        Parameters
-        ----------
-        array: numpy.ndarray or pycuda.gpuarray
+        :param array: numpy.ndarray or pycuda.gpuarray
             Input data. Must be consistent with the current context.
-        output: numpy.ndarray or pycuda.gpuarray, optional
+        :param output: numpy.ndarray or pycuda.gpuarray, optional
             Output data. By default, output is a numpy.ndarray.
         """
         data_in = self.set_input_data(array, copy=False)
@@ -232,11 +232,9 @@ class CUFFT(BaseFFT):
         Perform a
         (inverse) Fast Fourier Transform.
 
-        Parameters
-        ----------
-        array: numpy.ndarray or pycuda.gpuarray
+        :param array: numpy.ndarray or pycuda.gpuarray
             Input data. Must be consistent with the current context.
-        output: numpy.ndarray or pycuda.gpuarray, optional
+        :param output: numpy.ndarray or pycuda.gpuarray, optional
             Output data. By default, output is a numpy.ndarray.
         """
         data_in = self.set_output_data(array, copy=False)
@@ -256,6 +254,4 @@ class CUFFT(BaseFFT):
             res = self.data_in.get()
         self.recover_array_references()
         return res
-
-
 

--- a/silx/math/fft/fft.py
+++ b/silx/math/fft/fft.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+import numpy as np
+from .fftw import FFTW
+from .clfft import CLFFT
+from .npfft import NPFFT
+from .cufft import CUFFT
+
+
+def FFT(
+    shape=None,
+    dtype=None,
+    data=None,
+    shape_out=None,
+    axes=None,
+    normalize="rescale",
+    backend="numpy",
+    **kwargs
+):
+    """
+    Initialize a FFT plan.
+
+    Parameters
+    ----------
+    shape: tuple
+        Shape of the input data.
+    dtype: type
+        Data type of the input data.
+    data: numpy.ndarray, optional
+        Input data. If provided, the arguments "shape" and "dtype" are ignored,
+        and are instead infered from "data".
+    shape_out: tuple, optional
+        Shape of output data. By default, the data has the same shape as the input
+        data (in case of C2C transform), or a shape with the last dimension halved
+        (in case of R2C transform). If shape_out is provided, it must be greater
+        or equal than the shape of input data. In this case, FFT is performed
+        with zero-padding.
+    axes: tuple
+        Axes along which FFT is computed.
+          * For 2D transform: axes=(1,0)
+          * For batched 1D transform of 2D image: axes=(0,)
+    normalize: str
+        Whether to normalize FFT and IFFT. Possible values are:
+          * "rescale": in this case, Fourier data is divided by "N"
+            before IFFT, so that (FFT(data)) = data
+          * "ortho": in this case, FFT and IFFT are adjoint of eachother,
+            the transform is unitary. Both FFT and IFFT are scaled with 1/sqrt(N).
+          * "none": no normalizatio is done : IFFT(FFT(data)) = data*N
+    backend: str
+        FFT Backend to use. Value can be "numpy", "fftw", "opencl", "cuda".
+    """
+    backends = {
+        "numpy": NPFFT,
+        "np": NPFFT,
+        "fftw": FFTW,
+        "opencl": CLFFT,
+        "clfft": CLFFT,
+        "cuda": CUFFT,
+        "cufft": CUFFT,
+    }
+
+    backend = backend.lower()
+    if backend not in backends:
+        raise ValueError("Unknown backend %s, available are %s" % (backend, backends))
+    F = backends[backend](
+        shape=shape,
+        dtype=dtype,
+        data=data,
+        shape_out=shape_out,
+        axes=axes,
+        normalize=normalize,
+        **kwargs
+    )
+    return F
+
+
+
+
+
+

--- a/silx/math/fft/fft.py
+++ b/silx/math/fft/fft.py
@@ -43,33 +43,31 @@ def FFT(
     """
     Initialize a FFT plan.
 
-    Parameters
-    ----------
-    shape: tuple
+    :param shape: tuple
         Shape of the input data.
-    dtype: type
+    :param dtype: type
         Data type of the input data.
-    data: numpy.ndarray, optional
+    :param data: numpy.ndarray, optional
         Input data. If provided, the arguments "shape" and "dtype" are ignored,
         and are instead infered from "data".
-    shape_out: tuple, optional
+    :param shape_out: tuple, optional
         Shape of output data. By default, the data has the same shape as the input
         data (in case of C2C transform), or a shape with the last dimension halved
         (in case of R2C transform). If shape_out is provided, it must be greater
         or equal than the shape of input data. In this case, FFT is performed
         with zero-padding.
-    axes: tuple
+    :param axes: tuple
         Axes along which FFT is computed.
           * For 2D transform: axes=(1,0)
           * For batched 1D transform of 2D image: axes=(0,)
-    normalize: str
+    :param normalize: str
         Whether to normalize FFT and IFFT. Possible values are:
           * "rescale": in this case, Fourier data is divided by "N"
             before IFFT, so that (FFT(data)) = data
           * "ortho": in this case, FFT and IFFT are adjoint of eachother,
             the transform is unitary. Both FFT and IFFT are scaled with 1/sqrt(N).
           * "none": no normalizatio is done : IFFT(FFT(data)) = data*N
-    backend: str
+    :param backend: str
         FFT Backend to use. Value can be "numpy", "fftw", "opencl", "cuda".
     """
     backends = {
@@ -95,9 +93,3 @@ def FFT(
         **kwargs
     )
     return F
-
-
-
-
-
-

--- a/silx/math/fft/fftw.py
+++ b/silx/math/fft/fftw.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+import numpy as np
+
+from .basefft import BaseFFT, check_version
+try:
+    import pyfftw
+    __have_fftw__ = True
+except ImportError:
+    __have_fftw__ = False
+
+
+# Check pyfftw version
+__required_pyfftw_version__ = "0.10.0"
+if __have_fftw__:
+    __have_fftw__ = check_version(pyfftw, __required_pyfftw_version__)
+
+
+class FFTW(BaseFFT):
+    def __init__(
+        self,
+        shape=None,
+        dtype=None,
+        data=None,
+        shape_out=None,
+        axes=None,
+        normalize="rescale",
+        check_alignment=False,
+        num_threads=1,
+    ):
+        """
+        Initialize a FFTW plan.
+        Please see FFT class for parameters help.
+
+        FFTW-specific parameters:
+        check_alignment: bool
+            If set to True and "data" is provided, this will enforce the input data
+            to be "byte aligned", which might imply extra memory usage.
+        num_threads: int
+            Number of threads for computing FFT.
+        """
+        if not(__have_fftw__):
+            raise ImportError("Please install pyfftw >= %s to use the FFTW back-end" % __required_pyfftw_version__)
+        super(FFTW, self).__init__(
+            shape=shape,
+            dtype=dtype,
+            data=data,
+            shape_out=shape_out,
+            axes=axes,
+            normalize=normalize,
+        )
+        self.check_alignment = check_alignment
+        self.num_threads = num_threads
+        self.backend = "fftw"
+
+        self.allocate_arrays()
+        self.set_fftw_flags()
+        self.compute_forward_plan()
+        self.compute_inverse_plan()
+
+
+    def set_fftw_flags(self):
+        self.fftw_flags = ('FFTW_MEASURE', ) # TODO
+        self.fftw_planning_timelimit = None # TODO
+        self.fftw_norm_modes = {
+            "rescale": {"ortho": False, "normalize": True},
+            "ortho": {"ortho": True, "normalize": False},
+            "none": {"ortho": False, "normalize": False},
+        }
+        if self.normalize not in self.fftw_norm_modes:
+            raise ValueError("Unknown normalization mode %s. Possible values are %s" %
+                (self.normalize, self.fftw_norm_modes.keys())
+            )
+        self.fftw_norm_mode = self.fftw_norm_modes[self.normalize]
+
+
+    def _allocate(self, shape, dtype):
+        return pyfftw.zeros_aligned(shape, dtype=dtype)
+
+
+    def check_array(self, array, shape, dtype, copy=True):
+        """
+        Check that a given array is compatible with the FFTW plans,
+        in terms of alignment and data type.
+        If the provided array does not meet any of the checks, a new array
+        is returned.
+        """
+        if array.shape != shape:
+            raise ValueError("Invalid data shape: expected %s, got %s" %
+                (shape, array.shape)
+            )
+        if array.dtype != dtype:
+            raise ValueError("Invalid data type: expected %s, got %s" %
+                (dtype, array.dtype)
+            )
+        if self.check_alignment and not(pyfftw.is_byte_aligned(array)):
+            array2 = pyfftw.zeros_aligned(self.shape, dtype=self.dtype_in)
+            np.copyto(array2, array)
+        else:
+            if copy:
+                array2 = np.copy(array)
+            else:
+                array2 = array
+        return array2
+
+
+    def set_data(self, dst, src, shape, dtype, copy=True, name=None):
+        dst = self.check_array(src, shape, dtype, copy=copy)
+        return dst
+
+
+    def compute_forward_plan(self):
+        self.plan_forward = pyfftw.FFTW(
+            self.data_in,
+            self.data_out,
+            axes=self.axes,
+            direction='FFTW_FORWARD',
+            flags=self.fftw_flags,
+            threads=self.num_threads,
+            planning_timelimit=self.fftw_planning_timelimit,
+            # the following seems to be taken into account only when using __call__
+            ortho=self.fftw_norm_mode["ortho"],
+            normalise_idft=self.fftw_norm_mode["normalize"],
+        )
+
+
+    def compute_inverse_plan(self):
+        self.plan_inverse = pyfftw.FFTW(
+            self.data_out,
+            self.data_in,
+            axes=self.axes,
+            direction='FFTW_BACKWARD',
+            flags=self.fftw_flags,
+            threads=self.num_threads,
+            planning_timelimit=self.fftw_planning_timelimit,
+            # the following seem to be taken into account only when using __call__
+            ortho=self.fftw_norm_mode["ortho"],
+            normalise_idft=self.fftw_norm_mode["normalize"],
+        )
+
+
+    def fft(self, array, output=None):
+        data_in = self.set_input_data(array, copy=True)
+        data_out = self.set_output_data(output, copy=False)
+        # execute.__call__ does both update_arrays() and normalization
+        self.plan_forward(
+            input_array=data_in,
+            output_array=data_out,
+            ortho=self.fftw_norm_mode["ortho"],
+        )
+        assert id(self.plan_forward.output_array) == id(self.data_out) == id(data_out) # DEBUG
+        return data_out
+
+
+    def ifft(self, array, output=None):
+        data_in = self.set_output_data(array, copy=True)
+        data_out = self.set_input_data(output, copy=False)
+        # execute.__call__ does both update_arrays() and normalization
+        self.plan_inverse(
+            input_array=data_in,
+            output_array=data_out,
+            ortho=self.fftw_norm_mode["ortho"],
+            normalise_idft=self.fftw_norm_mode["normalize"]
+        )
+        assert id(self.plan_inverse.output_array) == id(self.data_in) == id(data_out) # DEBUG
+        return data_out
+
+

--- a/silx/math/fft/fftw.py
+++ b/silx/math/fft/fftw.py
@@ -40,6 +40,19 @@ if __have_fftw__:
 
 
 class FFTW(BaseFFT):
+    """
+    Initialize a FFTW plan.
+    Please see FFT class for parameters help.
+
+    FFTW-specific parameters
+    -------------------------
+
+    :param check_alignment: bool
+        If set to True and "data" is provided, this will enforce the input data
+        to be "byte aligned", which might imply extra memory usage.
+    :param num_threads: int
+        Number of threads for computing FFT.
+    """
     def __init__(
         self,
         shape=None,
@@ -51,17 +64,6 @@ class FFTW(BaseFFT):
         check_alignment=False,
         num_threads=1,
     ):
-        """
-        Initialize a FFTW plan.
-        Please see FFT class for parameters help.
-
-        FFTW-specific parameters:
-        check_alignment: bool
-            If set to True and "data" is provided, this will enforce the input data
-            to be "byte aligned", which might imply extra memory usage.
-        num_threads: int
-            Number of threads for computing FFT.
-        """
         if not(__have_fftw__):
             raise ImportError("Please install pyfftw >= %s to use the FFTW back-end" % __required_pyfftw_version__)
         super(FFTW, self).__init__(
@@ -163,6 +165,15 @@ class FFTW(BaseFFT):
 
 
     def fft(self, array, output=None):
+        """
+        Perform a
+        (forward) Fast Fourier Transform.
+
+        :param array: numpy.ndarray or pyopencl.array
+            Input data. Must be consistent with the current context.
+        :param output: numpy.ndarray, optional
+            Output data.
+        """
         data_in = self.set_input_data(array, copy=True)
         data_out = self.set_output_data(output, copy=False)
         # execute.__call__ does both update_arrays() and normalization
@@ -176,6 +187,15 @@ class FFTW(BaseFFT):
 
 
     def ifft(self, array, output=None):
+        """
+        Perform a
+        (inverse) Fast Fourier Transform.
+
+        :param array: numpy.ndarray or pycuda.gpuarray
+            Input data. Must be consistent with the current context.
+        :param output: numpy.ndarray, optional
+            Output data.
+        """
         data_in = self.set_output_data(array, copy=True)
         data_out = self.set_input_data(output, copy=False)
         # execute.__call__ does both update_arrays() and normalization

--- a/silx/math/fft/npfft.py
+++ b/silx/math/fft/npfft.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+import numpy as np
+
+from .basefft import BaseFFT
+
+
+class NPFFT(BaseFFT):
+    def __init__(
+        self,
+        shape=None,
+        dtype=None,
+        data=None,
+        shape_out=None,
+        axes=None,
+        normalize="rescale",
+    ):
+        """
+        Initialize a numpy plan.
+        Please see FFT class for parameters help.
+        """
+
+        super(NPFFT, self).__init__(
+            shape=shape,
+            dtype=dtype,
+            data=data,
+            shape_out=shape_out,
+            axes=axes,
+            normalize=normalize,
+        )
+        self.backend = "numpy"
+        self.real_transform = False
+        if data is not None and np.isrealobj(data):
+            self.real_transform = True
+        # For numpy functions.
+        # TODO Issue warning if user wants ifft(fft(data)) = N*data ?
+        if normalize != "ortho":
+            self.normalize = None
+        self.set_fft_functions()
+        #~ self.allocate_arrays() # not needed for this backend
+        self.compute_plans()
+
+
+    def set_fft_functions(self):
+        # (fwd, inv) = _fft_functions[is_real][ndim]
+        self._fft_functions = {
+            True: {
+                1: (np.fft.rfft, np.fft.irfft),
+                2: (np.fft.rfft2, np.fft.irfft2),
+                3: (np.fft.rfftn, np.fft.irfftn),
+            },
+            False: {
+                1: (np.fft.fft, np.fft.ifft),
+                2: (np.fft.fft2, np.fft.ifft2),
+                3: (np.fft.fftn, np.fft.ifftn),
+            }
+        }
+
+
+    def _allocate(self, shape, dtype):
+        return np.zeros(self.queue, shape, dtype=dtype)
+
+
+    def compute_plans(self):
+        ndim = len(self.shape)
+        funcs = self._fft_functions[self.real_transform][np.minimum(ndim, 3)]
+        self.numpy_args = {"norm": self.normalize}
+        # Batched transform
+        if (self.user_axes is not None) and len(self.user_axes) < ndim:
+            funcs = self._fft_functions[self.real_transform][np.minimum(ndim-1, 3)]
+            self.numpy_args["axes"] = self.user_axes
+            # Special case of batched 1D transform on 2D data
+            if ndim == 2:
+                assert len(self.user_axes) == 1
+                self.numpy_args["axis"] = self.user_axes[0]
+                self.numpy_args.pop("axes")
+        self.numpy_funcs = funcs
+
+
+    def fft(self, array):
+        """
+        Perform a
+        (forward) Fast Fourier Transform.
+
+        Parameters
+        ----------
+        array: numpy.ndarray or pyopencl.array
+            Input data. Must be consistent with the current context.
+
+        """
+        return self.numpy_funcs[0](array, **self.numpy_args)
+
+
+    def ifft(self, array):
+        """
+        Perform a
+        (inverse) Fast Fourier Transform.
+
+        Parameters
+        ----------
+        array: numpy.ndarray or pyopencl.array
+            Input data. Must be consistent with the current context.
+        """
+        return self.numpy_funcs[1](array, **self.numpy_args)
+
+
+

--- a/silx/math/fft/npfft.py
+++ b/silx/math/fft/npfft.py
@@ -29,6 +29,10 @@ from .basefft import BaseFFT
 
 
 class NPFFT(BaseFFT):
+    """
+    Initialize a numpy plan.
+    Please see FFT class for parameters help.
+    """
     def __init__(
         self,
         shape=None,
@@ -38,11 +42,6 @@ class NPFFT(BaseFFT):
         axes=None,
         normalize="rescale",
     ):
-        """
-        Initialize a numpy plan.
-        Please see FFT class for parameters help.
-        """
-
         super(NPFFT, self).__init__(
             shape=shape,
             dtype=dtype,
@@ -105,11 +104,8 @@ class NPFFT(BaseFFT):
         Perform a
         (forward) Fast Fourier Transform.
 
-        Parameters
-        ----------
-        array: numpy.ndarray or pyopencl.array
+        :param array: numpy.ndarray or pyopencl.array
             Input data. Must be consistent with the current context.
-
         """
         return self.numpy_funcs[0](array, **self.numpy_args)
 
@@ -119,12 +115,8 @@ class NPFFT(BaseFFT):
         Perform a
         (inverse) Fast Fourier Transform.
 
-        Parameters
-        ----------
-        array: numpy.ndarray or pyopencl.array
+        :param array: numpy.ndarray or pyopencl.array
             Input data. Must be consistent with the current context.
         """
         return self.numpy_funcs[1](array, **self.numpy_args)
-
-
 

--- a/silx/math/fft/setup.py
+++ b/silx/math/fft/setup.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,20 +21,21 @@
 # THE SOFTWARE.
 #
 # ############################################################################*/
-"""This package provides some processing functions for 1D, 2D, 3D or nD arrays.
 
-For additional processing functions dedicated to 2D images,
-see the silx.image package.
-For OpenCL-based processing functions see the silx.opencl package.
-
-See silx documentation: http://www.silx.org/doc/silx/latest/
-"""
-
-__authors__ = ["D. Naudet", "V.A. Sole", "P. Knobel"]
+__authors__ = ["P. Naudet"]
 __license__ = "MIT"
-__date__ = "11/05/2017"
+__date__ = "12/12/2018"
 
-from .histogram import Histogramnd  # noqa
-from .histogram import HistogramndLut  # noqa
-from .medianfilter import medfilt, medfilt1d, medfilt2d
-from .fft import fft
+import numpy
+from numpy.distutils.misc_util import Configuration
+
+
+def configuration(parent_package='', top_path=None):
+    config = Configuration('fft', parent_package, top_path)
+    config.add_subpackage('test')
+    return config
+
+
+if __name__ == "__main__":
+    from numpy.distutils.core import setup
+    setup(configuration=configuration)

--- a/silx/math/fft/test/__init__.py
+++ b/silx/math/fft/test/__init__.py
@@ -21,20 +21,8 @@
 # THE SOFTWARE.
 #
 # ############################################################################*/
-"""This package provides some processing functions for 1D, 2D, 3D or nD arrays.
 
-For additional processing functions dedicated to 2D images,
-see the silx.image package.
-For OpenCL-based processing functions see the silx.opencl package.
+from .test_fft import test_all
 
-See silx documentation: http://www.silx.org/doc/silx/latest/
-"""
-
-__authors__ = ["D. Naudet", "V.A. Sole", "P. Knobel"]
-__license__ = "MIT"
-__date__ = "11/05/2017"
-
-from .histogram import Histogramnd  # noqa
-from .histogram import HistogramndLut  # noqa
-from .medianfilter import medfilt, medfilt1d, medfilt2d
-from .fft import fft
+def suite():
+    return test_all()

--- a/silx/math/fft/test/test_fft.py
+++ b/silx/math/fft/test/test_fft.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Test of the MFFT module"""
+
+import numpy as np
+import unittest
+from scipy.misc import ascent
+from mfft.fft import FFT
+from mfft.clfft import __have_clfft__
+from mfft.cufft import __have_cufft__
+from mfft.fftw import __have_fftw__
+
+
+# http://eli.thegreenplace.net/2011/08/02/python-unit-testing-parametrized-test-cases/
+class ParametrizedTestCase(unittest.TestCase):
+    """ TestCase classes that want to be parametrized should
+        inherit from this class.
+    """
+    def __init__(self, methodName='runTest', param=None):
+        super(ParametrizedTestCase, self).__init__(methodName)
+        self.param = param
+
+    @staticmethod
+    def parametrize(testcase_klass, param=None):
+        """ Create a suite containing all tests taken from the given
+            subclass, passing them the parameter 'param'.
+        """
+        testloader = unittest.TestLoader()
+        testnames = testloader.getTestCaseNames(testcase_klass)
+        suite = unittest.TestSuite()
+        for name in testnames:
+            suite.addTest(testcase_klass(name, param=param))
+        return suite
+
+
+class TransformInfos(object):
+    def __init__(self):
+        self.dimensions = [
+            "1D",
+            "batched_1D",
+            "2D",
+            "batched_2D",
+            #~ "3D",
+        ]
+        self.modes = {
+            "R2C": np.float32,
+            "R2C_double": np.float64,
+            "C2C": np.complex64,
+            "C2C_double": np.complex128,
+        }
+        self.sizes = {
+            "1D": [(512,), (511,)],
+            "2D": [(512, 512), (512, 511), (511, 512), (511, 511)],
+            "3D": [(128, 128, 128), (128, 128, 127), (128, 127, 128), (127, 128, 128),
+                 (128, 127, 127), (127, 128, 127), (127, 127, 128), (127, 127, 127)]
+        }
+        self.axes = {
+            "1D": None,
+            "batched_1D": (-1,),
+            "2D": None,
+            "batched_2D": (-2, -1),
+            "3D": None,
+        }
+        self.sizes["batched_1D"] = self.sizes["2D"]
+        self.sizes["batched_2D"] = self.sizes["3D"]
+
+
+class TestData(object):
+    def __init__(self):
+        self.data = ascent().astype("float32")
+        self.data1d = self.data[:, 0] # non-contiguous data
+        self.data3d = np.tile(self.data[:128, :128], (128, 1, 1))
+        self.data_refs = {
+            1: self.data1d,
+            2: self.data,
+            3: self.data3d,
+        }
+
+
+
+class TestFFT(ParametrizedTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestFFT, cls).setUpClass()
+        if __have_clfft__:
+            import pyopencl
+            cls.Ctx = pyopencl.create_some_context()
+
+
+    @classmethod
+    def tearDownClass(cls):
+        super(TestFFT, cls).tearDownClass()
+        if __have_clfft__:
+            del cls.Ctx
+
+    def setUp(self):
+        self.tol = {
+            np.dtype("float32"): 1e-3,
+            np.dtype("float64"): 1e-9,
+            np.dtype("complex64"): 1e-3,
+            np.dtype("complex128"): 1e-9,
+        }
+        self.backend = self.param["backend"]
+        self.trdim = self.param["trdim"]
+        self.mode = self.param["mode"]
+        self.size = self.param["size"]
+        self.transform_infos = self.param["transform_infos"]
+        self.test_data = self.param["test_data"]
+        self.configure_backends()
+        self.configure_extra_args()
+
+
+    def tearDown(self):
+        pass
+
+
+    def configure_backends(self):
+        self.__have_clfft__ = __have_clfft__
+        self.__have_cufft__ = __have_cufft__
+        self.__have_fftw__ = __have_fftw__
+
+        if self.backend in ["cuda", "cufft"] and __have_cufft__:
+            import pycuda.autoinit
+            # Error is higher when using cuda. fast_math mode ?
+            self.tol[np.dtype("float32")] *= 2
+
+
+    def configure_extra_args(self):
+        self.extra_args = {}
+        if __have_clfft__ and self.backend in ["opencl", "clfft"]:
+            self.extra_args["ctx"] = self.Ctx
+
+
+    def check_current_backend(self):
+        if self.backend in ["cuda", "cufft"] and not(self.__have_cufft__):
+            return "cuda back-end requires pycuda and scikit-cuda"
+        if self.backend in ["opencl", "clfft"] and not(self.__have_clfft__):
+            return "opencl back-end requires pyopencl and gpyfft"
+        if self.backend == "fftw" and not(self.__have_fftw__):
+            return "fftw back-end requires pyfftw"
+        return None
+
+
+    @staticmethod
+    def calc_mae(arr1, arr2):
+        """
+        Compute the Max Absolute Error between two arrays
+        """
+        return np.max(np.abs(arr1 - arr2))
+
+
+    def test_fft(self):
+        err = self.check_current_backend()
+        if err is not None:
+            self.skipTest(err)
+
+        ndim = len(self.size)
+        input_data = self.test_data.data_refs[ndim].astype(self.transform_infos.modes[self.mode])
+        tol = self.tol[np.dtype(input_data.dtype)]
+        if self.trdim == "3D":
+            tol *= 10 # Error is relatively high in high dimensions
+
+        # Python < 3.5 does not want to mix **extra_args with existing kwargs
+        fft_args = {
+            "data": input_data,
+            "axes": self.transform_infos.axes[self.trdim],
+            "backend": self.backend,
+        }
+        fft_args.update(self.extra_args)
+        F = FFT(
+            **fft_args
+        )
+        F_np = FFT(
+            data=input_data,
+            axes=self.transform_infos.axes[self.trdim],
+            backend="numpy"
+        )
+
+        # Forward FFT
+        res = F.fft(input_data)
+        res_np = F_np.fft(input_data)
+        mae = self.calc_mae(res, res_np)
+        self.assertTrue(
+            mae < np.abs(input_data.max()) * tol,
+            "FFT %s:%s, MAE(%s, numpy) = %f" % (self.mode, self.trdim, self.backend, mae)
+        )
+
+        # Inverse FFT
+        res2 = F.ifft(res)
+        mae = self.calc_mae(res2, input_data)
+        self.assertTrue(
+            mae < tol,
+            "IFFT %s:%s, MAE(%s, numpy) = %f" % (self.mode, self.trdim, self.backend, mae)
+        )
+
+
+
+
+
+class TestNumpyFFT(ParametrizedTestCase):
+    """
+    Test the Numpy backend individually.
+    """
+
+
+    def setUp(self):
+        transforms = {
+            "1D": {
+                True: (np.fft.rfft, np.fft.irfft),
+                False: (np.fft.fft, np.fft.ifft),
+            },
+            "2D": {
+                True: (np.fft.rfft2, np.fft.irfft2),
+                False: (np.fft.fft2, np.fft.ifft2),
+            },
+            "3D": {
+                True: (np.fft.rfftn, np.fft.irfftn),
+                False: (np.fft.fftn, np.fft.ifftn),
+            },
+        }
+        transforms["batched_1D"] = transforms["1D"]
+        transforms["batched_2D"] = transforms["2D"]
+        self.transforms = transforms
+
+
+
+    def test_numpy_fft(self):
+        """
+        Test the numpy backend against native fft.
+        Results should be exactly the same.
+        """
+        trinfos = self.param["transform_infos"]
+        trdim = self.param["trdim"]
+        ndim = len(self.param["size"])
+        input_data = self.param["test_data"].data_refs[ndim].astype(trinfos.modes[self.param["mode"]])
+        np_fft, np_ifft = self.transforms[trdim][np.isrealobj(input_data)]
+
+        F = FFT(
+            data=input_data,
+            axes=trinfos.axes[trdim],
+            backend="numpy"
+        )
+        # Test FFT
+        res = F.fft(input_data)
+        ref = np_fft(input_data)
+        self.assertTrue(np.allclose(res, ref))
+
+        # Test IFFT
+        res2 = F.ifft(res)
+        ref2 = np_ifft(ref)
+        self.assertTrue(np.allclose(res2, ref2))
+
+
+
+
+def test_numpy_backend(dimensions=None):
+    testSuite = unittest.TestSuite()
+    transform_infos = TransformInfos()
+    test_data = TestData()
+    dimensions = dimensions or transform_infos.dimensions
+
+    for trdim in dimensions:
+        print("   testing %s" % trdim)
+        for mode in transform_infos.modes:
+            print("   testing %s:%s" % (trdim, mode))
+            for size in transform_infos.sizes[trdim]:
+                print("      size: %s" % str(size))
+                testcase = ParametrizedTestCase.parametrize(
+                    TestNumpyFFT,
+                    param={
+                        "transform_infos": transform_infos,
+                        "test_data": test_data,
+                        "trdim": trdim,
+                        "mode": mode,
+                        "size": size,
+                    }
+                )
+                testSuite.addTest(testcase)
+    return testSuite
+
+
+def test_fft(backend, dimensions=None):
+    testSuite = unittest.TestSuite()
+    transform_infos = TransformInfos()
+    test_data = TestData()
+    dimensions = dimensions or transform_infos.dimensions
+
+    print("Testing backend: %s" % backend)
+    for trdim in dimensions:
+        print("   testing %s" % trdim)
+        for mode in transform_infos.modes:
+            print("   testing %s:%s" % (trdim, mode))
+            for size in transform_infos.sizes[trdim]:
+                print("      size: %s" % str(size))
+                testcase = ParametrizedTestCase.parametrize(
+                    TestFFT,
+                    param={
+                        "transform_infos": transform_infos,
+                        "test_data": test_data,
+                        "backend": backend,
+                        "trdim": trdim,
+                        "mode": mode,
+                        "size": size,
+                    }
+                )
+                testSuite.addTest(testcase)
+    return testSuite
+
+
+def test_all():
+    suite = unittest.TestSuite()
+
+    #~ suite.addTest(test_numpy_backend())
+
+    #~ suite.addTest(test_fft("fftw"))
+    suite.addTest(test_fft("opencl"))
+    #~ suite.addTest(test_fft("cuda"))
+    return suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest="test_all")
+
+

--- a/silx/math/fft/test/test_fft.py
+++ b/silx/math/fft/test/test_fft.py
@@ -165,7 +165,7 @@ class TestFFT(unittest.TestCase):
         err = self.check_current_backend()
         if err is not None:
             self.skipTest(err)
-        if test_options.TEST_LOW_MEM:
+        if self.size == "3D" and test_options.TEST_LOW_MEM:
             self.skipTest("low mem")
 
         ndim = len(self.size)

--- a/silx/math/setup.py
+++ b/silx/math/setup.py
@@ -38,6 +38,7 @@ def configuration(parent_package='', top_path=None):
     config.add_subpackage('test')
     config.add_subpackage('fit')
     config.add_subpackage('medianfilter')
+    config.add_subpackage('fft')
 
     # =====================================
     # histogramnd

--- a/silx/math/test/__init__.py
+++ b/silx/math/test/__init__.py
@@ -38,6 +38,7 @@ from ..medianfilter.test import suite as test_medianfilter_suite
 from .test_combo import suite as test_combo_suite
 from .test_calibration import suite as test_calibration_suite
 from .test_colormap import suite as test_colormap_suite
+from ..fft.test import suite as test_fft_suite
 
 def suite():
     test_suite = unittest.TestSuite()
@@ -51,4 +52,5 @@ def suite():
     test_suite.addTest(test_combo_suite())
     test_suite.addTest(test_calibration_suite())
     test_suite.addTest(test_colormap_suite())
+    test_suite.addTest(test_fft_suite())
     return test_suite


### PR DESCRIPTION
## About

This PR adds a FFT with multiple backends: numpy, FFTW, OpenCL and CUDA. The idea is to have the same API for all the underlying backends. All the boring work (plans computation, axes, data type, memory alignment) is taken care of.

The numpy backend serves as a reference to compare the 3 other against. 
Therefore, the numpy backend is tested separately. 

All comments/suggestions on the API are welcome.

## Features 

  - 1D -> ND transforms (all what the underlying backend can support)
  - Batched transforms
  - R2C, C2C modes, with float32 and float64 data types
  - For GPU backends, input and/or output can be a device array.

## Currently not supported

  - In-place transforms
  - Hermitian transforms
  - For CUFFT backend, batched transform where batch is other than dimension 0.
  - Nice-to-have: transforms with "easy" zero-padding

## Examples

### Simple FFT with numpy
```python
import numpy as np
from scipy.misc import ascent
from silx.math.fft import FFT
img = ascent().astype(np.float32)

F = FFT(data=img, backend="numpy") # automatically chooses R2C transform
img_f = F.fft(img)
```

### Using FFTW
```python
F = FFT(data=img, backend="fftw", num_threads=4) 
img_f = F.fft(img)
# do some operation of img_f ...
F.ifft(img_f)
```

### Using OpenCL
```python
import pyopencl.array as parray
F = FFT(data=img, backend="opencl")
# All the Host <-> Device copies are handled under the hood
img_f = F.fft(img) # by default, result is a numpy array
# Input and/or output can be device array as well
d_in = parray.to_device(F.queue, img)
d_out = parray.zeros(F.queue, F.shape_out, dtype=F.dtype_out)
F.fft(d_in, output=d_out)
```


### Using CUDA
```python
import pycuda.autoinit
import pycuda.gpuarray as gpuarray 
F = FFT(data=img, backend="cuda")
d_in = gpuarray.to_gpu(img)
d_out = gpuarray.zeros(F.shape_out, F.dtype_out)
F.fft(d_in, output=d_out) # CUFFT is twice faster than clfft for R2C transforms