### PR TITLE
Allow to drop URI from hdf5 tree to external applications

### DIFF
--- a/examples/dropZones.py
+++ b/examples/dropZones.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""
+Example of drop zone supporting application/x-silx-uri
+"""
+
+from __future__ import absolute_import
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "25/01/2019"
+
+import logging
+import silx.io
+from silx.gui import qt
+from silx.gui.plot.PlotWidget import PlotWidget
+
+_logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.DEBUG)
+
+
+class DropPlotWidget(PlotWidget):
+
+    def __init__(self, parent=None, backend=None):
+        PlotWidget.__init__(self, parent=parent, backend=backend)
+        self.setAcceptDrops(True)
+
+    def dragEnterEvent(self, event):
+        if event.mimeData().hasFormat("application/x-silx-uri"):
+            event.acceptProposedAction()
+
+    def dropEvent(self, event):
+        byteString = event.mimeData().data("application/x-silx-uri")
+        silxUrl = byteString.data().decode("utf-8")
+        with silx.io.open(silxUrl) as h5:
+            if silx.io.is_dataset(h5):
+                dataset = h5[...]
+            else:
+                _logger.error("Unsupported URI")
+                dataset = None
+
+        if dataset is not None:
+            if dataset.ndim == 1:
+                self.clear()
+                self.addCurve(y=dataset, x=range(dataset.size))
+                event.acceptProposedAction()
+            elif dataset.ndim == 2:
+                self.clear()
+                self.addImage(data=dataset)
+                event.acceptProposedAction()
+            else:
+                _logger.error("Unsupported dataset")
+
+
+class DropLabel(qt.QLabel):
+
+    def __init__(self, parent=None, backend=None):
+        qt.QLabel.__init__(self)
+        self.setAcceptDrops(True)
+        self.setText("Drop something here")
+
+    def dragEnterEvent(self, event):
+        if event.mimeData().hasFormat("application/x-silx-uri"):
+            event.acceptProposedAction()
+
+    def dropEvent(self, event):
+        byteString = event.mimeData().data("application/x-silx-uri")
+        silxUrl = byteString.data().decode("utf-8")
+        url = silx.io.url.DataUrl(silxUrl)
+        self.setText(url.path())
+
+        toolTipTemplate = ("<html><ul>"
+                           "<li><b>file_path</b>: {file_path}</li>"
+                           "<li><b>data_path</b>: {data_path}</li>"
+                           "<li><b>data_slice</b>: {data_slice}</li>"
+                           "<li><b>scheme</b>: {scheme}</li>"
+                           "</html>"
+                           "</ul></html>"
+                           )
+
+        toolTip = toolTipTemplate.format(
+            file_path=url.file_path(),
+            data_path=url.data_path(),
+            data_slice=url.data_slice(),
+            scheme=url.scheme())
+
+        self.setToolTip(toolTip)
+        event.acceptProposedAction()
+
+
+class DropExample(qt.QMainWindow):
+
+    def __init__(self, parent=None):
+        super(DropExample, self).__init__(parent)
+        centralWidget = qt.QWidget(self)
+        layout = qt.QVBoxLayout()
+        centralWidget.setLayout(layout)
+        layout.addWidget(DropPlotWidget(parent=self))
+        layout.addWidget(DropLabel(parent=self))
+        self.setCentralWidget(centralWidget)
+
+
+def main():
+    app = qt.QApplication([])
+    example = DropExample()
+    example.show()
+    app.exec_()
+
+
+if __name__ == "__main__":
+    main()

--- a/silx/app/view/main.py
+++ b/silx/app/view/main.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "20/11/2018"
+__date__ = "17/01/2019"
 
 import sys
 import argparse
@@ -75,6 +75,9 @@ def mainQt(options):
 
     import silx
     from silx.gui import qt
+    # Make sure matplotlib is configured
+    # Needed for Debian 8: compatibility between Qt4/Qt5 and old matplotlib
+    from silx.gui.plot import matplotlib
 
     try:
         # it should be loaded before h5py

--- a/silx/gui/hdf5/Hdf5Item.py
+++ b/silx/gui/hdf5/Hdf5Item.py
@@ -25,13 +25,11 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "29/11/2018"
+__date__ = "17/01/2019"
 
 
 import logging
 import collections
-
-import six
 
 from .. import qt
 from .. import icons

--- a/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/silx/gui/hdf5/Hdf5TreeModel.py
@@ -25,7 +25,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "08/10/2018"
+__date__ = "17/01/2019"
 
 
 import os
@@ -360,9 +360,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
 
     def mimeTypes(self):
         types = []
-        if self.__fileMoveEnabled:
-            types.append(_utils.Hdf5NodeMimeData.MIME_TYPE)
-        if self.__datasetDragEnabled:
+        if self.__fileMoveEnabled or self.__datasetDragEnabled:
             types.append(_utils.Hdf5DatasetMimeData.MIME_TYPE)
         return types
 
@@ -386,7 +384,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         node = self.nodeFromIndex(indexes[0])
 
         if self.__fileMoveEnabled and node.parent is self.__root:
-            mimeData = _utils.Hdf5NodeMimeData(node=node)
+            mimeData = _utils.Hdf5DatasetMimeData(node=node, isRoot=True)
         elif self.__datasetDragEnabled:
             mimeData = _utils.Hdf5DatasetMimeData(node=node)
         else:
@@ -413,23 +411,24 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         if action == qt.Qt.IgnoreAction:
             return True
 
-        if self.__fileMoveEnabled and mimedata.hasFormat(_utils.Hdf5NodeMimeData.MIME_TYPE):
-            dragNode = mimedata.node()
-            parentNode = self.nodeFromIndex(parentIndex)
-            if parentNode is not dragNode.parent:
-                return False
+        if self.__fileMoveEnabled and mimedata.hasFormat(_utils.Hdf5DatasetMimeData.MIME_TYPE):
+            if mimedata.isRoot():
+                dragNode = mimedata.node()
+                parentNode = self.nodeFromIndex(parentIndex)
+                if parentNode is not dragNode.parent:
+                    return False
 
-            if row == -1:
-                # append to the parent
-                row = parentNode.childCount()
-            else:
-                # insert at row
-                pass
+                if row == -1:
+                    # append to the parent
+                    row = parentNode.childCount()
+                else:
+                    # insert at row
+                    pass
 
-            dragNodeParent = dragNode.parent
-            sourceRow = dragNodeParent.indexOfChild(dragNode)
-            self.moveRow(parentIndex, sourceRow, parentIndex, row)
-            return True
+                dragNodeParent = dragNode.parent
+                sourceRow = dragNodeParent.indexOfChild(dragNode)
+                self.moveRow(parentIndex, sourceRow, parentIndex, row)
+                return True
 
         if self.__fileDropEnabled and mimedata.hasFormat("text/uri-list"):
 

--- a/silx/gui/hdf5/_utils.py
+++ b/silx/gui/hdf5/_utils.py
@@ -28,12 +28,16 @@ package `silx.gui.hdf5` package.
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "04/05/2018"
+__date__ = "17/01/2019"
 
 
 import logging
-from .. import qt
+import os.path
+
 import silx.io.utils
+import silx.io.url
+
+from .. import qt
 from silx.utils.html import escape
 
 _logger = logging.getLogger(__name__)
@@ -419,3 +423,43 @@ class H5Node(object):
         :rtype: str
         """
         return self.physical_name.split("/")[-1]
