### PR TITLE
Some performance improvements

### DIFF
--- a/silx/gui/plot/Profile.py
+++ b/silx/gui/plot/Profile.py
@@ -419,7 +419,8 @@ class ProfileToolBar(qt.QToolBar):
         """
 
         if self._profileWindow is None:
-            self._profileMainWindow = ProfileMainWindow(self)
+            backend = type(plot._backend)
+            self._profileMainWindow = ProfileMainWindow(self, backend=backend)
 
         # Actions
         self._browseAction = actions.mode.ZoomModeAction(self.plot, parent=self)

--- a/silx/gui/plot/ProfileMainWindow.py
+++ b/silx/gui/plot/ProfileMainWindow.py
@@ -35,8 +35,15 @@ __date__ = "21/02/2017"
 class ProfileMainWindow(qt.QMainWindow):
     """QMainWindow providing 2 plot widgets specialized in
     1D and 2D plotting, with different toolbars.
+
     Only one of the plots is visible at any given time.
+
+    :param qt.QWidget parent: The parent of this widget or None (default).
+    :param Union[str,Class] backend: The backend to use, in:
+                    'matplotlib' (default), 'mpl', 'opengl', 'gl', 'none'
+                    or a :class:`BackendBase.BackendBase` class
     """
+
     sigProfileDimensionsChanged = qt.Signal(int)
     """This signal is emitted when :meth:`setProfileDimensions` is called.
     It carries the number of dimensions for the profile data (1 or 2).

--- a/silx/gui/plot/ProfileMainWindow.py
+++ b/silx/gui/plot/ProfileMainWindow.py
@@ -51,13 +51,14 @@ class ProfileMainWindow(qt.QMainWindow):
     """Emitted when the method to compute the profile changed (for now can be
     sum or mean)"""
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, backend=None):
         qt.QMainWindow.__init__(self, parent=parent)
 
         self.setWindowTitle('Profile window')
         # plots are created on demand, in self.setProfileDimensions()
         self._plot1D = None
         self._plot2D = None
+        self._backend = backend
         # by default, profile is assumed to be a 1D curve
         self._profileType = None
         self.setProfileType("1D")
@@ -76,7 +77,7 @@ class ProfileMainWindow(qt.QMainWindow):
             if self._plot2D is not None:
                 self._plot2D.setParent(None)   # necessary to avoid widget destruction
             if self._plot1D is None:
-                self._plot1D = Plot1D()
+                self._plot1D = Plot1D(backend=self._backend)
                 self._plot1D.setGraphYLabel('Profile')
                 self._plot1D.setGraphXLabel('')
             self.setCentralWidget(self._plot1D)
@@ -84,7 +85,7 @@ class ProfileMainWindow(qt.QMainWindow):
             if self._plot1D is not None:
                 self._plot1D.setParent(None)   # necessary to avoid widget destruction
             if self._plot2D is None:
-                self._plot2D = Plot2D()
+                self._plot2D = Plot2D(backend=self._backend)
             self.setCentralWidget(self._plot2D)
         else:
             raise ValueError("Profile type must be '1D' or '2D'")


### PR DESCRIPTION
When using the OpenGL backend of the Plot2D widget, the profile window still uses the default matplotlib backend. Additionally, the profile is updated every time the image changes, even when the profile window was never shown.

The first commit adds the backend parameter to the ProfileMainWindow and forwards to it the backend of the main plot. This already leads to a noticeable speedup.

The second commit updates the profile only when the profile window is visible. As I haven't spent much time looking for side effects, this approach might be too simple.

Unfortunately, the test suite segfaults on my Debian 9 installation. Therefore, I have run only the Profile tests.
