### PR TITLE
[silx view] Use SceneWindow for 3D to enable 3D complex field visualization

### DIFF
--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -904,7 +904,7 @@ class _Plot3dView(DataView):
         from ._VolumeWindow import VolumeWindow
 
         plot = VolumeWindow(parent)
-        plot.setAxesNames(*reversed(self.axesNames(None, None)))
+        plot.setAxesLabels(*reversed(self.axesNames(None, None)))
         return plot
 
     def clear(self):

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -901,45 +901,59 @@ class _Plot3dView(DataView):
         self.__resetZoomNextTime = True
 
     def createWidget(self, parent):
-        from silx.gui.plot3d import ScalarFieldView
-        from silx.gui.plot3d import SFViewParamTree
+        from silx.gui.plot3d import SceneWindow
 
-        plot = ScalarFieldView.ScalarFieldView(parent)
-        plot.setAxesLabels(*reversed(self.axesNames(None, None)))
-
-        def computeIsolevel(data):
-            data = data[numpy.isfinite(data)]
-            if len(data) == 0:
-                return 0
-            else:
-                return numpy.mean(data) + numpy.std(data)
-
-        plot.addIsosurface(computeIsolevel, '#FF0000FF')
-
-        # Create a parameter tree for the scalar field view
-        options = SFViewParamTree.TreeView(plot)
-        options.setSfView(plot)
-
-        # Add the parameter tree to the main window in a dock widget
-        dock = qt.QDockWidget()
-        dock.setWidget(options)
-        plot.addDockWidget(qt.Qt.RightDockWidgetArea, dock)
+        plot = SceneWindow.SceneWindow(parent)
+        # Hide global parameter dock
+        plot.getGroupResetWidget().parent().setVisible(False)
+        sceneWidget = plot.getSceneWidget()
+        sceneWidget.getSceneGroup().setAxesLabels(
+            *reversed(self.axesNames(None, None)))
 
         return plot
 
+    @staticmethod
+    def __computeIsolevel(data):
+        data = data[numpy.isfinite(data)]
+        if len(data) == 0:
+            return 0
+        else:
+            return numpy.mean(data) + numpy.std(data)
+
     def clear(self):
-        self.getWidget().setData(None)
+        from silx.gui.plot3d.items import ScalarField3D, ComplexField3D
+
+        sceneWidget = self.getWidget().getSceneWidget()
+        items = sceneWidget.getItems()
+        if (len(items) == 1 and
+                isinstance(items[0], (ScalarField3D, ComplexField3D))):
+            items[0].setData(None)
+        else:  # Safety net
+            sceneWidget.clearItems()
         self.__resetZoomNextTime = True
 
-    def normalizeData(self, data):
-        data = DataView.normalizeData(self, data)
-        data = _normalizeComplex(data)
-        return data
-
     def setData(self, data):
+        from silx.gui.plot3d.items import ScalarField3D, ComplexField3D
+
         data = self.normalizeData(data)
         plot = self.getWidget()
-        plot.setData(data)
+        sceneWidget = plot.getSceneWidget()
+
+        previousItems = sceneWidget.getItems()
+        if (len(previousItems) == 1 and
+                isinstance(previousItems[0], (ScalarField3D, ComplexField3D)) and
+                numpy.iscomplexobj(data) == isinstance(previousItems[0], ComplexField3D)):
+            # Reuse existing volume item
+            volume = sceneWidget.getItems()[0]
+            volume.setData(data, copy=False)
+        else:
+            # Add a new volume
+            volume = sceneWidget.addVolume(data, copy=False)
+            volume.setLabel('Volume')
+            for plane in volume.getCutPlanes():
+                plane.setVisible(False)
+            volume.addIsosurface(self.__computeIsolevel, '#FF0000FF')
+
         self.__resetZoomNextTime = False
 
     def axesNames(self, data, info):

