### PR TITLE
Update default symbol

### DIFF
--- a/silx/_config.py
+++ b/silx/_config.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -57,7 +57,7 @@ class Config(object):
     DEFAULT_COLORMAP_NAME = 'gray'
     """Default LUT for the plot widgets.
 
-    The available list of names are availaible in the module
+    The available list of names are available in the module
     :module:`silx.gui.colors`.
 
     .. versionadded:: 0.8
@@ -110,8 +110,8 @@ class Config(object):
     .. versionadded:: 0.9
     """
 
-    DEFAULT_PLOT_SYMBOL = ''
-    """Default marker the item.
+    DEFAULT_PLOT_SYMBOL = 'o'
+    """Default marker of the item.
 
     It will have an influence on PlotWidget items
 

--- a/silx/_config.py
+++ b/silx/_config.py
@@ -110,6 +110,25 @@ class Config(object):
     .. versionadded:: 0.9
     """
 
+    DEFAULT_PLOT_CURVE_SYMBOL = ''
+    """Default marker of the curve item of the plot.
+
+    It will have an influence on PlotWidget curve items
+
+    Supported symbols:
+
+        - 'o', 'Circle'
+        - 'd', 'Diamond'
+        - 's', 'Square'
+        - '+', 'Plus'
+        - 'x', 'Cross'
+        - '.', 'Point'
+        - ',', 'Pixel'
+        - '',  'None'
+
+    .. versionadded:: 0.10
+    """
+
     DEFAULT_PLOT_SYMBOL = 'o'
     """Default marker of the item.
 

--- a/silx/gui/plot/PlotToolButtons.py
+++ b/silx/gui/plot/PlotToolButtons.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -45,6 +45,7 @@ import weakref
 
 from .. import icons
 from .. import qt
+from ... import config
 
 from .items import SymbolMixIn
 
@@ -370,7 +371,7 @@ class SymbolToolButton(PlotToolButton):
 
         slider = qt.QSlider(qt.Qt.Horizontal)
         slider.setRange(1, 20)
-        slider.setValue(SymbolMixIn._DEFAULT_SYMBOL_SIZE)
+        slider.setValue(config.DEFAULT_PLOT_SYMBOL_SIZE)
         slider.setTracking(False)
         slider.valueChanged.connect(self._sizeChanged)
         widgetAction = qt.QWidgetAction(menu)

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2372,7 +2372,7 @@ class PlotWidget(qt.QMainWindow):
     # Defaults
 
     def isDefaultPlotPoints(self):
-        """Return True if default Curve symbol is not, False for no symbol."""
+        """Return True if the default Curve symbol is set and False if not."""
         return self._defaultPlotPoints == silx.config.DEFAULT_PLOT_CURVE_SYMBOL
 
     def setDefaultPlotPoints(self, flag):

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -252,7 +252,7 @@ class PlotWidget(qt.QMainWindow):
 
         self.setDefaultColormap()  # Init default colormap
 
-        self.setDefaultPlotPoints(False)
+        self.setDefaultPlotPoints(silx.config.DEFAULT_PLOT_CURVE_SYMBOL != '')
         self.setDefaultPlotLines(True)
 
         self._limitsHistory = LimitsHistory(self)
@@ -2373,7 +2373,7 @@ class PlotWidget(qt.QMainWindow):
 
     def isDefaultPlotPoints(self):
         """Return True if default Curve symbol is not, False for no symbol."""
-        return self._defaultPlotPoints == silx.config.DEFAULT_PLOT_SYMBOL
+        return self._defaultPlotPoints == silx.config.DEFAULT_PLOT_CURVE_SYMBOL
 
     def setDefaultPlotPoints(self, flag):
         """Set the default symbol of all curves.
@@ -2383,7 +2383,7 @@ class PlotWidget(qt.QMainWindow):
         :param bool flag: True to use 'o' as the default curve symbol,
                           False to use no symbol.
         """
-        self._defaultPlotPoints = silx.config.DEFAULT_PLOT_SYMBOL if flag else ''
+        self._defaultPlotPoints = silx.config.DEFAULT_PLOT_CURVE_SYMBOL if flag else ''
 
         # Reset symbol of all curves
         curves = self.getAllCurves(just_legend=False, withhidden=True)

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2372,8 +2372,8 @@ class PlotWidget(qt.QMainWindow):
     # Defaults
 
     def isDefaultPlotPoints(self):
-        """Return True if default Curve symbol is 'o', False for no symbol."""
-        return self._defaultPlotPoints == 'o'
+        """Return True if default Curve symbol is not, False for no symbol."""
+        return self._defaultPlotPoints == silx.config.DEFAULT_PLOT_SYMBOL
 
     def setDefaultPlotPoints(self, flag):
         """Set the default symbol of all curves.
@@ -2383,7 +2383,7 @@ class PlotWidget(qt.QMainWindow):
         :param bool flag: True to use 'o' as the default curve symbol,
                           False to use no symbol.
         """
-        self._defaultPlotPoints = 'o' if flag else ''
+        self._defaultPlotPoints = silx.config.DEFAULT_PLOT_SYMBOL if flag else ''
 
         # Reset symbol of all curves
         curves = self.getAllCurves(just_legend=False, withhidden=True)

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -441,7 +441,7 @@ class ColormapMixIn(ItemMixInBase):
 class SymbolMixIn(ItemMixInBase):
     """Mix-in class for items with symbol type"""
 
