### PR TITLE
[plot3d] Add complex 3D volume item to SceneWidget

### DIFF
--- a/silx/gui/plot3d/SceneWidget.py
+++ b/silx/gui/plot3d/SceneWidget.py
@@ -267,7 +267,7 @@ class SceneSelection(qt.QObject):
             assert isinstance(parent, SceneWidget)
 
             if item.root() != parent.getSceneGroup():
-                self.setSelectedItem(None)
+                self.setCurrentItem(None)
 
     # Synchronization with QItemSelectionModel
 

--- a/silx/gui/plot3d/SceneWidget.py
+++ b/silx/gui/plot3d/SceneWidget.py
@@ -45,7 +45,6 @@ from .scene import interaction
 from ._model import SceneModel, visitQAbstractItemModel
 from ._model.items import Item3DRow
 
-
 __all__ = ['items', 'SceneWidget']
 
 
@@ -482,26 +481,36 @@ class SceneWidget(Plot3DWidget):
 
     # Add/remove items
 
-    def add3DScalarField(self, data, copy=True, index=None):
-        """Add 3D scalar data volume to :class:`SceneWidget` content.
+    def addVolume(self, data, copy=True, index=None):
+        """Add 3D data volume of scalar or complex to :class:`SceneWidget` content.
 
         Dataset order is zyx (i.e., first dimension is z).
 
-        :param data: 3D array
-        :type data: 3D numpy.ndarray of float32 with shape at least (2, 2, 2)
+        :param data: 3D array of complex with shape at least (2, 2, 2)
+        :type data: numpy.ndarray[Union[numpy.complex64,numpy.float32]]
         :param bool copy:
             True (default) to make a copy,
             False to avoid copy (DO NOT MODIFY data afterwards)
         :param int index: The index at which to place the item.
                           By default it is appended to the end of the list.
-        :return: The newly created scalar volume item
-        :rtype: ~silx.gui.plot3d.items.volume.ScalarField3D
+        :return: The newly created 3D volume item
+        :rtype: Union[ScalarField3D,ComplexField3D]
 
         """
-        volume = items.ScalarField3D()
+        if data is not None:
+            data = numpy.array(data, copy=False)
+
+        if numpy.iscomplexobj(data):
+            volume = items.ComplexField3D()
+        else:
+            volume = items.ScalarField3D()
         volume.setData(data, copy=copy)
         self.addItem(volume, index)
         return volume
+
+    def add3DScalarField(self, data, copy=True, index=None):
+        # TODO deprecate in the future
+        return self.addVolume(data, copy=copy, index=index)
 
     def add3DScatter(self, x, y, z, value, copy=True, index=None):
         """Add 3D scatter data to :class:`SceneWidget` content.

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -988,7 +988,10 @@ class IsosurfaceRow(Item3DRow):
                 dataRange = scalarField3D.getDataRange()
                 if dataRange is not None:
                     dataMin, dataMax = dataRange[0], dataRange[-1]
-                    offset = (item.getLevel() - dataMin) / (dataMax - dataMin)
+                    if dataMax != dataMin:
+                        offset = (item.getLevel() - dataMin) / (dataMax - dataMin)
+                    else:
+                        offset = 0.
 
                     sliderMin, sliderMax = self._LEVEL_SLIDER_RANGE
                     value = sliderMin + (sliderMax - sliderMin) * offset

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -1209,7 +1209,9 @@ class VolumeIsoSurfacesRow(StaticRow):
         if volume is None:
             return
 
