### PR TITLE
[plot] Implement line bg color for shapes

### DIFF
--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -506,6 +506,11 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
     def addItem(self, x, y, legend, shape, color, fill, overlay, z,
                 linestyle, linewidth, linebgcolor):
+        if (linebgcolor is not None and
+                shape not in ('rectangle', 'polygon', 'polylines')):
+            _logger.warning(
+                'linebgcolor not implemented for %s with matplotlib backend',
+                shape)
         xView = numpy.array(x, copy=False)
         yView = numpy.array(y, copy=False)
 

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -752,12 +752,28 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                 # Ignore items <= 0. on log axes
                 continue
 
-            points = numpy.array([
-                self.dataToPixel(x, y, axis='left', check=False)
-                for (x, y) in zip(item['x'], item['y'])])
+            if item['shape'] == 'hline':
+                width = self._plotFrame.size[0]
+                _, yPixel = self.dataToPixel(
+                    None, item['y'], axis='left', check=False)
+                points = numpy.array(((0., yPixel), (width, yPixel)),
+                                     dtype=numpy.float32)
+
+            elif item['shape'] == 'vline':
+                xPixel, _ = self.dataToPixel(
+                    item['x'], None, axis='left', check=False)
+                height = self._plotFrame.size[1]
+                points = numpy.array(((xPixel, 0), (xPixel, height)),
+                                     dtype=numpy.float32)
+
+            else:
+                points = numpy.array([
+                    self.dataToPixel(x, y, axis='left', check=False)
+                    for (x, y) in zip(item['x'], item['y'])])
 
             # Draw the fill
-            if item['fill'] is not None:
+            if (item['fill'] is not None and
+                    item['shape'] not in ('hline', 'vline')):
                 self._progBase.use()
                 gl.glUniformMatrix4fv(
                     self._progBase.uniforms['matrix'], 1, gl.GL_TRUE,

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -782,6 +782,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                 lines = GLLines2D(points[:, 0], points[:, 1],
                                   style=item['linestyle'],
                                   color=item['color'],
+                                  dash2ndColor=item['linebgcolor'],
                                   width=item['linewidth'])
                 lines.render(self.matScreenProj)
 
@@ -1030,7 +1031,6 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
     def addItem(self, x, y, legend, shape, color, fill, overlay, z,
                 linestyle, linewidth, linebgcolor):
-        # FIXME: implement lineStyle and lineBgColor
         # TODO handle overlay
         if shape not in ('polygon', 'rectangle', 'line',
                          'vline', 'hline', 'polylines'):
@@ -1063,7 +1063,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             'x': x,
             'y': y,
             'linestyle': linestyle,
-            'linewidth': linewidth
+            'linewidth': linewidth,
+            'linebgcolor': linebgcolor,
         }
 
         return legend, 'item'

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -562,7 +562,6 @@ class LineMixIn(ItemMixInBase):
     def __init__(self):
         self._linewidth = self._DEFAULT_LINEWIDTH
         self._linestyle = self._DEFAULT_LINESTYLE
-        self._lineBgColor = None
 
     @classmethod
     def getSupportedLineStyles(cls):
@@ -620,34 +619,6 @@ class LineMixIn(ItemMixInBase):
         if style != self._linestyle:
             self._linestyle = style
             self._updated(ItemChangedType.LINE_STYLE)
-
-    def getLineBgColor(self):
-        """Returns the RGBA color of the item
-        :rtype: 4-tuple of float in [0, 1] or array of colors
-        """
-        return self._lineBgColor
-
-    def setLineBgColor(self, color, copy=True):
-        """Set item color
-        :param color: color(s) to be used
-        :type color: str ("#RRGGBB") or (npoints, 4) unsigned byte array or
-                     one of the predefined color names defined in colors.py
-        :param bool copy: True (Default) to get a copy,
-                         False to use internal representation (do not modify!)
-        """
-        if color is not None:
-            if isinstance(color, six.string_types):
-                color = colors.rgba(color)
-            else:
-                color = numpy.array(color, copy=copy)
-                # TODO more checks + improve color array support
-                if color.ndim == 1:  # Single RGBA color
-                    color = colors.rgba(color)
-                else:  # Array of colors
-                    assert color.ndim == 2
-
-        self._lineBgColor = color
-        self._updated(ItemChangedType.LINE_BG_COLOR)
 
 
 class ColorMixIn(ItemMixInBase):

--- a/silx/gui/plot/items/shape.py
+++ b/silx/gui/plot/items/shape.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -33,7 +33,9 @@ __date__ = "21/12/2018"
 import logging
 
 import numpy
+import six
 
+from ... import colors
 from .core import Item, ColorMixIn, FillMixIn, ItemChangedType, LineMixIn
 
 
@@ -58,6 +60,7 @@ class Shape(Item, ColorMixIn, FillMixIn, LineMixIn):
         assert type_ in ('hline', 'polygon', 'rectangle', 'vline', 'polylines')
         self._type = type_
         self._points = ()
+        self._lineBgColor = None
 
         self._handle = None
 
@@ -123,3 +126,31 @@ class Shape(Item, ColorMixIn, FillMixIn, LineMixIn):
         """
         self._points = numpy.array(points, copy=copy)
         self._updated(ItemChangedType.DATA)
+
+    def getLineBgColor(self):
+        """Returns the RGBA color of the item
+        :rtype: 4-tuple of float in [0, 1] or array of colors
+        """
+        return self._lineBgColor
+
+    def setLineBgColor(self, color, copy=True):
+        """Set item color
+        :param color: color(s) to be used
+        :type color: str ("#RRGGBB") or (npoints, 4) unsigned byte array or
+                     one of the predefined color names defined in colors.py
+        :param bool copy: True (Default) to get a copy,
+                         False to use internal representation (do not modify!)
+        """
+        if color is not None:
+            if isinstance(color, six.string_types):
+                color = colors.rgba(color)
+            else:
+                color = numpy.array(color, copy=copy)
+                # TODO more checks + improve color array support
+                if color.ndim == 1:  # Single RGBA color
+                    color = colors.rgba(color)
+                else:  # Array of colors
+                    assert color.ndim == 2
+
+        self._lineBgColor = color
+        self._updated(ItemChangedType.LINE_BG_COLOR)


### PR DESCRIPTION
This PR follows PR #2266 and:
- adds implementation in the OpenGL backend of line background color,
- moves `get|setLineBgColor` from `LineMixIn` to `Shape` item as it is only implemented here for now, and
- adds a warning in matplotlib backend where it is not available (i.e., `line`, `hline` and `vline` shapes)
- fixes `hline` and `vline` shapes in the OpenGL backend.

The implementation of the dash line background color in the OpenGL backend is different than that of the matplotlib backend in that it fills the holes of the dash line with the second color rather than being a true background color (different behavior when there is some transparency).
This can be easily changed, but I think it is more the desired behavior.