### PR TITLE
More style support for plot items and ROIs

### DIFF
--- a/examples/plotInteractiveImageROI.py
+++ b/examples/plotInteractiveImageROI.py
@@ -39,6 +39,7 @@ from silx.gui.plot import Plot2D
 from silx.gui.plot.tools.roi import RegionOfInterestManager
 from silx.gui.plot.tools.roi import RegionOfInterestTableWidget
 from silx.gui.plot.items.roi import RectangleROI
+from silx.gui.plot.items import LineMixIn, SymbolMixIn
 
 
 def dummy_image():
@@ -69,7 +70,12 @@ def updateAddedRegionOfInterest(roi):
     """Called for each added region of interest: set the name"""
     if roi.getLabel() == '':
         roi.setLabel('ROI %d' % len(roiManager.getRois()))
-
+    if isinstance(roi, LineMixIn):
+        roi.setLineWidth(2)
+        roi.setLineStyle('--')
+    if isinstance(roi, SymbolMixIn):
+        roi.setSymbol('o')
+        roi.setSymbolSize(5)
 
 roiManager.sigRoiAdded.connect(updateAddedRegionOfInterest)
 

--- a/examples/plotInteractiveImageROI.py
+++ b/examples/plotInteractiveImageROI.py
@@ -46,8 +46,7 @@ def dummy_image():
     """Create a dummy image"""
     x = numpy.linspace(-1.5, 1.5, 1024)
     xv, yv = numpy.meshgrid(x, x)
-    signal = numpy.exp(- (xv ** 2 / 0.15 ** 2
-                          + yv ** 2 / 0.25 ** 2))
+    signal = numpy.exp(- (xv ** 2 / 0.15 ** 2 + yv ** 2 / 0.25 ** 2))
     # add noise
     signal += 0.3 * numpy.random.random(size=signal.shape)
     return signal
@@ -55,8 +54,12 @@ def dummy_image():
 
 app = qt.QApplication([])  # Start QApplication
 
+backend = "matplotlib"
+if "--opengl" in sys.argv:
+    backend = "opengl"
+
 # Create the plot widget and add an image
-plot = Plot2D()
+plot = Plot2D(backend=backend)
 plot.getDefaultColormap().setName('viridis')
 plot.addImage(dummy_image())
 
@@ -76,6 +79,7 @@ def updateAddedRegionOfInterest(roi):
     if isinstance(roi, SymbolMixIn):
         roi.setSymbol('o')
         roi.setSymbolSize(5)
+
 
 roiManager.sigRoiAdded.connect(updateAddedRegionOfInterest)
 
@@ -105,6 +109,7 @@ widget.setLayout(layout)
 layout.addWidget(roiToolbar)
 layout.addWidget(roiTable)
 
+
 def roiDockVisibilityChanged(visible):
     """Handle change of visibility of the roi dock widget
 
@@ -112,6 +117,7 @@ def roiDockVisibilityChanged(visible):
     """
     if not visible:
         roiManager.stop()
+
 
 dock = qt.QDockWidget('Image ROI')
 dock.setWidget(widget)

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -170,7 +170,8 @@ class BackendBase(object):
         """
         return legend
 
-    def addItem(self, x, y, legend, shape, color, fill, overlay, z):
+    def addItem(self, x, y, legend, shape, color, fill, overlay, z,
+                linestyle, linewidth):
         """Add an item (i.e. a shape) to the plot.
 
         :param numpy.ndarray x: The X coords of the points of the shape
@@ -182,6 +183,17 @@ class BackendBase(object):
         :param bool fill: True to fill the shape
         :param bool overlay: True if item is an overlay, False otherwise
         :param int z: Layer on which to draw the item
