### PR TITLE
OpenCL convolution

### DIFF
--- a/doc/source/modules/opencl/convolution.rst
+++ b/doc/source/modules/opencl/convolution.rst
@@ -1,0 +1,10 @@
+
+.. currentmodule:: silx.opencl
+
+:mod:`convolution`: Convolution
+-------------------------------
+
+.. automodule:: silx.opencl.convolution
+    :members: Convolution, gaussian_kernel
+    :show-inheritance:
+    :undoc-members:

--- a/doc/source/modules/opencl/index.rst
+++ b/doc/source/modules/opencl/index.rst
@@ -11,6 +11,9 @@
    sift/index.rst
    fbp.rst
    sinofilter.rst
+   processing.rst
+   convolution.rst
+   statistics.rst
    medfilt.rst
    codec_cbf.rst
 

--- a/doc/source/modules/opencl/processing.rst
+++ b/doc/source/modules/opencl/processing.rst
@@ -1,0 +1,10 @@
+
+.. currentmodule:: silx.opencl
+
+:mod:`processing`: Processing
+-------------------------------
+
+.. automodule:: silx.opencl.processing
+    :members: OpenclProcessing, KernelContainer
+    :show-inheritance:
+    :undoc-members:

--- a/doc/source/modules/opencl/statistics.rst
+++ b/doc/source/modules/opencl/statistics.rst
@@ -1,0 +1,10 @@
+
+.. currentmodule:: silx.opencl
+
+:mod:`statistics`: Statistics
+-------------------------------
+
+.. automodule:: silx.opencl.statistics
+    :members: Statistics
+    :show-inheritance:
+    :undoc-members:

--- a/silx/opencl/convolution.py
+++ b/silx/opencl/convolution.py
@@ -293,12 +293,10 @@ class Convolution(OpenclProcessing):
             self.Nz
         ]
         if self.kernel_ndim == 2:
-            kernel_args.insert(6, self.kernel.shape[1])
-            kernel_args.insert(7, self.kernel.shape[0])
+            kernel_args.insert(6, np.int32(self.kernel.shape[1]))
         if self.kernel_ndim == 3:
-            kernel_args.insert(6, self.kernel.shape[2])
-            kernel_args.insert(7, self.kernel.shape[1])
-            kernel_args.insert(8, self.kernel.shape[0])
+            kernel_args.insert(6, np.int32(self.kernel.shape[2]))
+            kernel_args.insert(7, np.int32(self.kernel.shape[1]))
         self.kernel_args = tuple(kernel_args)
 
 

--- a/silx/opencl/convolution.py
+++ b/silx/opencl/convolution.py
@@ -127,7 +127,7 @@ class Convolution(OpenclProcessing):
     A class for performing convolution on CPU/GPU with OpenCL.
     """
 
-    def __init__(self, shape, kernel, axes=None, ctx=None,
+    def __init__(self, shape, kernel, axes=None, mode=None, ctx=None,
                  devicetype="all", platformid=None, deviceid=None,
                  profile=False, extra_options=None):
         """Constructor of OpenCL Convolution.
@@ -136,6 +136,7 @@ class Convolution(OpenclProcessing):
         :param kernel: convolution kernel (1D, 2D or 3D).
         :param axes: axes along which the convolution is performed,
             for batched convolutions.
+        :param mode: Boundary handling mode. Default is ??
         :param ctx: actual working context, left to None for automatic
                     initialization from device type or platformid/deviceid
         :param devicetype: type of device, can be "CPU", "GPU", "ACC" or "ALL"

--- a/silx/opencl/convolution.py
+++ b/silx/opencl/convolution.py
@@ -33,7 +33,7 @@ __date__ = "11/02/2019"
 
 import numpy as np
 from math import ceil
-from copy import copy # python2
+from copy import copy  # python2
 from .common import pyopencl as cl
 import pyopencl.array as parray
 from .processing import OpenclProcessing, EventDescription
@@ -167,7 +167,6 @@ class Convolution(OpenclProcessing):
         self._allocate_memory(mode)
         self._init_kernels()
 
-
     def _configure_extra_options(self, extra_options):
         self.extra_options = {
             "allocate_input_array": True,
@@ -180,7 +179,6 @@ class Convolution(OpenclProcessing):
         self.is_cpu = (self.device.type == "CPU")
         self.use_textures = not(self.extra_options["dont_use_textures"])
         self.use_textures *= not(self.is_cpu)
-
 
     def _get_dimensions(self, shape, kernel):
         self.shape = shape
@@ -198,7 +196,6 @@ class Convolution(OpenclProcessing):
         self.Nx = np.int32(Nx)
         self.Ny = np.int32(Ny)
         self.Nz = np.int32(Nz)
-
 
     def _determine_use_case(self, shape, kernel, axes):
         """
@@ -251,7 +248,6 @@ class Convolution(OpenclProcessing):
         if self.use_textures:
             for i, kern_name in enumerate(self.use_case_kernels):
                 self.use_case_kernels[i] = kern_name + "_tex"
-
 
     def _allocate_memory(self, mode):
         self.mode = mode or "reflect"
@@ -306,12 +302,10 @@ class Convolution(OpenclProcessing):
         #
         self._c_conv_mode = mp[self.mode]
 
-
     def _allocate_textures(self):
         self.data_in_tex = self.allocate_texture(self.shape)
         self.d_kernel_tex = self.allocate_texture(self.kernel.shape)
         self.transfer_to_texture(self.d_kernel, self.d_kernel_tex)
-
 
     def _init_kernels(self):
         if self.kernel_ndim > 1:
@@ -373,7 +367,6 @@ class Convolution(OpenclProcessing):
                 # TODO
                 raise NotImplementedError("For now, data_tmp has to be allocated")
 
-
     def _get_swapped_arrays(self, i):
         """
         Get the input and output arrays to use when using a "swap pattern".
@@ -395,7 +388,6 @@ class Convolution(OpenclProcessing):
         d_out = getattr(self, out_ref)
         return d_in, d_out
 
-
     def _configure_kernel_args(self, opencl_kernel_args, input_ref, output_ref):
         # TODO more elegant
         if isinstance(input_ref, parray.Array):
@@ -411,7 +403,6 @@ class Convolution(OpenclProcessing):
             opencl_kernel_args = tuple(opencl_kernel_args)
         return opencl_kernel_args
 
-
     @staticmethod
     def _check_dimensions(arr=None, shape=None, name="", dim_min=1, dim_max=3):
         if shape is not None:
@@ -426,7 +417,6 @@ class Convolution(OpenclProcessing):
             )
         return ndim
 
-
     def _check_array(self, arr):
         # TODO allow cl.Buffer
         if not(isinstance(arr, parray.Array) or isinstance(arr, np.ndarray)):
@@ -436,7 +426,6 @@ class Convolution(OpenclProcessing):
             raise TypeError("Data must be float32")
         if arr.shape != self.shape:
             raise ValueError("Expected data shape = %s" % str(self.shape))
-
 
     def _set_arrays(self, array, output=None):
         # When using textures: copy
@@ -462,14 +451,12 @@ class Convolution(OpenclProcessing):
             self.data_out
         )
 
-
     def _separable_convolution(self):
         assert len(self.axes) == len(self.use_case_kernels)
         # Separable: one kernel call per data dimension
         for i, axis in enumerate(self.axes):
             in_ref, out_ref = self._get_swapped_arrays(i)
             self._batched_convolution(axis, input_ref=in_ref, output_ref=out_ref)
-
 
     def _batched_convolution(self, axis, input_ref=None, output_ref=None):
         # Batched: one kernel call in total
@@ -483,14 +470,12 @@ class Convolution(OpenclProcessing):
         if self.profile:
             self.events.append(EventDescription("batched convolution", ev))
 
-
     def _nd_convolution(self):
         assert len(self.use_case_kernels) == 1
         opencl_kernel = self.kernels.get_kernel(self.use_case_kernels[0])
         ev = opencl_kernel(*self.kernel_args)
         if self.profile:
             self.events.append(EventDescription("ND convolution", ev))
-
 
     def _recover_arrays_references(self):
         if self._old_input_ref is not None:
@@ -505,7 +490,6 @@ class Convolution(OpenclProcessing):
             self.data_out
         )
 
-
     def _get_output(self, output):
         if output is None:
             res = self.data_out.get()
@@ -515,7 +499,6 @@ class Convolution(OpenclProcessing):
                 output[:] = self.data_out[:]
         self._recover_arrays_references()
         return res
