### PR TITLE
Foreground color

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -21,7 +21,7 @@ import logging
 import collections
 from argparse import ArgumentParser
 
-#logging.basicConfig()
+logging.basicConfig()
 logger = logging.getLogger("bootstrap")
 
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -21,7 +21,7 @@ import logging
 import collections
 from argparse import ArgumentParser
 
-logging.basicConfig()
+#logging.basicConfig()
 logger = logging.getLogger("bootstrap")
 
 

--- a/examples/bg_color.py
+++ b/examples/bg_color.py
@@ -18,7 +18,7 @@ from silx.gui.plot.Colormap import Colormap
 
 logger = logging.getLogger("main")
 
-if 1:
+if 0:
     BACKEND = 'mpl'
 else:
     BACKEND = 'gl'
@@ -88,11 +88,18 @@ def makePlot1D():
     xAxis = plot1D.getXAxis()
     xAxis.setLimits(-11, 35)
 
-    foregroundColor = QColor(Qt.red)
-    gridColor = QColor(Qt.magenta)
-
-    backgroundColor = QColor(255, 255, 0)
-    dataBackgroundColor = QColor(200, 200, 0)
+    if 0:
+        # Debugging them with ugly but obvious colors.
+        foregroundColor = QColor(Qt.red)
+        gridColor = QColor(Qt.magenta)
+        backgroundColor = QColor(255, 255, 0)
+        dataBackgroundColor = QColor(200, 200, 0)
+    else:
+        # Dark theme
+        foregroundColor = QColor(255, 255, 255)
+        gridColor = QColor(100, 100, 100)
+        backgroundColor = QColor(0, 0, 0)
+        dataBackgroundColor = QColor(40, 40, 40)
 
     plot1D.setGraphTitle("My Title")
     plot1D.setForegroundColor(foregroundColor)
@@ -100,8 +107,8 @@ def makePlot1D():
     plot1D.setBackgroundColor(backgroundColor)
     plot1D.setDataBackgroundColor(dataBackgroundColor) # does't work in with grid on GL backend
 
-    #setWidgetColor(plot1D, testColor, PaletteRoleEnum.Window)
-    #setWidgetColor(plot1D, foregroundColor, PaletteRoleEnum.WindowText)
+    setWidgetColor(plot1D, backgroundColor, PaletteRoleEnum.Window)
+    setWidgetColor(plot1D, foregroundColor, PaletteRoleEnum.WindowText)
 
     plot1D.addCurve(x=x, y=y, legend='curve')
 

--- a/examples/bg_color.py
+++ b/examples/bg_color.py
@@ -11,13 +11,14 @@ import numpy as np
 
 from PyQt5 import QtWidgets
 from PyQt5.QtGui import QColor, QPalette
+from PyQt5.QtCore import Qt
 from silx.gui.plot import Plot1D, Plot2D, TickMode
 from silx.gui.plot.Colormap import Colormap
 
 
 logger = logging.getLogger("main")
 
-if 0:
+if 1:
     BACKEND = 'mpl'
 else:
     BACKEND = 'gl'
@@ -87,18 +88,17 @@ def makePlot1D():
     xAxis = plot1D.getXAxis()
     xAxis.setLimits(-11, 35)
 
-    foregroundColor = QColor(0, 0, 0)
-    #gridColor = QColor(40, 40, 40)
-    gridColor = QColor(255, 0, 0,)
+    foregroundColor = QColor(Qt.red)
+    gridColor = QColor(Qt.magenta)
 
-    backgroundColor = QColor(255, 255, 255)
-    dataBackgroundColor = QColor(200, 200, 200)
+    backgroundColor = QColor(255, 255, 0)
+    dataBackgroundColor = QColor(200, 200, 0)
 
     plot1D.setGraphTitle("My Title")
     plot1D.setForegroundColor(foregroundColor)
     plot1D.setGridColor(gridColor)
     plot1D.setBackgroundColor(backgroundColor)
