### PR TITLE
python 3.8 compatibility

### DIFF
--- a/silx/gui/_glutils/Texture.py
+++ b/silx/gui/_glutils/Texture.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,11 @@ __license__ = "MIT"
 __date__ = "04/10/2016"
 
 
-import collections
+try:
+    from collections import abc
+except ImportError:  # Python2 support
+    import collections as abc
+
 from ctypes import c_void_p
 import logging
 
@@ -93,7 +97,7 @@ class Texture(object):
         self.magFilter = magFilter if magFilter is not None else gl.GL_LINEAR
 
         if wrap is not None:
-            if not isinstance(wrap, collections.Iterable):
+            if not isinstance(wrap, abc.Iterable):
                 wrap = [wrap] * self.ndim
 
             assert len(wrap) == self.ndim

--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -31,7 +31,10 @@ __authors__ = ["V.A. Sole", "T. Vincent"]
 __license__ = "MIT"
 __date__ = "12/04/2019"
 
-import collections
+try:
+    from collections import abc
+except ImportError:  # Python2 support
+    import collections as abc
 import logging
 import weakref
 
@@ -251,7 +254,7 @@ class PlotWindow(PlotWidget):
                 hbox.addWidget(self.controlButton)
 
             if position:  # Add PositionInfo widget to the bottom of the plot
-                if isinstance(position, collections.Iterable):
+                if isinstance(position, abc.Iterable):
                     # Use position as a set of converters
                     converters = position
                 else:

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -30,6 +30,10 @@ __license__ = "MIT"
 __date__ = "29/01/2019"
 
 import collections
+try:
+    from collections import abc
+except ImportError:  # Python2 support
+    import collections as abc
 from copy import deepcopy
 import logging
 import enum
@@ -1026,12 +1030,12 @@ class Points(Item, SymbolMixIn, AlphaMixIn):
         assert x.ndim == y.ndim == 1
 
         if xerror is not None:
-            if isinstance(xerror, collections.Iterable):
+            if isinstance(xerror, abc.Iterable):
                 xerror = numpy.array(xerror, copy=copy)
             else:
                 xerror = float(xerror)
         if yerror is not None:
-            if isinstance(yerror, collections.Iterable):
+            if isinstance(yerror, abc.Iterable):
                 yerror = numpy.array(yerror, copy=copy)
             else:
                 yerror = float(yerror)

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +31,10 @@ __license__ = "MIT"
 __date__ = "20/10/2017"
 
 
-from collections import Sequence
+try:
+    from collections import abc
+except ImportError:  # Python2 support
+    import collections as abc
 import logging
 
 import numpy
@@ -199,7 +202,7 @@ class ImageBase(Item, LabelsMixIn, DraggableMixIn, AlphaMixIn):
         :param origin: (ox, oy) Offset from origin
         :type origin: float or 2-tuple of float
         """
-        if isinstance(origin, Sequence):
+        if isinstance(origin, abc.Sequence):
             origin = float(origin[0]), float(origin[1])
         else:  # single value origin
             origin = float(origin), float(origin)
@@ -227,7 +230,7 @@ class ImageBase(Item, LabelsMixIn, DraggableMixIn, AlphaMixIn):
         :param scale: (sx, sy) Scale of the image
         :type scale: float or 2-tuple of float
         """
-        if isinstance(scale, Sequence):
+        if isinstance(scale, abc.Sequence):
             scale = float(scale[0]), float(scale[1])
         else:  # single value scale
             scale = float(scale), float(scale)

--- a/silx/gui/plot3d/items/scatter.py
+++ b/silx/gui/plot3d/items/scatter.py
@@ -31,7 +31,10 @@ __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "15/11/2017"
 
-import collections
+try:
+    from collections import abc
+except ImportError:  # Python2 support
+    import collections as abc
 import logging
 import sys
 import numpy
@@ -374,7 +377,7 @@ class Scatter2D(DataItem3D, ColormapMixIn, SymbolMixIn):
             y, copy=copy, dtype=numpy.float32, order='C').reshape(-1)
         assert len(x) == len(y)
 
