### PR TITLE
Feature a SelectManyDataViews object

### DIFF
--- a/silx/gui/data/DataViewer.py
+++ b/silx/gui/data/DataViewer.py
@@ -432,7 +432,7 @@ class DataViewer(qt.QFrame):
         """
         views = []
         for v in self.availableViews():
-            views.extend(v.getMatchableViews())
+            views.extend(v.getReachableViews())
         return views
 
     def availableViews(self):

--- a/silx/gui/data/DataViewer.py
+++ b/silx/gui/data/DataViewer.py
@@ -35,7 +35,7 @@ from silx.gui.data.NumpyAxesSelector import NumpyAxesSelector
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "24/04/2018"
+__date__ = "12/02/2019"
 
 
 _logger = logging.getLogger(__name__)
@@ -344,18 +344,16 @@ class DataViewer(qt.QFrame):
         data = self.__data
         info = self._getInfo()
         # sort available views according to priority
-        priorities = [v.getDataPriority(data, info) for v in self.__views]
-        views = zip(priorities, self.__views)
+        views = []
+        for v in self.__views:
+            views.extend(v.getMatchingViews(data, info))
+        views = [(v.getCachedDataPriority(data, info), v) for v in views]
         views = filter(lambda t: t[0] > DataViews.DataView.UNSUPPORTED, views)
         views = sorted(views, reverse=True)
+        views = [v[1] for v in views]
 
         # store available views
-        if len(views) == 0:
-            self.__setCurrentAvailableViews([])
-            available = []
-        else:
-            available = [v[1] for v in views]
-            self.__setCurrentAvailableViews(available)
+        self.__setCurrentAvailableViews(views)
 
     def __updateView(self):
         """Display the data using the widget which fit the best"""

--- a/silx/gui/data/DataViewer.py
+++ b/silx/gui/data/DataViewer.py
@@ -424,6 +424,17 @@ class DataViewer(qt.QFrame):
         """
         return self.__currentAvailableViews
 
+    def getReachableViews(self):
+        """Returns the list of reachable views from the registred available
+        views.
+
+        :rtype: List[DataView]
+        """
+        views = []
+        for v in self.availableViews():
+            views.extend(v.getMatchableViews())
+        return views
+
     def availableViews(self):
         """Returns the list of registered views
 

--- a/silx/gui/data/DataViewerFrame.py
+++ b/silx/gui/data/DataViewerFrame.py
@@ -27,7 +27,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "24/04/2018"
+__date__ = "12/02/2019"
 
 from silx.gui import qt
 from .DataViewer import DataViewer
@@ -119,6 +119,9 @@ class DataViewerFrame(qt.QWidget):
         :param DataViewHooks context: The hooks to use
         """
         self.__dataViewer.setGlobalHooks(hooks)
+
+    def getReachableViews(self):
+        return self.__dataViewer.getReachableViews()
 
     def availableViews(self):
         """Returns the list of registered views

--- a/silx/gui/data/DataViewerSelector.py
+++ b/silx/gui/data/DataViewerSelector.py
@@ -29,7 +29,7 @@ from __future__ import division
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "23/01/2018"
+__date__ = "12/02/2019"
 
 import weakref
 import functools
@@ -85,7 +85,7 @@ class DataViewerSelector(qt.QWidget):
 
         iconSize = qt.QSize(16, 16)
 
-        for view in self.__dataViewer.availableViews():
+        for view in self.__dataViewer.getReachableViews():
             label = view.label()
             icon = view.icon()
             button = qt.QPushButton(label)
@@ -155,7 +155,7 @@ class DataViewerSelector(qt.QWidget):
         self.__dataViewer.setDisplayedView(view)
 
     def __checkAvailableButtons(self):
-        views = set(self.__dataViewer.availableViews())
+        views = set(self.__dataViewer.getReachableViews())
         if views == set(self.__buttons.keys()):
             return
         # Recreate all the buttons

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -479,7 +479,7 @@ class SelectOneDataView(_CompositeDataView):
     def getMatchingViews(self, data, info):
         view = self.__getBestView(data, info)
         if isinstance(view, SelectManyDataView):
-            return [view.getMatchingViews()]
+            return view.getMatchingViews(data, info)
         else:
             return [self]
 

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -41,7 +41,7 @@ from silx.gui.dialog.ColormapDialog import ColormapDialog
 
 __authors__ = ["V. Valls", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "23/05/2018"
+__date__ = "12/02/2019"
 
 _logger = logging.getLogger(__name__)
 
@@ -377,7 +377,7 @@ class DataView(object):
         return str(self) < str(other)
 
 
-class CompositeDataView(DataView):
+class SelectOneDataView(DataView):
     """Data view which can display a data using different view according to
     the kind of the data."""
 
@@ -386,7 +386,7 @@ class CompositeDataView(DataView):
 
         :param qt.QWidget parent: Parent of the hold widget
         """
