### PR TITLE
Improve mask tools GUI

### DIFF
--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -767,6 +767,7 @@ class BaseMaskToolsWidget(qt.QWidget):
         layout.addWidget(container)
 
         form = qt.QFormLayout()
+        form.setContentsMargins(0, 0, 0, 0)
 
         self.minLineLabel = qt.QLabel("Min:", self)
         self.minLineEdit = FloatEdit(self, value=0)
@@ -788,8 +789,6 @@ class BaseMaskToolsWidget(qt.QWidget):
         thresholdWidget = qt.QWidget()
         thresholdWidget.setLayout(form)
         layout.addWidget(thresholdWidget)
-
-        layout.addStretch(1)
 
         self.thresholdGroup = qt.QGroupBox('Threshold')
         self.thresholdGroup.setLayout(layout)

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -480,6 +480,7 @@ class BaseMaskToolsWidget(qt.QWidget):
         layout.addWidget(self._initMaskGroupBox())
         layout.addWidget(self._initDrawGroupBox())
         layout.addWidget(self._initThresholdGroupBox())
+        layout.addWidget(self._initOtherToolsGroupBox())
         layout.addStretch(1)
         self.setLayout(layout)
 
@@ -781,11 +782,6 @@ class BaseMaskToolsWidget(qt.QWidget):
         self.applyMaskBtn.clicked.connect(self._maskBtnClicked)
         form.addRow(self.applyMaskBtn)
 
-        self.maskNanBtn = qt.QPushButton('Mask not finite values')
-        self.maskNanBtn.setToolTip('Mask Not a Number and infinite values')
-        self.maskNanBtn.clicked.connect(self._maskNotFiniteBtnClicked)
-        form.addRow(self.maskNanBtn)
-
         thresholdWidget = qt.QWidget()
         thresholdWidget.setLayout(form)
         layout.addWidget(thresholdWidget)
@@ -798,6 +794,18 @@ class BaseMaskToolsWidget(qt.QWidget):
         return self.thresholdGroup
 
         # track widget visibility and plot active image changes
+
+    def _initOtherToolsGroupBox(self):
+        layout = qt.QVBoxLayout()
+
+        self.maskNanBtn = qt.QPushButton('Mask not finite values')
+        self.maskNanBtn.setToolTip('Mask Not a Number and infinite values')
+        self.maskNanBtn.clicked.connect(self._maskNotFiniteBtnClicked)
+        layout.addWidget(self.maskNanBtn)
+
+        self.otherToolGroup = qt.QGroupBox('Other tools')
+        self.otherToolGroup.setLayout(layout)
+        return self.otherToolGroup
 
     def changeEvent(self, event):
         """Reset drawing action when disabling widget"""

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -768,17 +768,16 @@ class BaseMaskToolsWidget(qt.QWidget):
 
         form = qt.QFormLayout()
 
+        self.minLineLabel = qt.QLabel("Min:", self)
         self.minLineEdit = FloatEdit(self, value=0)
-        self.minLineEdit.setEnabled(False)
-        form.addRow('Min:', self.minLineEdit)
+        form.addRow(self.minLineLabel, self.minLineEdit)
 
+        self.maxLineLabel = qt.QLabel("Max:", self)
         self.maxLineEdit = FloatEdit(self, value=0)
-        self.maxLineEdit.setEnabled(False)
-        form.addRow('Max:', self.maxLineEdit)
+        form.addRow(self.maxLineLabel, self.maxLineEdit)
 
         self.applyMaskBtn = qt.QPushButton('Apply mask')
         self.applyMaskBtn.clicked.connect(self._maskBtnClicked)
-        self.applyMaskBtn.setEnabled(False)
         form.addRow(self.applyMaskBtn)
 
         self.maskNanBtn = qt.QPushButton('Mask not finite values')
@@ -1017,17 +1016,24 @@ class BaseMaskToolsWidget(qt.QWidget):
     def _thresholdActionGroupTriggered(self, triggeredAction):
         """Threshold action group listener."""
         if triggeredAction is self.belowThresholdAction:
-            self.minLineEdit.setEnabled(True)
-            self.maxLineEdit.setEnabled(False)
-            self.applyMaskBtn.setEnabled(True)
+            self.minLineLabel.setVisible(True)
+            self.maxLineLabel.setVisible(False)
+            self.minLineEdit.setVisible(True)
+            self.maxLineEdit.setVisible(False)
+            self.applyMaskBtn.setText("Mask bellow")
         elif triggeredAction is self.betweenThresholdAction:
-            self.minLineEdit.setEnabled(True)
-            self.maxLineEdit.setEnabled(True)
-            self.applyMaskBtn.setEnabled(True)
+            self.minLineLabel.setVisible(True)
+            self.maxLineLabel.setVisible(True)
+            self.minLineEdit.setVisible(True)
+            self.maxLineEdit.setVisible(True)
+            self.applyMaskBtn.setText("Mask between")
         elif triggeredAction is self.aboveThresholdAction:
-            self.minLineEdit.setEnabled(False)
-            self.maxLineEdit.setEnabled(True)
-            self.applyMaskBtn.setEnabled(True)
+            self.minLineLabel.setVisible(False)
+            self.maxLineLabel.setVisible(True)
+            self.minLineEdit.setVisible(False)
+            self.maxLineEdit.setVisible(True)
+            self.applyMaskBtn.setText("Mask above")
+        self.applyMaskBtn.setToolTip(triggeredAction.toolTip())
 
     def _maskBtnClicked(self):
         if self.belowThresholdAction.isChecked():

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -710,9 +710,6 @@ class BaseMaskToolsWidget(qt.QWidget):
 
     def _initThresholdGroupBox(self):
         """Init thresholding widgets"""
-        layout = qt.QVBoxLayout()
-
-        # Thresholing
 
         self.belowThresholdAction = qt.QAction(
                 icons.getQIcon('plot-roi-below'), 'Mask below threshold', None)
@@ -764,27 +761,28 @@ class BaseMaskToolsWidget(qt.QWidget):
         loadColormapRangeBtn.setDefaultAction(self.loadColormapRangeAction)
         widgets.append(loadColormapRangeBtn)
 
-        container = self._hboxWidget(*widgets, stretch=False)
-        layout.addWidget(container)
+        toolBar = self._hboxWidget(*widgets, stretch=False)
 
-        form = qt.QFormLayout()
-        form.setContentsMargins(0, 0, 0, 0)
+        config = qt.QGridLayout()
+        config.setContentsMargins(0, 0, 0, 0)
 
         self.minLineLabel = qt.QLabel("Min:", self)
         self.minLineEdit = FloatEdit(self, value=0)
-        form.addRow(self.minLineLabel, self.minLineEdit)
+        config.addWidget(self.minLineLabel, 0, 0)
+        config.addWidget(self.minLineEdit, 0, 1)
 
         self.maxLineLabel = qt.QLabel("Max:", self)
         self.maxLineEdit = FloatEdit(self, value=0)
-        form.addRow(self.maxLineLabel, self.maxLineEdit)
+        config.addWidget(self.maxLineLabel, 1, 0)
+        config.addWidget(self.maxLineEdit, 1, 1)
 
         self.applyMaskBtn = qt.QPushButton('Apply mask')
         self.applyMaskBtn.clicked.connect(self._maskBtnClicked)
-        form.addRow(self.applyMaskBtn)
 
-        thresholdWidget = qt.QWidget()
-        thresholdWidget.setLayout(form)
-        layout.addWidget(thresholdWidget)
+        layout = qt.QVBoxLayout()
+        layout.addWidget(toolBar)
+        layout.addLayout(config)
+        layout.addWidget(self.applyMaskBtn)
 
         self.thresholdGroup = qt.QGroupBox('Threshold')
         self.thresholdGroup.setLayout(layout)

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -29,7 +29,7 @@ from __future__ import division
 
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "26/11/2018"
+__date__ = "13/02/2019"
 
 import os
 import weakref
@@ -718,27 +718,22 @@ class BaseMaskToolsWidget(qt.QWidget):
         self.belowThresholdAction.setToolTip(
                 'Mask image where values are below given threshold')
         self.belowThresholdAction.setCheckable(True)
-        self.belowThresholdAction.triggered[bool].connect(
-                self._belowThresholdActionTriggered)
+        self.belowThresholdAction.setChecked(True)
 
         self.betweenThresholdAction = qt.QAction(
                 icons.getQIcon('plot-roi-between'), 'Mask within range', None)
         self.betweenThresholdAction.setToolTip(
                 'Mask image where values are within given range')
         self.betweenThresholdAction.setCheckable(True)
