### PR TITLE
[plot3d] Optimize parameter tree updates and fix synchronization

### DIFF
--- a/silx/gui/data/_VolumeWindow.py
+++ b/silx/gui/data/_VolumeWindow.py
@@ -32,7 +32,7 @@ __date__ = "22/03/2019"
 import numpy
 
 from ..plot3d.SceneWindow import SceneWindow
-from ..plot3d.items import ScalarField3D, ComplexField3D
+from ..plot3d.items import ScalarField3D, ComplexField3D, ItemChangedType
 
 
 class VolumeWindow(SceneWindow):
@@ -100,11 +100,23 @@ class VolumeWindow(SceneWindow):
             volume.setData(data, copy=False)
         else:
             # Add a new volume
+            sceneWidget.clearItems()
             volume = sceneWidget.addVolume(data, copy=False)
             volume.setLabel('Volume')
             for plane in volume.getCutPlanes():
                 plane.setVisible(False)
+                plane.sigItemChanged.connect(self.__cutPlaneUpdated)
             volume.addIsosurface(self.__computeIsolevel, '#FF0000FF')
 
         volume.setTranslation(*offset)
         volume.setScale(*scale)
+
+    def __cutPlaneUpdated(self, event):
+        """Handle the change of visibility of the cut plane
+
+        :param event: Kind of update
+        """
+        if event == ItemChangedType.VISIBLE:
+            plane = self.sender()
+            if plane.isVisible():
+                self.getSceneWidget().selection().setCurrentItem(plane)

--- a/silx/gui/data/_VolumeWindow.py
+++ b/silx/gui/data/_VolumeWindow.py
@@ -31,6 +31,7 @@ __date__ = "22/03/2019"
 
 import numpy
 
+from .. import qt
 from ..plot3d.SceneWindow import SceneWindow
 from ..plot3d.items import ScalarField3D, ComplexField3D, ItemChangedType
 
@@ -115,6 +116,19 @@ class VolumeWindow(SceneWindow):
                 plane.setVisible(False)
                 plane.sigItemChanged.connect(self.__cutPlaneUpdated)
             volume.addIsosurface(self.__computeIsolevel, '#FF0000FF')
+
+            # Expand the parameter tree
+            model = self.getParamTreeView().model()
+            index = qt.QModelIndex()  # Invalid index for top level
+            while 1:
+                rowCount = model.rowCount(parent=index)
+                if rowCount == 0:
+                    break
+                index = model.index(rowCount - 1, 0, parent=index)
+                self.getParamTreeView().setExpanded(index, True)
+                if not index.isValid():
+                    break
+
 
         volume.setTranslation(*offset)
         volume.setScale(*scale)

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -307,7 +307,7 @@ class Item3DRow(BaseRow):
                      items.Item3DChangedType.LABEL):
             model = self.model()
             if model is not None:
-                index = self.index(column=1)
+                index = self.index(column=0)
                 model.dataChanged.emit(index, index)
 
     def item(self):

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -139,8 +139,8 @@ class _DirectionalLightProxy(qt.QObject):
         super(_DirectionalLightProxy, self).__init__()
         self._light = light
         light.addListener(self._directionUpdated)
-        self._azimuth = 0.
-        self._altitude = 0.
+        self._azimuth = 0
+        self._altitude = 0
 
     def getAzimuthAngle(self):
         """Returns the signed angle in the horizontal plane.
@@ -148,7 +148,7 @@ class _DirectionalLightProxy(qt.QObject):
          Unit: degrees.
         The 0 angle corresponds to the axis perpendicular to the screen.
 
-        :rtype: float
+        :rtype: int
         """
         return self._azimuth
 
@@ -158,15 +158,16 @@ class _DirectionalLightProxy(qt.QObject):
         Unit: degrees.
         Range: [-90, +90]
 
-        :rtype: float
+        :rtype: int
         """
         return self._altitude
 
     def setAzimuthAngle(self, angle):
         """Set the horizontal angle.
 