-        if isinstance(value, collections.Iterable):
+        if isinstance(value, abc.Iterable):
             value = numpy.array(
                 value, copy=copy, dtype=numpy.float32, order='C').reshape(-1)
             assert len(value) == len(x)

--- a/silx/gui/plot3d/scene/primitives.py
+++ b/silx/gui/plot3d/scene/primitives.py
@@ -29,8 +29,10 @@ __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "24/04/2018"
 
-
-import collections
+try:
+    from collections import abc
+except ImportError:  # Python2 support
+    import collections as abc
 import ctypes
 from functools import reduce
 import logging
@@ -146,7 +148,7 @@ class Geometry(core.Elem):
         :param bool copy: True to make a copy of the array, False to use as is
         """
         # Convert single value (int, float, numpy types) to tuple
-        if not isinstance(array, collections.Iterable):
+        if not isinstance(array, abc.Iterable):
             array = (array, )
 
         # Makes sure it is an array
@@ -1508,7 +1510,7 @@ class GridPoints(Geometry):
 
     def __init__(self, values=0., shape=None, sizes=1., indices=None,
                  minValue=None, maxValue=None):
-        if isinstance(values, collections.Iterable):
+        if isinstance(values, abc.Iterable):
             values = numpy.array(values, copy=False)
 
             # Test if gl_VertexID will overflow

--- a/silx/io/commonh5.py
+++ b/silx/io/commonh5.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,6 +29,10 @@ files. They are used in :mod:`spech5` and :mod:`fabioh5`.
     library, which is not a mandatory dependency for `silx`.
 """
 import collections
+try:
+    from collections import abc
+except ImportError:  # Python2 support
+    import collections as abc
 import weakref
 
 import h5py
@@ -42,7 +46,7 @@ __license__ = "MIT"
 __date__ = "02/07/2018"
 
 
-class _MappingProxyType(collections.MutableMapping):
+class _MappingProxyType(abc.MutableMapping):
     """Read-only dictionary
 
     This class is available since Python 3.3, but not on earlyer Python

--- a/silx/sx/_plot.py
+++ b/silx/sx/_plot.py
@@ -31,6 +31,10 @@ __date__ = "06/11/2018"
 
 
 import collections
+try:
+    from collections import abc
+except ImportError:  # Python2 support
+    import collections as abc
 import logging
 import weakref
 
@@ -362,7 +366,7 @@ def scatter(x=None, y=None, value=None, size=None,
         if value is None:
             value = numpy.ones(len(x), dtype=numpy.float32)
 
-        elif isinstance(value, collections.Iterable):
+        elif isinstance(value, abc.Iterable):
             value = numpy.array(value, copy=True).reshape(-1)
             assert len(x) == len(value)
 
@@ -400,7 +404,7 @@ class _GInputResult(tuple):
     def __init__(self, position, item, indices, data):
         self._itemRef = weakref.ref(item) if item is not None else None
         self._indices = numpy.array(indices, copy=True)
-        if isinstance(data, collections.Iterable):
+        if isinstance(data, abc.Iterable):
             self._data = numpy.array(data, copy=True)
         else:
             self._data = data

--- a/silx/sx/_plot3d.py
+++ b/silx/sx/_plot3d.py
@@ -30,7 +30,10 @@ __license__ = "MIT"
 __date__ = "24/04/2018"
 
 
-from collections import Iterable
+try:
+    from collections import abc
+except ImportError:  # Python2 support
+    import collections as abc
 import logging
 import numpy
 
@@ -111,7 +114,7 @@ def contour3d(scalars,
     elif isinstance(contours, float):
         contours = [contours]
 
-    assert isinstance(contours, Iterable)
+    assert isinstance(contours, abc.Iterable)
 
     # Prepare colors
     if color is not None:


### PR DESCRIPTION
This PR makes `silx` compatible with python3.8 which provides abstract base classes only in `collections.abc` (and no longer in `collections`).

This could be simpler if we'd drop python2.7 (as it does not provide a `collections.abc` module)...