-    #plot1D.setDataBackgroundColor(dataBackgroundColor)
+    plot1D.setDataBackgroundColor(dataBackgroundColor) # does't work in with grid on GL backend
 
     #setWidgetColor(plot1D, testColor, PaletteRoleEnum.Window)
     #setWidgetColor(plot1D, foregroundColor, PaletteRoleEnum.WindowText)

--- a/examples/bg_color.py
+++ b/examples/bg_color.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# pylint: skip-file
+
+""" Small demo for demonstrating the silx bg color.
+
+"""
+
+import enum
+import logging
+import numpy as np
+
+from PyQt5 import QtWidgets
+from PyQt5.QtGui import QColor, QPalette
+from silx.gui.plot import Plot1D, Plot2D, TickMode
+from silx.gui.plot.Colormap import Colormap
+
+
+logger = logging.getLogger("main")
+
+if 0:
+    BACKEND = 'mpl'
+else:
+    BACKEND = 'gl'
+
+
+@enum.unique
+class PaletteRoleEnum(enum.Enum):
+    """ Enumeration for the role in a QPalette.
+
+        # See http://doc.qt.io/archives/qt-5.6/qpalette.html for the full descriptions.
+    """
+    # Central roles
+    Window        = QPalette.Window         # A general background color.
+    WindowText    = QPalette.WindowText     # A general foreground color.
+    Base          = QPalette.Base           # Typically the background color for text entry widgets.
+    AlternateBase = QPalette.AlternateBase  # Alternate background color when alternating rows
+    ToolTipBase   = QPalette.ToolTipBase	# Used as the background color for QToolTip
+    ToolTipText   = QPalette.ToolTipText    # Used as the foreground color for QToolTip
+    Text          = QPalette.Text           # The foreground color used with Base.
+    Button        = QPalette.Button	        # The general button background color.
+    ButtonText    = QPalette.ButtonText     # A foreground color used with the Button color.
+    BrightText    = QPalette.BrightText     # A text color that is very different from WindowText
+
+    Light         = QPalette.Light          # Lighter than Button color.
+    Midlight      = QPalette.Midlight       # Between Button and Light.
+    Dark          = QPalette.Dark	        # Darker than Button.
+    Mid           = QPalette.Mid            # Between Button and Dark.
+    Shadow        = QPalette.Shadow         # A very dark color. By default it's Qt::black.
+
+    Highlight       = QPalette.Highlight        # Indicates a selected item or the current item.
+    HighlightedText = QPalette.HighlightedText	# A text color that contrasts with Highlight.
+    Link          = QPalette.Link           # A text color used for unvisited hyperlinks.
+    LinkVisited   = QPalette.LinkVisited    # A text color used for already visited hyperlinks.
+
+
+def setWidgetColor(widget, color, role, group=None):
+    """ Sets the background color of a widget.
+
+        Note: if the widget remains transparent use: widget.setAutoFillBackground(True)
+
+        :param QWidget widget: the Qt Widget
+        :param QtGui.QColor color: the color to set
+        :param PaletteGroupEnum group: the Palette group that is used.(None = current):
+        :param PaletteRoleEnum role: the role (foreground color, back ground color,etc)
+    """
+    pal = widget.palette()
+    if group is None:
+        pal.setColor(role.value, color)
+    else:
+        pal.setColor(group.value, role.value, color)
+    widget.setPalette(pal)
+
+
+def makePlot1D():
+
+    CREATE_DATES = False
+
+    if not CREATE_DATES:
+        y = np.random.normal(size=int(1e4))
+        y[1000] = 23
+
+        x = np.arange(len(y)) + 900
+        x = list(x)
+
+    plot1D = Plot1D(backend=BACKEND)
+    plot1D.setGraphGrid("both")
+    xAxis = plot1D.getXAxis()
+    xAxis.setLimits(-11, 35)
+
+    foregroundColor = QColor(0, 0, 0)
+    #gridColor = QColor(40, 40, 40)
+    gridColor = QColor(255, 0, 0,)
+
+    backgroundColor = QColor(255, 255, 255)
+    dataBackgroundColor = QColor(200, 200, 200)
+
+    plot1D.setGraphTitle("My Title")
+    plot1D.setForegroundColor(foregroundColor)
+    plot1D.setGridColor(gridColor)
+    plot1D.setBackgroundColor(backgroundColor)
+    #plot1D.setDataBackgroundColor(dataBackgroundColor)
+
+    #setWidgetColor(plot1D, testColor, PaletteRoleEnum.Window)
+    #setWidgetColor(plot1D, foregroundColor, PaletteRoleEnum.WindowText)
+
+    plot1D.addCurve(x=x, y=y, legend='curve')
+
+    return plot1D
+
+
+
+def makePlot2D():
+    plot = Plot2D(backend=BACKEND)
+
+    colormap = Colormap(name='viridis', normalization='linear', vmin=0.0, vmax=2.0)
+    plot.setDefaultColormap(colormap)
+
+    data = np.random.random(512 * 512).reshape(512, -1)
+    plot.addImage(data, legend='random', replace=False)
+
+    plot.setBackgroundColor(QColor(80, 80, 80))
+
+    data = np.arange(512 * 512.).reshape(512, -1)
+    plot.addImage(data, legend='arange', replace=False, origin=(512, 512))
+    
+    return plot
+
+
+
+class MyWin(QtWidgets.QWidget):
+    def __init__(self, parent=None):
+        super(MyWin, self).__init__(parent=parent)
+
+        # Layout with legend
+        self.contentsLayout = QtWidgets.QVBoxLayout()
+        self.setLayout(self.contentsLayout)
+
+        self.plot = makePlot1D()
+        self.contentsLayout.addWidget(self.plot)
+
+        self.myTestAction = QtWidgets.QAction("My test", self, triggered=self.myTest)
+        self.myTestAction.setShortcut("Ctrl+T")
+        self.addAction(self.myTestAction)
+
+
+    def myTest(self):
+        logger.info("Called my test")
+
+        y = np.random.normal(size=int(1e5)) + 5
+        x = np.arange(len(y)) + 9000
+        self.plot.addCurve(x=x, y=y, color='red', legend='test curve')
+
+
+    
+
+def main():
+    fmt = '%(asctime)s %(filename)25s:%(lineno)-4d : %(levelname)-7s: %(message)s'
+    logging.basicConfig(level='DEBUG', format=fmt)
+    logger.info("START")
+    print("START------------------------------------------------")
+
+    app = QtWidgets.QApplication([])
+    #win = makePlot2D()
+    win = MyWin()
+    #win = makeHistogram()
+    win.show()
+    app.exec_()
+    
+    
+    
+if __name__ == "__main__":
+    main()
+

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -229,6 +229,8 @@ class PlotWidget(qt.QMainWindow):
         self._activeLegend = {'curve': None, 'image': None,
                               'scatter': None}
 
