### PR TITLE
[plot3d] 3D volume visualization/parameter tree improvements

### DIFF
--- a/silx/gui/data/_VolumeWindow.py
+++ b/silx/gui/data/_VolumeWindow.py
@@ -32,7 +32,7 @@ __date__ = "22/03/2019"
 import numpy
 
 from ..plot3d.SceneWindow import SceneWindow
-from ..plot3d.items import ScalarField3D, ComplexField3D
+from ..plot3d.items import ScalarField3D, ComplexField3D, ItemChangedType
 
 
 class VolumeWindow(SceneWindow):
@@ -100,11 +100,23 @@ class VolumeWindow(SceneWindow):
             volume.setData(data, copy=False)
         else:
             # Add a new volume
+            sceneWidget.clearItems()
             volume = sceneWidget.addVolume(data, copy=False)
             volume.setLabel('Volume')
             for plane in volume.getCutPlanes():
                 plane.setVisible(False)
+                plane.sigItemChanged.connect(self.__cutPlaneUpdated)
             volume.addIsosurface(self.__computeIsolevel, '#FF0000FF')
 
         volume.setTranslation(*offset)
         volume.setScale(*scale)
+
+    def __cutPlaneUpdated(self, event):
+        """Handle the change of visibility of the cut plane
+
+        :param event: Kind of update
+        """
+        if event == ItemChangedType.VISIBLE:
+            plane = self.sender()
+            if plane.isVisible():
+                self.getSceneWidget().selection().setCurrentItem(plane)

--- a/silx/gui/data/_VolumeWindow.py
+++ b/silx/gui/data/_VolumeWindow.py
@@ -31,6 +31,7 @@ __date__ = "22/03/2019"
 
 import numpy
 
+from .. import qt
 from ..plot3d.SceneWindow import SceneWindow
 from ..plot3d.items import ScalarField3D, ComplexField3D, ItemChangedType
 
@@ -115,6 +116,19 @@ class VolumeWindow(SceneWindow):
                 plane.setVisible(False)
                 plane.sigItemChanged.connect(self.__cutPlaneUpdated)
             volume.addIsosurface(self.__computeIsolevel, '#FF0000FF')
+
+            # Expand the parameter tree
+            model = self.getParamTreeView().model()
+            index = qt.QModelIndex()  # Invalid index for top level
+            while 1:
+                rowCount = model.rowCount(parent=index)
+                if rowCount == 0:
+                    break
+                index = model.index(rowCount - 1, 0, parent=index)
+                self.getParamTreeView().setExpanded(index, True)
+                if not index.isValid():
+                    break
+
 
         volume.setTranslation(*offset)
         volume.setScale(*scale)

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -896,10 +896,10 @@ class PlaneRow(ProxyRow):
                '-': None}
     """Mapping of plane names to normals"""
 
-    _PLANE_ICONS = {'Plane 0': icons.getQIcon('3d-plane-normal-x'),
-                    'Plane 1': icons.getQIcon('3d-plane-normal-y'),
-                    'Plane 2': icons.getQIcon('3d-plane-normal-z'),
-                    '-': icons.getQIcon('3d-plane')}
+    _PLANE_ICONS = {'Plane 0': '3d-plane-normal-x',
+                    'Plane 1': '3d-plane-normal-y',
+                    'Plane 2': '3d-plane-normal-z',
+                    '-': '3d-plane'}
     """Mapping of plane names to normals"""
 
     def __init__(self, item):
@@ -939,7 +939,7 @@ class PlaneRow(ProxyRow):
 
     def data(self, column, role):
         if column == 1 and role == qt.Qt.DecorationRole:
-            return self._PLANE_ICONS[self.__getPlaneName()]
+            return icons.getQIcon(self._PLANE_ICONS[self.__getPlaneName()])
         return super(PlaneRow, self).data(column, role)
 
 

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -1378,7 +1378,7 @@ def initVolumeCutPlaneNode(node, item):
     node.addRow(ColormapRow(item))
 
     node.addRow(ProxyRow(
-        name='Values<=Min',
+        name='Show <=Min',
         fget=item.getDisplayValuesBelowMin,
         fset=item.setDisplayValuesBelowMin,
         notify=item.sigItemChanged))

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -858,14 +858,14 @@ class SymbolSizeRow(ProxyRow):
             editorHint=(1, 20))  # TODO link with OpenGL max point size
 
 