+        :param str linestyle: Style of the line.
+            Only relevant for line markers where X or Y is None.
+            Value in:
+
+            - ' '  no line
+            - '-'  solid line
+            - '--' dashed line
+            - '-.' dash-dot line
+            - ':'  dotted line
+        :param float linewidth: Width of the line.
+            Only relevant for line markers where X or Y is None.
         :returns: The handle used by the backend to univocally access the item
         """
         return legend

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -450,23 +450,27 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
         return image
 
-    def addItem(self, x, y, legend, shape, color, fill, overlay, z):
+    def addItem(self, x, y, legend, shape, color, fill, overlay, z,
+                linestyle, linewidth):
         xView = numpy.array(x, copy=False)
         yView = numpy.array(y, copy=False)
 
         if shape == "line":
             item = self.ax.plot(x, y, label=legend, color=color,
-                                linestyle='-', marker=None)[0]
+                                linestyle=linestyle, linewidth=linewidth,
+                                marker=None)[0]
 
         elif shape == "hline":
             if hasattr(y, "__len__"):
                 y = y[-1]
-            item = self.ax.axhline(y, label=legend, color=color)
+            item = self.ax.axhline(y, label=legend, color=color,
+                                   linestyle=linestyle, linewidth=linewidth)
 
         elif shape == "vline":
             if hasattr(x, "__len__"):
                 x = x[-1]
-            item = self.ax.axvline(x, label=legend, color=color)
+            item = self.ax.axvline(x, label=legend, color=color,
+                                   linestyle=linestyle, linewidth=linewidth)
 
         elif shape == 'rectangle':
             xMin = numpy.nanmin(xView)
@@ -479,7 +483,9 @@ class BackendMatplotlib(BackendBase.BackendBase):
                              width=w,
                              height=h,
                              fill=False,
-                             color=color)
+                             color=color,
+                             linestyle=linestyle,
+                             linewidth=linewidth)
             if fill:
                 item.set_hatch('.')
 
@@ -495,7 +501,9 @@ class BackendMatplotlib(BackendBase.BackendBase):
                            closed=closed,
                            fill=False,
                            label=legend,
-                           color=color)
+                           color=color,
+                           linestyle=linestyle,
+                           linewidth=linewidth)
             if fill and shape == 'polygon':
                 item.set_hatch('/')
 

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -548,100 +548,6 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         glu.setGLContextGetter()
         _current_context = None
 
-    def _nonOrthoAxesLineMarkerPrimitives(self, marker, pixelOffset):
-        """Generates the vertices and label for a line marker.
-
-        :param dict marker: Description of a line marker
-        :param int pixelOffset: Offset of text from borders in pixels
-        :return: Line vertices and Text label or None
-        :rtype: 2-tuple (2x2 numpy.array of float, Text2D)
-        """
-        label, vertices = None, None
-
-        xCoord, yCoord = marker['x'], marker['y']
-        assert xCoord is None or yCoord is None  # Specific to line markers
-
-        # Get plot corners in data coords
-        plotLeft, plotTop, plotWidth, plotHeight = self.getPlotBoundsInPixels()
-
-        corners = [(plotLeft, plotTop),
-                   (plotLeft, plotTop + plotHeight),
-                   (plotLeft + plotWidth, plotTop + plotHeight),
-                   (plotLeft + plotWidth, plotTop)]
-        corners = numpy.array([self.pixelToData(x, y, axis='left', check=False)
-                               for (x, y) in corners])
-
-        borders = {
-            'right': (corners[3], corners[2]),
-            'top': (corners[0], corners[3]),
-            'bottom': (corners[2], corners[1]),
-            'left': (corners[1], corners[0])
-        }
-
-        textLayouts = {  # align, valign, offsets
-            'right': (RIGHT, BOTTOM, (-1., -1.)),
-            'top': (LEFT, TOP, (1., 1.)),
-            'bottom': (LEFT, BOTTOM, (1., -1.)),
-            'left': (LEFT, BOTTOM, (1., -1.))
-        }
-
-        if xCoord is None:  # Horizontal line in data space
-            if marker['text'] is not None:
-                # Find intersection of hline with borders in data
-                # Order is important as it stops at first intersection
-                for border_name in ('right', 'top', 'bottom', 'left'):
-                    (x0, y0), (x1, y1) = borders[border_name]
-
-                    if min(y0, y1) <= yCoord < max(y0, y1):
-                        xIntersect = (yCoord - y0) * (x1 - x0) / (y1 - y0) + x0
-
-                        # Add text label
-                        pixelPos = self.dataToPixel(
-                            xIntersect, yCoord, axis='left', check=False)
-
-                        align, valign, offsets = textLayouts[border_name]
-
-                        x = pixelPos[0] + offsets[0] * pixelOffset
-                        y = pixelPos[1] + offsets[1] * pixelOffset
-                        label = Text2D(marker['text'], x, y,
-                                       color=marker['color'],
-                                       bgColor=(1., 1., 1., 0.5),
-                                       align=align, valign=valign)
-                        break  # Stop at first intersection
-
-            xMin, xMax = corners[:, 0].min(), corners[:, 0].max()
-            vertices = numpy.array(
-                ((xMin, yCoord), (xMax, yCoord)), dtype=numpy.float32)
-
-        else:  # yCoord is None: vertical line in data space
-            if marker['text'] is not None:
-                # Find intersection of hline with borders in data
-                # Order is important as it stops at first intersection
-                for border_name in ('top', 'bottom', 'right', 'left'):
-                    (x0, y0), (x1, y1) = borders[border_name]
-                    if min(x0, x1) <= xCoord < max(x0, x1):
-                        yIntersect = (xCoord - x0) * (y1 - y0) / (x1 - x0) + y0
-
-                        # Add text label
-                        pixelPos = self.dataToPixel(
-                            xCoord, yIntersect, axis='left', check=False)
-
-                        align, valign, offsets = textLayouts[border_name]
-
-                        x = pixelPos[0] + offsets[0] * pixelOffset
-                        y = pixelPos[1] + offsets[1] * pixelOffset
-                        label = Text2D(marker['text'], x, y,
-                                       color=marker['color'],
-                                       bgColor=(1., 1., 1., 0.5),
-                                       align=align, valign=valign)
-                        break  # Stop at first intersection
-
-            yMin, yMax = corners[:, 1].min(), corners[:, 1].max()
-            vertices = numpy.array(
-                ((xCoord, yMin), (xCoord, yMax)), dtype=numpy.float32)
-
-        return vertices, label
-
     def _renderMarkersGL(self):
         if len(self._markers) == 0:
             return
@@ -682,46 +588,39 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                 continue
 
             if xCoord is None or yCoord is None:
-                if not self.isDefaultBaseVectors():  # Non-orthogonal axes
-                    vertices, label = self._nonOrthoAxesLineMarkerPrimitives(
-                        marker, pixelOffset)
-                    if label is not None:
+                pixelPos = self.dataToPixel(
+                    xCoord, yCoord, axis='left', check=False)
+
+                if xCoord is None:  # Horizontal line in data space
+                    if marker['text'] is not None:
+                        x = self._plotFrame.size[0] - \
+                            self._plotFrame.margins.right - pixelOffset
+                        y = pixelPos[1] - pixelOffset
+                        label = Text2D(marker['text'], x, y,
+                                       color=marker['color'],
+                                       bgColor=(1., 1., 1., 0.5),
+                                       align=RIGHT, valign=BOTTOM)
                         labels.append(label)
 
-                else:  # Orthogonal axes
-                    pixelPos = self.dataToPixel(
-                        xCoord, yCoord, axis='left', check=False)
+                    width = self._plotFrame.size[0]
+                    vertices = numpy.array(((0, pixelPos[1]),
+                                            (width, pixelPos[1])),
+                                           dtype=numpy.float32)
 
-                    if xCoord is None:  # Horizontal line in data space
-                        if marker['text'] is not None:
-                            x = self._plotFrame.size[0] - \
-                                self._plotFrame.margins.right - pixelOffset
-                            y = pixelPos[1] - pixelOffset
-                            label = Text2D(marker['text'], x, y,
-                                           color=marker['color'],
-                                           bgColor=(1., 1., 1., 0.5),
-                                           align=RIGHT, valign=BOTTOM)
-                            labels.append(label)
+                else:  # yCoord is None: vertical line in data space
+                    if marker['text'] is not None:
+                        x = pixelPos[0] + pixelOffset
+                        y = self._plotFrame.margins.top + pixelOffset
+                        label = Text2D(marker['text'], x, y,
+                                       color=marker['color'],
+                                       bgColor=(1., 1., 1., 0.5),
+                                       align=LEFT, valign=TOP)
+                        labels.append(label)
 
-                        width = self._plotFrame.size[0]
-                        vertices = numpy.array(((0, pixelPos[1]),
-                                                (width, pixelPos[1])),
-                                               dtype=numpy.float32)
-
-                    else:  # yCoord is None: vertical line in data space
-                        if marker['text'] is not None:
-                            x = pixelPos[0] + pixelOffset
-                            y = self._plotFrame.margins.top + pixelOffset
-                            label = Text2D(marker['text'], x, y,
-                                           color=marker['color'],
-                                           bgColor=(1., 1., 1., 0.5),
-                                           align=LEFT, valign=TOP)
-                            labels.append(label)
-
-                        height = self._plotFrame.size[1]
-                        vertices = numpy.array(((pixelPos[0], 0),
-                                                (pixelPos[0], height)),
-                                               dtype=numpy.float32)
+                    height = self._plotFrame.size[1]
+                    vertices = numpy.array(((pixelPos[0], 0),
+                                            (pixelPos[0], height)),
+                                           dtype=numpy.float32)
 
                 self._progBase.use()
                 gl.glUniform4f(self._progBase.uniforms['color'],
@@ -1464,37 +1363,6 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             if label:
                 _logger.warning('Right axis label not implemented')
 
-    # Non orthogonal axes
-
-    def setBaseVectors(self, x=(1., 0.), y=(0., 1.)):
-        """Set base vectors.
-
-        Useful for non-orthogonal axes.
-        If an axis is in log scale, skew is applied to log transformed values.
-
-        Base vector does not work well with log axes, to investi
-        """
-        if x != (1., 0.) and y != (0., 1.):
-            if self._plotFrame.xAxis.isLog:
-                _logger.warning("setBaseVectors disables X axis logarithmic.")
-                self.setXAxisLogarithmic(False)
-            if self._plotFrame.yAxis.isLog:
-                _logger.warning("setBaseVectors disables Y axis logarithmic.")
-                self.setYAxisLogarithmic(False)
-
-            if self.isKeepDataAspectRatio():
-                _logger.warning("setBaseVectors disables keepDataAspectRatio.")
-                self.keepDataAspectRatio(False)
-
-        self._plotFrame.baseVectors = x, y
-
-    def getBaseVectors(self):
-        return self._plotFrame.baseVectors
-
-    def isDefaultBaseVectors(self):
-        return self._plotFrame.baseVectors == \
-            self._plotFrame.DEFAULT_BASE_VECTORS
-
     # Graph limits
 
     def _setDataRanges(self, xlim=None, ylim=None, y2lim=None):
@@ -1508,26 +1376,6 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         """
         # Update axes range with a clipped range if too wide
         self._plotFrame.setDataRanges(xlim, ylim, y2lim)
