### PR TITLE
Fix ImageFileDialog selection

### DIFF
--- a/silx/gui/dialog/AbstractDataFileDialog.py
+++ b/silx/gui/dialog/AbstractDataFileDialog.py
@@ -1044,13 +1044,12 @@ class AbstractDataFileDialog(qt.QDialog):
         self.__processing += 1
         index = self.__fileModel.setRootPath(path)
         if not index.isValid():
+            # There is a problem with this path
+            # No asynchronous process will be waked up
             self.__processing -= 1
             self.__browser.setRootIndex(index, model=self.__fileModel)
             self.__clearData()
             self.__updatePath()
-        else:
-            # asynchronous process
-            pass
 
     def __directoryLoaded(self, path):
         if self.__directoryLoadedFilter is not None:

--- a/silx/gui/dialog/AbstractDataFileDialog.py
+++ b/silx/gui/dialog/AbstractDataFileDialog.py
@@ -546,6 +546,10 @@ class AbstractDataFileDialog(qt.QDialog):
     def _init(self):
         self.setWindowTitle("Open")
 
+        self.__openedFiles = []
+        """Store the list of files opened by the model itself."""
+        # FIXME: It should be managed one by one by Hdf5Item itself
+
         self.__directory = None
         self.__directoryLoadedFilter = None
         self.__errorWhileLoadingFile = None
@@ -594,10 +598,6 @@ class AbstractDataFileDialog(qt.QDialog):
         # Update the file model filter
         self.__fileTypeCombo.setCurrentIndex(0)
         self.__filterSelected(0)
-
-        self.__openedFiles = []
-        """Store the list of files opened by the model itself."""
-        # FIXME: It should be managed one by one by Hdf5Item itself
 
         # It is not possible to override the QObject destructor nor
         # to access to the content of the Python object with the `destroyed`

--- a/silx/gui/dialog/ImageFileDialog.py
+++ b/silx/gui/dialog/ImageFileDialog.py
@@ -28,7 +28,7 @@ This module contains an :class:`ImageFileDialog`.
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "12/02/2018"
+__date__ = "05/03/2019"
 
 import logging
 from silx.gui.plot import actions
@@ -36,7 +36,6 @@ from silx.gui import qt
 from silx.gui.plot.PlotWidget import PlotWidget
 from .AbstractDataFileDialog import AbstractDataFileDialog
 import silx.io
-import fabio
 
 
 _logger = logging.getLogger(__name__)
@@ -61,7 +60,7 @@ class _ImageSelection(qt.QWidget):
 
     def isUsed(self):
         if self.__shape is None:
-            return None
+            return False
         return len(self.__shape) > 2
 
     def getSelectedData(self, data):
@@ -70,6 +69,10 @@ class _ImageSelection(qt.QWidget):
         return image
 
     def setData(self, data):
+        if data is None:
+            self.__visibleSliders = 0
+            return
+
         shape = data.shape
         if self.__shape is not None:
             # clean up
@@ -113,6 +116,22 @@ class _ImageSelection(qt.QWidget):
             if i > len(self.__axis):
                 break
             self.__axis[i].setValue(value)
+
+    def selectSlicing(self, slicing):
+        """Select a slicing.
+
+        The provided value could be unconsistent and therefore is not supposed
+        to be retrivable with a getter.
+
+        :param Union[None,Tuple[int]] slicing:
+        """
+        if slicing is None:
+            # Create a default slicing
+            needed = self.__visibleSliders
+            slicing = (0,) * needed
+        if len(slicing) < self.__visibleSliders:
+            slicing = slicing + (0,) * (self.__visibleSliders - len(slicing))
+        self.setSlicing(slicing)
 
 
 class _ImagePreview(qt.QWidget):

--- a/silx/gui/dialog/test/test_datafiledialog.py
+++ b/silx/gui/dialog/test/test_datafiledialog.py
@@ -385,7 +385,7 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         filename = _tmpDirectory + "/singleimage.edf"
         url = silx.io.url.DataUrl(scheme="silx", file_path=filename, data_path="/scan_0/instrument/detector_0/data")
         dialog.selectUrl(url.path())
-        self.assertTrue(dialog._selectedData().shape, (100, 100))
+        self.assertEqual(dialog._selectedData().shape, (100, 100))
         self.assertSamePath(dialog.selectedFile(), filename)
         self.assertSamePath(dialog.selectedUrl(), url.path())
 