-        super(CompositeDataView, self).__init__(parent, modeId, icon, label)
+        super(SelectOneDataView, self).__init__(parent, modeId, icon, label)
         self.__views = OrderedDict()
         self.__currentView = None
 
@@ -395,7 +395,7 @@ class CompositeDataView(DataView):
 
         :param DataViewHooks hooks: The data view hooks to use
         """
-        super(CompositeDataView, self).setHooks(hooks)
+        super(SelectOneDataView, self).setHooks(hooks)
         if hooks is not None:
             for v in self.__views:
                 v.setHooks(hooks)
@@ -502,7 +502,7 @@ class CompositeDataView(DataView):
             if view.modeId() == modeId:
                 oldView = view
                 break
-            elif isinstance(view, CompositeDataView):
+            elif isinstance(view, SelectOneDataView):
                 # recurse
                 hooks = self.getHooks()
                 if hooks is not None:
@@ -517,6 +517,10 @@ class CompositeDataView(DataView):
                 (newView, None) if view is oldView else (view, idx) for
                 view, idx in self.__views.items())
         return True
+
+
+# NOTE: Introduced with silx 0.10
+CompositeDataView = SelectOneDataView
 
 
 class _EmptyView(DataView):

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -365,7 +365,7 @@ class DataView(object):
         """
         return []
 
-    def getMatchableViews(self):
+    def getReachableViews(self):
         """Returns the views that can be returned by `getMatchingViews`.
 
         :param object data: Any object to be displayed
@@ -474,12 +474,12 @@ class SelectOneDataView(_CompositeDataView):
             dataView.setHooks(hooks)
         self.__views[dataView] = None
 
-    def getMatchableViews(self):
+    def getReachableViews(self):
         views = []
         addSelf = False
         for v in self.__views:
             if isinstance(v, SelectManyDataView):
-                views.extend(v.getMatchableViews())
+                views.extend(v.getReachableViews())
             else:
                 addSelf = True
         if addSelf:
@@ -655,10 +655,10 @@ class SelectManyDataView(_CompositeDataView):
         """
         return list(self.__views)
 
-    def getMatchableViews(self):
+    def getReachableViews(self):
         views = []
         for v in self.__views:
-            views.extend(v.getMatchableViews())
+            views.extend(v.getReachableViews())
         return views
 
     def getMatchingViews(self, data, info):

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -424,8 +424,24 @@ class _CompositeDataView(DataView):
         """
         raise NotImplementedError()
 
-    def getDisplayableViews(self):
-        """Returns all view that can possibly be displayed."""
+    def getReachableViews(self):
+        """Returns all views that can be reachable at on point.
+
+        This method return any sub view provided (recursivly).
+
+        :rtype: List[DataView]
+        """
+        raise NotImplementedError()
+
+    def getMatchingViews(self, data, info):
+        """Returns sub views matching this data and info.
+
+        This method return any sub view provided (recursivly).
+
+        :param object data: Any object to be displayed
+        :param DataInfo info: Information cached about this data
+        :rtype: List[DataView]
+        """
         raise NotImplementedError()
 
     @deprecation.deprecated(replacement="getRegisteredViews", since_version="0.10")

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -414,7 +414,7 @@ class CompositeDataView(DataView):
         """
         return list(self.__views.keys())
 
-    def getBestView(self, data, info):
+    def __getBestView(self, data, info):
         """Returns the best view according to priorities."""
         views = [(v.getDataPriority(data, info), v) for v in self.__views.keys()]
         views = filter(lambda t: t[0] > DataView.UNSUPPORTED, views)
@@ -471,12 +471,12 @@ class CompositeDataView(DataView):
         self.__currentView.setData(data)
 
     def axesNames(self, data, info):
-        view = self.getBestView(data, info)
+        view = self.__getBestView(data, info)
         self.__currentView = view
         return view.axesNames(data, info)
 
     def getDataPriority(self, data, info):
-        view = self.getBestView(data, info)
+        view = self.__getBestView(data, info)
         self.__currentView = view
         if view is None:
             return DataView.UNSUPPORTED

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -417,7 +417,7 @@ class DataView(object):
 class _CompositeDataView(DataView):
     """Contains sub views"""
 
-    def getSubViews(self):
+    def getViews(self):
         """Returns the direct sub views registered in this view.
 
         :rtype: List[DataView]
@@ -430,7 +430,7 @@ class _CompositeDataView(DataView):
 
     @deprecation.deprecated(replacement="getRegisteredViews", since_version="0.10")
     def availableViews(self):
-        return self.getSubViews()
+        return self.getViews()
 
 
 class SelectOneDataView(_CompositeDataView):
@@ -483,7 +483,7 @@ class SelectOneDataView(_CompositeDataView):
         else:
             return [self]
 
-    def getSubViews(self):
+    def getViews(self):
         """Returns the list of registered views
 
         :rtype: List[DataView]