-
-        if not self.isDefaultBaseVectors():
-            # Update axes range with axes bounds in data coords
-            plotLeft, plotTop, plotWidth, plotHeight = \
-                self.getPlotBoundsInPixels()
-
-            self._plotFrame.xAxis.dataRange = sorted([
-                self.pixelToData(x, y, axis='left', check=False)[0]
-                for (x, y) in ((plotLeft, plotTop + plotHeight),
-                               (plotLeft + plotWidth, plotTop + plotHeight))])
-
-            self._plotFrame.yAxis.dataRange = sorted([
-                self.pixelToData(x, y, axis='left', check=False)[1]
-                for (x, y) in ((plotLeft, plotTop + plotHeight),
-                               (plotLeft, plotTop))])
-
-            self._plotFrame.y2Axis.dataRange = sorted([
-                self.pixelToData(x, y, axis='right', check=False)[1]
-                for (x, y) in ((plotLeft + plotWidth, plotTop + plotHeight),
-                               (plotLeft + plotWidth, plotTop))])
 
     def _ensureAspectRatio(self, keepDim=None):
         """Update plot bounds in order to keep aspect ratio.
@@ -1642,11 +1490,6 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                 _logger.warning(
                     "KeepDataAspectRatio is ignored with log axes")
 
-            if flag and not self.isDefaultBaseVectors():
-                _logger.warning(
-                    "setXAxisLogarithmic ignored because baseVectors are set")
-                return
-
             self._plotFrame.xAxis.isLog = flag
 
     def setYAxisLogarithmic(self, flag):
@@ -1655,11 +1498,6 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             if flag and self._keepDataAspectRatio:
                 _logger.warning(
                     "KeepDataAspectRatio is ignored with log axes")
-
-            if flag and not self.isDefaultBaseVectors():
-                _logger.warning(
-                    "setYAxisLogarithmic ignored because baseVectors are set")
-                return
 
             self._plotFrame.yAxis.isLog = flag
             self._plotFrame.y2Axis.isLog = flag
@@ -1681,9 +1519,6 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         if flag and (self._plotFrame.xAxis.isLog or
                      self._plotFrame.yAxis.isLog):
             _logger.warning("KeepDataAspectRatio is ignored with log axes")
-        if flag and not self.isDefaultBaseVectors():
-            _logger.warning(
-                "keepDataAspectRatio ignored because baseVectors are set")
 
         self._keepDataAspectRatio = flag
 

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -882,6 +882,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                               stroke=True,
                               strokeColor=item['color'],
                               strokeClosed=closed)
+            # TODO support linestyle and linewidth
 
             posAttrib = self._progBase.attributes['position']
             colorUnif = self._progBase.uniforms['color']
@@ -1131,7 +1132,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
         return legend, 'image'
 
-    def addItem(self, x, y, legend, shape, color, fill, overlay, z):
+    def addItem(self, x, y, legend, shape, color, fill, overlay, z,
+                linestyle, linewidth):
         # TODO handle overlay
         if shape not in ('polygon', 'rectangle', 'line',
                          'vline', 'hline', 'polylines'):
@@ -1162,7 +1164,9 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             'color': colors.rgba(color),
             'fill': 'hatch' if fill else None,
             'x': x,
-            'y': y
+            'y': y,
+            'linestyle': linestyle,
+            'linewidth': linewidth
         }
 
         return legend, 'item'

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -42,7 +42,7 @@ import numpy
 from silx.math.combo import min_max
 
 from ...._glutils import gl
-from ...._glutils import Program, vertexBuffer
+from ...._glutils import Program, vertexBuffer, VertexBufferAttrib
 from .GLSupport import buildFillMaskIndices, mat4Identity, mat4Translate
 
 
@@ -245,7 +245,7 @@ class _Fill2D(object):
 SOLID, DASHED, DASHDOT, DOTTED = '-', '--', '-.', ':'
 
 
-class _Lines2D(object):
+class GLLines2D(object):
     """Object rendering curve as a polyline
 
     :param xVboData: X coordinates VBO
