### PR TITLE
pyopencl: Dont use numpy.int32 for workgroup param

### DIFF
--- a/silx/opencl/convolution.py
+++ b/silx/opencl/convolution.py
@@ -330,7 +330,7 @@ class Convolution(OpenclProcessing):
             kernel_files=kernel_files,
             compile_options=compile_options
         )
-        self.ndrange = np.int32(self.shape)[::-1]
+        self.ndrange = self.shape[::-1]
         self.wg = None
         kernel_args = [
             self.queue,


### PR DESCRIPTION
This PR attempts to fix a bug occurring with pyopencl 2014.x, crashing the continuous integration on edna-site.