-
 
     def convolve(self, array, output=None):
         """
@@ -530,7 +513,7 @@ class Convolution(OpenclProcessing):
             if self.separable:
                 self._separable_convolution()
             elif self.batched:
-                assert len(self.axes) == 1 #
+                assert len(self.axes) == 1
                 self._batched_convolution(self.axes[0])
             # else: ND-ND convol
         else:
@@ -542,7 +525,6 @@ class Convolution(OpenclProcessing):
 
 
     __call__ = convolve
-
 
 
 def gaussian_kernel(sigma, cutoff=4, force_odd_size=False):

--- a/silx/opencl/convolution.py
+++ b/silx/opencl/convolution.py
@@ -280,48 +280,26 @@ class Convolution(OpenclProcessing):
         )
         self.ndrange = np.int32(self.shape)[::-1]
         self.wg = None
-        if self.kernel_ndim == 1:
-            self.kernel_args = (
-                self.queue,
-                self.ndrange,
-                self.wg,
-                self.data_in.data,
-                self.data_out.data,
-                self.d_kernel.data,
-                np.int32(self.kernel.shape[0]),
-                self.Nx,
-                self.Ny,
-                self.Nz
-            )
-        elif self.kernel_ndim == 2:
-            self.kernel_args = (
-                self.queue,
-                self.ndrange,
-                self.wg,
-                self.data_in.data,
-                self.data_out.data,
-                self.d_kernel.data,
-                np.int32(self.kernel.shape[1]),
-                np.int32(self.kernel.shape[0]),
-                self.Nx,
-                self.Ny,
-                self.Nz
-            )
-        else:
-            self.kernel_args = (
-                self.queue,
-                self.ndrange,
-                self.wg,
-                self.data_in.data,
-                self.data_out.data,
-                self.d_kernel.data,
-                np.int32(self.kernel.shape[2]),
-                np.int32(self.kernel.shape[1]),
-                np.int32(self.kernel.shape[0]),
-                self.Nx,
-                self.Ny,
-                self.Nz
-            )
+        kernel_args = [
+            self.queue,
+            self.ndrange,
+            self.wg,
+            self.data_in.data,
+            self.data_out.data,
+            self.d_kernel.data,
+            np.int32(self.kernel.shape[0]),
+            self.Nx,
+            self.Ny,
+            self.Nz
+        ]
+        if self.kernel_ndim == 2:
+            kernel_args.insert(6, self.kernel.shape[1])
+            kernel_args.insert(7, self.kernel.shape[0])
+        if self.kernel_ndim == 3:
+            kernel_args.insert(6, self.kernel.shape[2])
+            kernel_args.insert(7, self.kernel.shape[1])
+            kernel_args.insert(8, self.kernel.shape[0])
+        self.kernel_args = tuple(kernel_args)
 
 
         # If self.data_tmp is allocated, separable transforms can be performed

--- a/silx/opencl/convolution.py
+++ b/silx/opencl/convolution.py
@@ -164,7 +164,7 @@ class Convolution(OpenclProcessing):
             "allocate_input_array": True,
             "allocate_output_array": True,
             "allocate_tmp_array": True,
-            "dont_use_textures": False,
+            "dont_use_textures": True,
         }
         extra_opts = extra_options or {}
         self.extra_options.update(extra_opts)

--- a/silx/opencl/convolution.py
+++ b/silx/opencl/convolution.py
@@ -282,9 +282,16 @@ class Convolution(OpenclProcessing):
             "reflect": 0,
             "constant": 3,
         }
-        if self.mode.lower() not in self.textures_modes_mapping:
-            raise ValueError("Mode %s is not available for textures" % self.mode)
-        self._c_conv_mode = self.textures_modes_mapping[self.mode]
+        mp = self.textures_modes_mapping
+        if self.mode.lower() not in mp:
+            raise ValueError(
+                """
+                Mode %s is not available for textures. Available modes are:
+                %s
+                """
+                % (self.mode, str(mp.keys()))
+            )
+        self._c_conv_mode = mp[self.mode]
 
 
     def _init_kernels(self):
@@ -298,7 +305,7 @@ class Convolution(OpenclProcessing):
             compile_options = [
                 str("-DIMAGE_DIMS=%d" % self.data_ndim),
                 str("-DFILTER_DIMS=%d" % self.kernel_ndim),
-                str("-DCONV_MODE=%d" % self._c_conv_mode),
+                str("-DUSED_CONV_MODE=%d" % self._c_conv_mode),
             ]
             data_in_ref = self.data_in_tex
             d_kernel_ref = self.d_kernel_tex

--- a/silx/opencl/convolution.py
+++ b/silx/opencl/convolution.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,8 @@ __license__ = "MIT"
 __date__ = "11/02/2019"
 
 import numpy as np
-from copy import copy
+from math import ceil
+from copy import copy # python2
 from .common import pyopencl as cl
 import pyopencl.array as parray
 from .processing import OpenclProcessing, EventDescription
@@ -543,3 +544,30 @@ class Convolution(OpenclProcessing):
     __call__ = convolve
 
 
+
+def gaussian_kernel(sigma, cutoff=4, force_odd_size=False):
+    """
+    Generates a Gaussian convolution kernel.
+
+    :param sigma: Standard Deviation of the Gaussian curve.
+    :param cutoff: Parameter tuning the truncation of the Gaussian.
+        The higher cutoff, the biggest the array will be (and the closest to
+        a "true" Gaussian function).
+    :param force_odd_size: when set to True, the resulting array will always
+        have an odd size, regardless of the values of "sigma" and "cutoff".
+    :return: a numpy.ndarray containing the truncated Gaussian function.
+        The array size is 2*c*s+1 where c=cutoff, s=sigma.
+
+    Nota: due to the quick decay of the Gaussian function, small values of the
+        "cutoff" parameter are usually fine. The energy difference between a
+        Gaussian truncated to [-c, c] and a "true" one is
+            erfc(c/(sqrt(2)*s))
+        so choosing cutoff=4*sigma keeps the truncation error below 1e-4.
+    """
+    size = int(ceil(2 * cutoff * sigma + 1))
+    if force_odd_size and size % 2 == 0:
+        size += 1
+    x = np.arange(size) - (size - 1.0) / 2.0
+    g = np.exp(-(x / sigma) ** 2 / 2.0)
+    g /= g.sum()
+    return g

--- a/silx/opencl/processing.py
+++ b/silx/opencl/processing.py
@@ -309,7 +309,7 @@ class OpenclProcessing(object):
         """
         copy_args = [self.queue, tex_ref, arr]
         copy_kwargs = {"origin":(0, 0), "region": arr.shape[::-1]}
-        if not(isinstance(arr, np.ndarray)): # assuming pyopencl.array.Array
+        if not(isinstance(arr, numpy.ndarray)): # assuming pyopencl.array.Array
             # D->D copy
             copy_args[2] = arr.data
             copy_kwargs["offset"] = 0

--- a/silx/opencl/test/__init__.py
+++ b/silx/opencl/test/__init__.py
@@ -38,6 +38,7 @@ from ..codec import test as test_codec
 from . import test_image
 from . import test_kahan
 from . import test_stats
+from . import test_convolution
 
 
 def suite():

--- a/silx/opencl/test/__init__.py
+++ b/silx/opencl/test/__init__.py
@@ -52,6 +52,7 @@ def suite():
     test_suite.addTests(test_image.suite())
     test_suite.addTests(test_kahan.suite())
     test_suite.addTests(test_stats.suite())
+    test_suite.addTests(test_convolution.suite())
     # Allow to remove sift from the project
     test_base_dir = os.path.dirname(__file__)
     sift_dir = os.path.join(test_base_dir, "..", "sift")

--- a/silx/opencl/test/test_convolution.py
+++ b/silx/opencl/test/test_convolution.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+
+"""
+Test of the Convolution class.
+"""
+
+from __future__ import division, print_function
+
+__authors__ = ["Pierre Paleo"]
+__contact__ = "pierre.paleo@esrf.fr"
+__license__ = "MIT"
+__copyright__ = "2019 European Synchrotron Radiation Facility, Grenoble, France"
+__date__ = "15/02/2019"
+
+import logging
+import numpy as np
+from math import ceil
+try:
+    from scipy.ndimage import convolve, convolve1d
+    from scipy.misc import ascent
+    scipy_convolve = convolve
+    scipy_convolve1d = convolve1d
+except ImportError:
+    scipy_convolve = None
+import unittest
+from ..common import ocl
+if ocl:
+    import pyopencl
+    import pyopencl.array
+    from ..convolution import Convolution
+logger = logging.getLogger(__name__)
+
+
+# TODO move elsewhere
+def gaussian_kernel(sigma, cutoff=4, force_odd_size=False):
+    size = int(ceil(2 * cutoff * sigma + 1))
+    if force_odd_size and size % 2 == 0:
+        size += 1
+    x = np.arange(size) - (size - 1.0) / 2.0
+    g = np.exp(-(x / sigma) ** 2 / 2.0)
+    g /= g.sum()
+    return g
+
+
+@unittest.skipUnless(ocl and scipy_convolve, "PyOpenCl/scipy is missing")
+class TestConvolution(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestConvolution, cls).setUpClass()
+        cls.image = ascent().astype("f")
+        cls.kernel = gaussian_kernel(1.)
+        cls.ctx = ocl.create_context()
+        cls.tol = 1e-4
+
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.image = None
+
+
+    @staticmethod
+    def compare(arr1, arr2):
+        return np.max(np.abs(arr1 - arr2))
+
+
+    def test_1D(self):
+        data = self.image[0]
+        conv = Convolution(data.shape, self.kernel, ctx=self.ctx)
+        res = conv(data)
+        ref = scipy_convolve1d(data, self.kernel, mode="wrap")
+        metric = self.compare(res, ref)
+        logger.info("test_1D: max error = %.2e" % metric)
+        self.assertLess(metric, self.tol, "Something wrong with 1D convolution")
+
+
+    def test_separable_2D(self):
+        data = self.image
+        conv = Convolution(data.shape, self.kernel, ctx=self.ctx)
+        res = conv(data)
+        ref1 = scipy_convolve1d(data, self.kernel, mode="wrap", axis=1)
+        ref = scipy_convolve1d(ref1, self.kernel, mode="wrap", axis=0)
+        metric = self.compare(res, ref)
+        logger.info("test_separable_2D: max error = %.2e" % metric)
+        self.assertLess(
+            metric,
+            self.tol,
+            "Something wrong with separable 2D convolution"
+        )
+
+
+
+def suite():
+    testSuite = unittest.TestSuite()
+    testSuite.addTest(TestConvolution("test_1D"))
+    testSuite.addTest(TestConvolution("test_separable_2D"))
+    return testSuite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest="suite")

--- a/silx/opencl/test/test_convolution.py
+++ b/silx/opencl/test/test_convolution.py
@@ -39,7 +39,6 @@ __date__ = "15/02/2019"
 import logging
 from itertools import product
 import numpy as np
-from math import ceil
 from silx.utils.testutils import parameterize
 try:
     from scipy.ndimage import convolve, convolve1d
@@ -50,24 +49,11 @@ except ImportError:
     scipy_convolve = None
 import unittest
 from ..common import ocl
-#~ from silx.opencl.common import ocl
 if ocl:
     import pyopencl as cl
     import pyopencl.array as parray
-    from ..convolution import Convolution
-    #~ from silx.opencl.convolution import Convolution
+    from ..convolution import Convolution, gaussian_kernel
 logger = logging.getLogger(__name__)
-
-
-# TODO move elsewhere
-def gaussian_kernel(sigma, cutoff=4, force_odd_size=False):
-    size = int(ceil(2 * cutoff * sigma + 1))
-    if force_odd_size and size % 2 == 0:
-        size += 1
-    x = np.arange(size) - (size - 1.0) / 2.0
-    g = np.exp(-(x / sigma) ** 2 / 2.0)
-    g /= g.sum()
-    return g
 
 
 @unittest.skipUnless(ocl and scipy_convolve, "PyOpenCl/scipy is missing")

--- a/silx/opencl/test/test_convolution.py
+++ b/silx/opencl/test/test_convolution.py
@@ -135,19 +135,10 @@ class TestConvolution(unittest.TestCase):
 
     def test_1D(self):
         data = self.image[0]
-        self.kernel = np.array([0, 1, 0], dtype="f")# DEBUG
         conv = self.instantiate_convol(data.shape, self.kernel)
         res = conv(data)
         ref = scipy_convolve1d(data, self.kernel, mode=self.mode)
         metric = self.compare(res, ref)
-        #
-        #~ import matplotlib.pyplot as plt
-        #~ plt.figure()
-        #~ plt.plot(res)
-        #~ plt.plot(ref)
-        #~ plt.title(str("%s/%s - %s" % (conv.mode, self.mode, conv.use_textures)))
-        #~ plt.show()
-        #
         logger.info("test_1D: max error = %.2e" % metric)
         self.assertLess(metric, self.tol["1D"], self.print_err(conv))
 
@@ -223,10 +214,9 @@ class TestConvolution(unittest.TestCase):
 
 
 def test_convolution():
-    #~ boundary_handling_ = ["reflect"]
     boundary_handling_ = ["reflect", "nearest", "wrap", "constant"]
-    #~ use_textures_ = [True, False]
-    use_textures_ = [True] # DEBUG
+    use_textures_ = [True, False]
+    #~ use_textures_ = [True] # DEBUG
     #~ input_gpu_ = [True, False]
     input_gpu_ = [False] # DEBUG
     #~ output_gpu_ = [True, False]
@@ -240,6 +230,8 @@ def test_convolution():
         output_gpu_
     ))
     for boundary_handling, use_textures, input_gpu, output_gpu in param_vals:
+        if not(use_textures) and boundary_handling == "constant":
+            continue # NIY
         testcase = parameterize(
             TestConvolution,
             param={

--- a/silx/opencl/test/test_convolution.py
+++ b/silx/opencl/test/test_convolution.py
@@ -77,10 +77,12 @@ class TestConvolution(unittest.TestCase):
     def setUpClass(cls):
         super(TestConvolution, cls).setUpClass()
         cls.image = np.ascontiguousarray(ascent()[:, :511], dtype="f")
+        cls.data1d = cls.image[0]
+        cls.data2d = cls.image
         cls.data3d = np.tile(cls.image[224:-224, 224:-224], (62, 1, 1))
-        cls.kernel = gaussian_kernel(1.)
-        cls.kernel2d = np.outer(cls.kernel, cls.kernel)
-        cls.kernel3d = np.multiply.outer(cls.kernel2d, cls.kernel)
+        cls.kernel1d = gaussian_kernel(1.)
+        cls.kernel2d = np.outer(cls.kernel1d, cls.kernel1d)
+        cls.kernel3d = np.multiply.outer(cls.kernel2d, cls.kernel1d)
         cls.ctx = ocl.create_context()
         cls.tol = {
             "1D": 1e-4,
@@ -90,7 +92,8 @@ class TestConvolution(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.image = cls.data3d = cls.kernel = cls.kernel2d = cls.kernel3d = None
+        cls.data1d = cls.data2d = cls.data3d = cls.image = None
+        cls.kernel1d = cls.kernel2d = cls.kernel3d = None
 
     @staticmethod
     def compare(arr1, arr2):
@@ -137,67 +140,76 @@ class TestConvolution(unittest.TestCase):
         )
         return C
 
+    def get_data_and_kernel(self, test_name):
+        dims = {
+            "test_1D": (1, 1),
+            "test_separable_2D": (2, 1),
+            "test_separable_3D": (3, 1),
+            "test_nonseparable_2D": (2, 2),
+            "test_nonseparable_3D":  (3, 3),
+        }
+        dim_data = {
+            1: self.data1d,
+            2: self.data2d,
+            3: self.data3d
+        }
+        dim_kernel = {
+            1: self.kernel1d,
+            2: self.kernel2d,
+            3: self.kernel3d,
+        }
+        dd, kd = dims[test_name]
+        return dim_data[dd], dim_kernel[kd]
+
+    def get_reference_function(self, test_name):
+        ref_func = {
+            "test_1D":
+                lambda x, y : scipy_convolve1d(x, y, mode=self.mode),
+            "test_separable_2D":
+                lambda x, y : scipy_convolve1d(
+                    scipy_convolve1d(x, y, mode=self.mode, axis=1),
+                    y, mode=self.mode, axis=0
+                ),
+            "test_separable_3D":
+                lambda x, y: scipy_convolve1d(
+                    scipy_convolve1d(
+                        scipy_convolve1d(x, y, mode=self.mode, axis=2),
+                        y, mode=self.mode, axis=1),
+                    y, mode=self.mode, axis=0
+                ),
+            "test_nonseparable_2D":
+                lambda x, y: scipy_convolve(x, y, mode=self.mode),
+            "test_nonseparable_3D":
+                lambda x, y : scipy_convolve(x, y, mode=self.mode),
+        }
+        return ref_func[test_name]
+
+    def template_test(self, test_name):
+        data, kernel = self.get_data_and_kernel(test_name)
+        conv = self.instantiate_convol(data.shape, kernel)
+        res = conv(data)
+        ref_func = self.get_reference_function(test_name)
+        ref = ref_func(data, kernel)
+        metric = self.compare(res, ref)
+        logger.info("%s: max error = %.2e" % (test_name, metric))
+        tol = self.tol[str("%dD" % kernel.ndim)]
+        self.assertLess(metric, tol, self.print_err(conv))
 
     def test_1D(self):
-        data = self.image[0]
-        conv = self.instantiate_convol(data.shape, self.kernel)
-        res = conv(data)
-        ref = scipy_convolve1d(data, self.kernel, mode=self.mode)
-        metric = self.compare(res, ref)
-        logger.info("test_1D: max error = %.2e" % metric)
-        self.assertLess(metric, self.tol["1D"], self.print_err(conv))
+        self.template_test("test_1D")
 
-
-    #~ @unittest.skipUnless(False, "WIP")
     def test_separable_2D(self):
-        data = self.image
-        conv = self.instantiate_convol(data.shape, self.kernel)
-        res = conv(data)
-        ref1 = scipy_convolve1d(data, self.kernel, mode=self.mode, axis=1)
-        ref = scipy_convolve1d(ref1, self.kernel, mode=self.mode, axis=0)
-        metric = self.compare(res, ref)
-        logger.info("test_separable_2D: max error = %.2e" % metric)
-        self.assertLess(metric, self.tol["1D"], self.print_err(conv))
+        self.template_test("test_separable_2D")
 
-
-    #~ @unittest.skipUnless(False, "WIP")
     def test_separable_3D(self):
-        data = np.tile(self.image, (64, 1, 1))
-        conv = self.instantiate_convol(data.shape, self.kernel)
-        res = conv(data)
-        ref1 = scipy_convolve1d(data, self.kernel, mode=self.mode, axis=2)
-        ref2 = scipy_convolve1d(ref1, self.kernel, mode=self.mode, axis=1)
-        ref = scipy_convolve1d(ref2, self.kernel, mode=self.mode, axis=0)
-        metric = self.compare(res, ref)
-        logger.info("test_separable_3D: max error = %.2e" % metric)
-        self.assertLess(metric, self.tol["1D"], self.print_err(conv))
+        self.template_test("test_separable_3D")
 
-
-    #~ @unittest.skipUnless(False, "WIP")
     def test_nonseparable_2D(self):
-        data = self.image
-        kernel = np.outer(self.kernel, self.kernel) # "non-separable" kernel
-        conv = self.instantiate_convol(data.shape, kernel)
-        res = conv(data)
-        ref = scipy_convolve(data, kernel, mode=self.mode)
-        metric = self.compare(res, ref)
-        logger.info("test_nonseparable_2D: max error = %.2e" % metric)
-        self.assertLess(metric, self.tol["2D"], self.print_err(conv))
+        self.template_test("test_nonseparable_2D")
 
-
-    #~ @unittest.skipUnless(False, "WIP")
     def test_nonseparable_3D(self):
-        data = self.data3d
-        kernel = self.kernel3d
-        conv = self.instantiate_convol(data.shape, kernel)
-        res = conv(data)
-        ref = scipy_convolve(data, kernel, mode=self.mode)
-        metric = self.compare(res, ref)
-        logger.info("test_nonseparable_3D: max error = %.2e" % metric)
-        self.assertLess(metric, self.tol["3D"], self.print_err(conv))
+        self.template_test("test_nonseparable_3D")
 
-
-    #~ @unittest.skipUnless(False, "WIP")
     def test_batched_2D(self):
         """
         Test batched (nonseparable) 2D convolution on 3D data.

--- a/silx/resources/opencl/convolution.cl
+++ b/silx/resources/opencl/convolution.cl
@@ -1,7 +1,5 @@
 #define MAX_CONST_SIZE 16384
 
-
-
 /******************************************************************************/
 /**************************** Macros ******************************************/
 /******************************************************************************/
@@ -27,7 +25,6 @@
 #define CONV_PERIODIC_IDX_X int idx_x = gidx - c + jx; if (idx_x < 0) idx_x += Nx; if (idx_x >= Nx) idx_x -= Nx;
 #define CONV_PERIODIC_IDX_Y int idx_y = gidy - c + jy; if (idx_y < 0) idx_y += Ny; if (idx_y >= Ny) idx_y -= Ny;
 #define CONV_PERIODIC_IDX_Z int idx_z = gidz - c + jz; if (idx_z < 0) idx_z += Nz; if (idx_z >= Nz) idx_z -= Nz;
-
 
 
 /******************************************************************************/
@@ -93,7 +90,6 @@ __kernel void convol_1D_Y(
 }
 
 
-
 // Convolution with 1D kernel along axis "Z"
 // Works for batched 1D on 2D and batched 2D on 3D, along axis "Z".
 __kernel void convol_1D_Z(
@@ -122,6 +118,10 @@ __kernel void convol_1D_Z(
     output[(gidz*Ny + gidy)*Nx + gidx] = sum;
 }
 
+
+/******************************************************************************/
+/**************************** 2D Convolution **********************************/
+/******************************************************************************/
 
 // Convolution with 2D kernel
 // Works for batched 2D on 3D.
@@ -154,7 +154,6 @@ __kernel void convol_2D_XY(
     }
     output[(gidz*Ny + gidy)*Nx + gidx] = sum;
 }
-
 
 
 // Convolution with 2D kernel
@@ -223,6 +222,11 @@ __kernel void convol_2D_YZ(
 }
 
 
+
+/******************************************************************************/
+/**************************** 3D Convolution **********************************/
+/******************************************************************************/
+
 // Convolution with 3D kernel
 __kernel void convol_3D_XYZ(
     const __global float * input,
@@ -257,157 +261,4 @@ __kernel void convol_3D_XYZ(
     }
     output[(gidz*Ny + gidy)*Nx + gidx] = sum;
 }
-
-
-
-
-
-
-
-///
-/// Horizontal convolution (along fast dim)
-///
-
-__kernel void horizontal_convolution(
-    const __global float * input,  // input array
-    __global float * output, // output array
-    __global float * filter,// __attribute__((max_constant_size(MAX_CONST_SIZE))), // filter coefficients
-    int hlen,       // filter size
-    int IMAGE_W,
-    int IMAGE_H,
-    int IMAGE_Z
-)
-{
-    int gidz = (int) get_global_id(2); // slow dim
-    int gidy = (int) get_global_id(1);
-    int gidx = (int) get_global_id(0); // fast dim
-
-    if (gidy < IMAGE_H && gidx < IMAGE_W && gidz < IMAGE_Z) {
-
-        int c, hL, hR;
-        if (hlen & 1) { // odd kernel size
-            c = hlen/2;
-            hL = c;
-            hR = c;
-        }
-        else { // even kernel size : center is shifted to the left
-            c = hlen/2 - 1;
-            hL = c;
-            hR = c+1;
-        }
-        int jx1 = c - gidx;
-        int jx2 = IMAGE_W - 1 - gidx + c;
-        float sum = 0.0f;
-
-        // Convolution with boundaries extension
-        for (int jx = 0; jx <= hR+hL; jx++) {
-            int idx_x = gidx - c + jx;
-            if (jx < jx1) idx_x = jx1-jx-1;
-            if (jx > jx2) idx_x = IMAGE_W - (jx-jx2);
-
-            sum += input[(gidz*IMAGE_H + gidy)*IMAGE_W + idx_x] * filter[hlen-1 - jx];
-        }
-        output[(gidz*IMAGE_H + gidy)*IMAGE_W + gidx] =  sum;
-    }
-}
-
-
-///
-/// Vertical convolution
-///
-
-__kernel void vertical_convolution(
-    const __global float * input,  // input array
-    __global float * output, // output array
-    __global float * filter,// __attribute__((max_constant_size(MAX_CONST_SIZE))), // filter coefficients
-    int hlen,       // filter size
-    int IMAGE_W,
-    int IMAGE_H,
-    int IMAGE_Z
-)
-{
-    int gidz = (int) get_global_id(2); // slow dim
-    int gidy = (int) get_global_id(1);
-    int gidx = (int) get_global_id(0); // fast dim
-
-    if (gidy < IMAGE_H && gidx < IMAGE_W && gidz < IMAGE_Z) {
-
-        int c, hL, hR;
-        if (hlen & 1) { // odd kernel size
-            c = hlen/2;
-            hL = c;
-            hR = c;
-        }
-        else { // even kernel size : center is shifted to the left
-            c = hlen/2 - 1;
-            hL = c;
-            hR = c+1;
-        }
-        int jy1 = c - gidy;
-        int jy2 = IMAGE_H - 1 - gidy + c;
-        float sum = 0.0f;
-
-        // Convolution with boundaries extension
-        for (int jy = 0; jy <= hR+hL; jy++) {
-            int idx_y = gidy - c + jy;
-            if (jy < jy1) idx_y = jy1-jy-1;
-            if (jy > jy2) idx_y = IMAGE_H - (jy-jy2);
-
-            sum += input[(gidz*IMAGE_H + idx_y)*IMAGE_W + gidx] * filter[hlen-1 - jy];
-        }
-        output[(gidz*IMAGE_H + gidy)*IMAGE_W + gidx] =  sum;
-    }
-}
-
-
-
-
-///
-/// Depth convolution (along fast dim)
-///
-
-__kernel void depth_convolution(
-    const __global float * input,  // input array
-    __global float * output, // output array
-    __global float * filter,// __attribute__((max_constant_size(MAX_CONST_SIZE))), // filter coefficients
-    int hlen,       // filter size
-    int IMAGE_W,
-    int IMAGE_H,
-    int IMAGE_Z
-)
-{
-    int gidz = (int) get_global_id(2); // slow dim
-    int gidy = (int) get_global_id(1);
-    int gidx = (int) get_global_id(0); // fast dim
-
-    if (gidy < IMAGE_H && gidx < IMAGE_W && gidz < IMAGE_Z) {
-
-        int c, hL, hR;
-        if (hlen & 1) { // odd kernel size
-            c = hlen/2;
-            hL = c;
-            hR = c;
-        }
-        else { // even kernel size : center is shifted to the left
-            c = hlen/2 - 1;
-            hL = c;
-            hR = c+1;
-        }
-        int jz1 = c - gidz;
-        int jz2 = IMAGE_Z - 1 - gidz + c;
-        float sum = 0.0f;
-
-        // Convolution with boundaries extension
-        for (int jz = 0; jz <= hR+hL; jz++) {
-            int idx_z = gidz - c + jz;
-            if (jz < jz1) idx_z = jz1-jz-1;
-            if (jz > jz2) idx_z = IMAGE_Z - (jz-jz2);
-
-            sum += input[(idx_z*IMAGE_H + gidy)*IMAGE_W + gidx] * filter[hlen-1 - jz];
-        }
-        output[(gidz*IMAGE_H + gidy)*IMAGE_W + gidx] =  sum;
-    }
-}
-
-
 

--- a/silx/resources/opencl/convolution.cl
+++ b/silx/resources/opencl/convolution.cl
@@ -62,15 +62,46 @@ __kernel void convol_1D_X(
 
     int c, hL, hR;
     GET_CENTER_HL(L);
-
     float sum = 0.0f;
 
     for (int jx = 0; jx <= hR+hL; jx++) {
         CONV_PERIODIC_IDX_X; // Get index "x"
         sum += input[(gidz*Ny + gidy)*Nx + idx_x] * filter[L-1 - jx];
     }
-    output[(gidz*Ny + gidy)*Nx + gidx] =  sum;
+    output[(gidz*Ny + gidy)*Nx + gidx] = sum;
 }
+
+
+// Convolution with 1D kernel along axis "Y"
+// Works for batched 1D on 2D and batched 2D on 3D, along axis "Y".
+__kernel void convol_1D_Y(
+    const __global float * input,
+    __global float * output,
+    __global float * filter,
+    int L, // filter size
+    int Nx, // input/output number of columns
+    int Ny, // input/output number of rows
+    int Nz  // input/output depth
+)
+{
+    uint gidx = get_global_id(0);
+    uint gidy = get_global_id(1);
+    uint gidz = get_global_id(2);
+    if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+
+    int c, hL, hR;
+    GET_CENTER_HL(L);
+    float sum = 0.0f;
+
+    for (int jy = 0; jy <= hR+hL; jy++) {
+        CONV_PERIODIC_IDX_Y; // Get index "y"
+        sum += input[(gidz*Ny + idx_y)*Nx + gidx] * filter[L-1 - jy];
+    }
+    output[(gidz*Ny + gidy)*Nx + gidx] = sum;
+}
+
+
+
 
 
 

--- a/silx/resources/opencl/convolution.cl
+++ b/silx/resources/opencl/convolution.cl
@@ -102,7 +102,6 @@ __kernel void convol_1D_Y(
 
 
 
-
 // Convolution with 1D kernel along axis "Z"
 // Works for batched 1D on 2D and batched 2D on 3D, along axis "Z".
 __kernel void convol_1D_Z(
@@ -132,9 +131,7 @@ __kernel void convol_1D_Z(
 }
 
 
-
-
-// Convolution with 2D kernel along axis "X,Y"
+// Convolution with 2D kernel
 // Works for batched 2D on 3D.
 __kernel void convol_2D_XY(
     const __global float * input,
@@ -156,15 +153,54 @@ __kernel void convol_2D_XY(
     GET_CENTER_HL(Lx);
     float sum = 0.0f;
 
-    for (int jx = 0; jx <= hR+hL; jx++) {
-        CONV_PERIODIC_IDX_X; // Get index "x"
-        for (int jy = 0; jy <= hR+hL; jy++) {
-            CONV_PERIODIC_IDX_Y; // Get index "y"
+    for (int jy = 0; jy <= hR+hL; jy++) {
+        CONV_PERIODIC_IDX_Y; // Get index "y"
+        for (int jx = 0; jx <= hR+hL; jx++) {
+            CONV_PERIODIC_IDX_X; // Get index "x"
             sum += input[(gidz*Ny + idx_y)*Nx + idx_x] * filter[(Ly-1-jy)*Lx + (Lx-1 - jx)];
         }
     }
     output[(gidz*Ny + gidy)*Nx + gidx] = sum;
 }
+
+
+
+// Convolution with 2D kernel
+// Works for batched 2D on 3D.
+__kernel void convol_2D_XZ(
+    const __global float * input,
+    __global float * output,
+    __global float * filter,
+    int Lx, // filter number of columns,
+    int Ly, // filter number of rows,
+    int Nx, // input/output number of columns
+    int Ny, // input/output number of rows
+    int Nz  // input/output depth
+)
+{
+    uint gidx = get_global_id(0);
+    uint gidy = get_global_id(1);
+    uint gidz = get_global_id(2);
+    if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+
+    int c, hL, hR;
+    GET_CENTER_HL(L);
+    float sum = 0.0f;
+
+    for (int jz = 0; jz <= hR+hL; jz++) {
+        CONV_PERIODIC_IDX_Z; // Get index "z"
+        for (int jx = 0; jx <= hR+hL; jx++) {
+            CONV_PERIODIC_IDX_X; // Get index "x"
+            sum += input[(idx_z*Ny + gidy)*Nx + idx_x] * filter[(Ly-1-jz)*Lx + (Lx-1 - jx)];
+        }
+    }
+    output[(gidz*Ny + gidy)*Nx + gidx] = sum;
+}
+
+
+
+
+
 
 
 

--- a/silx/resources/opencl/convolution.cl
+++ b/silx/resources/opencl/convolution.cl
@@ -1,6 +1,10 @@
 #define MAX_CONST_SIZE 16384
 
-A FINIR
+
+
+/******************************************************************************/
+/**************************** Macros ******************************************/
+/******************************************************************************/
 
 // Get the center index of the filter,
 // and the "half-Left" and "half-Right" lengths.
@@ -18,41 +22,52 @@ A FINIR
         }\
 }\
 
-// S
-#define GET_SUM_BOUNDS(N, gid, c){\
-    jx1 = c - gidx;
-    jx2 = Nx - 1 - gidx + c;
+
+// Get the lower and upper bound for the summation part of convolution.
+#define GET_SUM_BOUNDS_X int jx1 = c - gidx, jx2 = Nx - 1 - gidx + c;
+#define GET_SUM_BOUNDS_Y int jy1 = c - gidy, jy2 = Ny - 1 - gidy + c;
+#define GET_SUM_BOUNDS_Z int jz1 = c - gidz, jz2 = Nz - 1 - gidz + c;
+
+// Get the moving convolution index for periodic boundary extension.
+#define CONV_PERIODIC_IDX_X int idx_x = gidx - c + jx; if (jx < jx1) idx_x = jx1-jx-1; if (jx > jx2) idx_x = Nx - (jx-jx2);
+#define CONV_PERIODIC_IDX_Y int idx_y = gidy - c + jy; if (jy < jy1) idx_y = jy1-jy-1; if (jy > jy2) idx_y = Ny - (jy-jy2);
+#define CONV_PERIODIC_IDX_Z int idx_z = gidz - c + jz; if (jz < jz1) idx_z = jz1-jz-1; if (jz > jz2) idx_z = Nz - (jz-jz2);
 
 
 
-__kernel void convol_1D(
+/******************************************************************************/
+/**************************** 1D Convolution **********************************/
+/******************************************************************************/
+
+
+// Convolution with 1D kernel along axis "X" (fast dimension)
+// Works for batched 1D on 2D and batched 2D on 3D, along axis "X".
+__kernel void convol_1D_X(
     const __global float * input,
     __global float * output,
     __global float * filter,
-    int filter_len, // filter size
-    int signal_len, // input/output size
+    int L, // filter size
+    int Nx, // input/output number of columns
+    int Ny, // input/output number of rows
+    int Nz  // input/output depth
 )
 {
-    int gidx = (int) get_global_id(0);
-    if (gidx >= filter_len) return;
+    uint gidx = get_global_id(0);
+    uint gidy = get_global_id(1);
+    uint gidz = get_global_id(2);
+    if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+
     int c, hL, hR;
-    GET_CENTER_HL(filter_len);
+    GET_CENTER_HL(L);
 
+    float sum = 0.0f;
+    GET_SUM_BOUNDS_X;
 
-        int jx1 = c - gidx;
-        int jx2 = IMAGE_W - 1 - gidx + c;
-        float sum = 0.0f;
-
-        // Convolution with boundaries extension
-        for (int jx = 0; jx <= hR+hL; jx++) {
-            int idx_x = gidx - c + jx;
-            if (jx < jx1) idx_x = jx1-jx-1;
-            if (jx > jx2) idx_x = IMAGE_W - (jx-jx2);
-
-            sum += input[(gidz*IMAGE_H + gidy)*IMAGE_W + idx_x] * filter[hlen-1 - jx];
-        }
-        output[(gidz*IMAGE_H + gidy)*IMAGE_W + gidx] =  sum;
+    for (int jx = 0; jx <= hR+hL; jx++) {
+        CONV_PERIODIC_IDX_X; // Get index "x"
+        sum += input[(gidz*Ny + gidy)*Nx + idx_x] * filter[L-1 - jx];
     }
+    output[(gidz*Ny + gidy)*Nx + gidx] =  sum;
 }
 
 

--- a/silx/resources/opencl/convolution.cl
+++ b/silx/resources/opencl/convolution.cl
@@ -103,6 +103,71 @@ __kernel void convol_1D_Y(
 
 
 
+// Convolution with 1D kernel along axis "Z"
+// Works for batched 1D on 2D and batched 2D on 3D, along axis "Z".
+__kernel void convol_1D_Z(
+    const __global float * input,
+    __global float * output,
+    __global float * filter,
+    int L, // filter size
+    int Nx, // input/output number of columns
+    int Ny, // input/output number of rows
+    int Nz  // input/output depth
+)
+{
+    uint gidx = get_global_id(0);
+    uint gidy = get_global_id(1);
+    uint gidz = get_global_id(2);
+    if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+
+    int c, hL, hR;
+    GET_CENTER_HL(L);
+    float sum = 0.0f;
+
+    for (int jz = 0; jz <= hR+hL; jz++) {
+        CONV_PERIODIC_IDX_Z; // Get index "z"
+        sum += input[(idx_z*Ny + gidy)*Nx + gidx] * filter[L-1 - jz];
+    }
+    output[(gidz*Ny + gidy)*Nx + gidx] = sum;
+}
+
+
+
+
+// Convolution with 2D kernel along axis "X,Y"
+// Works for batched 2D on 3D.
+__kernel void convol_2D_XY(
+    const __global float * input,
+    __global float * output,
+    __global float * filter,
+    int Lx, // filter number of columns,
+    int Ly, // filter number of rows,
+    int Nx, // input/output number of columns
+    int Ny, // input/output number of rows
+    int Nz  // input/output depth
+)
+{
+    uint gidx = get_global_id(0);
+    uint gidy = get_global_id(1);
+    uint gidz = get_global_id(2);
+    if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+
+    int c, hL, hR;
+    GET_CENTER_HL(Lx);
+    float sum = 0.0f;
+
+    for (int jx = 0; jx <= hR+hL; jx++) {
+        CONV_PERIODIC_IDX_X; // Get index "x"
+        for (int jy = 0; jy <= hR+hL; jy++) {
+            CONV_PERIODIC_IDX_Y; // Get index "y"
+            sum += input[(gidz*Ny + idx_y)*Nx + idx_x] * filter[(Ly-1-jy)*Lx + (Lx-1 - jx)];
+        }
+    }
+    output[(gidz*Ny + gidy)*Nx + gidx] = sum;
+}
+
+
+
 
 
 

--- a/silx/resources/opencl/convolution.cl
+++ b/silx/resources/opencl/convolution.cl
@@ -24,14 +24,17 @@
 
 
 // Get the lower and upper bound for the summation part of convolution.
-#define GET_SUM_BOUNDS_X int jx1 = c - gidx, jx2 = Nx - 1 - gidx + c;
-#define GET_SUM_BOUNDS_Y int jy1 = c - gidy, jy2 = Ny - 1 - gidy + c;
-#define GET_SUM_BOUNDS_Z int jz1 = c - gidz, jz2 = Nz - 1 - gidz + c;
+//~ #define GET_SUM_BOUNDS_X int jx1 = c - gidx, jx2 = Nx - 1 - gidx + c;
+//~ #define GET_SUM_BOUNDS_Y int jy1 = c - gidy, jy2 = Ny - 1 - gidy + c;
+//~ #define GET_SUM_BOUNDS_Z int jz1 = c - gidz, jz2 = Nz - 1 - gidz + c;
 
 // Get the moving convolution index for periodic boundary extension.
-#define CONV_PERIODIC_IDX_X int idx_x = gidx - c + jx; if (jx < jx1) idx_x = jx1-jx-1; if (jx > jx2) idx_x = Nx - (jx-jx2);
-#define CONV_PERIODIC_IDX_Y int idx_y = gidy - c + jy; if (jy < jy1) idx_y = jy1-jy-1; if (jy > jy2) idx_y = Ny - (jy-jy2);
-#define CONV_PERIODIC_IDX_Z int idx_z = gidz - c + jz; if (jz < jz1) idx_z = jz1-jz-1; if (jz > jz2) idx_z = Nz - (jz-jz2);
+//~ #define CONV_PERIODIC_IDX_X int idx_x = gidx - c + jx; if (jx < jx1) idx_x = jx1-jx-1; if (jx > jx2) idx_x = Nx - (jx-jx2);
+//~ #define CONV_PERIODIC_IDX_Y int idx_y = gidy - c + jy; if (jy < jy1) idx_y = jy1-jy-1; if (jy > jy2) idx_y = Ny - (jy-jy2);
+//~ #define CONV_PERIODIC_IDX_Z int idx_z = gidz - c + jz; if (jz < jz1) idx_z = jz1-jz-1; if (jz > jz2) idx_z = Nz - (jz-jz2);
+#define CONV_PERIODIC_IDX_X int idx_x = gidx - c + jx; if (idx_x < 0) idx_x += Nx; if (idx_x >= Nx) idx_x -= Nx;
+#define CONV_PERIODIC_IDX_Y int idx_y = gidy - c + jy; if (idx_y < 0) idx_y += Ny; if (idx_y >= Ny) idx_y -= Ny;
+#define CONV_PERIODIC_IDX_Z int idx_z = gidz - c + jz; if (idx_z < 0) idx_z += Nz; if (idx_z >= Nz) idx_z -= Nz;
 
 
 
@@ -61,7 +64,6 @@ __kernel void convol_1D_X(
     GET_CENTER_HL(L);
 
     float sum = 0.0f;
-    GET_SUM_BOUNDS_X;
 
     for (int jx = 0; jx <= hR+hL; jx++) {
         CONV_PERIODIC_IDX_X; // Get index "x"

--- a/silx/resources/opencl/convolution_textures.cl
+++ b/silx/resources/opencl/convolution_textures.cl
@@ -2,6 +2,65 @@
 /**************************** Macros ******************************************/
 /******************************************************************************/
 
+// Convolution index for filter (+0.5f for texture access)
+#define FILTER_INDEX_X (Lx-1-jx+0.5f)
+#define FILTER_INDEX_Y (Ly-1-jy+0.5f)
+#define FILTER_INDEX_Z (Lz-1-jz+0.5f)
+// Convolution index for image (+0.5f for texture access)
+#define IMAGE_INDEX_X (gidx - c + jx + 0.5f)
+#define IMAGE_INDEX_Y (gidy - c + jy + 0.5f)
+#define IMAGE_INDEX_Z (gidz - c + jz + 0.5f)
+
+// Filter access patterns
+#define READ_FILTER_1D read_imagef(filter, sampler, (float) FILTER_INDEX_X).x;
+#define READ_FILTER_2D read_imagef(filter, sampler, (float2) (FILTER_INDEX_X, FILTER_INDEX_Y)).x;
+#define READ_FILTER_3D read_imagef(filter, sampler, (float4) (FILTER_INDEX_X, FILTER_INDEX_Y, FILTER_INDEX_Z), 0f).x;
+
+// Image access patterns
+#define READ_IMAGE_1D read_imagef(input, sampler, (float) IMAGE_INDEX_X).x
+
+#define READ_IMAGE_2D_X read_imagef(input, sampler, (float2) (IMAGE_INDEX_X , gidy + 0.5f)).x
+#define READ_IMAGE_2D_Y read_imagef(input, sampler, (float2) (gidx + 0.5f , IMAGE_INDEX_Y)).x
+#define READ_IMAGE_2D_XY read_imagef(input, sampler, (float2) (IMAGE_INDEX_X, IMAGE_INDEX_Y)).x
+
+#define READ_IMAGE_3D_X read_imagef(input, sampler, (float4) (IMAGE_INDEX_X, gidy+0.5f, gidz+0.5f, 0f)).x
+#define READ_IMAGE_3D_Y read_imagef(input, sampler, (float4) (gidx+0.5f, IMAGE_INDEX_Y, gidz+0.5f, 0f)).x
+#define READ_IMAGE_3D_Z read_imagef(input, sampler, (float4) (gidx+0.5f, gidy+0.5f, IMAGE_INDEX_Z, 0f)).x
+#define READ_IMAGE_3D_XY read_imagef(input, sampler, (float4) (IMAGE_INDEX_X, IMAGE_INDEX_Y, gidz+0.5f, 0f)).x
+#define READ_IMAGE_3D_XZ read_imagef(input, sampler, (float4) (IMAGE_INDEX_X, gidy+0.5f, IMAGE_INDEX_Z, 0f)).x
+#define READ_IMAGE_3D_YZ read_imagef(input, sampler, (float4) (gidx+0.5f, IMAGE_INDEX_Y, IMAGE_INDEX_Z, 0f)).x
+#define READ_IMAGE_3D_XYZ read_imagef(input, sampler, (float4) (IMAGE_INDEX_X, IMAGE_INDEX_Y, IMAGE_INDEX_Z, 0f)).x
+
+#if FILTER_DIMS == 1
+    #define FILTER_TYPE image1d_t
+    #define READ_FILTER_VAL READ_FILTER_1D
+#elif FILTER_DIMS == 2
+    #define FILTER_TYPE image2d_t
+    #define READ_FILTER_VAL READ_FILTER_2D
+#elif FILTER_DIMS == 3
+    #define FILTER_TYPE image3d_t
+    #define READ_FILTER_VAL READ_FILTER_3D
+#endif
+
+#if IMAGE_DIMS == 1
+    #define IMAGE_TYPE image1d_t
+    #define READ_IMAGE_X READ_IMAGE_1D
+#elif IMAGE_DIMS == 2
+    #define IMAGE_TYPE image2d_t
+    #define READ_IMAGE_X READ_IMAGE_2D_X
+    #define READ_IMAGE_Y READ_IMAGE_2D_Y
+    #define READ_IMAGE_XY READ_IMAGE_2D_XY
+#elif IMAGE_DIMS == 3
+    #define IMAGE_TYPE image3d_t
+    #define READ_IMAGE_X READ_IMAGE_3D_X
+    #define READ_IMAGE_Y READ_IMAGE_3D_Y
+    #define READ_IMAGE_Z READ_IMAGE_3D_Z
+    #define READ_IMAGE_XY READ_IMAGE_3D_XY
+    #define READ_IMAGE_XZ READ_IMAGE_3D_XZ
+    #define READ_IMAGE_YZ READ_IMAGE_3D_YZ
+    #define READ_IMAGE_XYZ READ_IMAGE_3D_XYZ
+#endif
+
 // Get the center index of the filter,
 // and the "half-Left" and "half-Right" lengths.
 // In the case of an even-sized filter, the center is shifted to the left.
@@ -20,13 +79,102 @@
 
 
 /******************************************************************************/
+/**************************** 1D Convolution **********************************/
+/******************************************************************************/
+
+
+// Convolution with 1D kernel along axis "X" (fast dimension)
+// Works for batched 1D on 2D and batched 2D on 3D, along axis "X".
+__kernel void convol_1D_X_tex(
+    read_only IMAGE_TYPE input,
+    __global float * output,
+    read_only FILTER_TYPE filter,
+    int L, // filter size
+    int Nx, // input/output number of columns
+    int Ny, // input/output number of rows
+    int Nz  // input/output depth
+)
+{
+    uint gidx = get_global_id(0);
+    uint gidy = get_global_id(1);
+    uint gidz = get_global_id(2);
+    if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+
+    int c, hL, hR;
+    GET_CENTER_HL(L);
+    float sum = 0.0f;
+
+    for (int jx = 0; jx <= hR+hL; jx++) {
+        sum += READ_IMAGE_X * READ_FILTER_X;
+    }
+    output[(gidz*Ny + gidy)*Nx + gidx] = sum;
+}
+
+
+// Convolution with 1D kernel along axis "Y"
+// Works for batched 1D on 2D and batched 2D on 3D, along axis "Y".
+__kernel void convol_1D_Y_tex(
+    read_only IMAGE_TYPE input,
+    __global float * output,
+    read_only FILTER_TYPE filter,
+    int L, // filter size
+    int Nx, // input/output number of columns
+    int Ny, // input/output number of rows
+    int Nz  // input/output depth
+)
+{
+    uint gidx = get_global_id(0);
+    uint gidy = get_global_id(1);
+    uint gidz = get_global_id(2);
+    if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+
+    int c, hL, hR;
+    GET_CENTER_HL(L);
+    float sum = 0.0f;
+
+    for (int jy = 0; jy <= hR+hL; jy++) {
+        sum += READ_IMAGE_Y * READ_FILTER_VAL;
+    }
+    output[(gidz*Ny + gidy)*Nx + gidx] = sum;
+}
+
+
+// Convolution with 1D kernel along axis "Z"
+// Works for batched 1D on 2D and batched 2D on 3D, along axis "Z".
+__kernel void convol_1D_Z_tex(
+    read_only IMAGE_TYPE input,
+    __global float * output,
+    read_only FILTER_TYPE filter,
+    int L, // filter size
+    int Nx, // input/output number of columns
+    int Ny, // input/output number of rows
+    int Nz  // input/output depth
+)
+{
+    uint gidx = get_global_id(0);
+    uint gidy = get_global_id(1);
+    uint gidz = get_global_id(2);
+    if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+
+    int c, hL, hR;
+    GET_CENTER_HL(L);
+    float sum = 0.0f;
+
+    for (int jz = 0; jz <= hR+hL; jz++) {
+        sum += READ_IMAGE_Z * READ_FILTER_VAL;
+    }
+    output[(gidz*Ny + gidy)*Nx + gidx] = sum;
+}
+
+
+/******************************************************************************/
 /**************************** 2D Convolution **********************************/
 /******************************************************************************/
 
 // Convolution with 2D kernel
 // Works for batched 2D on 3D.
 __kernel void convol_2D_XY_tex(
-    read_only image2d_t input,
+    read_only IMAGE_TYPE input,
     __global float * output,
     read_only image2d_t filter,
     int Lx, // filter number of columns,
@@ -48,17 +196,109 @@ __kernel void convol_2D_XY_tex(
 
     for (int jy = 0; jy <= hR+hL; jy++) {
         for (int jx = 0; jx <= hR+hL; jx++) {
-            // Fun thing: "0.5" instead of "0.5f" plummets performances
-            sum += read_imagef(
-                input,
-                sampler,
-                (float2) (gidx - c + jx + 0.5f , gidy - c + jy + 0.5f)
-            ).x * read_imagef(
-                filter,
-                sampler,
-                (float2) (Lx-1-jx+0.5f, Ly-1-jy+0.5f)
-            ).x;
+            sum += READ_IMAGE_XY * READ_FILTER_VAL;
         }
     }
     output[(gidz*Ny + gidy)*Nx + gidx] = sum;
 }
+
+
+// Convolution with 2D kernel
+// Works for batched 2D on 3D.
+__kernel void convol_2D_XZ_tex(
+    const __global float * input,
+    __global float * output,
+    __global float * filter,
+    int Lx, // filter number of columns,
+    int Lz, // filter number of rows,
+    int Nx, // input/output number of columns
+    int Ny, // input/output number of rows
+    int Nz  // input/output depth
+)
+{
+    uint gidx = get_global_id(0);
+    uint gidy = get_global_id(1);
+    uint gidz = get_global_id(2);
+    if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+
+    int c, hL, hR;
+    GET_CENTER_HL(Lx);
+    float sum = 0.0f;
+
+    for (int jz = 0; jz <= hR+hL; jz++) {
+        for (int jx = 0; jx <= hR+hL; jx++) {
+            sum += READ_IMAGE_XZ * READ_FILTER_VAL;
+        }
+    }
+    output[(gidz*Ny + gidy)*Nx + gidx] = sum;
+}
+
+
+// Convolution with 2D kernel
+// Works for batched 2D on 3D.
+__kernel void convol_2D_YZ_tex(
+    const __global float * input,
+    __global float * output,
+    __global float * filter,
+    int Ly, // filter number of columns,
+    int Lz, // filter number of rows,
+    int Nx, // input/output number of columns
+    int Ny, // input/output number of rows
+    int Nz  // input/output depth
+)
+{
+    uint gidx = get_global_id(0);
+    uint gidy = get_global_id(1);
+    uint gidz = get_global_id(2);
+    if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+
+    int c, hL, hR;
+    GET_CENTER_HL(Ly);
+    float sum = 0.0f;
+
+    for (int jz = 0; jz <= hR+hL; jz++) {
+        for (int jy = 0; jy <= hR+hL; jy++) {
+            sum += READ_IMAGE_YZ * READ_FILTER_VAL;
+        }
+    }
+    output[(gidz*Ny + gidy)*Nx + gidx] = sum;
+}
+
+
+
+/******************************************************************************/
+/**************************** 3D Convolution **********************************/
+/******************************************************************************/
+
+// Convolution with 3D kernel
+__kernel void convol_3D_XYZ_tex(
+    const __global float * input,
+    __global float * output,
+    __global float * filter,
+    int Lx, // filter number of columns,
+    int Ly, // filter number of rows,
+    int Lz, // filter number of rows,
+    int Nx, // input/output number of columns
+    int Ny, // input/output number of rows
+    int Nz  // input/output depth
+)
+{
+    uint gidx = get_global_id(0);
+    uint gidy = get_global_id(1);
+    uint gidz = get_global_id(2);
+    if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+
+    int c, hL, hR;
+    GET_CENTER_HL(Lx);
+    float sum = 0.0f;
+
+    for (int jz = 0; jz <= hR+hL; jz++) {
+        for (int jy = 0; jy <= hR+hL; jy++) {
+            for (int jx = 0; jx <= hR+hL; jx++) {
+                sum += READ_IMAGE_XYZ * READ_FILTER_VAL;
+            }
+        }
+    }
+    output[(gidz*Ny + gidy)*Nx + gidx] = sum;
+}
+

--- a/silx/resources/opencl/convolution_textures.cl
+++ b/silx/resources/opencl/convolution_textures.cl
@@ -75,7 +75,6 @@
     #define GIDZ gidz
 #endif
 
-//~ static const sampler_t filter_sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
 static const sampler_t sampler = CLK_COORDS | CLK_BOUNDARY | CLK_FILTER_NEAREST;
 
 // Image access patterns

--- a/silx/resources/opencl/convolution_textures.cl
+++ b/silx/resources/opencl/convolution_textures.cl
@@ -13,33 +13,40 @@
     #error "Filter cannot have more dimensions than image"
 #endif
 
+/*
+// Boundary handling modes
+#define BOUNDARY_MODE_PERIODIC 0
+#define BOUNDARY_MODE_REFLECT CLK_ADDRESS_MIRRORED_REPEAT
+#define BOUNDARY_MODE_WRAP BOUNDARY_MODE_PERIODIC
 
-// Convolution index for filter (+0.5f for texture access)
-#define FILTER_INDEX(j) (Lx-1-j+0.5f)
-// Convolution index for image (+0.5f for texture access)
-#define IMAGE_INDEX_X (gidx - c + jx + 0.5f)
-#define IMAGE_INDEX_Y (gidy - c + jy + 0.5f)
-#define IMAGE_INDEX_Z (gidz - c + jz + 0.5f)
+*/
+
+// Convolution index for filter (+0.5f*0 for texture access)
+#define FILTER_INDEX(j) (Lx - 1 - j)
+// Convolution index for image (+0.5f*0 for texture access)
+#define IMAGE_INDEX_X (gidx - c + jx)
+#define IMAGE_INDEX_Y (gidy - c + jy)
+#define IMAGE_INDEX_Z (gidz - c + jz)
 
 // Filter access patterns
-#define READ_FILTER_1D(j) read_imagef(filter, sampler, (float2) (FILTER_INDEX(j), 0.0f)).x;
-#define READ_FILTER_2D(jx, jy) read_imagef(filter, sampler, (float2) (FILTER_INDEX(jx), FILTER_INDEX(jy))).x;
-#define READ_FILTER_3D(jx, jy, jz) read_imagef(filter, sampler, (float4) (FILTER_INDEX(jx), FILTER_INDEX(jy), FILTER_INDEX(jz), 0.0f)).x;
+#define READ_FILTER_1D(j) read_imagef(filter, sampler, (int2) (FILTER_INDEX(j), 0)).x;
+#define READ_FILTER_2D(jx, jy) read_imagef(filter, sampler, (int2) (FILTER_INDEX(jx), FILTER_INDEX(jy))).x;
+#define READ_FILTER_3D(jx, jy, jz) read_imagef(filter, sampler, (int4) (FILTER_INDEX(jx), FILTER_INDEX(jy), FILTER_INDEX(jz), 0)).x;
 
 // Image access patterns
-#define READ_IMAGE_1D read_imagef(input, sampler, (float2) (IMAGE_INDEX_X, 0.0f)).x
+#define READ_IMAGE_1D read_imagef(input, sampler, (int2) (IMAGE_INDEX_X, 0)).x
 
-#define READ_IMAGE_2D_X read_imagef(input, sampler, (float2) (IMAGE_INDEX_X , gidy + 0.5f)).x
-#define READ_IMAGE_2D_Y read_imagef(input, sampler, (float2) (gidx + 0.5f , IMAGE_INDEX_Y)).x
-#define READ_IMAGE_2D_XY read_imagef(input, sampler, (float2) (IMAGE_INDEX_X, IMAGE_INDEX_Y)).x
+#define READ_IMAGE_2D_X read_imagef(input, sampler, (int2) (IMAGE_INDEX_X , gidy)).x
+#define READ_IMAGE_2D_Y read_imagef(input, sampler, (int2) (gidx, IMAGE_INDEX_Y)).x
+#define READ_IMAGE_2D_XY read_imagef(input, sampler, (int2) (IMAGE_INDEX_X, IMAGE_INDEX_Y)).x
 
-#define READ_IMAGE_3D_X read_imagef(input, sampler, (float4) (IMAGE_INDEX_X, gidy+0.5f, gidz+0.5f, 0.0f)).x
-#define READ_IMAGE_3D_Y read_imagef(input, sampler, (float4) (gidx+0.5f, IMAGE_INDEX_Y, gidz+0.5f, 0.0f)).x
-#define READ_IMAGE_3D_Z read_imagef(input, sampler, (float4) (gidx+0.5f, gidy+0.5f, IMAGE_INDEX_Z, 0.0f)).x
-#define READ_IMAGE_3D_XY read_imagef(input, sampler, (float4) (IMAGE_INDEX_X, IMAGE_INDEX_Y, gidz+0.5f, 0.0f)).x
-#define READ_IMAGE_3D_XZ read_imagef(input, sampler, (float4) (IMAGE_INDEX_X, gidy+0.5f, IMAGE_INDEX_Z, 0.0f)).x
-#define READ_IMAGE_3D_YZ read_imagef(input, sampler, (float4) (gidx+0.5f, IMAGE_INDEX_Y, IMAGE_INDEX_Z, 0.0f)).x
-#define READ_IMAGE_3D_XYZ read_imagef(input, sampler, (float4) (IMAGE_INDEX_X, IMAGE_INDEX_Y, IMAGE_INDEX_Z, 0.0f)).x
+#define READ_IMAGE_3D_X read_imagef(input, sampler, (int4) (IMAGE_INDEX_X, gidy, gidz, 0)).x
+#define READ_IMAGE_3D_Y read_imagef(input, sampler, (int4) (gidx, IMAGE_INDEX_Y, gidz, 0)).x
+#define READ_IMAGE_3D_Z read_imagef(input, sampler, (int4) (gidx, gidy, IMAGE_INDEX_Z, 0)).x
+#define READ_IMAGE_3D_XY read_imagef(input, sampler, (int4) (IMAGE_INDEX_X, IMAGE_INDEX_Y, gidz, 0)).x
+#define READ_IMAGE_3D_XZ read_imagef(input, sampler, (int4) (IMAGE_INDEX_X, gidy, IMAGE_INDEX_Z, 0)).x
+#define READ_IMAGE_3D_YZ read_imagef(input, sampler, (int4) (gidx, IMAGE_INDEX_Y, IMAGE_INDEX_Z, 0)).x
+#define READ_IMAGE_3D_XYZ read_imagef(input, sampler, (int4) (IMAGE_INDEX_X, IMAGE_INDEX_Y, IMAGE_INDEX_Z, 0)).x
 
 // NOTE: pyopencl and OpenCL < 1.2 do not support image1d_t
 #if FILTER_DIMS == 1

--- a/silx/resources/opencl/convolution_textures.cl
+++ b/silx/resources/opencl/convolution_textures.cl
@@ -3,18 +3,16 @@
 /******************************************************************************/
 
 // Convolution index for filter (+0.5f for texture access)
-#define FILTER_INDEX_X (Lx-1-jx+0.5f)
-#define FILTER_INDEX_Y (Ly-1-jy+0.5f)
-#define FILTER_INDEX_Z (Lz-1-jz+0.5f)
+#define FILTER_INDEX(j) (Lx-1-j+0.5f)
 // Convolution index for image (+0.5f for texture access)
 #define IMAGE_INDEX_X (gidx - c + jx + 0.5f)
 #define IMAGE_INDEX_Y (gidy - c + jy + 0.5f)
 #define IMAGE_INDEX_Z (gidz - c + jz + 0.5f)
 
 // Filter access patterns
-#define READ_FILTER_1D read_imagef(filter, sampler, (float) FILTER_INDEX_X).x;
-#define READ_FILTER_2D read_imagef(filter, sampler, (float2) (FILTER_INDEX_X, FILTER_INDEX_Y)).x;
-#define READ_FILTER_3D read_imagef(filter, sampler, (float4) (FILTER_INDEX_X, FILTER_INDEX_Y, FILTER_INDEX_Z), 0f).x;
+#define READ_FILTER_1D(j) read_imagef(filter, sampler, (float) FILTER_INDEX(j)).x;
+#define READ_FILTER_2D(jx, jy) read_imagef(filter, sampler, (float2) (FILTER_INDEX(jx), FILTER_INDEX(jy))).x;
+#define READ_FILTER_3D(jx, jy, jz) read_imagef(filter, sampler, (float4) (FILTER_INDEX(jx), FILTER_INDEX(jy), FILTER_INDEX(jz), 0.0f)).x;
 
 // Image access patterns
 #define READ_IMAGE_1D read_imagef(input, sampler, (float) IMAGE_INDEX_X).x
@@ -23,23 +21,23 @@
 #define READ_IMAGE_2D_Y read_imagef(input, sampler, (float2) (gidx + 0.5f , IMAGE_INDEX_Y)).x
 #define READ_IMAGE_2D_XY read_imagef(input, sampler, (float2) (IMAGE_INDEX_X, IMAGE_INDEX_Y)).x
 
-#define READ_IMAGE_3D_X read_imagef(input, sampler, (float4) (IMAGE_INDEX_X, gidy+0.5f, gidz+0.5f, 0f)).x
-#define READ_IMAGE_3D_Y read_imagef(input, sampler, (float4) (gidx+0.5f, IMAGE_INDEX_Y, gidz+0.5f, 0f)).x
-#define READ_IMAGE_3D_Z read_imagef(input, sampler, (float4) (gidx+0.5f, gidy+0.5f, IMAGE_INDEX_Z, 0f)).x
-#define READ_IMAGE_3D_XY read_imagef(input, sampler, (float4) (IMAGE_INDEX_X, IMAGE_INDEX_Y, gidz+0.5f, 0f)).x
-#define READ_IMAGE_3D_XZ read_imagef(input, sampler, (float4) (IMAGE_INDEX_X, gidy+0.5f, IMAGE_INDEX_Z, 0f)).x
-#define READ_IMAGE_3D_YZ read_imagef(input, sampler, (float4) (gidx+0.5f, IMAGE_INDEX_Y, IMAGE_INDEX_Z, 0f)).x
-#define READ_IMAGE_3D_XYZ read_imagef(input, sampler, (float4) (IMAGE_INDEX_X, IMAGE_INDEX_Y, IMAGE_INDEX_Z, 0f)).x
+#define READ_IMAGE_3D_X read_imagef(input, sampler, (float4) (IMAGE_INDEX_X, gidy+0.5f, gidz+0.5f, 0.0f)).x
+#define READ_IMAGE_3D_Y read_imagef(input, sampler, (float4) (gidx+0.5f, IMAGE_INDEX_Y, gidz+0.5f, 0.0f)).x
+#define READ_IMAGE_3D_Z read_imagef(input, sampler, (float4) (gidx+0.5f, gidy+0.5f, IMAGE_INDEX_Z, 0.0f)).x
+#define READ_IMAGE_3D_XY read_imagef(input, sampler, (float4) (IMAGE_INDEX_X, IMAGE_INDEX_Y, gidz+0.5f, 0.0f)).x
+#define READ_IMAGE_3D_XZ read_imagef(input, sampler, (float4) (IMAGE_INDEX_X, gidy+0.5f, IMAGE_INDEX_Z, 0.0f)).x
+#define READ_IMAGE_3D_YZ read_imagef(input, sampler, (float4) (gidx+0.5f, IMAGE_INDEX_Y, IMAGE_INDEX_Z, 0.0f)).x
+#define READ_IMAGE_3D_XYZ read_imagef(input, sampler, (float4) (IMAGE_INDEX_X, IMAGE_INDEX_Y, IMAGE_INDEX_Z, 0.0f)).x
 
 #if FILTER_DIMS == 1
     #define FILTER_TYPE image1d_t
-    #define READ_FILTER_VAL READ_FILTER_1D
+    #define READ_FILTER_VAL(j) READ_FILTER_1D(j)
 #elif FILTER_DIMS == 2
     #define FILTER_TYPE image2d_t
-    #define READ_FILTER_VAL READ_FILTER_2D
+    #define READ_FILTER_VAL(jx, jy) READ_FILTER_2D(jx, jy)
 #elif FILTER_DIMS == 3
     #define FILTER_TYPE image3d_t
-    #define READ_FILTER_VAL READ_FILTER_3D
+    #define READ_FILTER_VAL(jx, jy, jz) READ_FILTER_3D(jx, jy, jz)
 #endif
 
 #if IMAGE_DIMS == 1
@@ -59,6 +57,10 @@
     #define READ_IMAGE_XZ READ_IMAGE_3D_XZ
     #define READ_IMAGE_YZ READ_IMAGE_3D_YZ
     #define READ_IMAGE_XYZ READ_IMAGE_3D_XYZ
+#endif
+
+#if FILTER_DIMS > IMAGE_DIMS
+    #error "Filter cannot have more dimensions than image"
 #endif
 
 // Get the center index of the filter,
@@ -82,14 +84,14 @@
 /**************************** 1D Convolution **********************************/
 /******************************************************************************/
 
-
+#if FILTER_DIMS == 1
 // Convolution with 1D kernel along axis "X" (fast dimension)
 // Works for batched 1D on 2D and batched 2D on 3D, along axis "X".
 __kernel void convol_1D_X_tex(
     read_only IMAGE_TYPE input,
     __global float * output,
     read_only FILTER_TYPE filter,
-    int L, // filter size
+    int Lx, // filter size
     int Nx, // input/output number of columns
     int Ny, // input/output number of rows
     int Nz  // input/output depth
@@ -99,25 +101,27 @@ __kernel void convol_1D_X_tex(
     uint gidy = get_global_id(1);
     uint gidz = get_global_id(2);
     if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+    const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
 
     int c, hL, hR;
-    GET_CENTER_HL(L);
+    GET_CENTER_HL(Lx);
     float sum = 0.0f;
 
     for (int jx = 0; jx <= hR+hL; jx++) {
-        sum += READ_IMAGE_X * READ_FILTER_X;
+        sum += READ_IMAGE_X * READ_FILTER_VAL(jx);
     }
     output[(gidz*Ny + gidy)*Nx + gidx] = sum;
 }
 
 
+#if IMAGE_DIMS >= 2
 // Convolution with 1D kernel along axis "Y"
 // Works for batched 1D on 2D and batched 2D on 3D, along axis "Y".
 __kernel void convol_1D_Y_tex(
     read_only IMAGE_TYPE input,
     __global float * output,
     read_only FILTER_TYPE filter,
-    int L, // filter size
+    int Lx, // filter size
     int Nx, // input/output number of columns
     int Ny, // input/output number of rows
     int Nz  // input/output depth
@@ -127,25 +131,27 @@ __kernel void convol_1D_Y_tex(
     uint gidy = get_global_id(1);
     uint gidz = get_global_id(2);
     if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+    const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
 
     int c, hL, hR;
-    GET_CENTER_HL(L);
+    GET_CENTER_HL(Lx);
     float sum = 0.0f;
 
     for (int jy = 0; jy <= hR+hL; jy++) {
-        sum += READ_IMAGE_Y * READ_FILTER_VAL;
+        sum += READ_IMAGE_Y * READ_FILTER_VAL(jy);
     }
     output[(gidz*Ny + gidy)*Nx + gidx] = sum;
 }
+#endif
 
-
+#if IMAGE_DIMS == 3
 // Convolution with 1D kernel along axis "Z"
 // Works for batched 1D on 2D and batched 2D on 3D, along axis "Z".
 __kernel void convol_1D_Z_tex(
     read_only IMAGE_TYPE input,
     __global float * output,
     read_only FILTER_TYPE filter,
-    int L, // filter size
+    int Lx, // filter size
     int Nx, // input/output number of columns
     int Ny, // input/output number of rows
     int Nz  // input/output depth
@@ -155,28 +161,31 @@ __kernel void convol_1D_Z_tex(
     uint gidy = get_global_id(1);
     uint gidz = get_global_id(2);
     if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+    const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
 
     int c, hL, hR;
-    GET_CENTER_HL(L);
+    GET_CENTER_HL(Lx);
     float sum = 0.0f;
 
     for (int jz = 0; jz <= hR+hL; jz++) {
-        sum += READ_IMAGE_Z * READ_FILTER_VAL;
+        sum += READ_IMAGE_Z * READ_FILTER_VAL(jz);
     }
     output[(gidz*Ny + gidy)*Nx + gidx] = sum;
 }
-
+#endif
+#endif
 
 /******************************************************************************/
 /**************************** 2D Convolution **********************************/
 /******************************************************************************/
 
+#if IMAGE_DIMS >= 2 && FILTER_DIMS == 2
 // Convolution with 2D kernel
 // Works for batched 2D on 3D.
 __kernel void convol_2D_XY_tex(
     read_only IMAGE_TYPE input,
     __global float * output,
-    read_only image2d_t filter,
+    read_only FILTER_TYPE filter,
     int Lx, // filter number of columns,
     int Ly, // filter number of rows,
     int Nx, // input/output number of columns
@@ -196,19 +205,20 @@ __kernel void convol_2D_XY_tex(
 
     for (int jy = 0; jy <= hR+hL; jy++) {
         for (int jx = 0; jx <= hR+hL; jx++) {
-            sum += READ_IMAGE_XY * READ_FILTER_VAL;
+            sum += READ_IMAGE_XY * READ_FILTER_VAL(jx, jy);
         }
     }
     output[(gidz*Ny + gidy)*Nx + gidx] = sum;
 }
+#endif
 
-
+#if IMAGE_DIMS == 3 && FILTER_DIMS == 2
 // Convolution with 2D kernel
 // Works for batched 2D on 3D.
 __kernel void convol_2D_XZ_tex(
-    const __global float * input,
+    read_only IMAGE_TYPE input,
     __global float * output,
-    __global float * filter,
+    read_only FILTER_TYPE filter,
     int Lx, // filter number of columns,
     int Lz, // filter number of rows,
     int Nx, // input/output number of columns
@@ -220,6 +230,7 @@ __kernel void convol_2D_XZ_tex(
     uint gidy = get_global_id(1);
     uint gidz = get_global_id(2);
     if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+    const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
 
     int c, hL, hR;
     GET_CENTER_HL(Lx);
@@ -227,7 +238,7 @@ __kernel void convol_2D_XZ_tex(
 
     for (int jz = 0; jz <= hR+hL; jz++) {
         for (int jx = 0; jx <= hR+hL; jx++) {
-            sum += READ_IMAGE_XZ * READ_FILTER_VAL;
+            sum += READ_IMAGE_XZ * READ_FILTER_VAL(jx, jz);
         }
     }
     output[(gidz*Ny + gidy)*Nx + gidx] = sum;
@@ -237,10 +248,10 @@ __kernel void convol_2D_XZ_tex(
 // Convolution with 2D kernel
 // Works for batched 2D on 3D.
 __kernel void convol_2D_YZ_tex(
-    const __global float * input,
+    read_only IMAGE_TYPE input,
     __global float * output,
-    __global float * filter,
-    int Ly, // filter number of columns,
+    read_only FILTER_TYPE filter,
+    int Lx, // filter number of columns,
     int Lz, // filter number of rows,
     int Nx, // input/output number of columns
     int Ny, // input/output number of rows
@@ -251,30 +262,32 @@ __kernel void convol_2D_YZ_tex(
     uint gidy = get_global_id(1);
     uint gidz = get_global_id(2);
     if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+    const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
 
     int c, hL, hR;
-    GET_CENTER_HL(Ly);
+    GET_CENTER_HL(Lx);
     float sum = 0.0f;
 
     for (int jz = 0; jz <= hR+hL; jz++) {
         for (int jy = 0; jy <= hR+hL; jy++) {
-            sum += READ_IMAGE_YZ * READ_FILTER_VAL;
+            sum += READ_IMAGE_YZ * READ_FILTER_VAL(jy, jz);
         }
     }
     output[(gidz*Ny + gidy)*Nx + gidx] = sum;
 }
-
+#endif
 
 
 /******************************************************************************/
 /**************************** 3D Convolution **********************************/
 /******************************************************************************/
 
+#if IMAGE_DIMS == 3 && FILTER_DIMS == 3
 // Convolution with 3D kernel
 __kernel void convol_3D_XYZ_tex(
-    const __global float * input,
+    read_only IMAGE_TYPE input,
     __global float * output,
-    __global float * filter,
+    read_only FILTER_TYPE filter,
     int Lx, // filter number of columns,
     int Ly, // filter number of rows,
     int Lz, // filter number of rows,
@@ -287,6 +300,7 @@ __kernel void convol_3D_XYZ_tex(
     uint gidy = get_global_id(1);
     uint gidz = get_global_id(2);
     if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+    const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
 
     int c, hL, hR;
     GET_CENTER_HL(Lx);
@@ -295,10 +309,10 @@ __kernel void convol_3D_XYZ_tex(
     for (int jz = 0; jz <= hR+hL; jz++) {
         for (int jy = 0; jy <= hR+hL; jy++) {
             for (int jx = 0; jx <= hR+hL; jx++) {
-                sum += READ_IMAGE_XYZ * READ_FILTER_VAL;
+                sum += READ_IMAGE_XYZ * READ_FILTER_VAL(jx, jy, jz);
             }
         }
     }
     output[(gidz*Ny + gidy)*Nx + gidx] = sum;
 }
-
+#endif

--- a/silx/resources/opencl/convolution_textures.cl
+++ b/silx/resources/opencl/convolution_textures.cl
@@ -1,0 +1,64 @@
+/******************************************************************************/
+/**************************** Macros ******************************************/
+/******************************************************************************/
+
+// Get the center index of the filter,
+// and the "half-Left" and "half-Right" lengths.
+// In the case of an even-sized filter, the center is shifted to the left.
+#define GET_CENTER_HL(hlen){\
+        if (hlen & 1) {\
+            c = hlen/2;\
+            hL = c;\
+            hR = c;\
+        }\
+        else {\
+            c = hlen/2 - 1;\
+            hL = c;\
+            hR = c+1;\
+        }\
+}\
+
+
+/******************************************************************************/
+/**************************** 2D Convolution **********************************/
+/******************************************************************************/
+
+// Convolution with 2D kernel
+// Works for batched 2D on 3D.
+__kernel void convol_2D_XY_tex(
+    read_only image2d_t input,
+    __global float * output,
+    read_only image2d_t filter,
+    int Lx, // filter number of columns,
+    int Ly, // filter number of rows,
+    int Nx, // input/output number of columns
+    int Ny, // input/output number of rows
+    int Nz  // input/output depth
+)
+{
+    uint gidx = get_global_id(0);
+    uint gidy = get_global_id(1);
+    uint gidz = get_global_id(2);
+    if ((gidx >= Nx) || (gidy >= Ny) || (gidz >= Nz)) return;
+    const sampler_t sampler = CLK_NORMALIZED_COORDS_FALSE | CLK_ADDRESS_CLAMP_TO_EDGE | CLK_FILTER_NEAREST;
+
+    int c, hL, hR;
+    GET_CENTER_HL(Lx);
+    float sum = 0.0f;
+
+    for (int jy = 0; jy <= hR+hL; jy++) {
+        for (int jx = 0; jx <= hR+hL; jx++) {
+            // Fun thing: "0.5" instead of "0.5f" plummets performances
+            sum += read_imagef(
+                input,
+                sampler,
+                (float2) (gidx - c + jx + 0.5f , gidy - c + jy + 0.5f)
+            ).x * read_imagef(
+                filter,
+                sampler,
+                (float2) (Lx-1-jx+0.5f, Ly-1-jy+0.5f)
+            ).x;
+        }
+    }
+    output[(gidz*Ny + gidy)*Nx + gidx] = sum;
+}

--- a/silx/resources/opencl/convolution_textures.cl
+++ b/silx/resources/opencl/convolution_textures.cl
@@ -2,6 +2,18 @@
 /**************************** Macros ******************************************/
 /******************************************************************************/
 
+// Error handling
+#ifndef IMAGE_DIMS
+    #error "IMAGE_DIMS must be defined"
+#endif
+#ifndef FILTER_DIMS
+    #error "FILTER_DIMS must be defined"
+#endif
+#if FILTER_DIMS > IMAGE_DIMS
+    #error "Filter cannot have more dimensions than image"
+#endif
+
+
 // Convolution index for filter (+0.5f for texture access)
 #define FILTER_INDEX(j) (Lx-1-j+0.5f)
 // Convolution index for image (+0.5f for texture access)
@@ -10,12 +22,12 @@
 #define IMAGE_INDEX_Z (gidz - c + jz + 0.5f)
 
 // Filter access patterns
-#define READ_FILTER_1D(j) read_imagef(filter, sampler, (float) FILTER_INDEX(j)).x;
+#define READ_FILTER_1D(j) read_imagef(filter, sampler, (float2) (FILTER_INDEX(j), 0.0f)).x;
 #define READ_FILTER_2D(jx, jy) read_imagef(filter, sampler, (float2) (FILTER_INDEX(jx), FILTER_INDEX(jy))).x;
 #define READ_FILTER_3D(jx, jy, jz) read_imagef(filter, sampler, (float4) (FILTER_INDEX(jx), FILTER_INDEX(jy), FILTER_INDEX(jz), 0.0f)).x;
 
 // Image access patterns
-#define READ_IMAGE_1D read_imagef(input, sampler, (float) IMAGE_INDEX_X).x
+#define READ_IMAGE_1D read_imagef(input, sampler, (float2) (IMAGE_INDEX_X, 0.0f)).x
 
 #define READ_IMAGE_2D_X read_imagef(input, sampler, (float2) (IMAGE_INDEX_X , gidy + 0.5f)).x
 #define READ_IMAGE_2D_Y read_imagef(input, sampler, (float2) (gidx + 0.5f , IMAGE_INDEX_Y)).x
@@ -29,8 +41,9 @@
 #define READ_IMAGE_3D_YZ read_imagef(input, sampler, (float4) (gidx+0.5f, IMAGE_INDEX_Y, IMAGE_INDEX_Z, 0.0f)).x
 #define READ_IMAGE_3D_XYZ read_imagef(input, sampler, (float4) (IMAGE_INDEX_X, IMAGE_INDEX_Y, IMAGE_INDEX_Z, 0.0f)).x
 
+// NOTE: pyopencl and OpenCL < 1.2 do not support image1d_t
 #if FILTER_DIMS == 1
-    #define FILTER_TYPE image1d_t
+    #define FILTER_TYPE image2d_t
     #define READ_FILTER_VAL(j) READ_FILTER_1D(j)
 #elif FILTER_DIMS == 2
     #define FILTER_TYPE image2d_t
@@ -41,7 +54,7 @@
 #endif
 
 #if IMAGE_DIMS == 1
-    #define IMAGE_TYPE image1d_t
+    #define IMAGE_TYPE image2d_t
     #define READ_IMAGE_X READ_IMAGE_1D
 #elif IMAGE_DIMS == 2
     #define IMAGE_TYPE image2d_t
@@ -59,9 +72,6 @@
     #define READ_IMAGE_XYZ READ_IMAGE_3D_XYZ
 #endif
 
-#if FILTER_DIMS > IMAGE_DIMS
-    #error "Filter cannot have more dimensions than image"
-#endif
 
 // Get the center index of the filter,
 // and the "half-Left" and "half-Right" lengths.


### PR DESCRIPTION
## About

This PR adds a general-purpose OpenCL convolution in silx.

## Work in progress

### Use cases
- [x] 1D <-> 1D
- [x] 2D <-> 2D
- [x] Batched 1D on 2D data
- [x] Separable (2D->1D) on 2D data
- [x] 3D <-> 3D
- [x] Batched 1D on 3D data
- [x] Batched 2D on 3D data
- [x] Separable (3D->1D) on 3D data
- [x] Separable (3D->2D) on 3D data
- [ ] Batched separable (2D->1D) on 3D data

### Additional internal work

- <del> Modify kernel and/or axes on-the-fly </del> --> not relevant, lot of compiled code depend from axes.
- [x] Allow for profiling with the use of OpenCL events
- [x] Bypass use of `d_tmp` when memory is lacking (only done for nonseparable transforms)
- <del>Put convolution kernel in constant memory</del> --> not relevant with textures
- [x] Use "textures" when possible
- [x] Refactor `convolution.cl` to use less code duplication
- [ ] Benchmark (eg. against arrayfire)
- [x] Add boundaries handling other than periodic
- [ ] Automatic composition with `ImageProcessing` for pre-processing
- [ ] Support OpenCL Buffers (not only pyopencl Arrays)
- [x] Built-in default kernels (ex. Gaussian)
- [ ] Nonseparable convolution with non-square kernels
- [ ] [Bonus] Input/output strides ?