@@ -340,11 +340,32 @@ class _Lines2D(object):
     def __init__(self, xVboData=None, yVboData=None,
                  colorVboData=None, distVboData=None,
                  style=SOLID, color=(0., 0., 0., 1.),
-                 width=1, dashPeriod=20, drawMode=None,
+                 width=1, dashPeriod=10., drawMode=None,
                  offset=(0., 0.)):
+        if (xVboData is not None and
+                not isinstance(xVboData, VertexBufferAttrib)):
+            xVboData = numpy.array(xVboData, copy=False, dtype=numpy.float32)
         self.xVboData = xVboData
+
+        if (yVboData is not None and
+                not isinstance(yVboData, VertexBufferAttrib)):
+            yVboData = numpy.array(yVboData, copy=False, dtype=numpy.float32)
         self.yVboData = yVboData
+
+        # Compute distances if not given while providing numpy array coordinates
+        if (isinstance(self.xVboData, numpy.ndarray) and
+                isinstance(self.yVboData, numpy.ndarray) and
+                distVboData is None):
+            distVboData = distancesFromArrays(self.xVboData, self.yVboData)
+
+        if (distVboData is not None and
+                not isinstance(distVboData, VertexBufferAttrib)):
+            distVboData = numpy.array(
+                distVboData, copy=False, dtype=numpy.float32)
         self.distVboData = distVboData
+
+        if colorVboData is not None:
+            assert isinstance(colorVboData, VertexBufferAttrib)
         self.colorVboData = colorVboData
         self.useColorVboData = colorVboData is not None
 
@@ -396,29 +417,39 @@ class _Lines2D(object):
             gl.glUniform2f(program.uniforms['halfViewportSize'],
                            0.5 * viewWidth, 0.5 * viewHeight)
 
+            dashPeriod = self.dashPeriod * self.width
             if self.style == DOTTED:
-                dash = (0.1 * self.dashPeriod,
-                        0.6 * self.dashPeriod,
-                        0.7 * self.dashPeriod,
-                        self.dashPeriod)
+                dash = (0.2 * dashPeriod,
+                        0.5 * dashPeriod,
+                        0.7 * dashPeriod,
+                        dashPeriod)
             elif self.style == DASHDOT:
-                dash = (0.3 * self.dashPeriod,
-                        0.5 * self.dashPeriod,
-                        0.6 * self.dashPeriod,
-                        self.dashPeriod)
+                dash = (0.3 * dashPeriod,
+                        0.5 * dashPeriod,
+                        0.6 * dashPeriod,
+                        dashPeriod)
             else:
-                dash = (0.5 * self.dashPeriod,
-                        self.dashPeriod,
-                        self.dashPeriod,
-                        self.dashPeriod)
+                dash = (0.5 * dashPeriod,
+                        dashPeriod,
+                        dashPeriod,
+                        dashPeriod)
 
             gl.glUniform4f(program.uniforms['dash'], *dash)
 
             distAttrib = program.attributes['distance']
             gl.glEnableVertexAttribArray(distAttrib)
-            self.distVboData.setVertexAttrib(distAttrib)
+            if isinstance(self.distVboData, VertexBufferAttrib):
+                self.distVboData.setVertexAttrib(distAttrib)
+            else:
+                gl.glVertexAttribPointer(distAttrib,
+                                         1,
+                                         gl.GL_FLOAT,
+                                         False,
+                                         0,
+                                         self.distVboData)
 
-        gl.glEnable(gl.GL_LINE_SMOOTH)
+        if self.width != 1:
+            gl.glEnable(gl.GL_LINE_SMOOTH)
 
         matrix = numpy.dot(matrix,
                            mat4Translate(*self.offset)).astype(numpy.float32)
@@ -435,11 +466,27 @@ class _Lines2D(object):
 
         xPosAttrib = program.attributes['xPos']
         gl.glEnableVertexAttribArray(xPosAttrib)
-        self.xVboData.setVertexAttrib(xPosAttrib)
+        if isinstance(self.xVboData, VertexBufferAttrib):
+            self.xVboData.setVertexAttrib(xPosAttrib)
+        else:
+            gl.glVertexAttribPointer(xPosAttrib,
+                                     1,
+                                     gl.GL_FLOAT,
+                                     False,
+                                     0,
+                                     self.xVboData)
 
         yPosAttrib = program.attributes['yPos']
         gl.glEnableVertexAttribArray(yPosAttrib)
-        self.yVboData.setVertexAttrib(yPosAttrib)
+        if isinstance(self.yVboData, VertexBufferAttrib):
+            self.yVboData.setVertexAttrib(yPosAttrib)
+        else:
+            gl.glVertexAttribPointer(yPosAttrib,
+                                     1,
+                                     gl.GL_FLOAT,
+                                     False,
+                                     0,
+                                     self.yVboData)
 
         gl.glLineWidth(self.width)
         gl.glDrawArrays(self._drawMode, 0, self.xVboData.size)
@@ -447,7 +494,7 @@ class _Lines2D(object):
         gl.glDisable(gl.GL_LINE_SMOOTH)
 
 
