### PR TITLE
Fix plotaction parent

### DIFF
--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -29,7 +29,7 @@ The :class:`PlotWindow` is a subclass of :class:`.PlotWidget`.
 
 __authors__ = ["V.A. Sole", "T. Vincent"]
 __license__ = "MIT"
-__date__ = "21/12/2018"
+__date__ = "12/04/2019"
 
 import collections
 import logging
@@ -129,53 +129,53 @@ class PlotWindow(PlotWidget):
         self.group.setExclusive(False)
 
         self.resetZoomAction = self.group.addAction(
-            actions.control.ResetZoomAction(self))
+            actions.control.ResetZoomAction(self, parent=self))
         self.resetZoomAction.setVisible(resetzoom)
         self.addAction(self.resetZoomAction)
 
-        self.zoomInAction = actions.control.ZoomInAction(self)
+        self.zoomInAction = actions.control.ZoomInAction(self, parent=self)
         self.addAction(self.zoomInAction)
 
-        self.zoomOutAction = actions.control.ZoomOutAction(self)
+        self.zoomOutAction = actions.control.ZoomOutAction(self, parent=self)
         self.addAction(self.zoomOutAction)
 
         self.xAxisAutoScaleAction = self.group.addAction(
-            actions.control.XAxisAutoScaleAction(self))
+            actions.control.XAxisAutoScaleAction(self, parent=self))
         self.xAxisAutoScaleAction.setVisible(autoScale)
         self.addAction(self.xAxisAutoScaleAction)
 
         self.yAxisAutoScaleAction = self.group.addAction(
-            actions.control.YAxisAutoScaleAction(self))
+            actions.control.YAxisAutoScaleAction(self, parent=self))
         self.yAxisAutoScaleAction.setVisible(autoScale)
         self.addAction(self.yAxisAutoScaleAction)
 
         self.xAxisLogarithmicAction = self.group.addAction(
-            actions.control.XAxisLogarithmicAction(self))
+            actions.control.XAxisLogarithmicAction(self, parent=self))
         self.xAxisLogarithmicAction.setVisible(logScale)
         self.addAction(self.xAxisLogarithmicAction)
 
         self.yAxisLogarithmicAction = self.group.addAction(
-            actions.control.YAxisLogarithmicAction(self))
+            actions.control.YAxisLogarithmicAction(self, parent=self))
         self.yAxisLogarithmicAction.setVisible(logScale)
         self.addAction(self.yAxisLogarithmicAction)
 
         self.gridAction = self.group.addAction(
-            actions.control.GridAction(self, gridMode='both'))
+            actions.control.GridAction(self, gridMode='both', parent=self))
         self.gridAction.setVisible(grid)
         self.addAction(self.gridAction)
 
         self.curveStyleAction = self.group.addAction(
-            actions.control.CurveStyleAction(self))
+            actions.control.CurveStyleAction(self, parent=self))
         self.curveStyleAction.setVisible(curveStyle)
         self.addAction(self.curveStyleAction)
 
         self.colormapAction = self.group.addAction(
-            actions.control.ColormapAction(self))
+            actions.control.ColormapAction(self, parent=self))
         self.colormapAction.setVisible(colormap)
         self.addAction(self.colormapAction)
 
         self.colorbarAction = self.group.addAction(
-            actions_control.ColorBarAction(self, self))
+            actions_control.ColorBarAction(self, parent=self))
         self.colorbarAction.setVisible(False)
         self.addAction(self.colorbarAction)
         self._colorbar.setVisible(False)
