### PR TITLE
Make setup.py compatible with numpy 1.16.0rc1|2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
               - BUILD_COMMAND=sdist
               - QT_BINDING=
               - SILX_OPENCL=1
+              - PIP_OPTIONS="-q"
 
         - python: 3.4
           os: linux
@@ -23,6 +24,7 @@ matrix:
               - QT_BINDING=
               - PIP_INSTALL_EXTRA_ARGS="--global-option build --global-option --debug"
               - SILX_OPENCL=1
+              - PIP_OPTIONS="-q"
 
         - python: 3.5
           os: linux
@@ -30,6 +32,7 @@ matrix:
               - BUILD_COMMAND=sdist
               - QT_BINDING=PyQt5
               - SILX_OPENCL=1
+              - PIP_OPTIONS="-q --pre"
 
         - python: 3.7
           os: linux
@@ -37,12 +40,14 @@ matrix:
               - BUILD_COMMAND=sdist
               - QT_BINDING=PySide2
               - SILX_OPENCL=1
+              - PIP_OPTIONS="-q --pre"
 
         - language: generic
           os: osx
           env:
               - BUILD_COMMAND=bdist_wheel
               - QT_BINDING=PyQt5
+              - PIP_OPTIONS="-q --pre"
 
 cache:
     apt: true
@@ -62,13 +67,13 @@ before_install:
 
 install:
     # Upgrade distribution modules
-    - python -m pip install -q --upgrade pip
-    - pip install -q --upgrade setuptools
+    - python -m pip install ${PIP_OPTIONS} --upgrade pip
+    - pip install ${PIP_OPTIONS} --upgrade setuptools
 
     # Install build dependencies
-    - pip install -q --upgrade wheel
-    - pip install -q --upgrade numpy --pre
-    - pip install -q --upgrade cython --pre
+    - pip install ${PIP_OPTIONS} --upgrade wheel
+    - pip install ${PIP_OPTIONS} --upgrade numpy
+    - pip install ${PIP_OPTIONS} --upgrade cython
 
     # Print Python info
     - python ./ci/info_platform.py
@@ -96,15 +101,15 @@ before_script:
     # First install any temporary pinned/additional requirements
     - if [ -s "ci/requirements-pinned.txt" ];
       then
-      pip install -q --pre -r ci/requirements-pinned.txt;
+      pip install ${PIP_OPTIONS} -r ci/requirements-pinned.txt;
       fi
 
     # This installs PyQt and scipy if wheels are available
-    - pip install -q --pre -r requirements.txt
+    - pip install ${PIP_OPTIONS} -r requirements.txt
     # Install PySide2 if needed
     - if [ "$QT_BINDING" == "PySide2" ];
       then
-          pip install -q --index-url=http://download.qt.io/snapshots/ci/pyside/5.11/latest/ pyside2 --trusted-host download.qt.io;
+          pip install ${PIP_OPTIONS} --index-url=http://download.qt.io/snapshots/ci/pyside/5.11/latest/ pyside2 --trusted-host download.qt.io;
       fi
 
     # Install built package
@@ -123,7 +128,7 @@ before_script:
 
     - if [ "$TRAVIS_OS_NAME" == "osx" ];
       then
-          pip install -q --upgrade pynput;
+          pip install ${PIP_OPTIONS} --upgrade pynput;
           python ci/close_popup.py;
       fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,8 @@ install:
 
     # Install build dependencies
     - pip install -q --upgrade wheel
-    - pip install -q --upgrade numpy
-    - pip install -q --upgrade cython
+    - pip install -q --upgrade numpy --pre
+    - pip install -q --upgrade cython --pre
 
     # Print Python info
     - python ./ci/info_platform.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
               - QT_BINDING=PyQt5
               - SILX_OPENCL=1
 
-        - python: 3.6
+        - python: 3.7
           os: linux
           env:
               - BUILD_COMMAND=sdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ before_script:
     # First install any temporary pinned/additional requirements
     - if [ -s "ci/requirements-pinned.txt" ];
       then
-          pip install -q -r ci/requirements-pinned.txt;
+      pip install -q --pre -r ci/requirements-pinned.txt;
       fi
 
     # This installs PyQt and scipy if wheels are available

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -28,22 +28,24 @@ environment:
         - PYTHON_DIR: "C:\\Python37-x64"
           QT_BINDING: "PyQt5"
           WITH_GL_TEST: True
+          PIP_OPTIONS: "-q --pre"
 
         # Python 2.7
         - PYTHON_DIR: "C:\\Python27-x64"
           QT_BINDING: "PyQt4"
           WITH_GL_TEST: False
+          PIP_OPTIONS: "-q"
 
 install:
     # Add Python to PATH
     - "SET PATH=%PYTHON_DIR%;%PYTHON_DIR%\\Scripts;%PATH%"
 
     # Upgrade/install distribution modules
-    - "pip install --upgrade setuptools"
-    - "python -m pip install --upgrade pip"
+    - "pip install %PIP_OPTIONS% --upgrade setuptools"
+    - "python -m pip install %PIP_OPTIONS% --upgrade pip"
 
     # Install virtualenv