-        row = volume.getIsosurfaces().index(item) + 1
+        row = volume.getIsosurfaces().index(item)
+        if isinstance(volume, items.ComplexMixIn):
+            row += 1  # Offset for the ComplexModeRow
         self.addRow(nodeFromItem(item), row)
 
     def _isosurfaceRemoved(self, item):

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -894,7 +894,7 @@ class ComplexModeRow(ProxyRow):
         names = [m.value.replace('_', ' ').title()
                  for m in item.supportedComplexModes()]
         super(ComplexModeRow, self).__init__(
-            name='Display',
+            name='Mode',
             fget=item.getComplexMode,
             fset=item.setComplexMode,
             notify=item.sigItemChanged,

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -884,6 +884,25 @@ class PlaneRow(ProxyRow):
         return super(PlaneRow, self).data(column, role)
 
 
+class ComplexModeRow(ProxyRow):
+    """Represents :class:`items.ComplexMixIn` symbol property.
+
+    :param Item3D item: Scene item with symbol property
+    """
+
+    def __init__(self, item):
+        names = [m.value.replace('_', ' ').title()
+                 for m in item.supportedComplexModes()]
+        super(ComplexModeRow, self).__init__(
+            name='Display',
+            fget=item.getComplexMode,
+            fset=item.setComplexMode,
+            notify=item.sigItemChanged,
+            toModelData=lambda data: data.value.replace('_', ' ').title(),
+            fromModelData=lambda data: data.lower().replace(' ', '_'),
+            editorHint=names)
+
+
 class RemoveIsosurfaceRow(BaseRow):
     """Class for Isosurface Delete button
 
@@ -933,9 +952,9 @@ class RemoveIsosurfaceRow(BaseRow):
         """Handle Delete button clicked"""
         isosurface = self.isosurface()
         if isosurface is not None:
-            scalarField3D = isosurface.parent()
-            if scalarField3D is not None:
-                scalarField3D.removeIsosurface(isosurface)
+            volume = isosurface.parent()
+            if volume is not None:
+                volume.removeIsosurface(isosurface)
 
 
 class IsosurfaceRow(Item3DRow):
@@ -983,9 +1002,9 @@ class IsosurfaceRow(Item3DRow):
         """
         item = self.item()
         if item is not None:
-            scalarField3D = item.parent()
-            if scalarField3D is not None:
-                dataRange = scalarField3D.getDataRange()
+            volume = item.parent()
+            if volume is not None:
+                dataRange = volume.getDataRange()
                 if dataRange is not None:
                     dataMin, dataMax = dataRange[0], dataRange[-1]
                     if dataMax != dataMin:
@@ -1005,9 +1024,9 @@ class IsosurfaceRow(Item3DRow):
         """
         item = self.item()
         if item is not None:
-            scalarField3D = item.parent()
-            if scalarField3D is not None:
-                dataRange = scalarField3D.getDataRange()
+            volume = item.parent()
+            if volume is not None:
+                dataRange = volume.getDataRange()
                 if dataRange is not None:
                     sliderMin, sliderMax = self._LEVEL_SLIDER_RANGE
                     offset = (value - sliderMin) / (sliderMax - sliderMin)
@@ -1095,13 +1114,13 @@ class IsosurfaceRow(Item3DRow):
 class AddIsosurfaceRow(BaseRow):
     """Class for Isosurface create button
 
-    :param ScalarField3D scalarField3D:
-        The ScalarField3D item to attach the button to.
+    :param Union[ScalarField3D,ComplexField3D] volume:
+        The volume item to attach the button to.
     """
 
-    def __init__(self, scalarField3D):
+    def __init__(self, volume):
         super(AddIsosurfaceRow, self).__init__()
-        self._scalarField3D = weakref.ref(scalarField3D)
+        self._volume = weakref.ref(volume)
 
     def createEditor(self):
         """Specific editor factory provided to the model"""
@@ -1119,12 +1138,12 @@ class AddIsosurfaceRow(BaseRow):
         layout.addStretch(1)
         return editor
 
-    def scalarField3D(self):
-        """Returns the controlled ScalarField3D
+    def volume(self):
+        """Returns the controlled volume item
 
-        :rtype: ScalarField3D
+        :rtype: Union[ScalarField3D,ComplexField3D]
         """
-        return self._scalarField3D()
+        return self._volume()
 
     def data(self, column, role):
         if column == 0 and role == qt.Qt.UserRole:  # editor hint
@@ -1140,53 +1159,57 @@ class AddIsosurfaceRow(BaseRow):
 
     def _addClicked(self):
         """Handle Delete button clicked"""
-        scalarField3D = self.scalarField3D()
-        if scalarField3D is not None:
-            dataRange = scalarField3D.getDataRange()
+        volume = self.volume()
+        if volume is not None:
+            dataRange = volume.getDataRange()
             if dataRange is None:
                 dataRange = 0., 1.
 
-            scalarField3D.addIsosurface(
+            volume.addIsosurface(
                 numpy.mean((dataRange[0], dataRange[-1])),
                 '#0000FF')
 
 
-class ScalarField3DIsoSurfacesRow(StaticRow):
+class VolumeIsoSurfacesRow(StaticRow):
     """Represents  :class:`ScalarFieldView`'s isosurfaces
 
-    :param ScalarFieldView scalarField3D: ScalarFieldView to control
+    :param Union[ScalarField3D,ComplexField3D] volume:
+        Volume item to control
     """
 
-    def __init__(self, scalarField3D):
-        super(ScalarField3DIsoSurfacesRow, self).__init__(
+    def __init__(self, volume):
+        super(VolumeIsoSurfacesRow, self).__init__(
             ('Isosurfaces', None))
-        self._scalarField3D = weakref.ref(scalarField3D)
+        self._volume = weakref.ref(volume)
 
-        scalarField3D.sigIsosurfaceAdded.connect(self._isosurfaceAdded)
-        scalarField3D.sigIsosurfaceRemoved.connect(self._isosurfaceRemoved)
+        volume.sigIsosurfaceAdded.connect(self._isosurfaceAdded)
+        volume.sigIsosurfaceRemoved.connect(self._isosurfaceRemoved)
 
-        for item in scalarField3D.getIsosurfaces():
+        if isinstance(volume, items.ComplexMixIn):
+            self.addRow(ComplexModeRow(volume))
+
+        for item in volume.getIsosurfaces():
             self.addRow(nodeFromItem(item))
 
-        self.addRow(AddIsosurfaceRow(scalarField3D))
+        self.addRow(AddIsosurfaceRow(volume))
 
-    def scalarField3D(self):
-        """Returns the controlled ScalarField3D
+    def volume(self):
+        """Returns the controlled volume item
 
-        :rtype: ScalarField3D
+        :rtype: Union[ScalarField3D,ComplexField3D]
         """
-        return self._scalarField3D()
+        return self._volume()
 
     def _isosurfaceAdded(self, item):
         """Handle isosurface addition
 
         :param Isosurface item: added isosurface
         """
-        scalarField3D = self.scalarField3D()
-        if scalarField3D is None:
+        volume = self.volume()
+        if volume is None:
             return
 
-        row = scalarField3D.getIsosurfaces().index(item)
+        row = volume.getIsosurfaces().index(item) + 1
         self.addRow(nodeFromItem(item), row)
 
     def _isosurfaceRemoved(self, item):
@@ -1194,13 +1217,13 @@ class ScalarField3DIsoSurfacesRow(StaticRow):
 
         :param Isosurface item: removed isosurface
         """
-        scalarField3D = self.scalarField3D()
-        if scalarField3D is None:
+        volume = self.volume()
+        if volume is None:
             return
 
         # Find item
         for row in self.children():
-            if row.item() is item:
+            if isinstance(row, IsosurfaceRow) and row.item() is item:
                 self.removeRow(row)
                 break  # Got it
         else:
@@ -1328,22 +1351,26 @@ def initScatter2DNode(node, item):
     node.addRow(Scatter2DLineWidth(item))
 
 
-def initScalarField3DNode(node, item):
-    """Specific node init for ScalarField3D
+def initVolumeNode(node, item):
+    """Specific node init for volume items
 
     :param Item3DRow node: The model node to setup
-    :param ScalarField3D item: The ScalarField3D the node is representing
+    :param Union[ScalarField3D,ComplexField3D] item:
+        The volume item represented by the node
     """
     node.addRow(nodeFromItem(item.getCutPlanes()[0]))  # Add cut plane
-    node.addRow(ScalarField3DIsoSurfacesRow(item))
+    node.addRow(VolumeIsoSurfacesRow(item))
 
 
-def initScalarField3DCutPlaneNode(node, item):
-    """Specific node init for ScalarField3D CutPlane
+def initVolumeCutPlaneNode(node, item):
+    """Specific node init for volume CutPlane
 
     :param Item3DRow node: The model node to setup
     :param CutPlane item: The CutPlane the node is representing
     """
+    if isinstance(item, items.ComplexMixIn):
+        node.addRow(ComplexModeRow(item))
+
     node.addRow(PlaneRow(item))
 
     node.addRow(ColormapRow(item))
@@ -1359,8 +1386,8 @@ def initScalarField3DCutPlaneNode(node, item):
 
 NODE_SPECIFIC_INIT = [  # class, init(node, item)
     (items.Scatter2D, initScatter2DNode),
-    (items.ScalarField3D, initScalarField3DNode),
-    (CutPlane, initScalarField3DCutPlaneNode),
+    (items.ScalarField3D, initVolumeNode),
+    (CutPlane, initVolumeCutPlaneNode),
 ]
 """List of specific node init for different item class"""
 

--- a/silx/gui/plot3d/items/__init__.py
+++ b/silx/gui/plot3d/items/__init__.py
@@ -37,8 +37,7 @@ from .core import ItemChangedType, Item3DChangedType  # noqa
 from .mixins import (ColormapMixIn, ComplexMixIn, InterpolationMixIn,  # noqa
                      PlaneMixIn, SymbolMixIn)  # noqa
 from .clipplane import ClipPlane  # noqa
-from .complexvolume import ComplexField3D  # noqa
 from .image import ImageData, ImageRgba  # noqa
 from .mesh import Mesh, ColormapMesh, Box, Cylinder, Hexagon  # noqa
 from .scatter import Scatter2D, Scatter3D  # noqa
-from .volume import ScalarField3D  # noqa
+from .volume import ComplexField3D, ScalarField3D  # noqa

--- a/silx/gui/plot3d/items/__init__.py
+++ b/silx/gui/plot3d/items/__init__.py
@@ -34,9 +34,10 @@ __date__ = "15/11/2017"
 
 from .core import DataItem3D, Item3D, GroupItem, GroupWithAxesItem  # noqa
 from .core import ItemChangedType, Item3DChangedType  # noqa
-from .mixins import (ColormapMixIn, InterpolationMixIn,  # noqa
+from .mixins import (ColormapMixIn, ComplexMixIn, InterpolationMixIn,  # noqa
                      PlaneMixIn, SymbolMixIn)  # noqa
 from .clipplane import ClipPlane  # noqa
+from .complexvolume import ComplexField3D  # noqa
 from .image import ImageData, ImageRgba  # noqa
 from .mesh import Mesh, ColormapMesh, Box, Cylinder, Hexagon  # noqa
 from .scatter import Scatter2D, Scatter3D  # noqa

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -140,7 +140,7 @@ class ColormapMixIn(_ColormapMixIn):
         self._dataRange = dataRange
 
         if self.getColormap().isAutoscale():
-            self._syncSceneColormap()
+            self._colormapChanged()
 
     def _getDataRange(self):
         """Returns the data range as used in the scene for colormap

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -139,7 +139,8 @@ class ColormapMixIn(_ColormapMixIn):
 
         self._dataRange = dataRange
 
-        if self.getColormap().isAutoscale():
+        colormap = self.getColormap()
+        if None in (colormap.getVMin(), colormap.getVMax()):
             self._colormapChanged()
 
     def _getDataRange(self):


### PR DESCRIPTION
This PR adds a `ComplexField3D` item to the `plot3d.SceneWidget` to display 3D array of complex.
It extends the `ScalarField3D` item by allowing to select a different display mode (i.e., real part, imaginary part, amplitude, phase, amplitude**2) for isosurfaces and the cut plane.

It does NOT provide yet:
- the display of a color-mapped isosurface e.g., an isosurface in the amplitude and colored with the phase.
- the integration in `silx view`.

There is also some work to make the `plot.items` and `plot3d.items` API regarding complex consistent (`getVisualizationMode` in `plot` and `getComplexMode` in `plot3d`).
All this will be done in other PRs.

related to #2323