### PR TITLE
Backprojection: compatibility with previous version

### DIFF
--- a/silx/opencl/backprojection.py
+++ b/silx/opencl/backprojection.py
@@ -37,7 +37,8 @@ import numpy as np
 from .common import pyopencl
 from .processing import EventDescription, OpenclProcessing, BufferDescription
 from .sinofilter import SinoFilter
-
+from .sinofilter import fourier_filter as fourier_filter_
+from ..utils.deprecation import deprecated
 
 if pyopencl:
     mf = pyopencl.mem_flags
@@ -104,14 +105,14 @@ class Backprojection(OpenclProcessing):
                                   platformid=platformid, deviceid=deviceid,
                                   profile=profile)
 
-        self.init_geometry(sino_shape, slice_shape, angles, axis_position,
+        self._init_geometry(sino_shape, slice_shape, angles, axis_position,
                            extra_options)
-        self.allocate_memory()
-        self.compute_angles()
-        self.init_kernels()
-        self.init_filter(filter_name)
+        self._allocate_memory()
+        self._compute_angles()
+        self._init_kernels()
+        self._init_filter(filter_name)
 
-    def init_geometry(self, sino_shape, slice_shape, angles, axis_position,
+    def _init_geometry(self, sino_shape, slice_shape, angles, axis_position,
                       extra_options):
         """Geometry Initialization
 
@@ -143,9 +144,9 @@ class Backprojection(OpenclProcessing):
         else:
             self.axis_pos = np.float32((sino_shape[1] - 1.) / 2)
         self.axis_array = None  # TODO: add axis correction front-end
-        self.init_extra_options(extra_options)
+        self._init_extra_options(extra_options)
 
-    def init_extra_options(self, extra_options):
+    def _init_extra_options(self, extra_options):
         """Backprojection extra option initialization
 
         :param dict extra_options: Advanced extra options
@@ -156,7 +157,7 @@ class Backprojection(OpenclProcessing):
         if extra_options is not None:
             self.extra_options.update(extra_options)
 
-    def allocate_memory(self):
+    def _allocate_memory(self):
         # Host memory
         self.slice = np.zeros(self.dimrec_shape, dtype=np.float32)
         self.is_cpu = False
@@ -176,12 +177,12 @@ class Backprojection(OpenclProcessing):
 
         # Texture memory (if relevant)
         if not(self.is_cpu):
-            self.allocate_textures()
+            self._allocate_textures()
 
         # Local memory
         self.local_mem = 256 * 3 * _sizeof(np.float32)  # constant for all image sizes
 
-    def compute_angles(self):
+    def _compute_angles(self):
         if self.angles is None:
             self.angles = np.linspace(0, np.pi, self.num_projs, False)
         h_cos = np.cos(self.angles).astype(np.float32)
@@ -193,7 +194,7 @@ class Backprojection(OpenclProcessing):
         else:
             self.cl_mem["d_axes"][:] = np.ones(self.num_projs, dtype="f") * self.axis_pos
 
-    def init_kernels(self):
+    def _init_kernels(self):
         OpenclProcessing.compile_kernels(self, self.kernel_files)
         # check that workgroup can actually be (16, 16)
         self.compiletime_workgroup_size = self.kernels.max_workgroup_size("backproj_cpu_kernel")
@@ -233,7 +234,7 @@ class Backprojection(OpenclProcessing):
             self._get_local_mem()
         )
 
-    def allocate_textures(self):
+    def _allocate_textures(self):
         """
         Allocate the texture for the sinogram.
         """
@@ -247,7 +248,7 @@ class Backprojection(OpenclProcessing):
             hostbuf=np.zeros(self.shape[::-1], dtype=np.float32)
         )
 