-        :param float angle: Angle from -z axis in zx plane in degrees.
+        :param int angle: Angle from -z axis in zx plane in degrees.
         """
+        angle = int(round(angle))
         if angle != self._azimuth:
             self._azimuth = angle
             self._updateLight()
@@ -175,8 +176,9 @@ class _DirectionalLightProxy(qt.QObject):
     def setAltitudeAngle(self, angle):
         """Set the horizontal angle.
 
-        :param float angle: Angle from -z axis in zy plane in degrees.
+        :param int angle: Angle from -z axis in zy plane in degrees.
         """
+        angle = int(round(angle))
         if angle != self._altitude:
             self._altitude = angle
             self._updateLight()
@@ -189,20 +191,21 @@ class _DirectionalLightProxy(qt.QObject):
         x, y, z = - self._light.direction
 
         # Horizontal plane is plane xz
-        azimuth = numpy.degrees(numpy.arctan2(x, z))
-        altitude = numpy.degrees(numpy.pi/2. - numpy.arccos(y))
+        azimuth = int(round(numpy.degrees(numpy.arctan2(x, z))))
+        altitude = int(round(numpy.degrees(numpy.pi/2. - numpy.arccos(y))))
 
-        if (abs(azimuth - self.getAzimuthAngle()) > 0.01 and
-                abs(abs(altitude) - 90.) >= 0.001):  # Do not update when at zenith
+        if azimuth != self.getAzimuthAngle():
             self.setAzimuthAngle(azimuth)
 
-        if abs(altitude - self.getAltitudeAngle()) > 0.01:
+        if altitude != self.getAltitudeAngle():
             self.setAltitudeAngle(altitude)
 
     def _updateLight(self):
         """Update light direction in the scene"""
         azimuth = numpy.radians(self._azimuth)
         delta = numpy.pi/2. - numpy.radians(self._altitude)
+        if delta == 0.:  # Avoids zenith position
+            delta = 0.0001
         z = - numpy.sin(delta) * numpy.cos(azimuth)
         x = - numpy.sin(delta) * numpy.sin(azimuth)
         y = - numpy.cos(delta)

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -289,6 +289,9 @@ class Item3DRow(BaseRow):
     :param str name: The optional name of the item
     """
 
+    _EVENTS = items.ItemChangedType.VISIBLE, items.Item3DChangedType.LABEL
+    """Events for which to update the first column in the tree"""
+
     def __init__(self, item, name=None):
         self.__name = None if name is None else six.text_type(name)
         super(Item3DRow, self).__init__()
@@ -302,9 +305,8 @@ class Item3DRow(BaseRow):
         item.sigItemChanged.connect(self._itemChanged)
 
     def _itemChanged(self, event):
-        """Handle visibility change"""
-        if event in (items.ItemChangedType.VISIBLE,
-                     items.Item3DChangedType.LABEL):
+        """Handle model update upon change"""
+        if event in self._EVENTS:
             model = self.model()
             if model is not None:
                 index = self.index(column=0)
@@ -1126,6 +1128,9 @@ class IsosurfaceRow(Item3DRow):
 
     _LEVEL_SLIDER_RANGE = 0, 1000
     """Range given as editor hint"""
+
+    _EVENTS = items.ItemChangedType.VISIBLE, items.ItemChangedType.COLOR
+    """Events for which to update the first column in the tree"""
 
     def __init__(self, item):
         super(IsosurfaceRow, self).__init__(item, name=item.getLevel())

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -896,10 +896,10 @@ class PlaneRow(ProxyRow):
                '-': None}
     """Mapping of plane names to normals"""
 
-    _PLANE_ICONS = {'Plane 0': icons.getQIcon('3d-plane-normal-x'),
-                    'Plane 1': icons.getQIcon('3d-plane-normal-y'),
-                    'Plane 2': icons.getQIcon('3d-plane-normal-z'),
-                    '-': icons.getQIcon('3d-plane')}
+    _PLANE_ICONS = {'Plane 0': '3d-plane-normal-x',
+                    'Plane 1': '3d-plane-normal-y',
+                    'Plane 2': '3d-plane-normal-z',
+                    '-': '3d-plane'}
     """Mapping of plane names to normals"""
 
     def __init__(self, item):