+        self._foregroundColor = None
+        self._gridColor = None
         self._backgroundColor = None
         self._dataBackgroundColor = None
 
@@ -350,6 +352,62 @@ class PlotWidget(qt.QMainWindow):
 
         if self._autoreplot and not wasDirty and self.isVisible():
             self._backend.postRedisplay()
+
+    def getForegroundColor(self):
+        """Returns the RGBA colors used to display the foreground of this widget
+
+        The default value is an invalid `QColor`.
+
+        :rtype: qt.QColor
+        """
+        if self._foregroundColor is None:
+            # An invalid color
+            return qt.QColor()
+        rgba = self._foregroundColor
+        color = qt.QColor.fromRgbF(*rgba)
+        return color
+
+    def setForegroundColor(self, color):
+        """Set the foreground color of this widget.
+
+        :param color: The new color. It can be farious formats (tuple,
+            numpy array, QColor)
+        """
+        if color is not None:
+            color = colors.rgba(color)
+        if self._foregroundColor == color:
+            return
+        self._foregroundColor = color
+        self._backend.setForegroundColors(self._foregroundColor, self._gridColor)
+        self._setDirtyPlot()
+
+    def getGridColor(self):
+        """Returns the RGBA colors used to display the grid lines
+
+        The default value is an invalid `QColor`.
+
+        :rtype: qt.QColor
+        """
+        if self._gridColor is None:
+            # An invalid color
+            return qt.QColor()
+        rgba = self._gridColor
+        color = qt.QColor.fromRgbF(*rgba)
+        return color
+
+    def setGridColor(self, color):
+        """Set the grid lines color
+
+        :param color: The new color. It can be farious formats (tuple,
+            numpy array, QColor)
+        """
+        if color is not None:
+            color = colors.rgba(color)
+        if self._gridColor == color:
+            return
+        self._gridColor = color
+        self._backend.setForegroundColors(self._foregroundColor, self._gridColor)
+        self._setDirtyPlot()    
 
     def getBackgroundColor(self):
         """Returns the RGBA colors used to display the background of this widget

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -548,7 +548,7 @@ class BackendBase(object):
         return self._axesDisplayed
 
 
-    def setForegroundColor(selfs, foregroundColor, gridColor=None):
+    def setForegroundColors(self, foregroundColor, gridColor=None):
         """
         Set foreground and grid colors used to display this widget.
         

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -547,6 +547,22 @@ class BackendBase(object):
         """
         return self._axesDisplayed
 
+
+    def setForegroundColor(selfs, foregroundColor, gridColor=None):
+        """
+        Set foreground and grid colors used to display this widget.
+        
+        If a `foregroundColor` is set, it is used for all the foreground of the
+        widget, while no `gridColor` is used.
+
+        If a `gridColor` is set, it is used to set the grid color only.
+
+        :param Union[Tuple[float],None] foregroundColor: Foreground of the
+            widget
+        :param Union[Tuple[float],None] gridColor: Grid color of the data view
+        """
+        pass
+
     def setBackgroundColors(self, backgroundColor, dataBackgroundColor=None):
         """
         Set background colors used to display this widget.

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -547,7 +547,6 @@ class BackendBase(object):
         """
         return self._axesDisplayed
 
-
     def setForegroundColors(self, foregroundColor, gridColor=None):
         """
         Set foreground and grid colors used to display this widget.

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -963,8 +963,6 @@ class BackendMatplotlib(BackendBase.BackendBase):
                 #self.ax.grid().set_markeredgecolor(gridColor)
 
 