@@ -399,7 +399,7 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         path = silx.io.url.DataUrl(scheme="silx", file_path=filename, data_path="/image").path()
         dialog.selectUrl(path)
         # test
-        self.assertTrue(dialog._selectedData().shape, (100, 100))
+        self.assertEqual(dialog._selectedData().shape, (100, 100))
         self.assertSamePath(dialog.selectedFile(), filename)
         self.assertSamePath(dialog.selectedUrl(), path)
 
@@ -479,11 +479,12 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         self.qWaitForPendingActions(dialog)
         browser = testutils.findChildren(dialog, qt.QWidget, name="browser")[0]
         filename = _tmpDirectory + "/badformat.h5"
-        index = browser.rootIndex().model().index(filename)
+        index = browser.model().index(filename)
+        browser.selectIndex(index)
         browser.activated.emit(index)
         self.qWaitForPendingActions(dialog)
         # test
-        self.assertTrue(dialog.selectedUrl(), filename)
+        self.assertEqual(dialog.selectedUrl(), filename)
 
     def _countSelectableItems(self, model, rootIndex):
         selectable = 0

--- a/silx/gui/dialog/test/test_datafiledialog.py
+++ b/silx/gui/dialog/test/test_datafiledialog.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "05/03/2019"
+__date__ = "08/03/2019"
 
 
 import unittest
@@ -484,7 +484,7 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         browser.activated.emit(index)
         self.qWaitForPendingActions(dialog)
         # test
-        self.assertEqual(dialog.selectedUrl(), filename)
+        self.assertSamePath(dialog.selectedUrl(), filename)
 
     def _countSelectableItems(self, model, rootIndex):
         selectable = 0

--- a/silx/gui/dialog/test/test_datafiledialog.py
+++ b/silx/gui/dialog/test/test_datafiledialog.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "05/10/2018"
+__date__ = "05/03/2019"
 
 
 import unittest
@@ -130,7 +130,7 @@ class _UtilsMixin(object):
         path2_ = os.path.normcase(path2)
         if path1_ == path2_:
             # Use the unittest API to log and display error
-            self.assertNotEquals(path1, path2)
+            self.assertNotEqual(path1, path2)
 
 
 class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
@@ -853,7 +853,7 @@ class TestDataFileDialogApi(testutils.TestCaseQt, _UtilsMixin):
         dialog2 = self.createDialog()
         result = dialog2.restoreState(state)
         self.assertTrue(result)
-        self.assertNotEquals(dialog2.directory(), directory)
+        self.assertNotEqual(dialog2.directory(), directory)
 
     def testHistory(self):
         dialog = self.createDialog()

--- a/silx/gui/dialog/test/test_imagefiledialog.py
+++ b/silx/gui/dialog/test/test_imagefiledialog.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "05/10/2018"
+__date__ = "05/03/2019"
 
 
 import unittest
@@ -70,24 +70,22 @@ def setUpModule():
     image.write(filename)
 
     filename = _tmpDirectory + "/data.h5"
-    f = h5py.File(filename, "w")
-    f["scalar"] = 10
-    f["image"] = data
-    f["cube"] = [data, data + 1, data + 2]
-    f["complex_image"] = data * 1j
-    f["group/image"] = data
-    f.close()
+    with h5py.File(filename, "w") as f:
+        f["scalar"] = 10
+        f["image"] = data
+        f["cube"] = [data, data + 1, data + 2]
+        f["complex_image"] = data * 1j
+        f["group/image"] = data
 
     directory = os.path.join(_tmpDirectory, "data")
     os.mkdir(directory)
     filename = os.path.join(directory, "data.h5")
-    f = h5py.File(filename, "w")
-    f["scalar"] = 10
-    f["image"] = data
-    f["cube"] = [data, data + 1, data + 2]
-    f["complex_image"] = data * 1j
-    f["group/image"] = data
-    f.close()
+    with h5py.File(filename, "w") as f:
+        f["scalar"] = 10
+        f["image"] = data
+        f["cube"] = [data, data + 1, data + 2]
+        f["complex_image"] = data * 1j
+        f["group/image"] = data
 
     filename = _tmpDirectory + "/badformat.edf"
     with io.open(filename, "wb") as f:

--- a/silx/gui/dialog/test/test_imagefiledialog.py
+++ b/silx/gui/dialog/test/test_imagefiledialog.py
@@ -489,8 +489,6 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         path = silx.io.url.DataUrl(scheme="silx", file_path=filename, data_path="/single_frame", data_slice=(0, )).path()
         dialog.selectUrl(path)
         # test
-        print(dialog.selectedImage().shape)
-        print(dialog.selectedImage()[0, 0])
         self.assertEqual(dialog.selectedImage().shape, (100, 100))
         self.assertEqual(dialog.selectedImage()[0, 0], 5)
         self.assertSamePath(dialog.selectedFile(), filename)

--- a/silx/gui/dialog/test/test_imagefiledialog.py
+++ b/silx/gui/dialog/test/test_imagefiledialog.py
@@ -135,7 +135,7 @@ class _UtilsMixin(object):
         path2_ = os.path.normcase(path2)
         if path1_ == path2_:
             # Use the unittest API to log and display error
-            self.assertNotEquals(path1, path2)
+            self.assertNotEqual(path1, path2)
 
 
 class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
@@ -670,7 +670,7 @@ class TestImageFileDialogApi(testutils.TestCaseQt, _UtilsMixin):
         dialog2 = self.createDialog()
         result = dialog2.restoreState(state)
         self.assertTrue(result)
-        self.assertNotEquals(dialog2.directory(), directory)
+        self.assertNotEqual(dialog2.directory(), directory)
 
     def testHistory(self):
         dialog = self.createDialog()

--- a/silx/gui/dialog/test/test_imagefiledialog.py
+++ b/silx/gui/dialog/test/test_imagefiledialog.py
@@ -74,6 +74,7 @@ def setUpModule():
         f["scalar"] = 10
         f["image"] = data
         f["cube"] = [data, data + 1, data + 2]
+        f["single_frame"] = [data + 5]
         f["complex_image"] = data * 1j
         f["group/image"] = data
 
@@ -84,6 +85,7 @@ def setUpModule():
         f["scalar"] = 10
         f["image"] = data
         f["cube"] = [data, data + 1, data + 2]
+        f["single_frame"] = [data + 5]
         f["complex_image"] = data * 1j
         f["group/image"] = data
 
@@ -476,6 +478,21 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         self.assertEqual(dialog.selectedImage()[0, 0], 1)
         self.assertSamePath(dialog.selectedFile(), filename)
         self.assertSamePath(dialog.selectedUrl(), path)
+
+    def testSelectSingleFrameFromH5(self):
+        dialog = self.createDialog()
+        dialog.show()
+        self.qWaitForWindowExposed(dialog)
+
+        # init state
+        filename = _tmpDirectory + "/data.h5"
+        path = silx.io.url.DataUrl(scheme="silx", file_path=filename, data_path="/single_frame", data_slice=(0, )).path()
+        dialog.selectUrl(path)
+        # test
+        print(dialog.selectedImage().shape)
+        print(dialog.selectedImage()[0, 0])
+        self.assertEqual(dialog.selectedImage().shape, (100, 100))
+        self.assertEqual(dialog.selectedImage()[0, 0], 5)
         self.assertSamePath(dialog.selectedFile(), filename)
         self.assertSamePath(dialog.selectedUrl(), path)
 

--- a/silx/gui/dialog/test/test_imagefiledialog.py
+++ b/silx/gui/dialog/test/test_imagefiledialog.py
@@ -26,7 +26,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "05/03/2019"
+__date__ = "08/03/2019"
 
 
 import unittest
@@ -511,7 +511,7 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         browser.activated.emit(index)
         self.qWaitForPendingActions(dialog)
         # test
-        self.assertEqual(dialog.selectedUrl(), filename)
+        self.assertSamePath(dialog.selectedUrl(), filename)
 
     def _countSelectableItems(self, model, rootIndex):
         selectable = 0

--- a/silx/gui/dialog/test/test_imagefiledialog.py
+++ b/silx/gui/dialog/test/test_imagefiledialog.py
@@ -371,7 +371,7 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         filename = _tmpDirectory + "/singleimage.edf"
         path = filename
         dialog.selectUrl(path)
-        self.assertTrue(dialog.selectedImage().shape, (100, 100))
+        self.assertEqual(dialog.selectedImage().shape, (100, 100))
         self.assertSamePath(dialog.selectedFile(), filename)
         path = silx.io.url.DataUrl(scheme="fabio", file_path=filename).path()
         self.assertSamePath(dialog.selectedUrl(), path)