@@ -939,7 +939,7 @@ class PlaneRow(ProxyRow):
 
     def data(self, column, role):
         if column == 1 and role == qt.Qt.DecorationRole:
-            return self._PLANE_ICONS[self.__getPlaneName()]
+            return icons.getQIcon(self._PLANE_ICONS[self.__getPlaneName()])
         return super(PlaneRow, self).data(column, role)
 
 

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -1378,7 +1378,7 @@ def initVolumeCutPlaneNode(node, item):
     node.addRow(ColormapRow(item))
 
     node.addRow(ProxyRow(
-        name='Values<=Min',
+        name='Show <=Min',
         fget=item.getDisplayValuesBelowMin,
         fset=item.setDisplayValuesBelowMin,
         notify=item.sigItemChanged))

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -858,14 +858,14 @@ class SymbolSizeRow(ProxyRow):
             editorHint=(1, 20))  # TODO link with OpenGL max point size
 
 
-class PlaneRow(ProxyRow):
-    """Represents :class:`PlaneMixIn` property.
+class PlaneEquationRow(ProxyRow):
+    """Represents :class:`PlaneMixIn` as plane equation.
 
     :param Item3D item: Scene item with plane equation property
     """
 
     def __init__(self, item):
-        super(PlaneRow, self).__init__(
+        super(PlaneEquationRow, self).__init__(
             name='Equation',
             fget=item.getParameters,
             fset=item.setParameters,
@@ -881,6 +881,65 @@ class PlaneRow(ProxyRow):
                 params = item.getParameters()
                 return ('%gx %+gy %+gz %+g = 0' %
                         (params[0], params[1], params[2], params[3]))
+        return super(PlaneEquationRow, self).data(column, role)
+
+
+class PlaneRow(ProxyRow):
+    """Represents :class:`PlaneMixIn` property.
+
+    :param Item3D item: Scene item with plane equation property
+    """
+
+    _PLANES = {'Plane 0': (1., 0., 0.),
+               'Plane 1': (0., 1., 0.),
+               'Plane 2': (0., 0., 1.),
+               '-': None}
+    """Mapping of plane names to normals"""
+
+    _PLANE_ICONS = {'Plane 0': icons.getQIcon('3d-plane-normal-x'),
+                    'Plane 1': icons.getQIcon('3d-plane-normal-y'),
+                    'Plane 2': icons.getQIcon('3d-plane-normal-z'),
+                    '-': icons.getQIcon('3d-plane')}
+    """Mapping of plane names to normals"""
+
+    def __init__(self, item):
+        super(PlaneRow, self).__init__(
+            name='Plane',
+            fget=self.__getPlaneName,
+            fset=self.__setPlaneName,
+            notify=item.sigItemChanged,
+            editorHint=tuple(self._PLANES.keys()))
+        self._item = weakref.ref(item)
+
+        self.addRow(PlaneEquationRow(item))
+
+    def __getPlaneName(self):
+        """Returns name of plane // to axes or '-'
+
+        :rtype: str
+        """
+        item = self._item()
+        planeNormal = item.getNormal() if item is not None else None
+
+        for name, normal in self._PLANES.items():
+            if numpy.array_equal(planeNormal, normal):
+                return name
+        return '-'
+
+    def __setPlaneName(self, data):
+        """Set plane normal according to given plane name
+
+        :param str data: Selected plane name
+        """
+        item = self._item()
+        if item is not None:
+            for name, normal in self._PLANES.items():
+                if data == name and normal is not None:
+                    item.setNormal(normal)
+
+    def data(self, column, role):
+        if column == 1 and role == qt.Qt.DecorationRole:
+            return self._PLANE_ICONS[self.__getPlaneName()]
         return super(PlaneRow, self).data(column, role)
 
 

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -33,6 +33,7 @@ __license__ = "MIT"
 __date__ = "24/04/2018"
 
 
+from collections import OrderedDict
 import functools
 import logging
 import weakref
@@ -52,6 +53,76 @@ from .core import AngleDegreeRow, BaseRow, ColorProxyRow, ProxyRow, StaticRow
 
 
 _logger = logging.getLogger(__name__)
+
+
+class ItemProxyRow(ProxyRow):
+    """Provides a node to proxy a data accessible through functions.
+
+    It listens on sigItemChanged to trigger the update.
+
+    Warning: Only weak reference are kept on fget and fset.
+
+    :param Item3D item: The item to
+    :param str name: The name of this node
+    :param callable fget: A callable returning the data
+    :param callable fset:
+        An optional callable setting the data with data as a single argument.
+    :param events:
+        An optional event kind or list of event kinds to react upon.
+    :param callable toModelData:
+        An optional callable to convert from fget
+        callable to data returned by the model.
+    :param callable fromModelData:
+        An optional callable converting data provided to the model to
+        data for fset.
+    :param editorHint: Data to provide as UserRole for editor selection/setup
+    """
+
+    def __init__(self,
+                 item,
+                 name='',
+                 fget=None,
+                 fset=None,
+                 events=None,
+                 toModelData=None,
+                 fromModelData=None,
+                 editorHint=None):
+        super(ItemProxyRow, self).__init__(
+            name=name,
+            fget=fget,
+            fset=fset,
+            notify=None,
+            toModelData=toModelData,
+            fromModelData=fromModelData,
+            editorHint=editorHint)
+
+        if isinstance(events, (items.ItemChangedType,
+                               items.Item3DChangedType)):
+            events = (events,)
+        self.__events = events
+        item.sigItemChanged.connect(self.__itemChanged)
+
+    def __itemChanged(self, event):
+        """Handle item changed
+
+        :param Union[ItemChangedType,Item3DChangedType] event:
+        """
+        if self.__events is None or event in self.__events:
+            self._notified()
+
+
+class ItemColorProxyRow(ColorProxyRow, ItemProxyRow):
+    """Combines :class:`ColorProxyRow` and :class:`ItemProxyRow`"""
+
+    def __init__(self, *args, **kwargs):
+        ItemProxyRow.__init__(self, *args, **kwargs)
+
+
+class ItemAngleDegreeRow(AngleDegreeRow, ItemProxyRow):
+    """Combines :class:`AngleDegreeRow` and :class:`ItemProxyRow`"""
+
+    def __init__(self, *args, **kwargs):
+        ItemProxyRow.__init__(self, *args, **kwargs)
 
 
 class _DirectionalLightProxy(qt.QObject):
@@ -278,7 +349,7 @@ class Item3DRow(BaseRow):
         return 2
 
 
-class DataItem3DBoundingBoxRow(ProxyRow):
+class DataItem3DBoundingBoxRow(ItemProxyRow):
     """Represents :class:`DataItem3D` bounding box visibility
 
     :param DataItem3D item: The item for which to display/control bounding box