-    def init_filter(self, filter_name):
+    def _init_filter(self, filter_name):
         """Filter initialization
 
         :param str filter_name: filter name
@@ -263,7 +264,7 @@ class Backprojection(OpenclProcessing):
     def _get_local_mem(self):
         return pyopencl.LocalMemory(self.local_mem)  # constant for all image sizes
 
-    def cpy2d_to_slice(self, dst):
+    def _cpy2d_to_slice(self, dst):
         ndrange = (int(self.slice_shape[1]), int(self.slice_shape[0]))
         slice_shape_ocl = np.int32(ndrange)
         wg = None
@@ -278,9 +279,9 @@ class Backprojection(OpenclProcessing):
         )
         return self.kernels.cpy2d(self.queue, ndrange, wg, *kernel_args)
 
-    def transfer_to_texture(self, sino):
+    def _transfer_to_texture(self, sino):
         if isinstance(sino, parray.Array):
-            return self.transfer_device_to_texture(sino)
+            return self._transfer_device_to_texture(sino)
         sino2 = sino
         if not(sino.flags["C_CONTIGUOUS"] and sino.dtype == np.float32):
             sino2 = np.ascontiguousarray(sino, dtype=np.float32)
@@ -303,7 +304,7 @@ class Backprojection(OpenclProcessing):
             what = "transfer filtered sino H->D texture"
         return EventDescription(what, ev)
 
-    def transfer_device_to_texture(self, d_sino):
+    def _transfer_device_to_texture(self, d_sino):
         if self.is_cpu:
             if id(self.d_sino) == id(d_sino):
                 return
@@ -336,7 +337,7 @@ class Backprojection(OpenclProcessing):
         """
         events = []
         with self.sem:
-            events.append(self.transfer_to_texture(sino))
+            events.append(self._transfer_to_texture(sino))
             # Call the backprojection kernel
             if self.is_cpu:
                 kernel_to_call = self.kernels.backproj_cpu_kernel
@@ -354,7 +355,7 @@ class Backprojection(OpenclProcessing):
                 res = res[:self.slice_shape[0], :self.slice_shape[1]]
             else:
                 res = output
-                self.cpy2d_to_slice(output)
+                self._cpy2d_to_slice(output)
 
         # /with self.sem
         if self.profile:
@@ -378,3 +379,18 @@ class Backprojection(OpenclProcessing):
         return res
 
     __call__ = filtered_backprojection
+
+
+    # -------------------
+    # - Compatibility  -
+    # -------------------
+
+    @deprecated(replacement="Backprojection.sino_filter", since_version="0.9")
+    def filter_projections(self, sino, rescale=True):
+        self.sino_filter(sino, output=self.d_sino)
+
+
+
+def fourier_filter(sino, filter_=None, fft_size=None):
+    return fourier_filter_(sino, filter_=filter_, fft_size=fft_size)
+

--- a/silx/opencl/backprojection.py
+++ b/silx/opencl/backprojection.py
@@ -385,7 +385,7 @@ class Backprojection(OpenclProcessing):
     # - Compatibility  -
     # -------------------
 
-    @deprecated(replacement="Backprojection.sino_filter", since_version="0.9")
+    @deprecated(replacement="Backprojection.sino_filter", since_version="0.10")
     def filter_projections(self, sino, rescale=True):
         self.sino_filter(sino, output=self.d_sino)
 

--- a/silx/opencl/sinofilter.py
+++ b/silx/opencl/sinofilter.py
@@ -488,7 +488,7 @@ class SinoFilter(OpenclProcessing):
 # - Compatibility  -
 # -------------------
 
-@deprecated(replacement="Backprojection.sino_filter", since_version="0.9")
+@deprecated(replacement="Backprojection.sino_filter", since_version="0.10")
 def fourier_filter(sino, filter_=None, fft_size=None):
     """Simple np based implementation of fourier space filter.
     This function is deprecated, please use silx.opencl.sinofilter.SinoFilter.

--- a/silx/opencl/sinofilter.py
+++ b/silx/opencl/sinofilter.py
@@ -39,7 +39,14 @@ import pyopencl.array as parray
 from .processing import OpenclProcessing
 from ..math.fft import FFT
 from ..math.fft.clfft import __have_clfft__
+from ..utils.deprecation import deprecated
 
+
+def nextpow2(N):
+    p = 1
+    while p < N:
+        p *= 2
+    return p
 
 def compute_ramlak_filter(dwidth_padded, dtype=np.float32):
     """
