### PR TITLE
Update CurvesROIWidget.py

### DIFF
--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -402,9 +402,6 @@ class CurvesROIWidget(qt.QWidget):
                 self._add()
                 self.calculateRois()
 
-    @deprecation.deprecated(reason="API modification",
-                            replacement="setRois",
-                            since_version="0.10.0")
     def fillFromROIDict(self, *args, **kwargs):
         self.roiTable.fillFromROIDict(*args, **kwargs)
 
@@ -562,10 +559,6 @@ class ROITable(TableWidget):
 
         # backward compatibility since 0.10.0
         if isinstance(rois, dict):
-            deprecation.deprecated_warning(name='rois', type_='Parameter',
-                                           reason='Rois should now be a list '
-                                                  'of ROI object',
-                                           since_version="0.10.0")
             for roiName, roi in rois.items():
                 roi['name'] = roiName
                 _roi = ROI._fromDict(roi)


### PR DESCRIPTION
- The method fillFromROIDict does not conflict with anything and it is very explicit. It should not be deprecated.
- If the method setRois wants to issue a deprecation warning when receiving a dict and not a Roi object, then fillFromROIDict should take care of generating that object. Until then, no warnings.