### PR TITLE
[doc][snapshot] fix issue when sphinx register parse the snapshot_dir…

### DIFF
--- a/doc/source/ext/snapshotqt_directive.py
+++ b/doc/source/ext/snapshotqt_directive.py
@@ -266,4 +266,4 @@ else:
         else:
             with open(script_or_module) as f:
                 code = compile(f.read(), script_or_module, 'exec')
-                exec(code)
+                exec(code, globals(), locals())


### PR DESCRIPTION
fix issue when sphinx register parse the snapshot_directive. Fail on exec() synthax. Need to add locals, globals... even if python2 will never execute this code...

/close #2339