@@ -286,13 +357,14 @@ class DataItem3DBoundingBoxRow(ProxyRow):
 
     def __init__(self, item):
         super(DataItem3DBoundingBoxRow, self).__init__(
+            item=item,
             name='Bounding box',
             fget=item.isBoundingBoxVisible,
             fset=item.setBoundingBoxVisible,
-            notify=item.sigItemChanged)
+            events=items.Item3DChangedType.BOUNDING_BOX_VISIBLE)
 
 
-class MatrixProxyRow(ProxyRow):
+class MatrixProxyRow(ItemProxyRow):
     """Proxy for a row of a DataItem3D 3x3 matrix transform
 
     :param DataItem3D item:
@@ -304,10 +376,11 @@ class MatrixProxyRow(ProxyRow):
         self._index = index
 
         super(MatrixProxyRow, self).__init__(
+            item=item,
             name='',
             fget=self._getMatrixRow,
             fset=self._setMatrixRow,
-            notify=item.sigItemChanged)
+            events=items.Item3DChangedType.TRANSFORM)
 
     def _getMatrixRow(self):
         """Returns the matrix row.
@@ -354,11 +427,13 @@ class DataItem3DTransformRow(StaticRow):
         super(DataItem3DTransformRow, self).__init__(('Transform', None))
         self._item = weakref.ref(item)
 