+
+    @property
+    def data_url(self):
+        """Returns a :class:`silx.io.url.DataUrl` object identify this node in the file
+        system.
+
+        :rtype: ~silx.io.url.DataUrl
+        """
+        absolute_filename = os.path.abspath(self.local_filename)
+        return silx.io.url.DataUrl(scheme="silx",
+                                   file_path=absolute_filename,
+                                   data_path=self.local_name)
+
+    @property
+    def url(self):
+        """Returns an URL object identifying this node in the file
+        system.
+
+        This URL can be used in different ways.
+
+        .. code-block:: python
+
+            # Parsing the URL
+            import silx.io.url
+            dataurl = silx.io.url.DataUrl(item.url)
+            # dataurl provides access to URL fields
+
+            # Open a numpy array
+            import silx.io
+            dataset = silx.io.get_data(item.url)
+
+            # Open an hdf5 object (URL targetting a file or a group)
+            import silx.io
+            with silx.io.open(item.url) as h5:
+                ...your stuff...
+
+        :rtype: str
+        """
+        data_url = self.data_url
+        return data_url.path()

--- a/silx/gui/hdf5/_utils.py
+++ b/silx/gui/hdf5/_utils.py
@@ -36,7 +36,6 @@ import os.path
 
 import silx.io.utils
 import silx.io.url