-def _distancesFromArrays(xData, yData):
+def distancesFromArrays(xData, yData):
     """Returns distances between each points
 
     :param numpy.ndarray xData: X coordinate of points
@@ -711,7 +758,7 @@ class _ErrorBars(object):
     This is using its own VBO as opposed to fill/points/lines.
     There is no picking on error bars.
 
-    It uses 2 vertices per error bars and uses :class:`_Lines2D` to
+    It uses 2 vertices per error bars and uses :class:`GLLines2D` to
     render error bars and :class:`_Points2D` to render the ends.
 
     :param numpy.ndarray xData: X coordinates of the data.
@@ -753,7 +800,7 @@ class _ErrorBars(object):
             self._xData, self._yData = None, None
             self._xError, self._yError = None, None
 
-        self._lines = _Lines2D(
+        self._lines = GLLines2D(
             None, None, color=color, drawMode=gl.GL_LINES, offset=offset)
         self._xErrPoints = _Points2D(
             None, None, color=color, marker=V_LINE, offset=offset)
@@ -957,7 +1004,7 @@ class GLPlotCurve2D(object):
                                      self.xMin, self.yMin,
                                      offset=self.offset)
 
-        self.lines = _Lines2D()
+        self.lines = GLLines2D()
         self.lines.style = lineStyle
         self.lines.color = lineColor
         self.lines.width = lineWidth
@@ -999,7 +1046,7 @@ class GLPlotCurve2D(object):
     @classmethod
     def init(cls):
         """OpenGL context initialization"""
-        _Lines2D.init()
+        GLLines2D.init()
         _Points2D.init()
 
     def prepare(self):
@@ -1007,7 +1054,7 @@ class GLPlotCurve2D(object):
         if self.xVboData is None:
             xAttrib, yAttrib, cAttrib, dAttrib = None, None, None, None
             if self.lineStyle in (DASHED, DASHDOT, DOTTED):
-                dists = _distancesFromArrays(self.xData, self.yData)
+                dists = distancesFromArrays(self.xData, self.yData)
                 if self.colorData is None:
                     xAttrib, yAttrib, dAttrib = vertexBuffer(
                         (self.xData, self.yData, dists))

--- a/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -825,23 +825,6 @@ class GLPlotFrame2D(GLPlotFrame):
                     _logger.info('yMax: warning log10(%f)', y2Max)
                     y2Max = 0.
 
-            # Non-orthogonal axes
-            if self.baseVectors != self.DEFAULT_BASE_VECTORS:
-                (xx, xy), (yx, yy) = self.baseVectors
-                skew_mat = numpy.array(((xx, yx), (xy, yy)))
-
-                corners = [(xMin, yMin), (xMin, yMax),
-                           (xMax, yMin), (xMax, yMax),
-                           (xMin, y2Min), (xMin, y2Max),
-                           (xMax, y2Min), (xMax, y2Max)]
-
-                corners = numpy.array(
-                    [numpy.dot(skew_mat, corner) for corner in corners],
-                    dtype=numpy.float32)
-                xMin, xMax = corners[:, 0].min(),  corners[:, 0].max()
-                yMin, yMax = corners[0:4, 1].min(), corners[0:4, 1].max()
-                y2Min, y2Max = corners[4:, 1].min(), corners[4:, 1].max()
-
             self._transformedDataRanges = self._DataRanges(
                 (xMin, xMax), (yMin, yMax), (y2Min, y2Max))
 
@@ -861,16 +844,6 @@ class GLPlotFrame2D(GLPlotFrame):
                 mat = mat4Ortho(xMin, xMax, yMax, yMin, 1, -1)
             else:
                 mat = mat4Ortho(xMin, xMax, yMin, yMax, 1, -1)
-
-            # Non-orthogonal axes
-            if self.baseVectors != self.DEFAULT_BASE_VECTORS:
-                (xx, xy), (yx, yy) = self.baseVectors
-                mat = numpy.dot(mat, numpy.array((
-                    (xx, yx, 0., 0.),
-                    (xy, yy, 0., 0.),
-                    (0., 0., 1., 0.),
-                    (0., 0., 0., 1.)), dtype=numpy.float64))
-
             self._transformedDataProjMat = mat
 
         return self._transformedDataProjMat
@@ -890,16 +863,6 @@ class GLPlotFrame2D(GLPlotFrame):
                 mat = mat4Ortho(xMin, xMax, y2Max, y2Min, 1, -1)
             else:
                 mat = mat4Ortho(xMin, xMax, y2Min, y2Max, 1, -1)
-
-            # Non-orthogonal axes
-            if self.baseVectors != self.DEFAULT_BASE_VECTORS:
-                (xx, xy), (yx, yy) = self.baseVectors
-                mat = numpy.dot(mat, numpy.matrix((
-                    (xx, yx, 0., 0.),
-                    (xy, yy, 0., 0.),
-                    (0., 0., 1., 0.),
-                    (0., 0., 0., 1.)), dtype=numpy.float64))
-
             self._transformedDataY2ProjMat = mat
 
         return self._transformedDataY2ProjMat

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -65,7 +65,7 @@ class RegionOfInterest(qt.QObject):
         # Avoid circular dependancy
         from ..tools import roi as roi_tools
         assert parent is None or isinstance(parent, roi_tools.RegionOfInterestManager)
-        super(RegionOfInterest, self).__init__(parent)
+        qt.QObject.__init__(self, parent)
         self._color = rgba('red')
         self._items = WeakList()
         self._editAnchors = WeakList()
@@ -108,7 +108,7 @@ class RegionOfInterest(qt.QObject):
         return qt.QColor.fromRgbF(*self._color)
 
     def _getAnchorColor(self, color):
-        """Returns the anchor color from the base ROI  color
+        """Returns the anchor color from the base ROI color
 
         :param Union[numpy.array,Tuple,List]: color
         :rtype: Union[numpy.array,Tuple,List]
@@ -209,7 +209,7 @@ class RegionOfInterest(qt.QObject):
     def setFirstShapePoints(self, points):
         """"Initialize the ROI using the points from the first interaction.
 
-        This interaction is constains by the plot API and only supports few
+        This interaction is constrained by the plot API and only supports few
         shapes.
         """
         points = self._createControlPointsFromFirstShape(points)
@@ -410,6 +410,13 @@ class RegionOfInterest(qt.QObject):
                 plot._remove(item)
         self._labelItem = None
 
+    def _updated(self, event=None, checkVisibility=True):
+        """Implement Item mix-in update method by updating the plot items
+
+        See :class:`~silx.gui.plot.items.Item._updated`
+        """
+        self._createPlotItems()
+
     def __str__(self):
         """Returns parameters of the ROI as a string."""
         points = self._getControlPoints()
@@ -417,7 +424,7 @@ class RegionOfInterest(qt.QObject):
         return "%s(%s)" % (self.__class__.__name__, params)
 
 
-class PointROI(RegionOfInterest):
+class PointROI(RegionOfInterest, items.SymbolMixIn):
     """A ROI identifying a point in a 2D plot."""
 
     _kind = "Point"
@@ -425,6 +432,10 @@ class PointROI(RegionOfInterest):
 
     _plotShape = "point"
     """Plot shape which is used for the first interaction"""
+
+    def __init__(self, parent=None):
+        items.SymbolMixIn.__init__(self)
+        RegionOfInterest.__init__(self, parent=parent)
 
     def getPosition(self):
         """Returns the position of this ROI