--- a/silx/gui/data/_VolumeWindow.py
+++ b/silx/gui/data/_VolumeWindow.py
@@ -1,0 +1,110 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This module provides a widget to visualize 3D arrays"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "22/03/2019"
+
+
+import numpy
+
+from ..plot3d.SceneWindow import SceneWindow
+from ..plot3d.items import ScalarField3D, ComplexField3D
+
+
+class VolumeWindow(SceneWindow):
+    """Extends SceneWindow with a convenient API for 3D array
+
+    :param QWidget: parent
+    """
+
+    def __init__(self, parent):
+        super(VolumeWindow, self).__init__(parent)
+        # Hide global parameter dock
+        self.getGroupResetWidget().parent().setVisible(False)
+
+    def setAxesNames(self, xlabel=None, ylabel=None, zlabel=None):
+        """Set the text labels of the axes.
+
+        :param Union[str,None] xlabel: Label of the X axis
+        :param Union[str,None] ylabel: Label of the Y axis
+        :param Union[str,None] zlabel: Label of the Z axis
+        """
+        sceneWidget = self.getSceneWidget()
+        sceneWidget.getSceneGroup().setAxesLabels(
+            'X' if xlabel is None else xlabel,
+            'Y' if ylabel is None else ylabel,
+            'Z' if zlabel is None else zlabel)
+
+    def clear(self):
+        """Clear any currently displayed data"""
+        sceneWidget = self.getSceneWidget()
+        items = sceneWidget.getItems()
+        if (len(items) == 1 and
+                isinstance(items[0], (ScalarField3D, ComplexField3D))):
+            items[0].setData(None)
+        else:  # Safety net
+            sceneWidget.clearItems()
+
+    @staticmethod
+    def __computeIsolevel(data):
+        """Returns a suitable isolevel value for data
+
+        :param numpy.ndarray data:
+        :rtype: float
+        """
+        data = data[numpy.isfinite(data)]
+        if len(data) == 0:
+            return 0
+        else:
+            return numpy.mean(data) + numpy.std(data)
+
+    def setData(self, data, offset=(0., 0., 0.), scale=(1., 1., 1.)):
+        """Set the 3D array data to display.
+
+        :param numpy.ndarray data: 3D array of float or complex
+        :param List[float] offset: (tx, ty, tz) coordinates of the origin
+        :param List[float] scale: (sx, sy, sz) scale for each dimension
+        """
+        sceneWidget = self.getSceneWidget()
+
+        previousItems = sceneWidget.getItems()
+        if (len(previousItems) == 1 and
+                isinstance(previousItems[0], (ScalarField3D, ComplexField3D)) and
+                numpy.iscomplexobj(data) == isinstance(previousItems[0], ComplexField3D)):
+            # Reuse existing volume item
+            volume = sceneWidget.getItems()[0]
+            volume.setData(data, copy=False)
+        else:
+            # Add a new volume
+            volume = sceneWidget.addVolume(data, copy=False)
+            volume.setLabel('Volume')
+            for plane in volume.getCutPlanes():
+                plane.setVisible(False)
+            volume.addIsosurface(self.__computeIsolevel, '#FF0000FF')
+
+        volume.setTranslation(*offset)
+        volume.setScale(*scale)

--- a/silx/gui/data/_VolumeWindow.py
+++ b/silx/gui/data/_VolumeWindow.py
@@ -46,7 +46,7 @@ class VolumeWindow(SceneWindow):
         # Hide global parameter dock
         self.getGroupResetWidget().parent().setVisible(False)
 
