### PR TITLE
Docstring decorator

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -456,7 +456,7 @@ class PlotWidget(qt.QMainWindow):
             return qt.QColor.fromRgbF(*self._dataBackgroundColor)
 
     def setDataBackgroundColor(self, color):
-        """Set the background color of this widget.
+        """Set the background color of the plot area.
 
         Set to None or an invalid QColor to use the background color.
 

--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -38,6 +38,7 @@ import weakref
 import silx
 from silx.utils.weakref import WeakMethodProxy
 from silx.utils.deprecation import deprecated
+from silx.utils.proxy import docstring
 
 from . import PlotWidget
 from . import actions
@@ -292,23 +293,20 @@ class PlotWindow(PlotWidget):
             for action in toolbar.actions():
                 self.addAction(action)
 
+    @docstring(PlotWidget)
     def setBackgroundColor(self, color):
         super(PlotWindow, self).setBackgroundColor(color)
         self._updateColorBarBackground()
 
-    setBackgroundColor.__doc__ = PlotWidget.setBackgroundColor.__doc__
-
+    @docstring(PlotWidget)
     def setDataBackgroundColor(self, color):
         super(PlotWindow, self).setDataBackgroundColor(color)
         self._updateColorBarBackground()
 
-    setDataBackgroundColor.__doc__ = PlotWidget.setDataBackgroundColor.__doc__
-
+    @docstring(PlotWidget)
     def setForegroundColor(self, color):
         super(PlotWindow, self).setForegroundColor(color)
         self._updateColorBarBackground()
-
-    setForegroundColor.__doc__ = PlotWidget.setForegroundColor.__doc__
 
     def _updateColorBarBackground(self):
         """Update the colorbar background according to the state of the plot"""

--- a/silx/gui/plot/ScatterView.py
+++ b/silx/gui/plot/ScatterView.py
@@ -47,6 +47,7 @@ from .ScatterMaskToolsWidget import ScatterMaskToolsWidget
 
 from ..widgets.BoxLayoutDockWidget import BoxLayoutDockWidget
 from .. import qt, icons
+from ...utils.proxy import docstring
 
 
 _logger = logging.getLogger(__name__)
@@ -307,10 +308,9 @@ class ScatterView(qt.QMainWindow):
         self.getScatterItem().setData(
             x=x, y=y, value=value, xerror=xerror, yerror=yerror, alpha=alpha, copy=copy)
 
+    @docstring(items.Scatter)
     def getData(self, *args, **kwargs):
         return self.getScatterItem().getData(*args, **kwargs)