@@ -195,18 +195,18 @@ class PlotWindow(PlotWidget):
         self.getMaskAction().setVisible(mask)
 
         self._intensityHistoAction = self.group.addAction(
-            actions_histogram.PixelIntensitiesHistoAction(self))
+            actions_histogram.PixelIntensitiesHistoAction(self, parent=self))
         self._intensityHistoAction.setVisible(False)
 
         self._medianFilter2DAction = self.group.addAction(
-            actions_medfilt.MedianFilter2DAction(self))
+            actions_medfilt.MedianFilter2DAction(self, parent=self))
         self._medianFilter2DAction.setVisible(False)
 
         self._medianFilter1DAction = self.group.addAction(
-            actions_medfilt.MedianFilter1DAction(self))
+            actions_medfilt.MedianFilter1DAction(self, parent=self))
         self._medianFilter1DAction.setVisible(False)
 
-        self.fitAction = self.group.addAction(actions_fit.FitAction(self))
+        self.fitAction = self.group.addAction(actions_fit.FitAction(self, parent=self))
         self.fitAction.setVisible(fit)
         self.addAction(self.fitAction)
 

--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -279,7 +279,7 @@ class PlotWindow(PlotWidget):
             parent=self, plot=self)
         self.addToolBar(self._interactiveModeToolBar)
 
-        self._toolbar = self._createToolBar(title='Plot', parent=None)
+        self._toolbar = self._createToolBar(title='Plot', parent=self)
         self.addToolBar(self._toolbar)
 
         self._outputToolBar = tools.OutputToolBar(parent=self, plot=self)

