### PR TITLE
[plot3d] Add scene fog

### DIFF
--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -279,7 +279,9 @@ class Plot3DWidget(glu.OpenGLWidget):
         :raise ValueError: If mode is not supported
         """
         mode = self.FogMode.asMember(mode)
-        self.viewport.fog.isOn = mode is self.FogMode.LINEAR
+        if mode != self.getFogMode():
+            self.viewport.fog.isOn = mode is self.FogMode.LINEAR
+            self.sigStyleChanged.emit('fogMode')
 
     def getFogMode(self):
         """Returns the kind of fog in use

--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -31,6 +31,7 @@ __license__ = "MIT"
 __date__ = "24/04/2018"
 
 
+import enum
 import logging
 
 from silx.gui import qt
@@ -105,6 +106,33 @@ class Plot3DWidget(glu.OpenGLWidget):
 
     It provides the updated property.
     """
+
+    @enum.unique
+    class FogMode(enum.Enum):
+        """Different mode to render the scene with fog"""
+
+        NONE = 'none'
+        """No fog effect"""
+
+        LINEAR = 'linear'
+        """Linear fog through the whole scene"""
+
+        @classmethod
+        def asMember(cls, value):
+            """Convert a str to corresponding enum member
+
+            :param Union[str,FogMode] value: The value to convert
+            :return: The corresponding enum member
+            :rtype: FogMode
+            :raise ValueError: In case the conversion is not possible
+            """
+            if isinstance(value, cls):
+                return value
+            value = str(value)
+            for member in cls:
+                if value == member.value:
+                    return member
+            raise ValueError("Cannot convert: %s" % value)
 
     def __init__(self, parent=None, f=qt.Qt.WindowFlags()):
         self._firstRender = True
@@ -243,6 +271,26 @@ class Plot3DWidget(glu.OpenGLWidget):
     def getBackgroundColor(self):
         """Returns the RGBA background color (QColor)."""
         return qt.QColor.fromRgbF(*self.viewport.background)
+
+    def setFogMode(self, mode):
+        """Set the kind of fog to use for the whole scene.
+
+        :param Union[str,FogMode] mode: The mode to use
+        :raise ValueError: If mode is not supported
+        """
+        mode = self.FogMode.asMember(mode)
+        self.viewport.fog.isOn = mode is self.FogMode.LINEAR
+
+    def getFogMode(self):
+        """Returns the kind of fog in use
+
+        :return: The kind of fog in use
+        :rtype: FogMode
+        """
+        if self.viewport.fog.isOn:
+            return self.FogMode.LINEAR
+        else:
+            return self.FogMode.NONE
 
     def isOrientationIndicatorVisible(self):
         """Returns True if the orientation indicator is displayed.

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -45,6 +45,7 @@ from ...colors import preferredColormaps
 from ... import qt, icons
 from .. import items
 from ..items.volume import Isosurface, CutPlane
+from ..Plot3DWidget import Plot3DWidget
 
 
 from .core import AngleDegreeRow, BaseRow, ColorProxyRow, ProxyRow, StaticRow
@@ -195,9 +196,18 @@ class Settings(StaticRow):
         lightDirection = StaticRow(('Light Direction', None),
                                    children=(azimuthNode, altitudeNode))
 
+        # Fog
+        fog = ProxyRow(
+            name='Fog',
+            fget=sceneWidget.getFogMode,
+            fset=sceneWidget.setFogMode,
+            notify=sceneWidget.sigStyleChanged,
+            toModelData=lambda mode: mode is Plot3DWidget.FogMode.LINEAR,
+            fromModelData=lambda mode: Plot3DWidget.FogMode.LINEAR if mode else Plot3DWidget.FogMode.NONE)
+
         # Settings row
         children = (background, foreground, text, highlight,
-                    axesIndicator, lightDirection)
+                    axesIndicator, lightDirection, fog)
         super(Settings, self).__init__(('Settings', None), children=children)
 
 

--- a/silx/gui/plot3d/scene/core.py
+++ b/silx/gui/plot3d/scene/core.py
@@ -113,7 +113,7 @@ class Base(event.Notifier):
 
     @property
     def root(self):
-        """The root not of the scene.
+        """The root node of the scene.
 
         If attached to a :class:`Viewport`, this is the item right under it
         """

--- a/silx/gui/plot3d/scene/core.py
+++ b/silx/gui/plot3d/scene/core.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -110,6 +110,15 @@ class Base(event.Notifier):
         """The viewport this node is attached to or None."""
         root = self.path[0]
         return root if isinstance(root, Viewport) else None
+
+    @property
+    def root(self):
+        """The root not of the scene.
+
+        If attached to a :class:`Viewport`, this is the item right under it
+        """
+        path = self.path
+        return path[1] if isinstance(path[0], Viewport) else path[0]
 
     @property
     def objectToNDCTransform(self):

--- a/silx/gui/plot3d/scene/function.py
+++ b/silx/gui/plot3d/scene/function.py
@@ -60,7 +60,7 @@ class ProgramFunction(object):
         pass
 
 
-class Fog(ProgramFunction):
+class Fog(event.Notifier, ProgramFunction):
     """Linear fog over the whole scene content.
 
     The background of the viewport is used as fog color,