-
-    getData.__doc__ = items.Scatter.getData.__doc__
 
     def getScatterItem(self):
         """Returns the plot item displaying the scatter data.
@@ -329,37 +329,30 @@ class ScatterView(qt.QMainWindow):
 
     # Convenient proxies
 
+    @docstring(PlotWidget)
     def getXAxis(self, *args, **kwargs):
         return self.getPlotWidget().getXAxis(*args, **kwargs)
 
-    getXAxis.__doc__ = PlotWidget.getXAxis.__doc__
-
+    @docstring(PlotWidget)
     def getYAxis(self, *args, **kwargs):
         return self.getPlotWidget().getYAxis(*args, **kwargs)
 
-    getYAxis.__doc__ = PlotWidget.getYAxis.__doc__
-
+    @docstring(PlotWidget)
     def setGraphTitle(self, *args, **kwargs):
         return self.getPlotWidget().setGraphTitle(*args, **kwargs)
 
-    setGraphTitle.__doc__ = PlotWidget.setGraphTitle.__doc__
-
+    @docstring(PlotWidget)
     def getGraphTitle(self, *args, **kwargs):
         return self.getPlotWidget().getGraphTitle(*args, **kwargs)
 
-    getGraphTitle.__doc__ = PlotWidget.getGraphTitle.__doc__
-
+    @docstring(PlotWidget)
     def resetZoom(self, *args, **kwargs):
         return self.getPlotWidget().resetZoom(*args, **kwargs)
 
-    resetZoom.__doc__ = PlotWidget.resetZoom.__doc__
-
+    @docstring(ScatterMaskToolsWidget)
     def getSelectionMask(self, *args, **kwargs):
         return self.getMaskToolsWidget().getSelectionMask(*args, **kwargs)
 
-    getSelectionMask.__doc__ = ScatterMaskToolsWidget.getSelectionMask.__doc__
-
+    @docstring(ScatterMaskToolsWidget)
     def setSelectionMask(self, *args, **kwargs):
         return self.getMaskToolsWidget().setSelectionMask(*args, **kwargs)
-
-    setSelectionMask.__doc__ = ScatterMaskToolsWidget.setSelectionMask.__doc__

--- a/silx/gui/plot/StatsWidget.py
+++ b/silx/gui/plot/StatsWidget.py
@@ -38,6 +38,7 @@ import weakref
 
 import numpy
 
+from silx.utils.proxy import docstring
 from silx.gui import qt
 from silx.gui import icons
 from silx.gui.plot import stats as statsmdl
@@ -993,33 +994,28 @@ class StatsWidget(qt.QWidget):
 
     # Proxy methods
 
+    @docstring(StatsTable)
     def setStats(self, statsHandler):
         return self._getStatsTable().setStats(statsHandler=statsHandler)
 
-    setStats.__doc__ = StatsTable.setStats.__doc__
-
+    @docstring(StatsTable)
     def setPlot(self, plot):
         self._options.setVisibleDataRangeModeEnabled(
             plot is None or isinstance(plot, PlotWidget))
         return self._getStatsTable().setPlot(plot=plot)
 
-    setPlot.__doc__ = StatsTable.setPlot.__doc__
-
+    @docstring(StatsTable)
     def getPlot(self):
         return self._getStatsTable().getPlot()
 
-    getPlot.__doc__ = StatsTable.getPlot.__doc__
-
+    @docstring(StatsTable)
     def setDisplayOnlyActiveItem(self, displayOnlyActItem):
         return self._getStatsTable().setDisplayOnlyActiveItem(
             displayOnlyActItem=displayOnlyActItem)
 
-    setDisplayOnlyActiveItem.__doc__ = StatsTable.setDisplayOnlyActiveItem.__doc__
-
+    @docstring(StatsTable)
     def setStatsOnVisibleData(self, b):
         return self._getStatsTable().setStatsOnVisibleData(b=b)
-
-    setStatsOnVisibleData.__doc__ = StatsTable.setStatsOnVisibleData.__doc__
 
 
 DEFAULT_STATS = StatsHandler((

--- a/silx/gui/plot3d/Plot3DWindow.py
+++ b/silx/gui/plot3d/Plot3DWindow.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -32,6 +32,7 @@ __license__ = "MIT"
 __date__ = "26/01/2017"
 
 
+from silx.utils.proxy import docstring
 from silx.gui import qt
 
 from .Plot3DWidget import Plot3DWidget
@@ -62,32 +63,26 @@ class Plot3DWindow(qt.QMainWindow):
 
     # Proxy to Plot3DWidget
 
+    @docstring(Plot3DWidget)
     def setProjection(self, projection):
         return self._plot3D.setProjection(projection)
 
-    setProjection.__doc__ = Plot3DWidget.setProjection.__doc__
-
+    @docstring(Plot3DWidget)
     def getProjection(self):
         return self._plot3D.getProjection()
 
-    getProjection.__doc__ = Plot3DWidget.getProjection.__doc__
-
+    @docstring(Plot3DWidget)
     def centerScene(self):
         return self._plot3D.centerScene()
 
-    centerScene.__doc__ = Plot3DWidget.centerScene.__doc__
-
+    @docstring(Plot3DWidget)
     def resetZoom(self):
         return self._plot3D.resetZoom()
 
-    resetZoom.__doc__ = Plot3DWidget.resetZoom.__doc__
-
+    @docstring(Plot3DWidget)
     def getBackgroundColor(self):
         return self._plot3D.getBackgroundColor()
 
-    getBackgroundColor.__doc__ = Plot3DWidget.getBackgroundColor.__doc__
-
+    @docstring(Plot3DWidget)
     def setBackgroundColor(self, color):
         return self._plot3D.setBackgroundColor(color)
-
-    setBackgroundColor.__doc__ = Plot3DWidget.setBackgroundColor.__doc__

--- a/silx/gui/plot3d/actions/mode.py
+++ b/silx/gui/plot3d/actions/mode.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -36,6 +36,7 @@ __date__ = "06/09/2017"
 
 import logging
 
+from silx.utils.proxy import docstring
 from silx.gui.icons import getQIcon
 from .Plot3DAction import Plot3DAction
 
@@ -69,6 +70,7 @@ class InteractiveModeAction(Plot3DAction):
             plot3d.setInteractiveMode(self._interaction)
             self.setChecked(True)
 
+    @docstring(Plot3DAction)
     def setPlot3DWidget(self, widget):
         # Disconnect from previous Plot3DWidget
         plot3d = self.getPlot3DWidget()
@@ -85,9 +87,6 @@ class InteractiveModeAction(Plot3DAction):
             self.setChecked(widget.getInteractiveMode() == self._interaction)
             widget.sigInteractiveModeChanged.connect(
                 self._interactiveModeChanged)
-
-    # Reuse docstring from super class
-    setPlot3DWidget.__doc__ = Plot3DAction.setPlot3DWidget.__doc__
 
     def _interactiveModeChanged(self):
         plot3d = self.getPlot3DWidget()

--- a/silx/utils/proxy.py
+++ b/silx/utils/proxy.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,8 @@ __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "02/10/2017"
 
+
+import functools
 import six
 
 
@@ -202,3 +204,38 @@ class Proxy(object):
         __irepeat__ = property(lambda self: self.__obj.__irepeat__)
 
     __call__ = property(lambda self: self.__obj.__call__)
+
+
+def _docstring(func, origin):
+    """Implementation of docstring decorator.
+
+    It patches func.__doc__.
+    """
+    if isinstance(origin, type):
+        # This is a class, get the method with the same name
+        try:
+            origin = getattr(origin, func.__name__)
+        except AttributeError:
+            raise ValueError(
+                "origin class has no %s method" % func.__name__)
+
+    func.__doc__ = origin.__doc__
+    return func
+
+
+def docstring(origin):
+    """Decorator to initialize the docstring from another source.
+
+    This is useful to duplicate a docstring for inheritance and composition.
+
+    If origin is a method or a function, it copies its docstring.
+    If origin is a class, the docstring is copied from the method
+    of that class which has the same name as the method/function
+    being decorated.
+
+    :param origin:
+        The method, function or class from which to get the docstring
+    :raises ValueError:
+        If the origin class has not method n case the
+    """
+    return functools.partial(_docstring, origin=origin)

--- a/silx/utils/test/test_proxy.py
+++ b/silx/utils/test/test_proxy.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,7 @@ __date__ = "02/10/2017"
 import unittest
 import pickle
 import numpy
-from ..proxy import Proxy
+from silx.utils.proxy import Proxy, docstring
 
 
 class Thing(object):
@@ -282,12 +282,61 @@ class TestPickle(unittest.TestCase):
         self.assertEqual(obj.value, obj2.value)
 
 
+class TestDocstring(unittest.TestCase):
+    """Test docstring decorator"""
+
+    class Base(object):
+        def method(self):
+            """Docstring"""
+            pass
+
+    def test_inheritance(self):
+        class Derived(TestDocstring.Base):
+            @docstring(TestDocstring.Base)
+            def method(self):
+                pass
+
+        self.assertEqual(Derived.method.__doc__,
+                         TestDocstring.Base.method.__doc__)
+
+    def test_composition(self):
+        class Composed(object):
+            def __init__(self):
+                self._base = TestDocstring.Base()
+
+            @docstring(TestDocstring.Base)
+            def method(self):
+                return self._base.method()
+
+            @docstring(TestDocstring.Base.method)
+            def renamed(self):
+                return self._base.method()
+
+        self.assertEqual(Composed.method.__doc__,
+                         TestDocstring.Base.method.__doc__)
+
+        self.assertEqual(Composed.renamed.__doc__,
+                         TestDocstring.Base.method.__doc__)
+
+    def test_function(self):
+        def f():
+            """Docstring"""
+            pass
+
+        @docstring(f)
+        def g():
+            pass
+
+        self.assertEqual(f.__doc__, g.__doc__)
+
+
 def suite():
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
     test_suite = unittest.TestSuite()
     test_suite.addTest(loadTests(TestProxy))
     test_suite.addTest(loadTests(TestPickle))
     test_suite.addTest(loadTests(TestInheritedProxy))
+    test_suite.addTest(loadTests(TestDocstring))
     return test_suite
 
 


### PR DESCRIPTION
This PR provides a `@docstring` decorator that allows to duplicate a docstring from a function or method.
This is convenient when overriding method or making proxy for object composition.

Usage:
```
from silx.utils.proxy import docstring

class B(A):
    @docstring(A)
    def overridden_method(self):
        pass
```

This PR makes use of it throughout silx.

closes #2443