-        translation = ProxyRow(name='Translation',
-                               fget=item.getTranslation,
-                               fset=self._setTranslation,
-                               notify=item.sigItemChanged,
-                               toModelData=lambda data: qt.QVector3D(*data))
+        translation = ItemProxyRow(
+            item=item,
+            name='Translation',
+            fget=item.getTranslation,
+            fset=self._setTranslation,
+            events=items.Item3DChangedType.TRANSFORM,
+            toModelData=lambda data: qt.QVector3D(*data))
         self.addRow(translation)
 
         # Here to keep a reference
@@ -369,51 +444,60 @@ class DataItem3DTransformRow(StaticRow):
         rotateCenter = StaticRow(
             ('Center', None),
             children=(
-                ProxyRow(name='X axis',
-                         fget=item.getRotationCenter,
-                         fset=self._xSetCenter,
-                         notify=item.sigItemChanged,
-                         toModelData=functools.partial(
-                             self._centerToModelData, index=0),
-                         editorHint=self._ROTATION_CENTER_OPTIONS),
-                ProxyRow(name='Y axis',
-                         fget=item.getRotationCenter,
-                         fset=self._ySetCenter,
-                         notify=item.sigItemChanged,
-                         toModelData=functools.partial(
-                             self._centerToModelData, index=1),
-                         editorHint=self._ROTATION_CENTER_OPTIONS),
-                ProxyRow(name='Z axis',
-                         fget=item.getRotationCenter,
-                         fset=self._zSetCenter,
-                         notify=item.sigItemChanged,
-                         toModelData=functools.partial(
-                             self._centerToModelData, index=2),
-                         editorHint=self._ROTATION_CENTER_OPTIONS),
+                ItemProxyRow(item=item,
+                             name='X axis',
+                             fget=item.getRotationCenter,
+                             fset=self._xSetCenter,
+                             events=items.Item3DChangedType.TRANSFORM,
+                             toModelData=functools.partial(
+                                 self._centerToModelData, index=0),
+                             editorHint=self._ROTATION_CENTER_OPTIONS),
+                ItemProxyRow(item=item,
+                             name='Y axis',
+                             fget=item.getRotationCenter,
+                             fset=self._ySetCenter,
+                             events=items.Item3DChangedType.TRANSFORM,
+                             toModelData=functools.partial(
+                                 self._centerToModelData, index=1),
+                             editorHint=self._ROTATION_CENTER_OPTIONS),
+                ItemProxyRow(item=item,
+                             name='Z axis',
+                             fget=item.getRotationCenter,
+                             fset=self._zSetCenter,
+                             events=items.Item3DChangedType.TRANSFORM,
+                             toModelData=functools.partial(
+                                 self._centerToModelData, index=2),
+                             editorHint=self._ROTATION_CENTER_OPTIONS),
             ))
 
         rotate = StaticRow(
             ('Rotation', None),
             children=(
-                AngleDegreeRow(name='Angle',
-                               fget=item.getRotation,
-                               fset=self._setAngle,
-                               notify=item.sigItemChanged,
-                               toModelData=lambda data: data[0]),
-                ProxyRow(name='Axis',
-                         fget=item.getRotation,
-                         fset=self._setAxis,
-                         notify=item.sigItemChanged,
-                         toModelData=lambda data: qt.QVector3D(*data[1])),
+                ItemAngleDegreeRow(
+                    item=item,
+                    name='Angle',
+                    fget=item.getRotation,
+                    fset=self._setAngle,
+                    events=items.Item3DChangedType.TRANSFORM,
+                    toModelData=lambda data: data[0]),
+                ItemProxyRow(
+                    item=item,
+                    name='Axis',
+                    fget=item.getRotation,
+                    fset=self._setAxis,
+                    events=items.Item3DChangedType.TRANSFORM,
+                    toModelData=lambda data: qt.QVector3D(*data[1])),
                 rotateCenter
             ))
         self.addRow(rotate)
 
