### PR TITLE
Silx/support 2dview for 3dnxdata

### DIFF
--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -445,7 +445,7 @@ class _CompositeDataView(DataView):
         """
         raise NotImplementedError()
 
-    @deprecation.deprecated(replacement="getRegisteredViews", since_version="0.10")
+    @deprecation.deprecated(replacement="getReachableViews", since_version="0.10")
     def availableViews(self):
         return self.getViews()
 

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -42,7 +42,7 @@ from silx.gui.dialog.ColormapDialog import ColormapDialog
 
 __authors__ = ["V. Valls", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "12/02/2019"
+__date__ = "15/02/2019"
 
 _logger = logging.getLogger(__name__)
 
@@ -68,7 +68,7 @@ NXDATA_CURVE_MODE = 73
 NXDATA_XYVSCATTER_MODE = 74
 NXDATA_IMAGE_MODE = 75
 NXDATA_STACK_MODE = 76
-NXDATA_PLOT3D_MODE = 77
+NXDATA_VOLUME_MODE = 77
 
 
 def _normalizeData(data):
@@ -1654,7 +1654,7 @@ class _NXdataStackView(DataView):
 class _NXdataVolumeView(DataView):
     def __init__(self, parent):
         DataView.__init__(self, parent,
-                          modeId=NXDATA_PLOT3D_MODE)
+                          modeId=NXDATA_VOLUME_MODE)
         try:
             import silx.gui.plot3d  # noqa
         except ImportError:

--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -29,6 +29,7 @@ __license__ = "MIT"
 __date__ = "12/11/2018"
 
 import logging
+import numbers
 import numpy
 
 from silx.gui import qt
@@ -938,6 +939,20 @@ class ArrayVolumePlot(qt.QWidget):
         """
         return self._view
 