-class PlaneRow(ProxyRow):
-    """Represents :class:`PlaneMixIn` property.
+class PlaneEquationRow(ProxyRow):
+    """Represents :class:`PlaneMixIn` as plane equation.
 
     :param Item3D item: Scene item with plane equation property
     """
 
     def __init__(self, item):
-        super(PlaneRow, self).__init__(
+        super(PlaneEquationRow, self).__init__(
             name='Equation',
             fget=item.getParameters,
             fset=item.setParameters,
@@ -881,6 +881,65 @@ class PlaneRow(ProxyRow):
                 params = item.getParameters()
                 return ('%gx %+gy %+gz %+g = 0' %
                         (params[0], params[1], params[2], params[3]))
+        return super(PlaneEquationRow, self).data(column, role)
+
+
+class PlaneRow(ProxyRow):
+    """Represents :class:`PlaneMixIn` property.
+
+    :param Item3D item: Scene item with plane equation property
+    """
+
+    _PLANES = {'Plane 0': (1., 0., 0.),
+               'Plane 1': (0., 1., 0.),
+               'Plane 2': (0., 0., 1.),
+               '-': None}
+    """Mapping of plane names to normals"""
+
+    _PLANE_ICONS = {'Plane 0': icons.getQIcon('3d-plane-normal-x'),
+                    'Plane 1': icons.getQIcon('3d-plane-normal-y'),
+                    'Plane 2': icons.getQIcon('3d-plane-normal-z'),
+                    '-': icons.getQIcon('3d-plane')}
+    """Mapping of plane names to normals"""
+
+    def __init__(self, item):
+        super(PlaneRow, self).__init__(
+            name='Plane',
+            fget=self.__getPlaneName,
+            fset=self.__setPlaneName,
+            notify=item.sigItemChanged,
+            editorHint=tuple(self._PLANES.keys()))
+        self._item = weakref.ref(item)
+
+        self.addRow(PlaneEquationRow(item))
+
+    def __getPlaneName(self):
+        """Returns name of plane // to axes or '-'
+
+        :rtype: str
+        """
+        item = self._item()
+        planeNormal = item.getNormal() if item is not None else None
+
+        for name, normal in self._PLANES.items():
+            if numpy.array_equal(planeNormal, normal):
+                return name
+        return '-'
+
+    def __setPlaneName(self, data):
+        """Set plane normal according to given plane name
+
+        :param str data: Selected plane name
+        """
+        item = self._item()
+        if item is not None:
+            for name, normal in self._PLANES.items():
+                if data == name and normal is not None:
+                    item.setNormal(normal)
+
+    def data(self, column, role):
+        if column == 1 and role == qt.Qt.DecorationRole:
+            return self._PLANE_ICONS[self.__getPlaneName()]
         return super(PlaneRow, self).data(column, role)
 
 

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -180,7 +180,7 @@ class ComplexMixIn(ItemMixInBase):
 
     class Mode(enum.Enum):
         """Identify available display mode for complex"""
-        ABSOLUTE = 'absolute'
+        ABSOLUTE = 'amplitude'
         PHASE = 'phase'
         REAL = 'real'
         IMAGINARY = 'imaginary'
@@ -206,7 +206,7 @@ class ComplexMixIn(ItemMixInBase):
             raise ValueError("Cannot convert: %s" % value)
 
     def __init__(self):
-        self._mode = self.Mode.REAL
+        self._mode = self.Mode.ABSOLUTE
 
     def getComplexMode(self):
         """Returns the current complex visualization mode.


### PR DESCRIPTION
This PR makes some improvements of ``silx view`` 3D volume view and ``SceneWidget`` model.
It:
- Adds a drop down menu in the parameter to set the cut plane // to each axis
- Expands the parameter tree when loading
- Sets the interaction mode to plane panning and select the cut plane when it is made visible.
- Initialize the plane position as going through the center of the dataset
- Renames the complex mode from ``Absolute`` to ``Amplitude``
- Uses ``Amplitude`` as the initial complex mode
- Renames ``Values<=Min`` to ``Show <=Min``

related to #2518