@@ -458,6 +469,8 @@ class PointROI(RegionOfInterest):
         marker.setPosition(points[0][0], points[0][1])
         marker.setText(self.getLabel())
         marker.setColor(rgba(self.getColor()))
+        marker.setSymbol(self.getSymbol())
+        marker.setSymbolSize(self.getSymbolSize())
         marker._setDraggable(False)
         return [marker]
 
@@ -466,6 +479,8 @@ class PointROI(RegionOfInterest):
         marker.setPosition(points[0][0], points[0][1])
         marker.setText(self.getLabel())
         marker._setDraggable(self.isEditable())
+        marker.setSymbol(self.getSymbol())
+        marker.setSymbolSize(self.getSymbolSize())
         return [marker]
 
     def __str__(self):
@@ -474,7 +489,7 @@ class PointROI(RegionOfInterest):
         return "%s(%s)" % (self.__class__.__name__, params)
 
 
-class LineROI(RegionOfInterest):
+class LineROI(RegionOfInterest, items.LineMixIn):
     """A ROI identifying a line in a 2D plot.
 
     This ROI provides 1 anchor for each boundary of the line, plus an center
@@ -486,6 +501,10 @@ class LineROI(RegionOfInterest):
 
     _plotShape = "line"
     """Plot shape which is used for the first interaction"""
+
+    def __init__(self, parent=None):
+        items.LineMixIn.__init__(self)
+        RegionOfInterest.__init__(self, parent=parent)
 
     def _createControlPointsFromFirstShape(self, points):
         center = numpy.mean(points, axis=0)
@@ -535,6 +554,8 @@ class LineROI(RegionOfInterest):
         item.setColor(rgba(self.getColor()))
         item.setFill(False)
         item.setOverlay(True)
+        item.setLineStyle(self.getLineStyle())
+        item.setLineWidth(self.getLineWidth())
         return [item]
 
     def _createAnchorItems(self, points):
@@ -582,7 +603,7 @@ class LineROI(RegionOfInterest):
         return "%s(%s)" % (self.__class__.__name__, params)
 
 
-class HorizontalLineROI(RegionOfInterest):
+class HorizontalLineROI(RegionOfInterest, items.LineMixIn):
     """A ROI identifying an horizontal line in a 2D plot."""
 
     _kind = "HLine"
@@ -590,6 +611,10 @@ class HorizontalLineROI(RegionOfInterest):
 
     _plotShape = "hline"
     """Plot shape which is used for the first interaction"""
+
+    def __init__(self, parent=None):
+        items.LineMixIn.__init__(self)
+        RegionOfInterest.__init__(self, parent=parent)
 
     def _createControlPointsFromFirstShape(self, points):
         points = numpy.array([(float('nan'), points[0, 1])],
@@ -636,6 +661,8 @@ class HorizontalLineROI(RegionOfInterest):
         marker.setText(self.getLabel())
         marker.setColor(rgba(self.getColor()))
         marker._setDraggable(False)
+        marker.setLineWidth(self.getLineWidth())
+        marker.setLineStyle(self.getLineStyle())
         return [marker]
 
     def _createAnchorItems(self, points):
@@ -643,6 +670,8 @@ class HorizontalLineROI(RegionOfInterest):
         marker.setPosition(points[0][0], points[0][1])
         marker.setText(self.getLabel())
         marker._setDraggable(self.isEditable())
+        marker.setLineWidth(self.getLineWidth())
+        marker.setLineStyle(self.getLineStyle())
         return [marker]
 
     def __str__(self):
@@ -651,7 +680,7 @@ class HorizontalLineROI(RegionOfInterest):
         return "%s(%s)" % (self.__class__.__name__, params)
 
 
-class VerticalLineROI(RegionOfInterest):
+class VerticalLineROI(RegionOfInterest, items.LineMixIn):
     """A ROI identifying a vertical line in a 2D plot."""
 
     _kind = "VLine"
@@ -659,6 +688,10 @@ class VerticalLineROI(RegionOfInterest):
 
     _plotShape = "vline"
     """Plot shape which is used for the first interaction"""
+
+    def __init__(self, parent=None):
+        items.LineMixIn.__init__(self)
+        RegionOfInterest.__init__(self, parent=parent)
 
     def _createControlPointsFromFirstShape(self, points):
         points = numpy.array([(points[0, 0], float('nan'))],
@@ -705,6 +738,8 @@ class VerticalLineROI(RegionOfInterest):
         marker.setText(self.getLabel())
         marker.setColor(rgba(self.getColor()))
         marker._setDraggable(False)
+        marker.setLineWidth(self.getLineWidth())
+        marker.setLineStyle(self.getLineStyle())
         return [marker]
 
     def _createAnchorItems(self, points):
@@ -712,6 +747,8 @@ class VerticalLineROI(RegionOfInterest):
         marker.setPosition(points[0][0], points[0][1])
         marker.setText(self.getLabel())
         marker._setDraggable(self.isEditable())
+        marker.setLineWidth(self.getLineWidth())
+        marker.setLineStyle(self.getLineStyle())
         return [marker]
 
     def __str__(self):
@@ -720,7 +757,7 @@ class VerticalLineROI(RegionOfInterest):
         return "%s(%s)" % (self.__class__.__name__, params)
 
 
-class RectangleROI(RegionOfInterest):
+class RectangleROI(RegionOfInterest, items.LineMixIn):
     """A ROI identifying a rectangle in a 2D plot.
 
     This ROI provides 1 anchor for each corner, plus an anchor in the