+    def normalizeComplexData(self, data):
+        """
+        Converts a complex data array to its amplitude, if necessary.
+        :param data: the data to normalize
+        :return:
+        """
+        if hasattr(data, "dtype"):
+            isComplex = numpy.issubdtype(data.dtype, numpy.complexfloating)
+        else:
+            isComplex = isinstance(data, numbers.Complex)
+        if isComplex:
+            data = numpy.absolute(data)
+        return data
+
     def setData(self, signal,
                 x_axis=None, y_axis=None, z_axis=None,
                 signal_name=None,
@@ -962,6 +977,7 @@ class ArrayVolumePlot(qt.QWidget):
         :param zlabel: Label for Z axis
         :param title: Graph title
         """
+        signal = self.normalizeComplexData(signal)
         if self.__selector_is_connected:
             self._selector.selectionChanged.disconnect(self._updateVolume)
             self.__selector_is_connected = False

--- a/silx/io/nxdata/parse.py
+++ b/silx/io/nxdata/parse.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/silx/io/nxdata/parse.py
+++ b/silx/io/nxdata/parse.py
@@ -138,7 +138,7 @@ class NXdata(object):
 
             self.axes_names = []
             # check if axis dataset defines @long_name
-            for i, dsname in enumerate(self.axes_dataset_names):
+            for _, dsname in enumerate(self.axes_dataset_names):
                 if dsname is not None and "long_name" in self.group[dsname].attrs:
                     self.axes_names.append(get_attr_as_unicode(self.group[dsname], "long_name"))
                 else:

--- a/silx/io/nxdata/parse.py
+++ b/silx/io/nxdata/parse.py
@@ -759,8 +759,8 @@ class NXdata(object):
 
         if self.signal_ndim != 3:
             return False
-        if self.interpretation not in [None, "scalar", "scaler", "vertex"]:
-            # Should 'scaler' and 'scalar' be accepted for a volume view ?
+        if self.interpretation not in [None, "scalar", "scaler"]:
+            # 'scaler' and 'scalar' for a three dimensional array indicate a scalar field in 3D
             return False
         volume_shape = self.signal.shape[-3:]
         for i, axis in enumerate(self.axes[-3:]):

--- a/silx/io/nxdata/parse.py
+++ b/silx/io/nxdata/parse.py
@@ -53,7 +53,7 @@ from ._utils import get_attr_as_unicode, INTERPDIM, nxdata_logger, \
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
-__date__ = "29/11/2018"
+__date__ = "15/02/2019"
 
 
 class InvalidNXdataError(Exception):
@@ -743,6 +743,27 @@ class NXdata(object):
         stack_shape = self.signal.shape[-3:]
         for i, axis in enumerate(self.axes[-3:]):
             if axis is not None and len(axis) not in [stack_shape[i], 2]:
+                return False
+        return True
+
+    @property
+    def is_volume(self):
+        """True in the signal is exactly 3D and interpretation
+            "scalar", or nothing.
+
+        The axes length must also be consistent with the 3 dimensions
+        of the signal.
+        """
+        if not self.is_valid:
+            raise InvalidNXdataError("Unable to parse invalid NXdata")
+
+        if self.signal_ndim != 3:
+            return False
+        if self.interpretation not in [None, "scalar", "scaler"]:
+            return False
+        volume_shape = self.signal.shape[-3:]
+        for i, axis in enumerate(self.axes[-3:]):
+            if axis is not None and len(axis) not in [volume_shape[i], 2]:
                 return False
         return True
 

--- a/silx/io/nxdata/parse.py
+++ b/silx/io/nxdata/parse.py
@@ -373,7 +373,7 @@ class NXdata(object):
         if not self.is_valid:
             raise InvalidNXdataError("Unable to parse invalid NXdata")
 
-        allowed_interpretations = [None, "scalar", "spectrum", "image",
+        allowed_interpretations = [None, "scaler", "scalar", "spectrum", "image",
                                    "rgba-image",  # "hsla-image", "cmyk-image"
                                    "vertex"]
 
@@ -383,7 +383,7 @@ class NXdata(object):
 
         if interpretation not in allowed_interpretations:
             nxdata_logger.warning("Interpretation %s is not valid." % interpretation +
-                                  " Valid values: " + ", ".join(allowed_interpretations))
+                                  " Valid values: " + ", ".join(str(s) for s in allowed_interpretations))
         return interpretation
 
     @property
@@ -759,7 +759,8 @@ class NXdata(object):
 
         if self.signal_ndim != 3:
             return False
-        if self.interpretation not in [None, "scalar", "scaler"]:
+        if self.interpretation not in [None, "scalar", "scaler", "vertex"]:
+            # Should 'scaler' and 'scalar' be accepted for a volume view ?
             return False
         volume_shape = self.signal.shape[-3:]
         for i, axis in enumerate(self.axes[-3:]):


### PR DESCRIPTION
Hi @vallsv (@vasole), thanks for adding this. Some additional changes in this PR:

- In NXData.interpretation:
  - "scaler" is not in "allowed_interpretations" even though it's the official NeXus keyword (I agree scalar should be better though !!)
  - if 'scaler' (or any other not-allowed value) is used for interpretation, the logger instruction (line 384 `if interpretation not in allowed_interpretations`) fails because of the 'None' in allowed_interpretation (`ERROR:silx.gui.qt._qt:<class 'TypeError'> sequence item 0: expected str instance, NoneType`)

- in NXData.is_volume(): the valid interpretation should be 'vertex', not scalar or scaler ? I left scaler and scalar as valid values, not sure what is intended

- I added a separate _NXdataComplexVolumeAsStackView to handle 3d complex data. It could be merged in _NXdataVolumeAsStackView  as well but may be more confusing.

- in ArrayVolumePlot use absolute value for complex arrays

One remaining issue is that opening the NXdata 3D view seems long (>10s for a 256**3 dataset) compared to the standard Cube view - I assume that's because of tricks used in the display in the Cube view (there's a delay too to compute the isosurface, but after the 3D interface pops up), but that's a minor issue.
