### PR TITLE
Add an Enum subclass to silx.utils

### DIFF
--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -274,7 +274,7 @@ class Plot3DWidget(glu.OpenGLWidget):
         :param Union[str,FogMode] mode: The mode to use
         :raise ValueError: If mode is not supported
         """
-        mode = self.FogMode.asmember(mode)
+        mode = self.FogMode.from_value(mode)
         if mode != self.getFogMode():
             self.viewport.fog.isOn = mode is self.FogMode.LINEAR
             self.sigStyleChanged.emit('fogMode')

--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -36,8 +36,9 @@ import logging
 
 from silx.gui import qt
 from silx.gui.colors import rgba
-from ....utils.enum import Enum as _Enum
 from . import actions
+
+from ...utils.enum import Enum as _Enum
 from ..utils.image import convertArrayToQImage
 
 from .. import _glutils as glu

--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -274,7 +274,7 @@ class Plot3DWidget(glu.OpenGLWidget):
         :param Union[str,FogMode] mode: The mode to use
         :raise ValueError: If mode is not supported
         """
-        mode = self.FogMode.asmember(str(mode))
+        mode = self.FogMode.asmember(mode)
         if mode != self.getFogMode():
             self.viewport.fog.isOn = mode is self.FogMode.LINEAR
             self.sigStyleChanged.emit('fogMode')

--- a/silx/gui/plot3d/Plot3DWidget.py
+++ b/silx/gui/plot3d/Plot3DWidget.py
@@ -36,6 +36,7 @@ import logging
 
 from silx.gui import qt
 from silx.gui.colors import rgba
+from ....utils.enum import Enum as _Enum
 from . import actions
 from ..utils.image import convertArrayToQImage
 
@@ -114,7 +115,7 @@ class Plot3DWidget(glu.OpenGLWidget):
     """
 
     @enum.unique
-    class FogMode(enum.Enum):
+    class FogMode(_Enum):
         """Different mode to render the scene with fog"""
 
         NONE = 'none'
@@ -122,23 +123,6 @@ class Plot3DWidget(glu.OpenGLWidget):
 
         LINEAR = 'linear'
         """Linear fog through the whole scene"""
-
-        @classmethod
-        def asMember(cls, value):
-            """Convert a str to corresponding enum member
-
-            :param Union[str,FogMode] value: The value to convert
-            :return: The corresponding enum member
-            :rtype: FogMode
-            :raise ValueError: In case the conversion is not possible
-            """
-            if isinstance(value, cls):
-                return value
-            value = str(value)
-            for member in cls:
-                if value == member.value:
-                    return member
-            raise ValueError("Cannot convert: %s" % value)
 
     def __init__(self, parent=None, f=qt.Qt.WindowFlags()):
         self._firstRender = True
@@ -289,7 +273,7 @@ class Plot3DWidget(glu.OpenGLWidget):
         :param Union[str,FogMode] mode: The mode to use
         :raise ValueError: If mode is not supported
         """
-        mode = self.FogMode.asMember(mode)
+        mode = self.FogMode.asmember(str(mode))
         if mode != self.getFogMode():
             self.viewport.fog.isOn = mode is self.FogMode.LINEAR
             self.sigStyleChanged.emit('fogMode')

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -31,11 +31,11 @@ __date__ = "24/04/2018"
 
 
 import collections
-import enum
 import numpy
 
 from silx.math.combo import min_max
 
+from .....utils.enum import Enum as _Enum
 from ...plot.items.core import ItemMixInBase
 from ...plot.items.core import ColormapMixIn as _ColormapMixIn
 from ...plot.items.core import SymbolMixIn as _SymbolMixIn
@@ -178,7 +178,7 @@ class ColormapMixIn(_ColormapMixIn):
 class ComplexMixIn(ItemMixInBase):
     """Mix-in class for converting complex data to scalar value"""
 
-    class Mode(enum.Enum):
+    class Mode(_Enum):
         """Identify available display mode for complex"""
         ABSOLUTE = 'amplitude'
         PHASE = 'phase'
@@ -187,23 +187,6 @@ class ComplexMixIn(ItemMixInBase):
         AMPLITUDE_PHASE = 'amplitude_phase'
         LOG10_AMPLITUDE_PHASE = 'log10_amplitude_phase'
         SQUARE_AMPLITUDE = 'square_amplitude'
-
-        @classmethod
-        def asMember(cls, value):
-            """Convert a str to corresponding enum member
-
-            :param Union[str,Mode] value: The value to convert
-            :return: The corresponding enum member
-            :rtype: Mode
-            :raise ValueError: In case the conversion is not possible
-            """
-            if isinstance(value, cls):
-                return value
-            value = str(value)
-            for member in cls:
-                if value == member.value:
-                    return member
-            raise ValueError("Cannot convert: %s" % value)
 
     def __init__(self):
         self._mode = self.Mode.ABSOLUTE
@@ -221,7 +204,7 @@ class ComplexMixIn(ItemMixInBase):
         :param Mode mode: The visualization mode in:
             'real', 'imaginary', 'phase', 'amplitude'
         """
-        mode = self.Mode.asMember(mode)
+        mode = self.Mode.asmember(str(mode))
         assert mode in self.supportedComplexModes()
 
         if mode != self._mode:

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -204,7 +204,7 @@ class ComplexMixIn(ItemMixInBase):
         :param Mode mode: The visualization mode in:
             'real', 'imaginary', 'phase', 'amplitude'
         """
-        mode = self.Mode.asmember(str(mode))
+        mode = self.Mode.asmember(mode)
         assert mode in self.supportedComplexModes()
 
         if mode != self._mode:

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -35,7 +35,7 @@ import numpy
 
 from silx.math.combo import min_max
 