@@ -732,6 +769,10 @@ class RectangleROI(RegionOfInterest):
 
     _plotShape = "rectangle"
     """Plot shape which is used for the first interaction"""
+
+    def __init__(self, parent=None):
+        items.LineMixIn.__init__(self)
+        RegionOfInterest.__init__(self, parent=parent)
 
     def _createControlPointsFromFirstShape(self, points):
         point0 = points[0]
@@ -838,6 +879,8 @@ class RectangleROI(RegionOfInterest):
         item.setColor(rgba(self.getColor()))
         item.setFill(False)
         item.setOverlay(True)
+        item.setLineStyle(self.getLineStyle())
+        item.setLineWidth(self.getLineWidth())
         return [item]
 
     def _createAnchorItems(self, points):
@@ -894,7 +937,7 @@ class RectangleROI(RegionOfInterest):
         return "%s(%s)" % (self.__class__.__name__, params)
 
 
-class PolygonROI(RegionOfInterest):
+class PolygonROI(RegionOfInterest, items.LineMixIn):
     """A ROI identifying a closed polygon in a 2D plot.
 
     This ROI provides 1 anchor for each point of the polygon.
@@ -905,6 +948,10 @@ class PolygonROI(RegionOfInterest):
 
     _plotShape = "polygon"
     """Plot shape which is used for the first interaction"""
+
+    def __init__(self, parent=None):
+        items.LineMixIn.__init__(self)
+        RegionOfInterest.__init__(self, parent=parent)
 
     def getPoints(self):
         """Returns the list of the points of this polygon.
@@ -948,6 +995,8 @@ class PolygonROI(RegionOfInterest):
             item.setColor(rgba(self.getColor()))
             item.setFill(False)
             item.setOverlay(True)
+            item.setLineStyle(self.getLineStyle())
+            item.setLineWidth(self.getLineWidth())
             return [item]
 
     def _createAnchorItems(self, points):
@@ -967,7 +1016,7 @@ class PolygonROI(RegionOfInterest):
         return "%s(%s)" % (self.__class__.__name__, params)
 
 
-class ArcROI(RegionOfInterest):
+class ArcROI(RegionOfInterest, items.LineMixIn):
     """A ROI identifying an arc of a circle with a width.
 
     This ROI provides 3 anchors to control the curvature, 1 anchor to control
@@ -986,6 +1035,7 @@ class ArcROI(RegionOfInterest):
                                                           'startAngle', 'endAngle'])
 
     def __init__(self, parent=None):
+        items.LineMixIn.__init__(self)
         RegionOfInterest.__init__(self, parent=parent)
         self._geometry = None
 
@@ -1357,6 +1407,8 @@ class ArcROI(RegionOfInterest):
         item.setColor(rgba(self.getColor()))
         item.setFill(False)
         item.setOverlay(True)
+        item.setLineStyle(self.getLineStyle())
+        item.setLineWidth(self.getLineWidth())
         return [item]
 
     def _createAnchorItems(self, points):

--- a/silx/gui/plot/items/shape.py
+++ b/silx/gui/plot/items/shape.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,7 @@ import logging
 
 import numpy
 
-from .core import (Item, ColorMixIn, FillMixIn, ItemChangedType)
+from .core import Item, ColorMixIn, FillMixIn, ItemChangedType, LineMixIn
 
 
 _logger = logging.getLogger(__name__)
@@ -42,7 +42,7 @@ _logger = logging.getLogger(__name__)
 
 # TODO probably make one class for each kind of shape
 # TODO check fill:polygon/polyline + fill = duplicated
-class Shape(Item, ColorMixIn, FillMixIn):
+class Shape(Item, ColorMixIn, FillMixIn, LineMixIn):
     """Description of a shape item
 
     :param str type_: The type of shape in:
@@ -53,6 +53,7 @@ class Shape(Item, ColorMixIn, FillMixIn):
         Item.__init__(self)
         ColorMixIn.__init__(self)
         FillMixIn.__init__(self)
+        LineMixIn.__init__(self)
         self._overlay = False
         assert type_ in ('hline', 'polygon', 'rectangle', 'vline', 'polylines')
         self._type = type_
@@ -71,7 +72,9 @@ class Shape(Item, ColorMixIn, FillMixIn):
                                color=self.getColor(),
                                fill=self.isFill(),
                                overlay=self.isOverlay(),
-                               z=self.getZValue())
+                               z=self.getZValue(),
+                               linestyle=self.getLineStyle(),
+                               linewidth=self.getLineWidth())
 
     def isOverlay(self):
         """Return true if shape is drawn as an overlay


### PR DESCRIPTION
This PR adds support of `linestyle` and `linewidth` to plot `items.Shape` and X and Y markers in OpenGL (closes #2089).
It also adds support for `linestyle`, `linewidth`, `symbol` and `symbolsize` to `items.roi` classes (related to  #2255).

It also remove support for non-orthogonal axes in the OpenGL backend: this feature is not used and was making this change more complicated.

I can split this PR if needed.