-    - "pip install --upgrade virtualenv"
+    - "pip install %PIP_OPTIONS% --upgrade virtualenv"
     - "virtualenv --version"
 
     # Download Mesa OpenGL in Python directory when testing OpenGL
@@ -55,9 +57,9 @@ build_script:
     - "%VENV_BUILD_DIR%\\Scripts\\activate.bat"
 
     # Install build dependencies
-    - "pip install --upgrade wheel"
-    - "pip install --upgrade numpy --pre"
-    - "pip install --upgrade cython --pre"
+    - "pip install %PIP_OPTIONS% --upgrade wheel"
+    - "pip install %PIP_OPTIONS% --upgrade numpy"
+    - "pip install %PIP_OPTIONS% --upgrade cython"
 
     # Print Python info
     - "python ci\\info_platform.py"
@@ -77,13 +79,13 @@ before_test:
     - "%VENV_TEST_DIR%\\Scripts\\activate.bat"
 
     # First install any temporary pinned/additional requirements
-    - pip install --pre -r "ci\requirements-pinned.txt
+    - pip install %PIP_OPTIONS% -r "ci\requirements-pinned.txt
 
     # Install dependencies
-    - pip install --pre -r requirements.txt
+    - pip install %PIP_OPTIONS% -r requirements.txt
 
     # Install selected Qt binding
-    - "pip install --pre --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ %QT_BINDING%"
+    - "pip install %PIP_OPTIONS% --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ %QT_BINDING%"
 
     # Install the generated wheel package to test it
     # Make sure silx does not come from cache or pypi

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -24,8 +24,8 @@ environment:
         VENV_TEST_DIR: "venv_test"
 
     matrix:
-        # Python 3.6
-        - PYTHON_DIR: "C:\\Python36-x64"
+        # Python 3.7
+        - PYTHON_DIR: "C:\\Python37-x64"
           QT_BINDING: "PyQt5"
           WITH_GL_TEST: True
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -77,7 +77,7 @@ before_test:
     - "%VENV_TEST_DIR%\\Scripts\\activate.bat"
 
     # First install any temporary pinned/additional requirements
-    - pip install -r "ci\requirements-pinned.txt
+    - pip install --pre -r "ci\requirements-pinned.txt
 
     # Install dependencies
     - pip install --pre -r requirements.txt

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -56,8 +56,8 @@ build_script:
 
     # Install build dependencies
     - "pip install --upgrade wheel"
-    - "pip install --upgrade numpy"
-    - "pip install --upgrade cython"
+    - "pip install --upgrade numpy --pre"
+    - "pip install --upgrade cython --pre"
 
     # Print Python info
     - "python ci\\info_platform.py"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # coding: utf8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -626,8 +626,17 @@ class BuildExt(build_ext):
             extern = 'extern "C" ' if ext.language == 'c++' else ''
             return_type = 'void' if sys.version_info[0] <= 2 else 'PyObject*'
 
-            ext.extra_compile_args.append(
-                '''-fvisibility=hidden -D'PyMODINIT_FUNC=%s__attribute__((visibility("default"))) %s ' ''' % (extern, return_type))
+            ext.extra_compile_args.append('-fvisibility=hidden')
+
+            import numpy
+            numpy_version = [int(i) for i in numpy.version.short_version.split(".", 2)[:2]]
+            if numpy_version < [1,16]:
+                ext.extra_compile_args.append(
+                    '''-D'PyMODINIT_FUNC=%s__attribute__((visibility("default"))) %s ' ''' % (extern, return_type))
+            else:
+                ext.define_macros.append(
+                    ('PyMODINIT_FUNC',
+                     '%s__attribute__((visibility("default"))) %s ' % (extern, return_type)))
 
     def is_debug_interpreter(self):
         """

--- a/setup.py
+++ b/setup.py
@@ -615,10 +615,15 @@ class BuildExt(build_ext):
 
         # Convert flags from gcc to MSVC if required
         if self.compiler.compiler_type == 'msvc':
-            ext.extra_compile_args = [self.COMPILE_ARGS_CONVERTER.get(f, f)
-                                      for f in ext.extra_compile_args]
-            ext.extra_link_args = [self.LINK_ARGS_CONVERTER.get(f, f)
-                                   for f in ext.extra_link_args]
+            extra_compile_args = [self.COMPILE_ARGS_CONVERTER.get(f, f)
+                                  for f in ext.extra_compile_args]
+            # Avoid empty arg
+            ext.extra_compile_args = [arg for arg in extra_compile_args if arg]
+
+            extra_link_args = [self.LINK_ARGS_CONVERTER.get(f, f)
+                               for f in ext.extra_link_args]
+            # Avoid empty arg
+            ext.extra_link_args = [arg for arg in extra_link_args if arg]
 
         elif self.compiler.compiler_type == 'unix':
             # Avoids runtime symbol collision for manylinux1 platform


### PR DESCRIPTION
This PR makes updates to `setup.py` to work with `numpy.distutils` from v1.16.0rc[1|2].

It also uses pre-release of numpy and cython during build not just during testing.