### PR TITLE
plot3d items: add ColormapMesh and add indices to Mesh

### DIFF
--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -573,7 +573,6 @@ class _ColormapBaseProxyRow(ProxyRow):
     """Signal used internally to notify colormap (or data) update"""
 
     def __init__(self, item, *args, **kwargs):
-        self._dataRange = None
         self._item = weakref.ref(item)
         self._colormap = item.getColormap()
 
@@ -592,19 +591,11 @@ class _ColormapBaseProxyRow(ProxyRow):
 
         :return: Colormap range (min, max)
         """
-        if self._dataRange is None:
-            item = self.item()
-            if item is not None and self._colormap is not None:
-                if hasattr(item, 'getDataRange'):
-                    data = item.getDataRange()
-                else:
-                    data = item.getData(copy=False)
-
-                self._dataRange = self._colormap.getColormapRange(data)
-
-            else:  # Fallback
-                self._dataRange = 1, 100
-        return self._dataRange
+        item = self.item()
+        if item is not None and self._colormap is not None:
+            return self._colormap.getColormapRange(item._getDataRange())
+        else:
+            return 1, 100  # Fallback
 
     def _modelUpdated(self, *args, **kwargs):
         """Emit dataChanged in the model"""
@@ -635,7 +626,6 @@ class _ColormapBaseProxyRow(ProxyRow):
                 self._colormap = None
 
         elif event == items.ItemChangedType.DATA:
-            self._dataRange = None
             self._sigColormapChanged.emit()
 
 

--- a/silx/gui/plot3d/items/__init__.py
+++ b/silx/gui/plot3d/items/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -38,6 +38,6 @@ from .mixins import (ColormapMixIn, InterpolationMixIn,  # noqa
                      PlaneMixIn, SymbolMixIn)  # noqa
 from .clipplane import ClipPlane  # noqa
 from .image import ImageData, ImageRgba  # noqa
-from .mesh import Mesh, Box, Cylinder, Hexagon  # noqa
+from .mesh import Mesh, ColormapMesh, Box, Cylinder, Hexagon  # noqa
 from .scatter import Scatter2D, Scatter3D  # noqa
 from .volume import ScalarField3D  # noqa

--- a/silx/gui/plot3d/items/mesh.py
+++ b/silx/gui/plot3d/items/mesh.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -59,6 +59,7 @@ class Mesh(DataItem3D):
                 color,
                 normal=None,
                 mode='triangles',
+                indices=None,
                 copy=True):
         """Set mesh geometry data.
 
@@ -67,8 +68,10 @@ class Mesh(DataItem3D):
         :param numpy.ndarray position:
             Position (x, y, z) of each vertex as a (N, 3) array
         :param numpy.ndarray color: Colors for each point or a single color
-        :param numpy.ndarray normal: Normals for each point or None (default)
+        :param Union[numpy.ndarray,None] normal: Normals for each point or None (default)
         :param str mode: The drawing mode.
+        :param Union[List[int],None] indices:
+            Array of vertex indices or None to use arrays directly.
         :param bool copy: True (default) to copy the data,
                           False to use as is (do not modify!).
         """
@@ -78,7 +81,7 @@ class Mesh(DataItem3D):
             self._mesh = None
         else:
             self._mesh = primitives.Mesh3D(
-                position, color, normal, mode=mode, copy=copy)
+                position, color, normal, mode=mode, indices=indices, copy=copy)
             self._getScenePrimitive().children.append(self._mesh)
 
         self.sigItemChanged.emit(ItemChangedType.DATA)
@@ -138,6 +141,20 @@ class Mesh(DataItem3D):
             return None
         else:
             return self._mesh.getAttribute('normal', copy=copy)
+
+    def getIndices(self, copy=True):
+        """Get the vertex indices.
+
+        :param bool copy:
+            True (default) to get a copy,
+            False to get internal representation (do not modify!).
+        :return: The vertex indices as an array or None.
+        :rtype: Union[numpy.ndarray,None]
+        """
+        if self._mesh is None:
+            return None
+        else:
+            return self._mesh.getIndices(copy=copy)
 
     def getDrawMode(self):
         """Get mesh rendering mode.