-    def setAxesNames(self, xlabel=None, ylabel=None, zlabel=None):
+    def setAxesLabels(self, xlabel=None, ylabel=None, zlabel=None):
         """Set the text labels of the axes.
 
         :param Union[str,None] xlabel: Label of the X axis

--- a/silx/gui/plot3d/SceneWidget.py
+++ b/silx/gui/plot3d/SceneWidget.py
@@ -267,7 +267,7 @@ class SceneSelection(qt.QObject):
             assert isinstance(parent, SceneWidget)
 
             if item.root() != parent.getSceneGroup():
-                self.setSelectedItem(None)
+                self.setCurrentItem(None)
 
     # Synchronization with QItemSelectionModel
 

--- a/silx/gui/plot3d/SceneWidget.py
+++ b/silx/gui/plot3d/SceneWidget.py
@@ -45,7 +45,6 @@ from .scene import interaction
 from ._model import SceneModel, visitQAbstractItemModel
 from ._model.items import Item3DRow
 
-
 __all__ = ['items', 'SceneWidget']
 
 
@@ -482,26 +481,36 @@ class SceneWidget(Plot3DWidget):
 
     # Add/remove items
 
-    def add3DScalarField(self, data, copy=True, index=None):
-        """Add 3D scalar data volume to :class:`SceneWidget` content.
+    def addVolume(self, data, copy=True, index=None):
+        """Add 3D data volume of scalar or complex to :class:`SceneWidget` content.
 
         Dataset order is zyx (i.e., first dimension is z).
 
-        :param data: 3D array
-        :type data: 3D numpy.ndarray of float32 with shape at least (2, 2, 2)
+        :param data: 3D array of complex with shape at least (2, 2, 2)
+        :type data: numpy.ndarray[Union[numpy.complex64,numpy.float32]]
         :param bool copy:
             True (default) to make a copy,
             False to avoid copy (DO NOT MODIFY data afterwards)
         :param int index: The index at which to place the item.
                           By default it is appended to the end of the list.
-        :return: The newly created scalar volume item
-        :rtype: ~silx.gui.plot3d.items.volume.ScalarField3D
+        :return: The newly created 3D volume item
+        :rtype: Union[ScalarField3D,ComplexField3D]
 
         """
-        volume = items.ScalarField3D()
+        if data is not None:
+            data = numpy.array(data, copy=False)
+
+        if numpy.iscomplexobj(data):
+            volume = items.ComplexField3D()
+        else:
+            volume = items.ScalarField3D()
         volume.setData(data, copy=copy)
         self.addItem(volume, index)
         return volume
+
+    def add3DScalarField(self, data, copy=True, index=None):
+        # TODO deprecate in the future
+        return self.addVolume(data, copy=copy, index=index)
 
     def add3DScatter(self, x, y, z, value, copy=True, index=None):
         """Add 3D scatter data to :class:`SceneWidget` content.

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -988,7 +988,10 @@ class IsosurfaceRow(Item3DRow):
                 dataRange = scalarField3D.getDataRange()
                 if dataRange is not None:
                     dataMin, dataMax = dataRange[0], dataRange[-1]
-                    offset = (item.getLevel() - dataMin) / (dataMax - dataMin)
+                    if dataMax != dataMin:
+                        offset = (item.getLevel() - dataMin) / (dataMax - dataMin)
+                    else:
+                        offset = 0.
 
                     sliderMin, sliderMax = self._LEVEL_SLIDER_RANGE
                     value = sliderMin + (sliderMax - sliderMin) * offset

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -1209,7 +1209,9 @@ class VolumeIsoSurfacesRow(StaticRow):
         if volume is None:
             return
 
-        row = volume.getIsosurfaces().index(item) + 1
+        row = volume.getIsosurfaces().index(item)
+        if isinstance(volume, items.ComplexMixIn):
+            row += 1  # Offset for the ComplexModeRow
         self.addRow(nodeFromItem(item), row)
 
     def _isosurfaceRemoved(self, item):

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -894,7 +894,7 @@ class ComplexModeRow(ProxyRow):
         names = [m.value.replace('_', ' ').title()
                  for m in item.supportedComplexModes()]
         super(ComplexModeRow, self).__init__(
-            name='Display',
+            name='Mode',
             fget=item.getComplexMode,
             fset=item.setComplexMode,
             notify=item.sigItemChanged,

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -884,6 +884,25 @@ class PlaneRow(ProxyRow):
         return super(PlaneRow, self).data(column, role)
 
 
+class ComplexModeRow(ProxyRow):
+    """Represents :class:`items.ComplexMixIn` symbol property.
+
+    :param Item3D item: Scene item with symbol property
+    """
+
+    def __init__(self, item):
+        names = [m.value.replace('_', ' ').title()
+                 for m in item.supportedComplexModes()]
+        super(ComplexModeRow, self).__init__(
+            name='Display',
+            fget=item.getComplexMode,
+            fset=item.setComplexMode,
+            notify=item.sigItemChanged,
+            toModelData=lambda data: data.value.replace('_', ' ').title(),
+            fromModelData=lambda data: data.lower().replace(' ', '_'),
+            editorHint=names)
+
+
 class RemoveIsosurfaceRow(BaseRow):
     """Class for Isosurface Delete button
 
