### PR TITLE
Avoid object leak at destruction of PlotWidget with OpenGL backend

### DIFF
--- a/silx/gui/_glutils/Context.py
+++ b/silx/gui/_glutils/Context.py
@@ -50,7 +50,7 @@ def getCurrent():
     created in.
 
     :return: Platform specific OpenGL context
-    :rtype: 'none' by default or a platform dependent object"""
+    """
     return _context
 
 

--- a/silx/gui/_glutils/Context.py
+++ b/silx/gui/_glutils/Context.py
@@ -32,14 +32,15 @@ __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "25/07/2016"
 
+import contextlib
 
-# context #####################################################################
 
+class _DEFAULT_CONTEXT(object):
+    """The default value for OpenGL context"""
+    pass
 
-def _defaultGLContextGetter():
-    return 'none'
-
-_glContextGetter = _defaultGLContextGetter
+_context = _DEFAULT_CONTEXT
+"""The current OpenGL context"""
 
 
 def getCurrent():
@@ -50,14 +51,25 @@ def getCurrent():
 
     :return: Platform specific OpenGL context
     :rtype: 'none' by default or a platform dependent object"""
-    return _glContextGetter()
+    return _context
 
 
-def setCurrentGetter(getter=_defaultGLContextGetter):
-    """Set a platform dependent function to retrieve the current OpenGL context
+def setCurrent(context=_DEFAULT_CONTEXT):
+    """Set a platform dependent OpenGL context
 
-    :param getter: Platform dependent GL context getter
-    :type getter: Function with no args returning the current OpenGL context
+    :param context: Platform dependent GL context
     """
-    global _glContextGetter
-    _glContextGetter = getter
+    global _context
+    _context = context
+
+
+@contextlib.contextmanager
+def current(context):
+    """Context manager setting the platform-dependent GL context
+
+    :param context: Platform dependent GL context
+    """
+    previous_context = getCurrent()
+    setCurrent(context)
+    yield
+    setCurrent(previous_context)

--- a/silx/gui/_glutils/Context.py
+++ b/silx/gui/_glutils/Context.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -42,7 +42,7 @@ def _defaultGLContextGetter():
 _glContextGetter = _defaultGLContextGetter
 
 
-def getGLContext():
+def getCurrent():
     """Returns platform dependent object of current OpenGL context.
 
     This is useful to associate OpenGL resources with the context they are
@@ -53,7 +53,7 @@ def getGLContext():
     return _glContextGetter()
 
 
-def setGLContextGetter(getter=_defaultGLContextGetter):
+def setCurrentGetter(getter=_defaultGLContextGetter):
     """Set a platform dependent function to retrieve the current OpenGL context
 
     :param getter: Platform dependent GL context getter

--- a/silx/gui/_glutils/Context.py
+++ b/silx/gui/_glutils/Context.py
@@ -37,7 +37,7 @@ __date__ = "25/07/2016"
 
 
 def _defaultGLContextGetter():
-    return None
+    return 'none'
 
 _glContextGetter = _defaultGLContextGetter
 
@@ -49,7 +49,7 @@ def getCurrent():
     created in.
 
     :return: Platform specific OpenGL context
-    :rtype: None by default or a platform dependent object"""
+    :rtype: 'none' by default or a platform dependent object"""
     return _glContextGetter()
 
 

--- a/silx/gui/_glutils/Program.py
+++ b/silx/gui/_glutils/Program.py
@@ -30,6 +30,7 @@ __date__ = "25/07/2016"
 
 
 import logging
+import weakref
 
 import numpy
 
@@ -60,7 +61,7 @@ class Program(object):
         self._vertexShader = vertexShader
         self._fragmentShader = fragmentShader
         self._attrib0 = attrib0
-        self._programs = {}
+        self._programs = weakref.WeakKeyDictionary()
 
     @staticmethod
     def _compileGL(vertexShader, fragmentShader, attrib0):