-    _DEFAULT_SYMBOL = config.DEFAULT_PLOT_SYMBOL
+    _DEFAULT_SYMBOL = None
     """Default marker of the item"""
 
     _DEFAULT_SYMBOL_SIZE = config.DEFAULT_PLOT_SYMBOL_SIZE
@@ -459,8 +459,15 @@ class SymbolMixIn(ItemMixInBase):
     """Dict of supported symbols"""
 
     def __init__(self):
-        self._symbol = self._DEFAULT_SYMBOL
-        self._symbol_size = self._DEFAULT_SYMBOL_SIZE
+        if self._DEFAULT_SYMBOL is None:  # Use default from config
+            self._symbol = config.DEFAULT_PLOT_SYMBOL
+        else:
+            self._symbol = self._DEFAULT_SYMBOL
+
+        if self._DEFAULT_SYMBOL_SIZE is None:  # Use default from config
+            self._symbol_size = config.DEFAULT_PLOT_SYMBOL_SIZE
+        else:
+            self._symbol_size = self._DEFAULT_SYMBOL_SIZE
 
     @classmethod
     def getSupportedSymbols(cls):

--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -160,9 +160,6 @@ class Curve(Points, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixIn):
     _DEFAULT_SELECTABLE = True
     """Default selectable state for curves"""
 
-    _DEFAULT_SYMBOL = ''
-    """Default symbol of the curve"""
-
     _DEFAULT_LINEWIDTH = 1.
     """Default line width of the curve"""
 

--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -159,6 +159,9 @@ class Curve(Points, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixIn):
 
     _DEFAULT_SELECTABLE = True
     """Default selectable state for curves"""
+
+    _DEFAULT_SYMBOL = ''
+    """Default symbol of the curve"""
 
     _DEFAULT_LINEWIDTH = 1.
     """Default line width of the curve"""

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -45,9 +45,6 @@ class Scatter(Points, ColormapMixIn):
 
     _DEFAULT_SELECTABLE = True
     """Default selectable state for scatter plots"""
-
-    _DEFAULT_SYMBOL = 'o'
-    """Default symbol of the scatter plots"""
 
     def __init__(self):
         Points.__init__(self)

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -176,8 +176,6 @@ class ColormapMixIn(_ColormapMixIn):
 class SymbolMixIn(_SymbolMixIn):
     """Mix-in class for symbol and symbolSize properties for Item3D"""
 
-    _DEFAULT_SYMBOL = 'o'
-    _DEFAULT_SYMBOL_SIZE = 7.0
     _SUPPORTED_SYMBOLS = collections.OrderedDict((
         ('o', 'Circle'),
         ('d', 'Diamond'),

--- a/silx/sx/_plot.py
+++ b/silx/sx/_plot.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -299,7 +299,7 @@ def imshow(data=None, cmap=None, norm=colors.Colormap.LINEAR,
 
 
 def scatter(x=None, y=None, value=None, size=None,
-            marker='o',
+            marker=None,
             cmap=None, norm=colors.Colormap.LINEAR,
             vmin=None, vmax=None):
     """
@@ -333,8 +333,8 @@ def scatter(x=None, y=None, value=None, size=None,
     :param numpy.ndarray y: 1D array-like of y coordinates
     :param numpy.ndarray value: 1D array-like of data values
     :param float size: Size^2 of the markers
-    :param str marker: Symbol used to represent the points (default: 'o')
-    :param str cmap: The name of the colormap to use for the plot.
+    :param str marker: Symbol used to represent the points
+    :param str cmap: The name of the colormap to use for the plot
     :param str norm: The normalization of the colormap:
                      'linear' (default) or 'log'
     :param float vmin: The value to use for the min of the colormap
@@ -371,7 +371,8 @@ def scatter(x=None, y=None, value=None, size=None,
 
         plt.setData(x, y, value)
         item = plt.getScatterItem()
-        item.setSymbol(marker)
+        if marker is not None:
+            item.setSymbol(marker)
         if size is not None:
             item.setSymbolSize(numpy.sqrt(size))
 

--- a/silx/sx/_plot3d.py
+++ b/silx/sx/_plot3d.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -177,7 +177,7 @@ def points3d(x, y, z=None,
              colormap='viridis',
              vmin=None,
              vmax=None,
-             mode='o'):
+             mode=None):
     """
     Plot a 3D scatter plot in a :class:`~silx.gui.plot3d.SceneWindow.SceneWindow` widget.
 
@@ -239,7 +239,8 @@ def points3d(x, y, z=None,
 
     colormap = Colormap(name=colormap, vmin=vmin, vmax=vmax)
     scatter.setColormap(colormap)
-    scatter.setSymbol(mode)
+    if mode is not None:
+        scatter.setSymbol(mode)
 
     window.show()
 


### PR DESCRIPTION
This extends and modify a bit what's been introduced in PR  #2419.
It makes sure `silx.config.DEFAULT_PLOT_SYMBOL` is used:
- in `plot3d` scatter items
- as the default symbol for `sx.scatter` and `sx.points3d` functions.

There is a change of behavior from the initial PR: What was set by the initial PR was the symbol of curves only, while here it changes the symbol of scatters.
@maurov, is that OK for you?
If you need to set a default symbol for curves as well, I would be in favor of introducing a `silx.config.DEFAULT_PLOT_CURVE_SYMBOL` (default to '') because 2 different default are needed for scatter and curves...