@@ -933,9 +952,9 @@ class RemoveIsosurfaceRow(BaseRow):
         """Handle Delete button clicked"""
         isosurface = self.isosurface()
         if isosurface is not None:
-            scalarField3D = isosurface.parent()
-            if scalarField3D is not None:
-                scalarField3D.removeIsosurface(isosurface)
+            volume = isosurface.parent()
+            if volume is not None:
+                volume.removeIsosurface(isosurface)
 
 
 class IsosurfaceRow(Item3DRow):
@@ -983,9 +1002,9 @@ class IsosurfaceRow(Item3DRow):
         """
         item = self.item()
         if item is not None:
-            scalarField3D = item.parent()
-            if scalarField3D is not None:
-                dataRange = scalarField3D.getDataRange()
+            volume = item.parent()
+            if volume is not None:
+                dataRange = volume.getDataRange()
                 if dataRange is not None:
                     dataMin, dataMax = dataRange[0], dataRange[-1]
                     if dataMax != dataMin:
@@ -1005,9 +1024,9 @@ class IsosurfaceRow(Item3DRow):
         """
         item = self.item()
         if item is not None:
-            scalarField3D = item.parent()
-            if scalarField3D is not None:
-                dataRange = scalarField3D.getDataRange()
+            volume = item.parent()
+            if volume is not None:
+                dataRange = volume.getDataRange()
                 if dataRange is not None:
                     sliderMin, sliderMax = self._LEVEL_SLIDER_RANGE
                     offset = (value - sliderMin) / (sliderMax - sliderMin)
@@ -1095,13 +1114,13 @@ class IsosurfaceRow(Item3DRow):
 class AddIsosurfaceRow(BaseRow):
     """Class for Isosurface create button
 
-    :param ScalarField3D scalarField3D:
-        The ScalarField3D item to attach the button to.
+    :param Union[ScalarField3D,ComplexField3D] volume:
+        The volume item to attach the button to.
     """
 
-    def __init__(self, scalarField3D):
+    def __init__(self, volume):
         super(AddIsosurfaceRow, self).__init__()
-        self._scalarField3D = weakref.ref(scalarField3D)
+        self._volume = weakref.ref(volume)
 
     def createEditor(self):
         """Specific editor factory provided to the model"""
@@ -1119,12 +1138,12 @@ class AddIsosurfaceRow(BaseRow):
         layout.addStretch(1)
         return editor
 
-    def scalarField3D(self):
-        """Returns the controlled ScalarField3D
+    def volume(self):
+        """Returns the controlled volume item
 