-        self.betweenThresholdAction.triggered[bool].connect(
-                self._betweenThresholdActionTriggered)
 
         self.aboveThresholdAction = qt.QAction(
                 icons.getQIcon('plot-roi-above'), 'Mask above threshold', None)
         self.aboveThresholdAction.setToolTip(
                 'Mask image where values are above given threshold')
         self.aboveThresholdAction.setCheckable(True)
-        self.aboveThresholdAction.triggered[bool].connect(
-                self._aboveThresholdActionTriggered)
 
         self.thresholdActionGroup = qt.QActionGroup(self)
-        self.thresholdActionGroup.setExclusive(False)
+        self.thresholdActionGroup.setExclusive(True)
         self.thresholdActionGroup.addAction(self.belowThresholdAction)
         self.thresholdActionGroup.addAction(self.betweenThresholdAction)
         self.thresholdActionGroup.addAction(self.aboveThresholdAction)
@@ -799,6 +794,9 @@ class BaseMaskToolsWidget(qt.QWidget):
 
         self.thresholdGroup = qt.QGroupBox('Threshold')
         self.thresholdGroup.setLayout(layout)
+
+        # Init widget state
+        self._thresholdActionGroupTriggered(self.belowThresholdAction)
         return self.thresholdGroup
 
         # track widget visibility and plot active image changes
@@ -1015,36 +1013,21 @@ class BaseMaskToolsWidget(qt.QWidget):
         return doMask
 
     # Handle threshold UI events
-    def _belowThresholdActionTriggered(self, triggered):
-        if triggered:
-            self.minLineEdit.setEnabled(True)
-            self.maxLineEdit.setEnabled(False)
-            self.applyMaskBtn.setEnabled(True)
-
-    def _betweenThresholdActionTriggered(self, triggered):
-        if triggered:
-            self.minLineEdit.setEnabled(True)
-            self.maxLineEdit.setEnabled(True)
-            self.applyMaskBtn.setEnabled(True)
-
-    def _aboveThresholdActionTriggered(self, triggered):
-        if triggered:
-            self.minLineEdit.setEnabled(False)
-            self.maxLineEdit.setEnabled(True)
-            self.applyMaskBtn.setEnabled(True)
 
     def _thresholdActionGroupTriggered(self, triggeredAction):
         """Threshold action group listener."""
-        if triggeredAction.isChecked():
-            # Uncheck other actions
-            for action in self.thresholdActionGroup.actions():
-                if action is not triggeredAction and action.isChecked():
-                    action.setChecked(False)
-        else:
-            # Disable min/max edit
-            self.minLineEdit.setEnabled(False)
+        if triggeredAction is self.belowThresholdAction:
+            self.minLineEdit.setEnabled(True)
             self.maxLineEdit.setEnabled(False)
-            self.applyMaskBtn.setEnabled(False)
+            self.applyMaskBtn.setEnabled(True)
+        elif triggeredAction is self.betweenThresholdAction:
+            self.minLineEdit.setEnabled(True)
+            self.maxLineEdit.setEnabled(True)
+            self.applyMaskBtn.setEnabled(True)
+        elif triggeredAction is self.aboveThresholdAction:
+            self.minLineEdit.setEnabled(False)
+            self.maxLineEdit.setEnabled(True)
+            self.applyMaskBtn.setEnabled(True)
 
     def _maskBtnClicked(self):
         if self.belowThresholdAction.isChecked():


### PR DESCRIPTION
Few small changes on the threshold tools to improve usability.

It was difficult to know how to use it.

- Split other tools on another group (make the group consistent)
- Setup the text button to know what it will do
- Select a tool by default (the `bellow` tool)
- Hide unused configuration widgets
- Plus some clean up on the layouts

On a side note application could need to add new tools (for pyFAI we could want to add filter designed to remove cosmic rays). With the new group it is more easy to add this kind of buttons.

![screenshot from 2019-02-13 14-44-37](https://user-images.githubusercontent.com/7579321/52716189-89845480-2f9e-11e9-96e3-b0cf37809c2d.png)
