### PR TITLE
[CI] Remove PyQt5 and PySide2 version pinpointing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ before_script:
     # Pin-pointing for now to avoid issues with versions [5.11.2 - 5.12.1]
     - if [ "$QT_BINDING" == "PySide2" ];
       then
-          pip install ${PIP_OPTIONS} pyside2==5.11.1;
+          pip install ${PIP_OPTIONS} pyside2;
       fi
 
     # Install built package

--- a/ci/requirements-pinned.txt
+++ b/ci/requirements-pinned.txt
@@ -8,6 +8,3 @@ pybind11  # Required to build pyopencl
 # on https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyopencl
 # Anyway, we don't test OpenCL on appveyor
 pyopencl == 2018.1.1; sys_platform == 'win32'
-
-# PyQt5.12 breaks CI, it needs to be investiguated
-PyQt5 == 5.11.3; python_version >= '3.5'


### PR DESCRIPTION
This PR tries to run CI with latest version of `PyQt5` and `PySide` (CI is currently using fixed versions).

Merge PR #2549 first (it is included here).

closes #2354