### PR TITLE
Support 2dview for 3dnxdata

### DIFF
--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -445,7 +445,7 @@ class _CompositeDataView(DataView):
         """
         raise NotImplementedError()
 
-    @deprecation.deprecated(replacement="getRegisteredViews", since_version="0.10")
+    @deprecation.deprecated(replacement="getReachableViews", since_version="0.10")
     def availableViews(self):
         return self.getViews()
 

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -42,7 +42,7 @@ from silx.gui.dialog.ColormapDialog import ColormapDialog
 
 __authors__ = ["V. Valls", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "12/02/2019"
+__date__ = "15/02/2019"
 
 _logger = logging.getLogger(__name__)
 
@@ -68,7 +68,7 @@ NXDATA_CURVE_MODE = 73
 NXDATA_XYVSCATTER_MODE = 74
 NXDATA_IMAGE_MODE = 75
 NXDATA_STACK_MODE = 76
-NXDATA_PLOT3D_MODE = 77
+NXDATA_VOLUME_MODE = 77
 
 
 def _normalizeData(data):
@@ -1654,7 +1654,7 @@ class _NXdataStackView(DataView):
 class _NXdataVolumeView(DataView):
     def __init__(self, parent):
         DataView.__init__(self, parent,
-                          modeId=NXDATA_PLOT3D_MODE)
+                          modeId=NXDATA_VOLUME_MODE)
         try:
             import silx.gui.plot3d  # noqa
         except ImportError:

--- a/silx/io/nxdata/parse.py
+++ b/silx/io/nxdata/parse.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/silx/io/nxdata/parse.py
+++ b/silx/io/nxdata/parse.py
@@ -138,7 +138,7 @@ class NXdata(object):
 
             self.axes_names = []
             # check if axis dataset defines @long_name
-            for i, dsname in enumerate(self.axes_dataset_names):
+            for _, dsname in enumerate(self.axes_dataset_names):
                 if dsname is not None and "long_name" in self.group[dsname].attrs:
                     self.axes_names.append(get_attr_as_unicode(self.group[dsname], "long_name"))
                 else:

--- a/silx/io/nxdata/parse.py
+++ b/silx/io/nxdata/parse.py
@@ -53,7 +53,7 @@ from ._utils import get_attr_as_unicode, INTERPDIM, nxdata_logger, \
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "29/11/2018"
+__date__ = "15/02/2019"
 
 
 class InvalidNXdataError(Exception):
@@ -743,6 +743,27 @@ class NXdata(object):
         stack_shape = self.signal.shape[-3:]
         for i, axis in enumerate(self.axes[-3:]):
             if axis is not None and len(axis) not in [stack_shape[i], 2]:
+                return False
+        return True
+
+    @property
+    def is_volume(self):
+        """True in the signal is exactly 3D and interpretation
+            "scalar", or nothing.
+
+        The axes length must also be consistent with the 3 dimensions
+        of the signal.
+        """
+        if not self.is_valid:
+            raise InvalidNXdataError("Unable to parse invalid NXdata")
+
+        if self.signal_ndim != 3:
+            return False
+        if self.interpretation not in [None, "scalar", "scaler"]:
+            return False
+        volume_shape = self.signal.shape[-3:]
+        for i, axis in enumerate(self.axes[-3:]):
+            if axis is not None and len(axis) not in [volume_shape[i], 2]:
                 return False
         return True
 


### PR DESCRIPTION
This PR allow to display an NXdata containing a volume using a 2D view or a 3D view.

This is the result of #2455 and #2433 

As commended https://github.com/silx-kit/silx/pull/2455#issuecomment-464116563, the NXdata interpretation have to be "scalar" (or no interpretation), the signal must have 3dim, and axes must have the right dimension (according to the signal).

The default selected view is the 2D one, as it is faster and it do not have dependency with OpenGL.

![screenshot from 2019-02-15 18-08-54](https://user-images.githubusercontent.com/7579321/52873024-47017a00-314e-11e9-83f5-806678c94e04.png)

Closes #2415