-        :rtype: ScalarField3D
+        :rtype: Union[ScalarField3D,ComplexField3D]
         """
-        return self._scalarField3D()
+        return self._volume()
 
     def data(self, column, role):
         if column == 0 and role == qt.Qt.UserRole:  # editor hint
@@ -1140,53 +1159,57 @@ class AddIsosurfaceRow(BaseRow):
 
     def _addClicked(self):
         """Handle Delete button clicked"""
-        scalarField3D = self.scalarField3D()
-        if scalarField3D is not None:
-            dataRange = scalarField3D.getDataRange()
+        volume = self.volume()
+        if volume is not None:
+            dataRange = volume.getDataRange()
             if dataRange is None:
                 dataRange = 0., 1.
 
-            scalarField3D.addIsosurface(
+            volume.addIsosurface(
                 numpy.mean((dataRange[0], dataRange[-1])),
                 '#0000FF')
 
 
-class ScalarField3DIsoSurfacesRow(StaticRow):
+class VolumeIsoSurfacesRow(StaticRow):
     """Represents  :class:`ScalarFieldView`'s isosurfaces
 
-    :param ScalarFieldView scalarField3D: ScalarFieldView to control
+    :param Union[ScalarField3D,ComplexField3D] volume:
+        Volume item to control
     """
 
-    def __init__(self, scalarField3D):
-        super(ScalarField3DIsoSurfacesRow, self).__init__(
+    def __init__(self, volume):
+        super(VolumeIsoSurfacesRow, self).__init__(
             ('Isosurfaces', None))
-        self._scalarField3D = weakref.ref(scalarField3D)
+        self._volume = weakref.ref(volume)
 
-        scalarField3D.sigIsosurfaceAdded.connect(self._isosurfaceAdded)
-        scalarField3D.sigIsosurfaceRemoved.connect(self._isosurfaceRemoved)
+        volume.sigIsosurfaceAdded.connect(self._isosurfaceAdded)
+        volume.sigIsosurfaceRemoved.connect(self._isosurfaceRemoved)
 
-        for item in scalarField3D.getIsosurfaces():
+        if isinstance(volume, items.ComplexMixIn):
+            self.addRow(ComplexModeRow(volume))
+
+        for item in volume.getIsosurfaces():
             self.addRow(nodeFromItem(item))
 
-        self.addRow(AddIsosurfaceRow(scalarField3D))
+        self.addRow(AddIsosurfaceRow(volume))
 
-    def scalarField3D(self):
-        """Returns the controlled ScalarField3D
+    def volume(self):
+        """Returns the controlled volume item
 
-        :rtype: ScalarField3D
+        :rtype: Union[ScalarField3D,ComplexField3D]
         """
-        return self._scalarField3D()
+        return self._volume()
 
     def _isosurfaceAdded(self, item):
         """Handle isosurface addition
 
         :param Isosurface item: added isosurface
         """
-        scalarField3D = self.scalarField3D()
-        if scalarField3D is None:
+        volume = self.volume()
+        if volume is None:
             return
 
-        row = scalarField3D.getIsosurfaces().index(item)
+        row = volume.getIsosurfaces().index(item) + 1
         self.addRow(nodeFromItem(item), row)
 
     def _isosurfaceRemoved(self, item):
@@ -1194,13 +1217,13 @@ class ScalarField3DIsoSurfacesRow(StaticRow):
 
         :param Isosurface item: removed isosurface
         """
-        scalarField3D = self.scalarField3D()
-        if scalarField3D is None:
+        volume = self.volume()
+        if volume is None:
             return
 
         # Find item
         for row in self.children():
-            if row.item() is item:
+            if isinstance(row, IsosurfaceRow) and row.item() is item:
                 self.removeRow(row)
                 break  # Got it
         else:
@@ -1328,22 +1351,26 @@ def initScatter2DNode(node, item):
     node.addRow(Scatter2DLineWidth(item))
 
 
-def initScalarField3DNode(node, item):
-    """Specific node init for ScalarField3D
+def initVolumeNode(node, item):
+    """Specific node init for volume items
 
     :param Item3DRow node: The model node to setup
-    :param ScalarField3D item: The ScalarField3D the node is representing
+    :param Union[ScalarField3D,ComplexField3D] item:
+        The volume item represented by the node
     """
     node.addRow(nodeFromItem(item.getCutPlanes()[0]))  # Add cut plane
