### PR TITLE
Fix plot default symbol

### DIFF
--- a/silx/_config.py
+++ b/silx/_config.py
@@ -110,7 +110,7 @@ class Config(object):
     .. versionadded:: 0.9
     """
 
-    DEFAULT_PLOT_CURVE_SYMBOL = False
+    DEFAULT_PLOT_CURVE_SYMBOL_MODE = False
     """Whether to display curves with markers or not by default in PlotWidget.
 
     It will have an influence on PlotWidget curve items.

--- a/silx/_config.py
+++ b/silx/_config.py
@@ -110,21 +110,10 @@ class Config(object):
     .. versionadded:: 0.9
     """
 
-    DEFAULT_PLOT_CURVE_SYMBOL = ''
-    """Default marker of the curve item of the plot.
+    DEFAULT_PLOT_CURVE_SYMBOL = False
+    """Whether to display curves with markers or not by default in PlotWidget.
 
-    It will have an influence on PlotWidget curve items
-
-    Supported symbols:
-
-        - 'o', 'Circle'
-        - 'd', 'Diamond'
-        - 's', 'Square'
-        - '+', 'Plus'
-        - 'x', 'Cross'
-        - '.', 'Point'
-        - ',', 'Pixel'
-        - '',  'None'
+    It will have an influence on PlotWidget curve items.
 
     .. versionadded:: 0.10
     """

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2373,7 +2373,8 @@ class PlotWidget(qt.QMainWindow):
 
     def isDefaultPlotPoints(self):
         """Return True if the default Curve symbol is set and False if not."""
-        return self._defaultPlotPoints == silx.config.DEFAULT_PLOT_CURVE_SYMBOL
+        symbol = silx.config.DEFAULT_PLOT_CURVE_SYMBOL
+        return self._defaultPlotPoints == (symbol if symbol != '' else 'o')
 
     def setDefaultPlotPoints(self, flag):
         """Set the default symbol of all curves.
@@ -2383,7 +2384,12 @@ class PlotWidget(qt.QMainWindow):
         :param bool flag: True to use 'o' as the default curve symbol,
                           False to use no symbol.
         """
-        self._defaultPlotPoints = silx.config.DEFAULT_PLOT_CURVE_SYMBOL if flag else ''
+        if not flag:
+            self._defaultPlotPoints = ''
+        elif silx.config.DEFAULT_PLOT_CURVE_SYMBOL != '':
+            self._defaultPlotPoints = silx.config.DEFAULT_PLOT_CURVE_SYMBOL
+        else:
+            self._defaultPlotPoints = 'o'  # Use a fallback
 
         # Reset symbol of all curves
         curves = self.getAllCurves(just_legend=False, withhidden=True)

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -252,7 +252,7 @@ class PlotWidget(qt.QMainWindow):
 
         self.setDefaultColormap()  # Init default colormap
 
-        self.setDefaultPlotPoints(silx.config.DEFAULT_PLOT_CURVE_SYMBOL != '')
+        self.setDefaultPlotPoints(silx.config.DEFAULT_PLOT_CURVE_SYMBOL)
         self.setDefaultPlotLines(True)
 
         self._limitsHistory = LimitsHistory(self)
@@ -2373,8 +2373,7 @@ class PlotWidget(qt.QMainWindow):
 
     def isDefaultPlotPoints(self):
         """Return True if the default Curve symbol is set and False if not."""
-        symbol = silx.config.DEFAULT_PLOT_CURVE_SYMBOL
-        return self._defaultPlotPoints == (symbol if symbol != '' else 'o')
+        return self._defaultPlotPoints == silx.config.DEFAULT_PLOT_SYMBOL
 
     def setDefaultPlotPoints(self, flag):
         """Set the default symbol of all curves.
@@ -2384,12 +2383,7 @@ class PlotWidget(qt.QMainWindow):
         :param bool flag: True to use 'o' as the default curve symbol,
                           False to use no symbol.
         """
-        if not flag:
-            self._defaultPlotPoints = ''
-        elif silx.config.DEFAULT_PLOT_CURVE_SYMBOL != '':
-            self._defaultPlotPoints = silx.config.DEFAULT_PLOT_CURVE_SYMBOL
-        else:
-            self._defaultPlotPoints = 'o'  # Use a fallback
+        self._defaultPlotPoints = silx.config.DEFAULT_PLOT_SYMBOL if flag else ''
 
         # Reset symbol of all curves
         curves = self.getAllCurves(just_legend=False, withhidden=True)

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -252,7 +252,7 @@ class PlotWidget(qt.QMainWindow):
 
         self.setDefaultColormap()  # Init default colormap
 
-        self.setDefaultPlotPoints(silx.config.DEFAULT_PLOT_CURVE_SYMBOL)
+        self.setDefaultPlotPoints(silx.config.DEFAULT_PLOT_CURVE_SYMBOL_MODE)
         self.setDefaultPlotLines(True)
 
         self._limitsHistory = LimitsHistory(self)

--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -303,9 +303,12 @@ class CurveStyleAction(PlotAction):
         currentState = (self.plot.isDefaultPlotLines(),
                         self.plot.isDefaultPlotPoints())
 
-        # line only, line and symbol, symbol only
-        states = (True, False), (True, True), (False, True)
-        newState = states[(states.index(currentState) + 1) % 3]
+        if currentState == (False, False):
+            newState = True, False
+        else:
+            # line only, line and symbol, symbol only
+            states = (True, False), (True, True), (False, True)
+            newState = states[(states.index(currentState) + 1) % 3]
 
         self.plot.setDefaultPlotLines(newState[0])
         self.plot.setDefaultPlotPoints(newState[1])


### PR DESCRIPTION
This PR fixes the issue with default symbol in plot widget.
To me the `silx.config.DEFAULT_PLOT_CURVE_SYMBOL` feature is a bit ambiguous, any better idea welcome.

closes #2488