### PR TITLE
FFT/clfft: choose best device based on ocl class

### DIFF
--- a/silx/math/__init__.py
+++ b/silx/math/__init__.py
@@ -37,4 +37,3 @@ __date__ = "11/05/2017"
 from .histogram import Histogramnd  # noqa
 from .histogram import HistogramndLut  # noqa
 from .medianfilter import medfilt, medfilt1d, medfilt2d
-from .fft import fft

--- a/silx/math/fft/test/test_fft.py
+++ b/silx/math/fft/test/test_fft.py
@@ -89,8 +89,8 @@ class TestFFT(unittest.TestCase):
     def setUpClass(cls):
         super(TestFFT, cls).setUpClass()
         if __have_clfft__:
-            import pyopencl
-            cls.Ctx = pyopencl.create_some_context()
+            from silx.opencl.common import ocl
+            cls.Ctx = ocl.create_context()
 
 
     @classmethod


### PR DESCRIPTION
This PR aims at solving #2383. It also removes the non-lazy import of FFT in `silx.math.__init__.py`, fixing #2375.