@@ -394,7 +394,7 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         browser.activated.emit(index)
         self.qWaitForPendingActions(dialog)
         # test
-        self.assertTrue(dialog.selectedImage().shape, (100, 100))
+        self.assertEqual(dialog.selectedImage().shape, (100, 100))
         self.assertSamePath(dialog.selectedFile(), filename)
         self.assertSamePath(dialog.selectedUrl(), path)
 
@@ -409,8 +409,8 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         dialog.selectUrl(path)
         # test
         image = dialog.selectedImage()
-        self.assertTrue(image.shape, (100, 100))
-        self.assertTrue(image[0, 0], 1)
+        self.assertEqual(image.shape, (100, 100))
+        self.assertEqual(image[0, 0], 1)
         self.assertSamePath(dialog.selectedFile(), filename)
         self.assertSamePath(dialog.selectedUrl(), path)
 
@@ -424,7 +424,7 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         path = silx.io.url.DataUrl(scheme="fabio", file_path=filename).path()
         dialog.selectUrl(path)
         # test
-        self.assertTrue(dialog.selectedImage().shape, (100, 100))
+        self.assertEqual(dialog.selectedImage().shape, (100, 100))
         self.assertSamePath(dialog.selectedFile(), filename)
         self.assertSamePath(dialog.selectedUrl(), path)
 
@@ -438,7 +438,7 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         path = silx.io.url.DataUrl(scheme="silx", file_path=filename, data_path="/image").path()
         dialog.selectUrl(path)
         # test
-        self.assertTrue(dialog.selectedImage().shape, (100, 100))
+        self.assertEqual(dialog.selectedImage().shape, (100, 100))
         self.assertSamePath(dialog.selectedFile(), filename)
         self.assertSamePath(dialog.selectedUrl(), path)
 
@@ -472,8 +472,10 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         path = silx.io.url.DataUrl(scheme="silx", file_path=filename, data_path="/cube", data_slice=(1, )).path()
         dialog.selectUrl(path)
         # test
-        self.assertTrue(dialog.selectedImage().shape, (100, 100))
-        self.assertTrue(dialog.selectedImage()[0, 0], 1)
+        self.assertEqual(dialog.selectedImage().shape, (100, 100))
+        self.assertEqual(dialog.selectedImage()[0, 0], 1)
+        self.assertSamePath(dialog.selectedFile(), filename)
+        self.assertSamePath(dialog.selectedUrl(), path)
         self.assertSamePath(dialog.selectedFile(), filename)
         self.assertSamePath(dialog.selectedUrl(), path)
 
@@ -487,11 +489,12 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         self.qWaitForPendingActions(dialog)
         browser = testutils.findChildren(dialog, qt.QWidget, name="browser")[0]
         filename = _tmpDirectory + "/badformat.edf"
-        index = browser.rootIndex().model().index(filename)
+        index = browser.model().index(filename)
+        browser.selectIndex(index)
         browser.activated.emit(index)
         self.qWaitForPendingActions(dialog)
         # test
-        self.assertTrue(dialog.selectedUrl(), filename)
+        self.assertEqual(dialog.selectedUrl(), filename)
 
     def _countSelectableItems(self, model, rootIndex):
         selectable = 0
@@ -547,7 +550,7 @@ class TestImageFileDialogApi(testutils.TestCaseQt, _UtilsMixin):
         result = dialog2.restoreState(state)
         self.qWaitForPendingActions(dialog2)
         self.assertTrue(result)
-        self.assertTrue(dialog2.colormap().getNormalization(), "log")
+        self.assertEqual(dialog2.colormap().getNormalization(), "log")
 
     def printState(self):
         """
@@ -644,7 +647,7 @@ class TestImageFileDialogApi(testutils.TestCaseQt, _UtilsMixin):
         result = dialog.restoreState(state)
         self.assertTrue(result)
         colormap = dialog.colormap()
-        self.assertTrue(colormap.getNormalization(), "log")
+        self.assertEqual(colormap.getNormalization(), "log")
 
     def testRestoreRobusness(self):
         """What's happen if you try to open a config file with a different


### PR DESCRIPTION
It was not possible to select the image of a cube with shape like `1,y,x`.

Plus few clean up

Closes #2484 