--- a/silx/gui/plot/Profile.py
+++ b/silx/gui/plot/Profile.py
@@ -28,7 +28,7 @@ and stacks of images"""
 
 __authors__ = ["V.A. Sole", "T. Vincent", "P. Knobel", "H. Payno"]
 __license__ = "MIT"
-__date__ = "24/07/2018"
+__date__ = "12/04/2019"
 
 
 import weakref
@@ -426,33 +426,33 @@ class ProfileToolBar(qt.QToolBar):
         self._browseAction = actions.mode.ZoomModeAction(self.plot, parent=self)
         self._browseAction.setVisible(False)
 
-        self.hLineAction = qt.QAction(
-            icons.getQIcon('shape-horizontal'),
-            'Horizontal Profile Mode', None)
+        self.hLineAction = qt.QAction(icons.getQIcon('shape-horizontal'),
+                                      'Horizontal Profile Mode',
+                                      parent=self)
         self.hLineAction.setToolTip(
             'Enables horizontal profile selection mode')
         self.hLineAction.setCheckable(True)
         self.hLineAction.toggled[bool].connect(self._hLineActionToggled)
 
-        self.vLineAction = qt.QAction(
-            icons.getQIcon('shape-vertical'),
-            'Vertical Profile Mode', None)
+        self.vLineAction = qt.QAction(icons.getQIcon('shape-vertical'),
+                                      'Vertical Profile Mode',
+                                      parent=self)
         self.vLineAction.setToolTip(
             'Enables vertical profile selection mode')
         self.vLineAction.setCheckable(True)
         self.vLineAction.toggled[bool].connect(self._vLineActionToggled)
 
-        self.lineAction = qt.QAction(
-            icons.getQIcon('shape-diagonal'),
-            'Free Line Profile Mode', None)
+        self.lineAction = qt.QAction(icons.getQIcon('shape-diagonal'),
+                                     'Free Line Profile Mode',
+                                     parent=self)
         self.lineAction.setToolTip(
             'Enables line profile selection mode')
         self.lineAction.setCheckable(True)
         self.lineAction.toggled[bool].connect(self._lineActionToggled)
 
-        self.clearAction = qt.QAction(
-            icons.getQIcon('profile-clear'),
-            'Clear Profile', None)
+        self.clearAction = qt.QAction(icons.getQIcon('profile-clear'),
+                                      'Clear Profile',
+                                      parent=self)
         self.clearAction.setToolTip(
             'Clear the profile Region of interest')
         self.clearAction.setCheckable(False)

--- a/silx/gui/plot/Profile.py
+++ b/silx/gui/plot/Profile.py
@@ -428,7 +428,7 @@ class ProfileToolBar(qt.QToolBar):
 
         self.hLineAction = qt.QAction(icons.getQIcon('shape-horizontal'),
                                       'Horizontal Profile Mode',
-                                      parent=self)
+                                      self)
         self.hLineAction.setToolTip(
             'Enables horizontal profile selection mode')
         self.hLineAction.setCheckable(True)
@@ -436,7 +436,7 @@ class ProfileToolBar(qt.QToolBar):
 
         self.vLineAction = qt.QAction(icons.getQIcon('shape-vertical'),
                                       'Vertical Profile Mode',
-                                      parent=self)
+                                      self)
         self.vLineAction.setToolTip(
             'Enables vertical profile selection mode')
         self.vLineAction.setCheckable(True)
@@ -444,7 +444,7 @@ class ProfileToolBar(qt.QToolBar):
 
         self.lineAction = qt.QAction(icons.getQIcon('shape-diagonal'),
                                      'Free Line Profile Mode',
-                                     parent=self)
+                                     self)
         self.lineAction.setToolTip(
             'Enables line profile selection mode')
         self.lineAction.setCheckable(True)
@@ -452,7 +452,7 @@ class ProfileToolBar(qt.QToolBar):
 
         self.clearAction = qt.QAction(icons.getQIcon('profile-clear'),
                                       'Clear Profile',
-                                      parent=self)
+                                      self)
         self.clearAction.setToolTip(
             'Clear the profile Region of interest')
         self.clearAction.setCheckable(False)

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -29,7 +29,7 @@ from __future__ import division
 
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "15/02/2019"
+__date__ = "12/04/2019"
 
 import os
 import weakref
@@ -519,7 +519,7 @@ class BaseMaskToolsWidget(qt.QWidget):
 
     def _initTransparencyWidget(self):
         """ Init the mask transparency widget """
-        transparencyWidget = qt.QWidget(self)
+        transparencyWidget = qt.QWidget(parent=self)
         grid = qt.QGridLayout()
         grid.setContentsMargins(0, 0, 0, 0)
         self.transparencySlider = qt.QSlider(qt.Qt.Horizontal, parent=transparencyWidget)
@@ -619,8 +619,9 @@ class BaseMaskToolsWidget(qt.QWidget):
         self.addAction(self.browseAction)
 
         # Draw tools
-        self.rectAction = qt.QAction(
-                icons.getQIcon('shape-rectangle'), 'Rectangle selection', None)
+        self.rectAction = qt.QAction(icons.getQIcon('shape-rectangle'),
+                                     'Rectangle selection',
+                                     parent=self)
         self.rectAction.setToolTip(
                 'Rectangle selection tool: (Un)Mask a rectangular region <b>R</b>')
         self.rectAction.setShortcut(qt.QKeySequence(qt.Qt.Key_R))
@@ -628,8 +629,9 @@ class BaseMaskToolsWidget(qt.QWidget):
         self.rectAction.triggered.connect(self._activeRectMode)
         self.addAction(self.rectAction)
 
-        self.ellipseAction = qt.QAction(
-                icons.getQIcon('shape-ellipse'), 'Circle selection', None)
+        self.ellipseAction = qt.QAction(icons.getQIcon('shape-ellipse'),
+                                        'Circle selection',
+                                        parent=self)
         self.ellipseAction.setToolTip(
                 'Rectangle selection tool: (Un)Mask a circle region <b>R</b>')
         self.ellipseAction.setShortcut(qt.QKeySequence(qt.Qt.Key_R))
@@ -637,8 +639,9 @@ class BaseMaskToolsWidget(qt.QWidget):
         self.ellipseAction.triggered.connect(self._activeEllipseMode)
         self.addAction(self.ellipseAction)
 
-        self.polygonAction = qt.QAction(
-                icons.getQIcon('shape-polygon'), 'Polygon selection', None)
+        self.polygonAction = qt.QAction(icons.getQIcon('shape-polygon'),
+                                        'Polygon selection',
+                                        parent=self)
         self.polygonAction.setShortcut(qt.QKeySequence(qt.Qt.Key_S))
         self.polygonAction.setToolTip(
                 'Polygon selection tool: (Un)Mask a polygonal region <b>S</b><br>'
@@ -648,8 +651,9 @@ class BaseMaskToolsWidget(qt.QWidget):
         self.polygonAction.triggered.connect(self._activePolygonMode)
         self.addAction(self.polygonAction)
 
-        self.pencilAction = qt.QAction(
-                icons.getQIcon('draw-pencil'), 'Pencil tool', None)
+        self.pencilAction = qt.QAction(icons.getQIcon('draw-pencil'),
+                                       'Pencil tool',
+                                       parent=self)
         self.pencilAction.setShortcut(qt.QKeySequence(qt.Qt.Key_P))
         self.pencilAction.setToolTip(
                 'Pencil tool: (Un)Mask using a pencil <b>P</b>')
@@ -733,21 +737,24 @@ class BaseMaskToolsWidget(qt.QWidget):
     def _initThresholdGroupBox(self):
         """Init thresholding widgets"""
 
-        self.belowThresholdAction = qt.QAction(
-                icons.getQIcon('plot-roi-below'), 'Mask below threshold', None)
+        self.belowThresholdAction = qt.QAction(icons.getQIcon('plot-roi-below'),
+                                               'Mask below threshold',
+                                               parent=self)
         self.belowThresholdAction.setToolTip(
                 'Mask image where values are below given threshold')
         self.belowThresholdAction.setCheckable(True)
         self.belowThresholdAction.setChecked(True)
 
-        self.betweenThresholdAction = qt.QAction(
-                icons.getQIcon('plot-roi-between'), 'Mask within range', None)
+        self.betweenThresholdAction = qt.QAction(icons.getQIcon('plot-roi-between'),
+                                                 'Mask within range',
+                                                 parent=self)
         self.betweenThresholdAction.setToolTip(
                 'Mask image where values are within given range')
         self.betweenThresholdAction.setCheckable(True)
 
-        self.aboveThresholdAction = qt.QAction(
-                icons.getQIcon('plot-roi-above'), 'Mask above threshold', None)
+        self.aboveThresholdAction = qt.QAction(icons.getQIcon('plot-roi-above'),
+                                               'Mask above threshold',
+                                               parent=self)
         self.aboveThresholdAction.setToolTip(
                 'Mask image where values are above given threshold')
         self.aboveThresholdAction.setCheckable(True)
@@ -760,8 +767,9 @@ class BaseMaskToolsWidget(qt.QWidget):
         self.thresholdActionGroup.triggered.connect(
                 self._thresholdActionGroupTriggered)
 
-        self.loadColormapRangeAction = qt.QAction(
-                icons.getQIcon('view-refresh'), 'Set min-max from colormap', None)
+        self.loadColormapRangeAction = qt.QAction(icons.getQIcon('view-refresh'),
+                                                  'Set min-max from colormap',
+                                                  parent=self)
         self.loadColormapRangeAction.setToolTip(
                 'Set min and max values from current colormap range')
         self.loadColormapRangeAction.setCheckable(False)
@@ -774,7 +782,7 @@ class BaseMaskToolsWidget(qt.QWidget):
             btn.setDefaultAction(action)
             widgets.append(btn)
 
-        spacer = qt.QWidget()
+        spacer = qt.QWidget(parent=self)
         spacer.setSizePolicy(qt.QSizePolicy.Expanding,
                              qt.QSizePolicy.Preferred)
         widgets.append(spacer)

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -621,7 +621,7 @@ class BaseMaskToolsWidget(qt.QWidget):
         # Draw tools
         self.rectAction = qt.QAction(icons.getQIcon('shape-rectangle'),
                                      'Rectangle selection',
-                                     parent=self)
+                                     self)
         self.rectAction.setToolTip(
                 'Rectangle selection tool: (Un)Mask a rectangular region <b>R</b>')
         self.rectAction.setShortcut(qt.QKeySequence(qt.Qt.Key_R))
@@ -631,7 +631,7 @@ class BaseMaskToolsWidget(qt.QWidget):
 
         self.ellipseAction = qt.QAction(icons.getQIcon('shape-ellipse'),
                                         'Circle selection',
-                                        parent=self)
+                                        self)
         self.ellipseAction.setToolTip(
                 'Rectangle selection tool: (Un)Mask a circle region <b>R</b>')
         self.ellipseAction.setShortcut(qt.QKeySequence(qt.Qt.Key_R))
@@ -641,7 +641,7 @@ class BaseMaskToolsWidget(qt.QWidget):
 
         self.polygonAction = qt.QAction(icons.getQIcon('shape-polygon'),
                                         'Polygon selection',
-                                        parent=self)
+                                        self)
         self.polygonAction.setShortcut(qt.QKeySequence(qt.Qt.Key_S))
         self.polygonAction.setToolTip(
                 'Polygon selection tool: (Un)Mask a polygonal region <b>S</b><br>'
@@ -653,7 +653,7 @@ class BaseMaskToolsWidget(qt.QWidget):
 
         self.pencilAction = qt.QAction(icons.getQIcon('draw-pencil'),
                                        'Pencil tool',
-                                       parent=self)
+                                       self)
         self.pencilAction.setShortcut(qt.QKeySequence(qt.Qt.Key_P))
         self.pencilAction.setToolTip(
                 'Pencil tool: (Un)Mask using a pencil <b>P</b>')
@@ -739,7 +739,7 @@ class BaseMaskToolsWidget(qt.QWidget):
 
         self.belowThresholdAction = qt.QAction(icons.getQIcon('plot-roi-below'),
                                                'Mask below threshold',
-                                               parent=self)
+                                               self)
         self.belowThresholdAction.setToolTip(
                 'Mask image where values are below given threshold')
         self.belowThresholdAction.setCheckable(True)
@@ -747,14 +747,14 @@ class BaseMaskToolsWidget(qt.QWidget):
 
         self.betweenThresholdAction = qt.QAction(icons.getQIcon('plot-roi-between'),
                                                  'Mask within range',
-                                                 parent=self)
+                                                 self)
         self.betweenThresholdAction.setToolTip(
                 'Mask image where values are within given range')
         self.betweenThresholdAction.setCheckable(True)
 
         self.aboveThresholdAction = qt.QAction(icons.getQIcon('plot-roi-above'),
                                                'Mask above threshold',
-                                               parent=self)
+                                               self)
         self.aboveThresholdAction.setToolTip(
                 'Mask image where values are above given threshold')
         self.aboveThresholdAction.setCheckable(True)
@@ -769,7 +769,7 @@ class BaseMaskToolsWidget(qt.QWidget):
 
         self.loadColormapRangeAction = qt.QAction(icons.getQIcon('view-refresh'),
                                                   'Set min-max from colormap',
-                                                  parent=self)
+                                                  self)
         self.loadColormapRangeAction.setToolTip(
                 'Set min and max values from current colormap range')
         self.loadColormapRangeAction.setCheckable(False)


### PR DESCRIPTION
Non-parented `QAction` creates memory leak.

This following code can be used to help to catch this problems.
```
def assert_qaction_parent():

    from PyQt5.QtWidgets import QAction
    qt_qaction_constructor = QAction.__init__

    def my__qaction__constructor(self, *args, **kwargs):
        parent = None
        # Maybe not a very accurate way to reach the parent
        if "parent" in kwargs:
            parent = kwargs["parent"]
        if len(args) != 0:
            parent = args[-1]
        if len(args) + len(kwargs) != 0:
            # Looks like it is used intetrnally like that
            assert(parent is not None)
        return qt_qaction_constructor(self, *args, **kwargs)

    QAction.__init__ = my__qaction__constructor

```

Closes #2538