-from .....utils.enum import Enum as _Enum
+from ....utils.enum import Enum as _Enum
 from ...plot.items.core import ItemMixInBase
 from ...plot.items.core import ColormapMixIn as _ColormapMixIn
 from ...plot.items.core import SymbolMixIn as _SymbolMixIn

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -204,7 +204,7 @@ class ComplexMixIn(ItemMixInBase):
         :param Mode mode: The visualization mode in:
             'real', 'imaginary', 'phase', 'amplitude'
         """
-        mode = self.Mode.asmember(mode)
+        mode = self.Mode.from_value(mode)
         assert mode in self.supportedComplexModes()
 
         if mode != self._mode:

--- a/silx/utils/enum.py
+++ b/silx/utils/enum.py
@@ -38,7 +38,7 @@ class Enum(enum.Enum):
     """Enum with additional class methods."""
 
     @classmethod
-    def asmember(cls, value):
+    def from_value(cls, value):
         """Convert a value to corresponding Enum member
 
         :param value: The value to compare to Enum members

--- a/silx/utils/enum.py
+++ b/silx/utils/enum.py
@@ -1,0 +1,79 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""An :class:`.Enum` class with additional features."""
+
+from __future__ import absolute_import
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "29/04/2019"
+
+
+import enum
+
+
+class Enum(enum.Enum):
+    """Enum with additional class methods."""
+
+    @classmethod
+    def asmember(cls, value):
+        """Convert a value to corresponding Enum member
+
+        :param value: The value to compare to Enum members
+           If it is already a member of Enum, it is returned directly.
+        :return: The corresponding enum member
+        :rtype: Enum
+        :raise ValueError: In case the conversion is not possible
+        """
+        if isinstance(value, cls):
+            return value
+        for member in cls:
+            if value == member.value:
+                return member
+        raise ValueError("Cannot convert: %s" % value)
+
+    @classmethod
+    def members(cls):
+        """Returns a tuple of all members.
+
+        :rtype: Tuple[Enum]
+        """
+        return tuple(member for member in cls)
+
+    @classmethod
+    def names(cls):
+        """Returns a tuple of all member names.
+
+        :rtype: Tuple[str]
+        """
+        return tuple(member.name for member in cls)
+
+    @classmethod
+    def values(cls):
+        """Returns a tuple of all member values.
+
+        :rtype: Tuple
+        """
+        return tuple(member.value for member in cls)

--- a/silx/utils/test/__init__.py
+++ b/silx/utils/test/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -37,6 +37,7 @@ from . import test_proxy
 from . import test_debug
 from . import test_number
 from . import test_external_resources
+from . import test_enum
 
 
 def suite():
@@ -50,4 +51,5 @@ def suite():
     test_suite.addTest(test_debug.suite())
     test_suite.addTest(test_number.suite())
     test_suite.addTest(test_external_resources.suite())
+    test_suite.addTest(test_enum.suite())
     return test_suite

--- a/silx/utils/test/test_enum.py
+++ b/silx/utils/test/test_enum.py
@@ -1,0 +1,96 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Tests of Enum class with extra class methods"""
+
+from __future__ import absolute_import
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "29/04/2019"
+
+
+import sys
+import unittest
+
+import enum
+from silx.utils.enum import Enum
+
+
+class TestEnum(unittest.TestCase):
+    """Tests for enum module."""
+
+    def test(self):
+        """Test with Enum"""
+        class Success(Enum):
+            A = 1
+            B = 'B'
+        self._check_enum_content(Success)
+
+    @unittest.skipIf(sys.version_info.major <= 2, 'Python3 only')
+    def test(self):
+        """Test Enum with member redefinition"""
+        with self.assertRaises(TypeError):
+            class Failure(Enum):
+                A = 1
+                A = 'B'
+
+    def test_unique(self):
+        """Test with enum.unique"""
+        with self.assertRaises(ValueError):
+            @enum.unique
+            class Failure(Enum):
+                A = 1
+                B = 1
+
+        @enum.unique
+        class Success(Enum):
+            A = 1
+            B = 'B'
+        self._check_enum_content(Success)
+
+    def _check_enum_content(self, enum_):
+        """Check that the content of an enum is: <A: 1, B: 2>.
+
+        :param Enum enum_:
+        """
+        self.assertEqual(enum_.members(), (enum_.A, enum_.B))
+        self.assertEqual(enum_.names(), ('A', 'B'))
+        self.assertEqual(enum_.values(), (1, 'B'))
+
+        self.assertEqual(enum_.asmember(1), enum_.A)
+        self.assertEqual(enum_.asmember('B'), enum_.B)
+        with self.assertRaises(ValueError):
+            enum_.asmember(3)
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(TestEnum))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/silx/utils/test/test_enum.py
+++ b/silx/utils/test/test_enum.py
@@ -79,10 +79,10 @@ class TestEnum(unittest.TestCase):
         self.assertEqual(enum_.names(), ('A', 'B'))
         self.assertEqual(enum_.values(), (1, 'B'))
 
-        self.assertEqual(enum_.asmember(1), enum_.A)
-        self.assertEqual(enum_.asmember('B'), enum_.B)
+        self.assertEqual(enum_.from_value(1), enum_.A)
+        self.assertEqual(enum_.from_value('B'), enum_.B)
         with self.assertRaises(ValueError):
-            enum_.asmember(3)
+            enum_.from_value(3)
 
 
 def suite():


### PR DESCRIPTION
This PR adds a subclass of `enum.Enum` in `silx.utils` with a few extra convenient class methods.
It makes use of it in `silx.gui.plot3d` and removes some code duplication.