-    node.addRow(ScalarField3DIsoSurfacesRow(item))
+    node.addRow(VolumeIsoSurfacesRow(item))
 
 
-def initScalarField3DCutPlaneNode(node, item):
-    """Specific node init for ScalarField3D CutPlane
+def initVolumeCutPlaneNode(node, item):
+    """Specific node init for volume CutPlane
 
     :param Item3DRow node: The model node to setup
     :param CutPlane item: The CutPlane the node is representing
     """
+    if isinstance(item, items.ComplexMixIn):
+        node.addRow(ComplexModeRow(item))
+
     node.addRow(PlaneRow(item))
 
     node.addRow(ColormapRow(item))
@@ -1359,8 +1386,8 @@ def initScalarField3DCutPlaneNode(node, item):
 
 NODE_SPECIFIC_INIT = [  # class, init(node, item)
     (items.Scatter2D, initScatter2DNode),
-    (items.ScalarField3D, initScalarField3DNode),
-    (CutPlane, initScalarField3DCutPlaneNode),
+    (items.ScalarField3D, initVolumeNode),
+    (CutPlane, initVolumeCutPlaneNode),
 ]
 """List of specific node init for different item class"""
 

--- a/silx/gui/plot3d/items/__init__.py
+++ b/silx/gui/plot3d/items/__init__.py
@@ -37,8 +37,7 @@ from .core import ItemChangedType, Item3DChangedType  # noqa
 from .mixins import (ColormapMixIn, ComplexMixIn, InterpolationMixIn,  # noqa
                      PlaneMixIn, SymbolMixIn)  # noqa
 from .clipplane import ClipPlane  # noqa
-from .complexvolume import ComplexField3D  # noqa
 from .image import ImageData, ImageRgba  # noqa
 from .mesh import Mesh, ColormapMesh, Box, Cylinder, Hexagon  # noqa
 from .scatter import Scatter2D, Scatter3D  # noqa
-from .volume import ScalarField3D  # noqa
+from .volume import ComplexField3D, ScalarField3D  # noqa

--- a/silx/gui/plot3d/items/__init__.py
+++ b/silx/gui/plot3d/items/__init__.py
@@ -34,9 +34,10 @@ __date__ = "15/11/2017"
 
 from .core import DataItem3D, Item3D, GroupItem, GroupWithAxesItem  # noqa
 from .core import ItemChangedType, Item3DChangedType  # noqa
-from .mixins import (ColormapMixIn, InterpolationMixIn,  # noqa
+from .mixins import (ColormapMixIn, ComplexMixIn, InterpolationMixIn,  # noqa
                      PlaneMixIn, SymbolMixIn)  # noqa
 from .clipplane import ClipPlane  # noqa
+from .complexvolume import ComplexField3D  # noqa
 from .image import ImageData, ImageRgba  # noqa
 from .mesh import Mesh, ColormapMesh, Box, Cylinder, Hexagon  # noqa
 from .scatter import Scatter2D, Scatter3D  # noqa

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -140,7 +140,7 @@ class ColormapMixIn(_ColormapMixIn):
         self._dataRange = dataRange
 
         if self.getColormap().isAutoscale():
-            self._syncSceneColormap()
+            self._colormapChanged()
 
     def _getDataRange(self):
         """Returns the data range as used in the scene for colormap

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -139,7 +139,8 @@ class ColormapMixIn(_ColormapMixIn):
 
         self._dataRange = dataRange
 
-        if self.getColormap().isAutoscale():
+        colormap = self.getColormap()
+        if None in (colormap.getVMin(), colormap.getVMax()):
             self._colormapChanged()
 
     def _getDataRange(self):


### PR DESCRIPTION
Merge PR #2512 first!

This PR replaces the `ScalarFieldView` widget in `silx view` 3D plotting with `SceneWindow`.
This brings support for 3D complex field visualization.

The pitfall is that `SceneWindow` is more generic and thus the parameter tree is more complicated...
Usability of it in this specific case can be improved, see #2518.

related to #2323