-        scale = ProxyRow(name='Scale',
-                         fget=item.getScale,
-                         fset=self._setScale,
-                         notify=item.sigItemChanged,
-                         toModelData=lambda data: qt.QVector3D(*data))
+        scale = ItemProxyRow(
+            item=item,
+            name='Scale',
+            fget=item.getScale,
+            fset=self._setScale,
+            events=items.Item3DChangedType.TRANSFORM,
+            toModelData=lambda data: qt.QVector3D(*data))
         self.addRow(scale)
 
         matrix = StaticRow(
@@ -555,7 +639,7 @@ class GroupItemRow(Item3DRow):
             raise RuntimeError("Model does not correspond to scene content")
 
 
-class InterpolationRow(ProxyRow):
+class InterpolationRow(ItemProxyRow):
     """Represents :class:`InterpolationMixIn` property.
 
     :param Item3D item: Scene item with interpolation property
@@ -564,10 +648,11 @@ class InterpolationRow(ProxyRow):
     def __init__(self, item):
         modes = [mode.title() for mode in item.INTERPOLATION_MODES]
         super(InterpolationRow, self).__init__(
+            item=item,
             name='Interpolation',
             fget=item.getInterpolation,
             fset=item.setInterpolation,
-            notify=item.sigItemChanged,
+            events=items.Item3DChangedType.INTERPOLATION,
             toModelData=lambda mode: mode.title(),
             fromModelData=lambda mode: mode.lower(),
             editorHint=modes)
@@ -827,7 +912,7 @@ class ColormapRow(_ColormapBaseProxyRow):
         return super(ColormapRow, self).data(column, role)
 
 
-class SymbolRow(ProxyRow):
+class SymbolRow(ItemProxyRow):
     """Represents :class:`SymbolMixIn` symbol property.
 
     :param Item3D item: Scene item with symbol property
@@ -836,14 +921,15 @@ class SymbolRow(ProxyRow):
     def __init__(self, item):
         names = [item.getSymbolName(s) for s in item.getSupportedSymbols()]
         super(SymbolRow, self).__init__(
-             name='Marker',
-             fget=item.getSymbolName,
-             fset=item.setSymbol,
-             notify=item.sigItemChanged,
-             editorHint=names)
+            item=item,
+            name='Marker',
+            fget=item.getSymbolName,
+            fset=item.setSymbol,
+            events=items.ItemChangedType.SYMBOL,
+            editorHint=names)
 
 
-class SymbolSizeRow(ProxyRow):
+class SymbolSizeRow(ItemProxyRow):
     """Represents :class:`SymbolMixIn` symbol size property.
 
     :param Item3D item: Scene item with symbol size property
@@ -851,14 +937,15 @@ class SymbolSizeRow(ProxyRow):
 
     def __init__(self, item):
         super(SymbolSizeRow, self).__init__(
+            item=item,
             name='Marker size',
             fget=item.getSymbolSize,
             fset=item.setSymbolSize,
-            notify=item.sigItemChanged,
+            events=items.ItemChangedType.SYMBOL_SIZE,
             editorHint=(1, 20))  # TODO link with OpenGL max point size
 
 
-class PlaneEquationRow(ProxyRow):
+class PlaneEquationRow(ItemProxyRow):
     """Represents :class:`PlaneMixIn` as plane equation.
 
     :param Item3D item: Scene item with plane equation property
@@ -866,10 +953,11 @@ class PlaneEquationRow(ProxyRow):
 
     def __init__(self, item):
         super(PlaneEquationRow, self).__init__(
+            item=item,
             name='Equation',
             fget=item.getParameters,
             fset=item.setParameters,
-            notify=item.sigItemChanged,
+            events=items.ItemChangedType.POSITION,
             toModelData=lambda data: qt.QVector4D(*data),
             fromModelData=lambda data: (data.x(), data.y(), data.z(), data.w()))
         self._item = weakref.ref(item)
@@ -884,16 +972,16 @@ class PlaneEquationRow(ProxyRow):
         return super(PlaneEquationRow, self).data(column, role)
 
 