-
 from .. import qt
 from silx.utils.html import escape
 
@@ -111,12 +110,19 @@ class Hdf5DatasetMimeData(qt.QMimeData):
 
     MIME_TYPE = "application/x-internal-h5py-dataset"
 
+    SILX_URI_TYPE = "application/x-silx-uri"
+
     def __init__(self, node=None, dataset=None, isRoot=False):
         qt.QMimeData.__init__(self)
         self.__dataset = dataset
         self.__node = node
         self.__isRoot = isRoot
         self.setData(self.MIME_TYPE, "".encode(encoding='utf-8'))
+        if node is not None:
+            h5Node = H5Node(node)
+            silxUrl = h5Node.url
+            self.setText(silxUrl)
+            self.setData(self.SILX_URI_TYPE, silxUrl.encode(encoding='utf-8'))
 
     def isRoot(self):
         return self.__isRoot

--- a/silx/gui/hdf5/_utils.py
+++ b/silx/gui/hdf5/_utils.py
@@ -111,11 +111,15 @@ class Hdf5DatasetMimeData(qt.QMimeData):
 
     MIME_TYPE = "application/x-internal-h5py-dataset"
 
-    def __init__(self, node=None, dataset=None):
+    def __init__(self, node=None, dataset=None, isRoot=False):
         qt.QMimeData.__init__(self)
         self.__dataset = dataset
         self.__node = node
+        self.__isRoot = isRoot
         self.setData(self.MIME_TYPE, "".encode(encoding='utf-8'))
+
+    def isRoot(self):
+        return self.__isRoot
 
     def node(self):
         return self.__node
@@ -124,20 +128,6 @@ class Hdf5DatasetMimeData(qt.QMimeData):
         if self.__node is not None:
             return self.__node.obj
         return self.__dataset
-
-
-class Hdf5NodeMimeData(qt.QMimeData):
-    """Mimedata class to identify an internal drag and drop of a Hdf5Node."""
-
-    MIME_TYPE = "application/x-internal-h5py-node"
-
-    def __init__(self, node=None):
-        qt.QMimeData.__init__(self)
-        self.__node = node
-        self.setData(self.MIME_TYPE, "".encode(encoding='utf-8'))
-
-    def node(self):
-        return self.__node
 
 
 class H5Node(object):


### PR DESCRIPTION
- Implement `url` from H5Node (object provided to user on tree interaction)
- Implement generic mimetypes for item of the tree
    - `text/uri-list` was NOT implemented as the behaviour with most application was not very nice
    - `text/plain` containing the URL, convenient to drag and drop thing to any application
    - `application/x-silx-uri` also containing the same URL, convenient for application that really expecting an URI from silx

The Qt drop code is easy to write. And silx provides API to read the URI in case:
```
# Parsing the URL
import silx.io.url
dataurl = silx.io.url.DataUrl(url)
# dataurl provides access to URL fields

# Read it as a numpy array
import silx.io
dataset = silx.io.get_data(url)

# Open an hdf5 object (URL targetting a file or a group)
import silx.io
with silx.io.open(url) as h5:
    # ...your stuff...
```

Closes #2355