@@ -164,13 +171,13 @@ class SinoFilter(OpenclProcessing):
                                   platformid=platformid, deviceid=deviceid,
                                   profile=profile)
 
-        self.calculate_shapes(sino_shape)
-        self.init_fft()
-        self.allocate_memory()
-        self.compute_filter(filter_name, extra_options)
-        self.init_kernels()
+        self._calculate_shapes(sino_shape)
+        self._init_fft()
+        self._allocate_memory()
+        self._compute_filter(filter_name, extra_options)
+        self._init_kernels()
 
-    def calculate_shapes(self, sino_shape):
+    def _calculate_shapes(self, sino_shape):
         """
 
         :param sino_shape: shape of the sinogram.
@@ -190,7 +197,7 @@ class SinoFilter(OpenclProcessing):
         sino_f_shape[-1] = sino_f_shape[-1]//2+1
         self.sino_f_shape = tuple(sino_f_shape)
 
-    def init_extra_options(self, extra_options):
+    def _init_extra_options(self, extra_options):
         """
 
         :param dict extra_options: Advanced extra options.
@@ -202,7 +209,7 @@ class SinoFilter(OpenclProcessing):
         if extra_options is not None:
             self.extra_options.update(extra_options)
 
-    def init_fft(self):
+    def _init_fft(self):
         if __have_clfft__:
             self.fft_backend = "opencl"
             self.fft = FFT(
@@ -223,7 +230,7 @@ class SinoFilter(OpenclProcessing):
                 backend="numpy",
             )
 
-    def allocate_memory(self):
+    def _allocate_memory(self):
         self.d_filter_f = parray.zeros(self.queue, (self.sino_f_shape[-1],), np.complex64)
         self.is_cpu = (self.device.type == "CPU")
         # These are already allocated by FFT() if using the opencl backend
@@ -238,13 +245,13 @@ class SinoFilter(OpenclProcessing):
         self.tmp_sino_device = parray.zeros(self.queue, self.sino_shape, "f")
         self.tmp_sino_host = np.zeros(self.sino_shape, "f")
 
-    def compute_filter(self, filter_name, extra_options):
+    def _compute_filter(self, filter_name, extra_options):
         """
 
         :param str filter_name: filter name
         :param dict extra_options: Advanced extra options.
         """