--- a/silx/gui/plot3d/items/mesh.py
+++ b/silx/gui/plot3d/items/mesh.py
@@ -35,17 +35,18 @@ __date__ = "17/07/2018"
 import logging
 import numpy
 
-from ..scene import primitives, utils
+from ..scene import primitives, utils, function
 from ..scene.transform import Rotate
 from .core import DataItem3D, ItemChangedType
+from .mixins import ColormapMixIn
 from ._pick import PickingResult
 
 
 _logger = logging.getLogger(__name__)
 
 
-class Mesh(DataItem3D):
-    """Description of mesh.
+class _MeshBase(DataItem3D):
+    """Base class for :class:`Mesh' and :class:`ColormapMesh`.
 
     :param parent: The View widget this item belongs to.
     """
@@ -54,51 +55,22 @@ class Mesh(DataItem3D):
         DataItem3D.__init__(self, parent=parent)
         self._mesh = None
 
-    def setData(self,
-                position,
-                color,
-                normal=None,
-                mode='triangles',
-                indices=None,
-                copy=True):
-        """Set mesh geometry data.
+    def _setMesh(self, mesh):
+        """Set mesh primitive
 
-        Supported drawing modes are: 'triangles', 'triangle_strip', 'fan'
-
-        :param numpy.ndarray position:
-            Position (x, y, z) of each vertex as a (N, 3) array
-        :param numpy.ndarray color: Colors for each point or a single color
-        :param Union[numpy.ndarray,None] normal: Normals for each point or None (default)
-        :param str mode: The drawing mode.
-        :param Union[List[int],None] indices:
-            Array of vertex indices or None to use arrays directly.
-        :param bool copy: True (default) to copy the data,
-                          False to use as is (do not modify!).
+        :param Union[None,Geometry] mesh: The scene primitive
         """
         self._getScenePrimitive().children = []  # Remove any previous mesh
 
-        if position is None or len(position) == 0:
-            self._mesh = None
-        else:
-            self._mesh = primitives.Mesh3D(
-                position, color, normal, mode=mode, indices=indices, copy=copy)
+        self._mesh = mesh
+        if self._mesh is not None:
             self._getScenePrimitive().children.append(self._mesh)
 
         self.sigItemChanged.emit(ItemChangedType.DATA)
 
-    def getData(self, copy=True):
-        """Get the mesh geometry.
-
-        :param bool copy:
-            True (default) to get a copy,
-            False to get internal representation (do not modify!).
-        :return: The positions, colors, normals and mode
-        :rtype: tuple of numpy.ndarray
-        """
-        return (self.getPositionData(copy=copy),
-                self.getColorData(copy=copy),
-                self.getNormalData(copy=copy),
-                self.getDrawMode())
+    def _getMesh(self):
+        """Returns the underlying Mesh scene primitive"""
+        return self._mesh
 
     def getPositionData(self, copy=True):
         """Get the mesh vertex positions.
@@ -109,24 +81,10 @@ class Mesh(DataItem3D):
         :return: The (x, y, z) positions as a (N, 3) array
         :rtype: numpy.ndarray
         """
-        if self._mesh is None:
+        if self._getMesh() is None:
             return numpy.empty((0, 3), dtype=numpy.float32)
         else:
-            return self._mesh.getAttribute('position', copy=copy)
-
-    def getColorData(self, copy=True):
-        """Get the mesh vertex colors.
-
-        :param bool copy:
-            True (default) to get a copy,
-            False to get internal representation (do not modify!).
-        :return: The RGBA colors as a (N, 4) array or a single color
-        :rtype: numpy.ndarray
-        """
-        if self._mesh is None:
-            return numpy.empty((0, 4), dtype=numpy.float32)
-        else:
-            return self._mesh.getAttribute('color', copy=copy)
+            return self._getMesh().getAttribute('position', copy=copy)
 
     def getNormalData(self, copy=True):
         """Get the mesh vertex normals.
@@ -137,10 +95,10 @@ class Mesh(DataItem3D):
         :return: The normals as a (N, 3) array, a single normal or None
         :rtype: Union[numpy.ndarray,None]
         """
-        if self._mesh is None:
+        if self._getMesh() is None:
             return None
         else:
-            return self._mesh.getAttribute('normal', copy=copy)
+            return self._getMesh().getAttribute('normal', copy=copy)
 
     def getIndices(self, copy=True):
         """Get the vertex indices.
@@ -151,10 +109,10 @@ class Mesh(DataItem3D):
         :return: The vertex indices as an array or None.
         :rtype: Union[numpy.ndarray,None]
         """
-        if self._mesh is None:
+        if self._getMesh() is None:
             return None
         else:
-            return self._mesh.getIndices(copy=copy)
+            return self._getMesh().getIndices(copy=copy)
 
     def getDrawMode(self):
         """Get mesh rendering mode.
@@ -162,9 +120,9 @@ class Mesh(DataItem3D):
         :return: The drawing mode of this primitive
         :rtype: str
         """
-        return self._mesh.drawMode
+        return self._getMesh().drawMode
 
-    def _pickFull(self, context):
+    def _pickFull(self, context):  # TODO add support of indices
         """Perform precise picking in this item at given widget position.
 
         :param PickContext context: Current picking context
@@ -229,6 +187,150 @@ class Mesh(DataItem3D):
                              positions=points,
                              indices=indices,
                              fetchdata=self.getPositionData)
+
+
+class Mesh(_MeshBase):
+    """Description of mesh.
+
+    :param parent: The View widget this item belongs to.
+    """
+
+    def __init__(self, parent=None):
+        _MeshBase.__init__(self, parent=parent)
+
+    def setData(self,
+                position,
+                color,
+                normal=None,
+                mode='triangles',
+                indices=None,
+                copy=True):
+        """Set mesh geometry data.
+
+        Supported drawing modes are: 'triangles', 'triangle_strip', 'fan'
+
+        :param numpy.ndarray position:
+            Position (x, y, z) of each vertex as a (N, 3) array
+        :param numpy.ndarray color: Colors for each point or a single color
+        :param Union[numpy.ndarray,None] normal: Normals for each point or None (default)
+        :param str mode: The drawing mode.
+        :param Union[List[int],None] indices:
+            Array of vertex indices or None to use arrays directly.
+        :param bool copy: True (default) to copy the data,
+                          False to use as is (do not modify!).
+        """
+        assert mode in ('triangles', 'triangle_strip', 'fan')
+        if position is None or len(position) == 0:
+            mesh = None
+        else:
+            mesh = primitives.Mesh3D(
+                position, color, normal, mode=mode, indices=indices, copy=copy)
+        self._setMesh(mesh)
+
+    def getData(self, copy=True):
+        """Get the mesh geometry.
+
+        :param bool copy:
+            True (default) to get a copy,
+            False to get internal representation (do not modify!).
+        :return: The positions, colors, normals and mode
+        :rtype: tuple of numpy.ndarray
+        """
+        return (self.getPositionData(copy=copy),
+                self.getColorData(copy=copy),
+                self.getNormalData(copy=copy),
+                self.getDrawMode())
+
+    def getColorData(self, copy=True):
+        """Get the mesh vertex colors.
+
+        :param bool copy:
+            True (default) to get a copy,
+            False to get internal representation (do not modify!).
+        :return: The RGBA colors as a (N, 4) array or a single color
+        :rtype: numpy.ndarray
+        """
+        if self._getMesh() is None:
+            return numpy.empty((0, 4), dtype=numpy.float32)
+        else:
+            return self._getMesh().getAttribute('color', copy=copy)
+
+
+class ColormapMesh(_MeshBase, ColormapMixIn):
+    """Description of mesh which color is defined by scalar and a colormap.
+
+    :param parent: The View widget this item belongs to.
+    """
+
+    def __init__(self, parent=None):
+        _MeshBase.__init__(self, parent=parent)
+        ColormapMixIn.__init__(self, function.Colormap())
+
+    def setData(self,
+                position,
+                value,
+                normal=None,
+                mode='triangles',
+                indices=None,
+                copy=True):
+        """Set mesh geometry data.
+
+        Supported drawing modes are: 'triangles', 'triangle_strip', 'fan'
+
+        :param numpy.ndarray position:
+            Position (x, y, z) of each vertex as a (N, 3) array
+        :param numpy.ndarray value: Data value for each vertex.
+        :param Union[numpy.ndarray,None] normal: Normals for each point or None (default)
+        :param str mode: The drawing mode.
+        :param Union[List[int],None] indices:
+            Array of vertex indices or None to use arrays directly.
+        :param bool copy: True (default) to copy the data,
+                          False to use as is (do not modify!).
+        """
+        assert mode in ('triangles', 'triangle_strip', 'fan')
+        if position is None or len(position) == 0:
+            mesh = None
+        else:
+            mesh = primitives.ColormapMesh3D(
+                position=position,
+                value=numpy.array(value, copy=False).reshape(-1, 1),  # Make it a 2D array
+                colormap=self._getSceneColormap(),
+                normal=normal,
+                mode=mode,
+                indices=indices,
+                copy=copy)
+        self._setMesh(mesh)
+
+        # Store data range info
+        ColormapMixIn._setRangeFromData(self, self.getValueData(copy=False))
+
+    def getData(self, copy=True):
+        """Get the mesh geometry.
+
+        :param bool copy:
+            True (default) to get a copy,
+            False to get internal representation (do not modify!).
+        :return: The positions, values, normals and mode
+        :rtype: tuple of numpy.ndarray
+        """
+        return (self.getPositionData(copy=copy),
+                self.getValueData(copy=copy),
+                self.getNormalData(copy=copy),
+                self.getDrawMode())
+
+    def getValueData(self, copy=True):
+        """Get the mesh vertex values.
+
+        :param bool copy:
+            True (default) to get a copy,
+            False to get internal representation (do not modify!).
+        :return: Array of data values
+        :rtype: numpy.ndarray
+        """
+        if self._getMesh() is None:
+            return numpy.empty((0,), dtype=numpy.float32)
+        else:
+            return self._getMesh().getAttribute('value', copy=copy)
 
 
 class _CylindricalVolume(DataItem3D):

--- a/silx/gui/plot3d/items/mesh.py
+++ b/silx/gui/plot3d/items/mesh.py
@@ -135,7 +135,7 @@ class Mesh(DataItem3D):
             True (default) to get a copy,
             False to get internal representation (do not modify!).
         :return: The normals as a (N, 3) array, a single normal or None
-        :rtype: numpy.ndarray or None
+        :rtype: Union[numpy.ndarray,None]
         """
         if self._mesh is None:
             return None

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -114,12 +114,10 @@ class ColormapMixIn(_ColormapMixIn):
         self.__sceneColormap = sceneColormap
         self._syncSceneColormap()
 
-        self.sigItemChanged.connect(self.__colormapUpdated)
-
-    def __colormapUpdated(self, event):
+    def _colormapChanged(self):
         """Handle colormap updates"""
-        if event == ItemChangedType.COLORMAP:
-            self._syncSceneColormap()
+        self._syncSceneColormap()
+        super(ColormapMixIn, self)._colormapChanged()
 
     def _setRangeFromData(self, data=None):
         """Compute the data range the colormap should use from provided data.

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -126,7 +126,7 @@ class ColormapMixIn(_ColormapMixIn):
 
         :param data: Data set from which to compute the range or None
         """
-        if data is None or len(data) == 0:
+        if data is None or data.size == 0:
             dataRange = None
         else:
             dataRange = min_max(data, min_positive=True, finite=True)
@@ -143,6 +143,13 @@ class ColormapMixIn(_ColormapMixIn):
 
         if self.getColormap().isAutoscale():
             self._syncSceneColormap()
+
+    def _getDataRange(self):
+        """Returns the data range as used in the scene for colormap
+
+        :rtype: Union[List[float],None]
+        """
+        return self._dataRange
 
     def _setSceneColormap(self, sceneColormap):
         """Set the scene colormap to sync with Colormap object.

--- a/silx/gui/plot3d/items/volume.py
+++ b/silx/gui/plot3d/items/volume.py
@@ -86,7 +86,7 @@ class CutPlane(Item3D, ColormapMixIn, InterpolationMixIn, PlaneMixIn):
             self._setRangeFromData(
                 None if self._dataRange is None else numpy.array(self._dataRange))
 
-            self.sigItemChanged.emit(ItemChangedType.DATA)
+            self._updated(ItemChangedType.DATA)
 
     # Colormap
 
@@ -106,7 +106,7 @@ class CutPlane(Item3D, ColormapMixIn, InterpolationMixIn, PlaneMixIn):
         display = bool(display)
         if display != self.getDisplayValuesBelowMin():
             self._getPlane().colormap.displayValuesBelowMin = display
-            self.sigItemChanged.emit(ItemChangedType.ALPHA)
+            self._updated(ItemChangedType.ALPHA)
 
     def getDataRange(self):
         """Return the range of the data as a 3-tuple of values.

--- a/silx/gui/plot3d/items/volume.py
+++ b/silx/gui/plot3d/items/volume.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -78,11 +78,13 @@ class CutPlane(Item3D, ColormapMixIn, InterpolationMixIn, PlaneMixIn):
     def _parentChanged(self, event):
         """Handle data change in the parent this plane belongs to"""
         if event == ItemChangedType.DATA:
-            self._getPlane().setData(self.sender().getData(copy=False),
-                                     copy=False)
+            data = self.sender().getData(copy=False)
+            self._getPlane().setData(data, copy=False)
 
             # Store data range info as 3-tuple of values
             self._dataRange = self.sender().getDataRange()
+            self._setRangeFromData(
+                None if self._dataRange is None else numpy.array(self._dataRange))
 
             self.sigItemChanged.emit(ItemChangedType.DATA)
 

--- a/silx/gui/plot3d/scene/primitives.py
+++ b/silx/gui/plot3d/scene/primitives.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1878,11 +1878,13 @@ class ColormapMesh3D(Geometry):
                  colormap=None,
                  normal=None,
                  mode='triangles',
-                 indices=None):
+                 indices=None,
+                 copy=True):
         super(ColormapMesh3D, self).__init__(mode, indices,
                                              position=position,
                                              normal=normal,
-                                             value=value)
+                                             value=value,
+                                             copy=copy)
 
         self._lineWidth = 1.0
         self._lineSmooth = True

--- a/silx/gui/plot3d/test/testSceneWidgetPicking.py
+++ b/silx/gui/plot3d/test/testSceneWidgetPicking.py
@@ -216,7 +216,6 @@ class TestSceneWidgetPicking(TestCaseQt, ParametricTestCase):
                 # Picking outside data
                 picking = list(self.widget.pickItems(1, 1))
                 self.assertEqual(len(picking), 0)
-                self.qWait(1*1000)
 
     def testPickMeshWithIndices(self):
         """Test picking of Mesh items defined by indices"""

--- a/silx/gui/plot3d/test/testSceneWidgetPicking.py
+++ b/silx/gui/plot3d/test/testSceneWidgetPicking.py
@@ -59,7 +59,7 @@ class TestSceneWidgetPicking(TestCaseQt, ParametricTestCase):
     def _widgetCenter(self):
         """Returns widget center"""
         size = self.widget.size()
-        return size.width() // 2 - 20, size.height() // 2
+        return size.width() // 2, size.height() // 2
 
     def testPickImage(self):
         """Test picking of ImageData and ImageRgba items"""


### PR DESCRIPTION
This PR mainly adds `indices` to `Mesh` and a `ColormapMesh` item for the `SceneWidget`.
It also improves the handling of data range in the model which has some issue for `Scatter2D|3D` and `ColormapMesh`.