@@ -91,6 +91,7 @@ class Fog(ProgramFunction):
     """
 
     def __init__(self):
+        super(Fog, self).__init__()
         self._isOn = True
 
     @property
@@ -100,7 +101,10 @@ class Fog(ProgramFunction):
 
     @isOn.setter
     def isOn(self, isOn):
-        self._isOn = bool(isOn)
+        isOn = bool(isOn)
+        if self._isOn != isOn:
+            self._isOn = bool(isOn)
+            self.notify()
 
     @property
     def fragDecl(self):

--- a/silx/gui/plot3d/scene/viewport.py
+++ b/silx/gui/plot3d/scene/viewport.py
@@ -76,6 +76,21 @@ class RenderContext(object):
         self._fog = Fog()
         self._fog.isOn = False
 
+        # cache
+        self.__cache = {}
+
+    def cache(self, key, factory, *args, **kwargs):
+        """Lazy-loading cache to store values in the context for rendering
+
+        :param key: The key to retrieve
+        :param factory: A callback taking args and kwargs as arguments
+            and returning the value to store.
+        :return: The stored or newly allocated value
+        """
+        if key not in self.__cache:
+            self.__cache[key] = factory(*args, **kwargs)
+        return self.__cache[key]
+
     @property
     def viewport(self):
         """Viewport doing the current rendering"""

--- a/silx/gui/plot3d/test/__init__.py
+++ b/silx/gui/plot3d/test/__init__.py
@@ -58,6 +58,7 @@ def suite():
     from ..tools.test import suite as toolsTestSuite
     from .testGL import suite as testGLSuite
     from .testScalarFieldView import suite as testScalarFieldViewSuite
+    from .testSceneWidget import suite as testSceneWidgetSuite
     from .testSceneWidgetPicking import suite as testSceneWidgetPickingSuite
     from .testStatsWidget import suite as testStatsWidgetSuite
 
@@ -65,6 +66,7 @@ def suite():
     testsuite.addTest(testGLSuite())
     testsuite.addTest(sceneTestSuite())
     testsuite.addTest(testScalarFieldViewSuite())
+    testsuite.addTest(testSceneWidgetSuite())
     testsuite.addTest(testSceneWidgetPickingSuite())
     testsuite.addTest(toolsTestSuite())
     testsuite.addTest(testStatsWidgetSuite())

--- a/silx/gui/plot3d/test/testSceneWidget.py
+++ b/silx/gui/plot3d/test/testSceneWidget.py
@@ -1,0 +1,84 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+# ###########################################################################*/
+"""Test SceneWidget"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "06/03/2019"
+
+
+import unittest
+
+import numpy
+
+from silx.utils.testutils import ParametricTestCase
+from silx.gui.utils.testutils import TestCaseQt
+from silx.gui import qt
+
+from silx.gui.plot3d.SceneWidget import SceneWidget
+
+
+class TestSceneWidget(TestCaseQt, ParametricTestCase):
+    """Tests SceneWidget picking feature"""
+
+    def setUp(self):
+        super(TestSceneWidget, self).setUp()
+        self.widget = SceneWidget()
+        self.widget.show()
+        self.qWaitForWindowExposed(self.widget)
+
+    def tearDown(self):
+        self.qapp.processEvents()
+        self.widget.setAttribute(qt.Qt.WA_DeleteOnClose)
+        self.widget.close()
+        del self.widget
+        super(TestSceneWidget, self).tearDown()
+
+    def testFogEffect(self):
+        """Test fog effect on scene primitive"""
+        image = self.widget.addImage(numpy.arange(100).reshape(10, 10))
+        scatter = self.widget.add3DScatter(*numpy.random.random(4000).reshape(4, -1))
+        scatter.setTranslation(10, 10)
+        scatter.setScale(10, 10, 10)
+
+        self.widget.resetZoom('front')
+        self.qapp.processEvents()
+
+        self.widget.setFogMode(self.widget.FogMode.LINEAR)
+        self.qapp.processEvents()
+
+        self.widget.setFogMode(self.widget.FogMode.NONE)
+        self.qapp.processEvents()
+
+
+def suite():
+    testsuite = unittest.TestSuite()
+    testsuite.addTest(
+        unittest.defaultTestLoader.loadTestsFromTestCase(
+            TestSceneWidget))
+    return testsuite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
This PR adds the option to render the scene with linear fog.

As it is, it is an on/off linear fog across the whole scene.
It is possible to add different kind of fog, to allow to set the range over which to apply it or to specify a fog color.

To try it, use `examples/plot3dSceneWindow.py`, and in the `Object parameters` dock widget on the right, expand the `Settings` node and toggle the `Fog` checkbox.

closes #2414