-        self.init_extra_options(extra_options)
+        self._init_extra_options(extra_options)
         self.filter_name = filter_name or "ram-lak"
         filter_f = compute_fourier_filter(
             self.dwidth_padded,
@@ -279,7 +286,7 @@ class SinoFilter(OpenclProcessing):
         self.filter_f = self.filter_f.astype(np.complex64)
         self.d_filter_f[:] = self.filter_f[:]
 
-    def init_kernels(self):
+    def _init_kernels(self):
         OpenclProcessing.compile_kernels(self, self.kernel_files)
         h, w = self.d_sino_f.shape
         self.mult_kern_args = (
@@ -340,7 +347,7 @@ class SinoFilter(OpenclProcessing):
         so = src_offset
         dst[do[0]:do[0]+s[0], do[1]:do[1]+s[1]] = src[so[0]:so[0]+s[0], so[1]:so[1]+s[1]]
 
-    def prepare_input_sino(self, sino):
+    def _prepare_input_sino(self, sino):
         """
 
         :param sino: sinogram
@@ -375,7 +382,7 @@ class SinoFilter(OpenclProcessing):
             # Rectangular copy H->H
             self.copy2d_host(self.d_sino_padded, h_sino_ref, self.sino_shape)
 
-    def get_output_sino(self, output):
+    def _get_output_sino(self, output):
         """
 
         :param Union[numpy.dtype,None] output: sinogram output.
@@ -415,7 +422,7 @@ class SinoFilter(OpenclProcessing):
                 self.copy2d_host(res, self.d_sino_padded, self.sino_shape)
         return res
 
-    def do_fft(self):
+    def _do_fft(self):
         if self.fft_backend == "opencl":
             self.fft.fft(self.d_sino_padded, output=self.d_sino_f)
             if self.is_cpu:
@@ -426,7 +433,7 @@ class SinoFilter(OpenclProcessing):
             res = self.fft.fft(self.d_sino_padded).astype(np.complex64)
             self.d_sino_f[:] = res[:]
 
-    def multiply_fourier(self):
+    def _multiply_fourier(self):
         if self.fft_backend == "opencl":
             # Everything is on device. Call the multiplication kernel.
             self.kernels.inplace_complex_mul_2Dby1D(
@@ -438,7 +445,7 @@ class SinoFilter(OpenclProcessing):
             # Everything is on host.
             self.d_sino_f *= self.filter_f
 
-    def do_ifft(self):
+    def _do_ifft(self):
         if self.fft_backend == "opencl":
             if self.is_cpu:
                 self.d_sino_padded.fill(0)
@@ -460,16 +467,62 @@ class SinoFilter(OpenclProcessing):
         :return: filtered sinogram
         """
         # Handle input sinogram
-        self.prepare_input_sino(sino)
+        self._prepare_input_sino(sino)
         # FFT
-        self.do_fft()
+        self._do_fft()
         # multiply with filter in the Fourier domain
-        self.multiply_fourier()
+        self._multiply_fourier()
         # iFFT
-        self.do_ifft()
+        self._do_ifft()
         # return
-        res = self.get_output_sino(output)
+        res = self._get_output_sino(output)
         return res
         #~ return output
 
     __call__ = filter_sino
+
+
+
+
+# -------------------
+# - Compatibility  -
+# -------------------
+
+@deprecated(replacement="Backprojection.sino_filter", since_version="0.9")
+def fourier_filter(sino, filter_=None, fft_size=None):
+    """Simple np based implementation of fourier space filter.
+    This function is deprecated, please use silx.opencl.sinofilter.SinoFilter.
+
+    :param sino: of shape shape = (num_projs, num_bins)
+    :param filter: filter function to apply in fourier space
+    :fft_size: size on which perform the fft. May be larger than the sino array
+    :return: filtered sinogram
+    """
+    assert sino.ndim == 2
+    num_projs, num_bins = sino.shape
+    if fft_size is None:
+        fft_size = nextpow2(num_bins * 2 - 1)
+    else:
+        assert fft_size >= num_bins
+    if fft_size == num_bins:
+        sino_zeropadded = sino.astype(np.float32)
+    else:
+        sino_zeropadded = np.zeros((num_projs, fft_size),
+                                      dtype=np.complex64)
+        sino_zeropadded[:, :num_bins] = sino.astype(np.float32)
+
+    if filter_ is None:
+        h = np.zeros(fft_size, dtype=np.float32)
+        L2 = fft_size // 2 + 1
+        h[0] = 1 / 4.
+        j = np.linspace(1, L2, L2 // 2, False)
+        h[1:L2:2] = -1. / (np.pi ** 2 * j ** 2)
+        h[L2:] = np.copy(h[1:L2 - 1][::-1])
+        filter_ = np.fft.fft(h).astype(np.complex64)
+
+    # Linear convolution
+    sino_f = np.fft.fft(sino, fft_size)
+    sino_f = sino_f * filter_
+    sino_filtered = np.fft.ifft(sino_f)[:, :num_bins].real
+
+    return np.ascontiguousarray(sino_filtered.real, dtype=np.float32)


### PR DESCRIPTION
This PR adds a compatibility with the previous  `filter_projections` and `fourier_filter` functions.
- [x] Deprecation warnings for   `filter_projections` and `fourier_filter`
- [x] Make some methods "private"