--- a/silx/gui/_glutils/Program.py
+++ b/silx/gui/_glutils/Program.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -33,8 +33,7 @@ import logging
 
 import numpy
 
-from . import gl
-from .Context import getGLContext
+from . import Context, gl
 
 _logger = logging.getLogger(__name__)
 
@@ -106,7 +105,7 @@ class Program(object):
         return program, attributes, uniforms
 
     def _getProgramInfo(self):
-        glcontext = getGLContext()
+        glcontext = Context.getCurrent()
         if glcontext not in self._programs:
             raise RuntimeError(
                 "Program was not compiled for current OpenGL context.")
@@ -149,7 +148,7 @@ class Program(object):
 
     def use(self):
         """Make use of the program, compiling it if necessary"""
-        glcontext = getGLContext()
+        glcontext = Context.getCurrent()
 
         if glcontext not in self._programs:
             self._programs[glcontext] = self._compileGL(

--- a/silx/gui/_glutils/__init__.py
+++ b/silx/gui/_glutils/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,7 @@ __date__ = "25/07/2016"
 
 # OpenGL convenient functions
 from .OpenGLWidget import OpenGLWidget  # noqa
-from .Context import getGLContext, setGLContextGetter  # noqa
+from . import Context  # noqa
 from .FramebufferTexture import FramebufferTexture  # noqa
 from .Program import Program  # noqa
 from .Texture import Texture  # noqa

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -547,7 +547,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         # self._paintDirectGL()
         self._paintFBOGL()
 
-        glu.setCurrentGetter()
+        glu.Context.setCurrentGetter()
         _current_context = None
 
     def _renderMarkersGL(self):

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -33,6 +33,7 @@ __date__ = "21/12/2018"
 from collections import OrderedDict, namedtuple
 from ctypes import c_void_p
 import logging
+import weakref
 
 import numpy
 
@@ -348,7 +349,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             _baseVertShd, _baseFragShd, attrib0='position')
         self._progTex = glu.Program(
             _texVertShd, _texFragShd, attrib0='position')
-        self._plotFBOs = {}
+        self._plotFBOs = weakref.WeakKeyDictionary()
 
         self._keepDataAspectRatio = False
 

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -462,7 +462,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         self._renderOverlayGL()
 
     def _paintFBOGL(self):
-        context = glu.getGLContext()
+        context = glu.Context.getCurrent()
         plotFBOTex = self._plotFBOs.get(context)
         if (self._plot._getDirtyPlot() or self._plotFrame.isDirty or
                 plotFBOTex is None):
@@ -529,7 +529,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         global _current_context
         _current_context = self.context()
 
-        glu.setGLContextGetter(_getContext)
+        glu.Context.setCurrentGetter(_getContext)
 
         # Release OpenGL resources
         for item in self._glGarbageCollector:
@@ -547,7 +547,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         # self._paintDirectGL()
         self._paintFBOGL()
 
-        glu.setGLContextGetter()
+        glu.setCurrentGetter()
         _current_context = None
 
     def _renderMarkersGL(self):

--- a/silx/gui/plot/backends/glutils/GLText.py
+++ b/silx/gui/plot/backends/glutils/GLText.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +35,7 @@ __date__ = "03/04/2017"
 from collections import OrderedDict
 import numpy
 
-from ...._glutils import font, gl, getGLContext, Program, Texture
+from ...._glutils import font, gl, Context, Program, Texture
 from .GLSupport import mat4Translate
 
 
@@ -159,7 +159,7 @@ class Text2D(object):
         self._rotate = numpy.radians(rotate)
 
     def _getTexture(self, text):
-        key = getGLContext(), text
+        key = Context.getCurrent(), text
 
         if key not in self._textures:
             image, offset = font.rasterText(text,


### PR DESCRIPTION
This PR avoids to keep reference to objects related to a given OpenGL context after this was destroyed.
It replaces the use of ``dict`` with ``WeakKeyDictionary`` to circumvent this.

It also includes the renaming of 2 functions used internally.

related to #2538