-
-
 class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
     """QWidget matplotlib backend using a QtAgg canvas.
 

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -911,7 +911,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
             backgroundColor = self._plot.getBackgroundColor()
             dataBackgroundColor = self._plot.getDataBackgroundColor()
 
-            if backgroundColor.isValid() is None:
+            if backgroundColor.isValid():
                 backgroundColor = backgroundColor.getRgbF()
             else:
                 backgroundColor = 'w'

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -904,6 +904,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
             self.ax.set_position([0, 0, 1, 1])
             self.ax2.set_position([0, 0, 1, 1])
         self._synchronizeBackgroundColors()
+        self._synchronizeBackgroundColors()
         self._plot._setDirtyPlot()
 
     def _synchronizeBackgroundColors(self):
@@ -928,6 +929,40 @@ class BackendMatplotlib(BackendBase.BackendBase):
                     self.ax.set_facecolor(dataBackgroundColor)
             else:
                 self.fig.patch.set_facecolor(dataBackgroundColor)
+
+    def _synchronizeForegroundColors(self):
+            foregroundColor = self._plot.getForegroundColor()
+            gridColor = self._plot.getGridColor()
+
+            if foregroundColor.isValid():
+                foregroundColor = foregroundColor.getRgbF()
+            else:
+                foregroundColor = 'k'
+
+            if gridColor.isValid():
+                gridColor = gridColor.getRgbF()
+            else:
+                gridColor = foregroundColor
+
+            if self.ax.axison:
+                self.ax.spines['bottom'].set_color(foregroundColor)
+                self.ax.spines['top'].set_color(foregroundColor)
+                self.ax.spines['right'].set_color(foregroundColor)
+                self.ax.spines['left'].set_color(foregroundColor)
+                self.ax.tick_params(axis='x', colors=foregroundColor)
+                self.ax.tick_params(axis='y', colors=foregroundColor)
+                self.ax.yaxis.label.set_color(foregroundColor)
+                self.ax.xaxis.label.set_color(foregroundColor)
+                self.ax.title.set_color(foregroundColor)
+
+                for line in self.ax.get_xgridlines():
+                    line.set_color(gridColor)
+
+                for line in self.ax.get_ygridlines():
+                    line.set_color(gridColor)
+                #self.ax.grid().set_markeredgecolor(gridColor)
+
+
 
 
 class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
@@ -1159,3 +1194,6 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
 
     def setBackgroundColors(self, backgroundColor, dataBackgroundColor=None):
         self._synchronizeBackgroundColors()
+
+    def setForegroundColors(self, foregroundColor, gridColor=None):
+        self._synchronizeForegroundColors()

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -338,6 +338,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                                   f=f)
         BackendBase.BackendBase.__init__(self, plot, parent)
 
+        self._foregroundColor = 0., 0., 0., 1.
+        self._gridColor = 0.3, 0.3, 0.3, 1.
         self._backgroundColor = 1., 1., 1., 1.
         self._dataBackgroundColor = None
 
@@ -360,6 +362,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         self._glGarbageCollector = []
 
         self._plotFrame = GLPlotFrame2D(
+            foregroundColor = self._foregroundColor,
+            gridColor = self._gridColor,
             margins={'left': 100, 'right': 50, 'top': 50, 'bottom': 50})
 
         # Make postRedisplay asynchronous using Qt signal
@@ -1731,6 +1735,20 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
     def setAxesDisplayed(self, displayed):
         BackendBase.BackendBase.setAxesDisplayed(self, displayed)
         self._plotFrame.displayed = displayed
+
+    def setForegroundColors(self, foregroundColor, gridColor=None):
+        if foregroundColor is not None:
+            self._foregroundColor = foregroundColor
+        else:
+            self._foregroundColor = 0., 0., 0., 1.
+
+        if gridColor is not None:
+            self._gridColor = gridColor
+        else:
+            self._gridColor = self._foregroundColor
+
+        self._plotFrame.foregroundColor = self._foregroundColor
+        self._plotFrame.gridColor = self._gridColor
 
     def setBackgroundColors(self, backgroundColor, dataBackgroundColor=None):
         if backgroundColor is not None:

--- a/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -1178,7 +1178,6 @@ class GLPlotFrame2D(GLPlotFrame):
 
         self._renderResources = (vertices, gridVertices, labels)
 
-
     @property
     def foregroundColor(self):
         """Color used for frame and labels"""
@@ -1192,4 +1191,3 @@ class GLPlotFrame2D(GLPlotFrame):
         if self._foregroundColor != color:
             self._y2Axis.foregroundColor = color
             GLPlotFrame.foregroundColor.fset(self, color) # call parent property
-


### PR DESCRIPTION
This PR implements foreground color (issue #2296).

I implemented a separate `foregroundColor` and `gridColor`, similar as the existing `backgroundColor` and `dataBackgroundColor`. It is implemented for both backends (OpenGL en Matplotlib).

Note that setting the `dataBackgroundColor` makes the grid lines invisible in the GL backend (the MPL backend works fine). This bug was already present before this PR and I didn't see an obvious fix.

If fixed another bug though: the `backgroundColor` didn't work in the MPL backend.

I added `bg_color.py` to the `examples` directory for if you want to test it. Feel free to remove this demo script if it's no longer necessary.