@@ -633,7 +633,7 @@ class SelectManyDataView(_CompositeDataView):
             dataView.setHooks(hooks)
         self.__views.append(dataView)
 
-    def getSubViews(self):
+    def getViews(self):
         """Returns the list of registered views
 
         :rtype: List[DataView]

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -641,8 +641,9 @@ class SelectManyDataView(_CompositeDataView):
         return list(self.__views)
 
     def getMatchableViews(self):
-        views = self.__view
-        views = [v.getMatchableViews() for v in views]
+        views = []
+        for v in self.__views:
+            views.extend(v.getMatchableViews())
         return views
 
     def getMatchingViews(self, data, info):

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -595,7 +595,7 @@ class SelectOneDataView(_CompositeDataView):
         return True
 
 
-# NOTE: Introduced with silx 0.10
+# NOTE: SelectOneDataView was introduced with silx 0.10
 CompositeDataView = SelectOneDataView
 
 

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -432,6 +432,17 @@ class _CompositeDataView(DataView):
     def availableViews(self):
         return self.getViews()
 
+    def isSupportedData(self, data, info):
+        """If true, the composite view allow sub views to access to this data.
+        Else this this data is considered as not supported by any of sub views
+        (incliding this composite view).
+
+        :param object data: Any object to be displayed
+        :param DataInfo info: Information cached about this data
+        :rtype: bool
+        """
+        return True
+
 
 class SelectOneDataView(_CompositeDataView):
     """Data view which can display a data using different view according to
@@ -477,6 +488,8 @@ class SelectOneDataView(_CompositeDataView):
         return views
 
     def getMatchingViews(self, data, info):
+        if not self.isSupportedData(data, info):
+            return []
         view = self.__getBestView(data, info)
         if isinstance(view, SelectManyDataView):
             return view.getMatchingViews(data, info)
@@ -492,6 +505,8 @@ class SelectOneDataView(_CompositeDataView):
 
     def __getBestView(self, data, info):
         """Returns the best view according to priorities."""
+        if not self.isSupportedData(data, info):
+            return None
         views = [(v.getCachedDataPriority(data, info), v) for v in self.__views.keys()]
         views = filter(lambda t: t[0] > DataView.UNSUPPORTED, views)
         views = sorted(views, key=lambda t: t[0], reverse=True)
@@ -652,6 +667,8 @@ class SelectManyDataView(_CompositeDataView):
         :param object data: Any object to be displayed
         :param DataInfo info: Information cached about this data
         """
+        if not self.isSupportedData(data, info):
+            return []
         views = [v for v in self.__views if v.getCachedDataPriority(data, info) != DataView.UNSUPPORTED]
         return views
 
@@ -678,6 +695,8 @@ class SelectManyDataView(_CompositeDataView):
         raise RuntimeError("Abstract view")
 
     def getDataPriority(self, data, info):
+        if not self.isSupportedData(data, info):
+            return DataView.UNSUPPORTED
         priorities = [v.getCachedDataPriority(data, info) for v in self.__views]
         priorities = [v for v in priorities if v != DataView.UNSUPPORTED]
         priorities = sorted(priorities)

--- a/silx/gui/data/Hdf5TableView.py
+++ b/silx/gui/data/Hdf5TableView.py
@@ -30,12 +30,14 @@ from __future__ import division
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "05/07/2018"
+__date__ = "12/02/2019"
 
 import collections
 import functools
 import os.path
 import logging
+import h5py
+
 from silx.gui import qt
 import silx.io
 from .TextFormatter import TextFormatter
@@ -43,8 +45,6 @@ import silx.gui.hdf5
 from silx.gui.widgets import HierarchicalTableView
 from ..hdf5.Hdf5Formatter import Hdf5Formatter
 from ..hdf5._utils import htmlFromDict
-
-import h5py
 
 
 _logger = logging.getLogger(__name__)
@@ -195,11 +195,9 @@ class _CellFilterAvailableData(_CellData):
     }
 
     def __init__(self, filterId):
-        import h5py.version
         if h5py.version.hdf5_version_tuple >= (1, 10, 2):
             # Previous versions only returns True if the filter was first used
             # to decode a dataset
-            import h5py.h5z
             self.__availability = h5py.h5z.filter_avail(filterId)
         else:
             self.__availability = "na"


### PR DESCRIPTION
This could be merged in the master if you think it is safe enough for the 0.10.

It prepares #2415

Here is an example: the `NxDataView` could provide 2 views for a 3D data (displayed at the same time). This new views are not part of the PR.
```
        self.addView(_NXdataCurveView(parent))
        self.addView(_NXdataXYVScatterView(parent))
        self.addView(_NXdataImageView(parent))
        self.addView(_NXdataStackView(parent))

        # The 3D view can be displayed using 2 ways
        nx3dViews = SelectManyDataView(parent)
        nx3dViews.addView(_NXdata3dView(parent))
        nx3dViews.addView(_NXdata3dAs2dView(parent))
        self.addView(nx3dViews)
```