-class PlaneRow(ProxyRow):
+class PlaneRow(ItemProxyRow):
     """Represents :class:`PlaneMixIn` property.
 
     :param Item3D item: Scene item with plane equation property
     """
 
-    _PLANES = {'Plane 0': (1., 0., 0.),
-               'Plane 1': (0., 1., 0.),
-               'Plane 2': (0., 0., 1.),
-               '-': None}
+    _PLANES = OrderedDict((('Plane 0', (1., 0., 0.)),
+                           ('Plane 1', (0., 1., 0.)),
+                           ('Plane 2', (0., 0., 1.)),
+                           ('-', None)))
     """Mapping of plane names to normals"""
 
     _PLANE_ICONS = {'Plane 0': '3d-plane-normal-x',
@@ -904,14 +992,24 @@ class PlaneRow(ProxyRow):
 
     def __init__(self, item):
         super(PlaneRow, self).__init__(
+            item=item,
             name='Plane',
             fget=self.__getPlaneName,
             fset=self.__setPlaneName,
-            notify=item.sigItemChanged,
+            events=items.ItemChangedType.POSITION,
             editorHint=tuple(self._PLANES.keys()))
         self._item = weakref.ref(item)
+        self._lastName = None
 
         self.addRow(PlaneEquationRow(item))
+
+    def _notified(self, *args, **kwargs):
+        """Handle notification of modification
+
+        Here only send if plane name actually changed
+        """
+        if self._lastName != self.__getPlaneName():
+            super(PlaneRow, self)._notified()
 
     def __getPlaneName(self):
         """Returns name of plane // to axes or '-'
@@ -940,10 +1038,13 @@ class PlaneRow(ProxyRow):
     def data(self, column, role):
         if column == 1 and role == qt.Qt.DecorationRole:
             return icons.getQIcon(self._PLANE_ICONS[self.__getPlaneName()])
-        return super(PlaneRow, self).data(column, role)
+        data = super(PlaneRow, self).data(column, role)
+        if column == 1 and role == qt.Qt.DisplayRole:
+            self._lastName = data
+        return data
 
 
-class ComplexModeRow(ProxyRow):
+class ComplexModeRow(ItemProxyRow):
     """Represents :class:`items.ComplexMixIn` symbol property.
 
     :param Item3D item: Scene item with symbol property
@@ -953,10 +1054,11 @@ class ComplexModeRow(ProxyRow):
         names = [m.value.replace('_', ' ').title()
                  for m in item.supportedComplexModes()]
         super(ComplexModeRow, self).__init__(
+            item=item,
             name='Mode',
             fget=item.getComplexMode,
             fset=item.setComplexMode,
-            notify=item.sigItemChanged,
+            events=items.ItemChangedType.VISUALIZATION_MODE,
             toModelData=lambda data: data.value.replace('_', ' ').title(),
             fromModelData=lambda data: data.lower().replace(' ', '_'),
             editorHint=names)
@@ -1032,24 +1134,27 @@ class IsosurfaceRow(Item3DRow):
 
         item.sigItemChanged.connect(self._levelChanged)
 
-        self.addRow(ProxyRow(
+        self.addRow(ItemProxyRow(
+            item=item,
             name='Level',
             fget=self._getValueForLevelSlider,
             fset=self._setLevelFromSliderValue,
-            notify=item.sigItemChanged,
+            events=items.Item3DChangedType.ISO_LEVEL,
             editorHint=self._LEVEL_SLIDER_RANGE))
 
-        self.addRow(ColorProxyRow(
+        self.addRow(ItemColorProxyRow(
+            item=item,
             name='Color',
             fget=self._rgbColor,
             fset=self._setRgbColor,
-            notify=item.sigItemChanged))
+            events=items.ItemChangedType.COLOR))
 
-        self.addRow(ProxyRow(
+        self.addRow(ItemProxyRow(
+            item=item,
             name='Opacity',
             fget=self._opacity,
             fset=self._setOpacity,
-            notify=item.sigItemChanged,
+            events=items.ItemChangedType.COLOR,
             editorHint=(0, 255)))
 
         self.addRow(RemoveIsosurfaceRow(item))
@@ -1364,7 +1469,7 @@ class Scatter2DSymbolSizeRow(Scatter2DPropertyMixInRow, SymbolSizeRow):
         Scatter2DPropertyMixInRow.__init__(self, item, 'symbolSize')
 
 
-class Scatter2DLineWidth(Scatter2DPropertyMixInRow, ProxyRow):
+class Scatter2DLineWidth(Scatter2DPropertyMixInRow, ItemProxyRow):
     """Specific class for Scatter2D symbol size.
 
     It is enabled/disabled according to visualization mode.
@@ -1374,12 +1479,13 @@ class Scatter2DLineWidth(Scatter2DPropertyMixInRow, ProxyRow):
 
     def __init__(self, item):
         # TODO link editorHint with OpenGL max line width
-        ProxyRow.__init__(self,
-                          name='Line width',
-                          fget=item.getLineWidth,
-                          fset=item.setLineWidth,
-                          notify=item.sigItemChanged,
-                          editorHint=(1, 10))
+        ItemProxyRow.__init__(self,
+                              item=item,
+                              name='Line width',
+                              fget=item.getLineWidth,
+                              fset=item.setLineWidth,
+                              events=items.ItemChangedType.LINE_WIDTH,
+                              editorHint=(1, 10))
         Scatter2DPropertyMixInRow.__init__(self, item, 'lineWidth')
 
 
@@ -1389,20 +1495,22 @@ def initScatter2DNode(node, item):
     :param Item3DRow node: The model node to setup
     :param Scatter2D item: The Scatter2D the node is representing
     """
-    node.addRow(ProxyRow(
+    node.addRow(ItemProxyRow(
+        item=item,
         name='Mode',
         fget=item.getVisualization,
         fset=item.setVisualization,
-        notify=item.sigItemChanged,
+        events=items.ItemChangedType.VISUALIZATION_MODE,
         editorHint=[m.title() for m in item.supportedVisualizations()],
         toModelData=lambda data: data.title(),
         fromModelData=lambda data: data.lower()))
 
-    node.addRow(ProxyRow(
+    node.addRow(ItemProxyRow(
+        item=item,
         name='Height map',
         fget=item.isHeightMap,
         fset=item.setHeightMap,
-        notify=item.sigItemChanged))
+        events=items.Item3DChangedType.HEIGHT_MAP))
 
     node.addRow(ColormapRow(item))
 
@@ -1436,11 +1544,12 @@ def initVolumeCutPlaneNode(node, item):
 
     node.addRow(ColormapRow(item))
 
-    node.addRow(ProxyRow(
+    node.addRow(ItemProxyRow(
+        item=item,
         name='Show <=Min',
         fget=item.getDisplayValuesBelowMin,
         fset=item.setDisplayValuesBelowMin,
-        notify=item.sigItemChanged))
+        events=items.ItemChangedType.ALPHA))
 
     node.addRow(InterpolationRow(item))
 

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -180,7 +180,7 @@ class ComplexMixIn(ItemMixInBase):
 
     class Mode(enum.Enum):
         """Identify available display mode for complex"""
-        ABSOLUTE = 'absolute'
+        ABSOLUTE = 'amplitude'
         PHASE = 'phase'
         REAL = 'real'
         IMAGINARY = 'imaginary'
@@ -206,7 +206,7 @@ class ComplexMixIn(ItemMixInBase):
             raise ValueError("Cannot convert: %s" % value)
 
     def __init__(self):
-        self._mode = self.Mode.REAL
+        self._mode = self.Mode.ABSOLUTE
 
     def getComplexMode(self):
         """Returns the current complex visualization mode.


### PR DESCRIPTION
Merge PR #2523 first !

This PR optimizes the ``plot3d`` parameter tree update by requesting model update only when the right event is received (before it was updated for any event for a given item).
It also fixes a few issues with model not sending correct update events (for item visibility, isosurface color and light direction), resulting in tree widget not being synchronized until the mouse hovers it.

closes #2513