### PR TITLE
[plot] add surface visualization to scatter item

### DIFF
--- a/silx/gui/plot/_utils/delaunay.py
+++ b/silx/gui/plot/_utils/delaunay.py
@@ -1,0 +1,72 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Wrapper over Delaunay implementation"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "02/05/2019"
+
+
+import logging
+import sys
+
+import numpy
+
+
+_logger = logging.getLogger(__name__)
+
+
+def triangulation(x, y, dtype=numpy.uint32):
+    """Run Delaunay tesselation and returns triangle indices.
+
+    :param numpy.ndarray x: X coordinates of points
+    :param numpy.ndarray y: Y coordinates of points
+    :param numpy.dtype dtype: Data type of output indices
+    :return: Point indices for triangles as a (N, 3) array
+    :rtype: Union[numpy.ndarray,None]
+    """
+    # Lazy loading of Delaunay
+    from silx.third_party.scipy_spatial import Delaunay as _Delaunay
+
+    coordinates = numpy.array((x, y)).T
+
+    if len(coordinates) > 3:
+        # Enough points to try a Delaunay tesselation
+
+        try:
+            tri = _Delaunay(coordinates)
+        except RuntimeError:
+            _logger.error("Delaunay tesselation failed: %s",
+                          sys.exc_info()[1])
+            return None
+
+        triangles = tri.simplices.astype(dtype)
+
+    else:
+        # 3 or less points: Draw one triangle
+        triangles = numpy.array(
+            [[0, 1, 2]], dtype=dtype) % len(coordinates)
+
+    return triangles

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -171,9 +171,7 @@ class BackendBase(object):
         return legend
 
     def addTriangles(self, x, y, triangles, legend,
-                 color, linewidth, linestyle,
-                 z, selectable,
-                 alpha):
+                 color, z, selectable, alpha):
         """Add a set of triangles.
 
         :param numpy.ndarray x: The data corresponding to the x axis
@@ -182,15 +180,6 @@ class BackendBase(object):
             as a (Ntriangle, 3) array
         :param str legend: The legend to be associated to the curve
         :param numpy.ndarray color: color(s) as (npoints, 4) array
-        :param float linewidth: The width of the curve in pixels
-        :param str linestyle: Type of line::
-
-            - ' ' or ''  no line
-            - '-'  solid line
-            - '--' dashed line
-            - '-.' dash-dot line
-            - ':'  dotted line
-
         :param int z: Layer on which to draw the cuve
         :param bool selectable: indicate if the curve can be selected
         :param float alpha: Curve opacity, as a float in [0., 1.]

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -170,6 +170,36 @@ class BackendBase(object):
         """
         return legend
 
+    def addTriangles(self, x, y, triangles, legend,
+                 color, linewidth, linestyle,
+                 z, selectable,
+                 alpha, visualization):
+        """Add a set of triangles.
+
+        :param numpy.ndarray x: The data corresponding to the x axis
+        :param numpy.ndarray y: The data corresponding to the y axis
+        :param numpy.ndarray triangles: The indices to make triangles
+            as a (Ntriangle, 3) array
+        :param str legend: The legend to be associated to the curve
+        :param numpy.ndarray color: color(s) as (npoints, 4) array
+        :param float linewidth: The width of the curve in pixels
+        :param str linestyle: Type of line::
+
+            - ' ' or ''  no line
+            - '-'  solid line
+            - '--' dashed line
+            - '-.' dash-dot line
+            - ':'  dotted line
+
+        :param int z: Layer on which to draw the cuve
+        :param bool selectable: indicate if the curve can be selected
+        :param float alpha: Curve opacity, as a float in [0., 1.]
+        :param str visualization: The way to display the triangles,
+            either 'edges' or 'fill'
+        :returns: The triangles' unique identifier used by the backend
+        """
+        return legend
+
     def addItem(self, x, y, legend, shape, color, fill, overlay, z,
                 linestyle, linewidth, linebgcolor):
         """Add an item (i.e. a shape) to the plot.

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -173,7 +173,7 @@ class BackendBase(object):
     def addTriangles(self, x, y, triangles, legend,
                  color, linewidth, linestyle,
                  z, selectable,
-                 alpha, visualization):
+                 alpha):
         """Add a set of triangles.
 
         :param numpy.ndarray x: The data corresponding to the x axis
@@ -194,8 +194,6 @@ class BackendBase(object):
         :param int z: Layer on which to draw the cuve
         :param bool selectable: indicate if the curve can be selected
         :param float alpha: Curve opacity, as a float in [0., 1.]
-        :param str visualization: The way to display the triangles,
-            either 'edges' or 'fill'
         :returns: The triangles' unique identifier used by the backend
         """
         return legend

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -171,7 +171,7 @@ class BackendBase(object):
         return legend
 
     def addTriangles(self, x, y, triangles, legend,
-                 color, z, selectable, alpha):
+                     color, z, selectable, alpha):
         """Add a set of triangles.
 
         :param numpy.ndarray x: The data corresponding to the x axis

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -477,6 +477,53 @@ class BackendMatplotlib(BackendBase.BackendBase):
         self.ax.add_artist(image)
         return image
 
+    def addTriangles(self, x, y, triangles, legend,
+                 color, linewidth, linestyle,
+                 z, selectable,
+                 alpha, visualization):
+        for parameter in (x, y, triangles, legend, color, linewidth, linestyle,
+                          z, selectable, alpha):
+            assert parameter is not None
+
+        picker = 3 if selectable else None
+
+        color = numpy.array(color, copy=False)
+        assert color.ndim == 2 and len(color) == len(x)
+
+        if color.dtype not in [numpy.float32, numpy.float]:
+            color = color.astype(numpy.float32) / 255.
+
+        if visualization == 'edges':
+            artist = Container(self.ax.triplot(
+                x, y, triangles,
+                label=legend,
+                color=color[0],  # TODO line with multiple colors
+                alpha=alpha,
+                linewidth=linewidth,
+                linestyle=linestyle,
+                picker=picker,
+                marker=None,
+                zorder=z))
+
+        elif visualization == 'fill':
+            artist = self.ax.tripcolor(
+                x, y, triangles,
+                color,
+                shading='gouraud',
+                label=legend,
+                alpha=alpha,
+                picker=picker,
+                zorder=z)
+            # Workaround issue in matplotlib
+            # TODO investiguate
+            artist.set_array(None)
+            artist.set_color(color)
+
+        else:
+            raise ValueError("Unsupported visualization: %s" % visualization)
+
+        return artist
+
     def addItem(self, x, y, legend, shape, color, fill, overlay, z,
                 linestyle, linewidth, linebgcolor):
         if (linebgcolor is not None and

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -479,10 +479,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
         return image
 
     def addTriangles(self, x, y, triangles, legend,
-                 color, linewidth, linestyle,
-                 z, selectable,
-                 alpha):
-        for parameter in (x, y, triangles, legend, color, linewidth, linestyle,
+                     color, z, selectable, alpha):
+        for parameter in (x, y, triangles, legend, color,
                           z, selectable, alpha):
             assert parameter is not None
 

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -508,14 +508,14 @@ class BackendMatplotlib(BackendBase.BackendBase):
         elif visualization == 'fill':
             artist = self.ax.tripcolor(
                 x, y, triangles,
-                color,
+                x,  # Pass x as color-mapped values, color is provided afterwards
+                vmin=1, vmax=2,  # Avoids autoscaling
                 shading='gouraud',
                 label=legend,
                 alpha=alpha,
                 picker=picker,
                 zorder=z)
-            # Workaround issue in matplotlib
-            # TODO investiguate
+            # Remove color-mapped values and use colors instead.
             artist.set_array(None)
             artist.set_color(color)
 

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -35,13 +35,13 @@ import logging
 import numpy
 
 from .._utils.delaunay import triangulation
-from .core import Points, ColormapMixIn, LineMixIn, ItemChangedType
+from .core import Points, ColormapMixIn, ItemChangedType
 
 
 _logger = logging.getLogger(__name__)
 
 
-class Scatter(Points, ColormapMixIn, LineMixIn):
+class Scatter(Points, ColormapMixIn):
     """Description of a scatter"""
 
     _DEFAULT_SELECTABLE = True
@@ -50,7 +50,6 @@ class Scatter(Points, ColormapMixIn, LineMixIn):
     def __init__(self):
         Points.__init__(self)
         ColormapMixIn.__init__(self)
-        LineMixIn.__init__(self)
         self.__mode = 'points'
         self._value = ()
         self.__alpha = None
@@ -107,8 +106,6 @@ class Scatter(Points, ColormapMixIn, LineMixIn):
                                             triangles,
                                             legend=self.getLegend(),
                                             color=rgbacolors,
-                                            linewidth=self.getLineWidth(),
-                                            linestyle=self.getLineStyle(),
                                             z=self.getZValue(),
                                             selectable=self.isSelectable(),
                                             alpha=self.getAlpha())

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -85,7 +85,7 @@ class Scatter(Points, ColormapMixIn, LineMixIn):
                                     fill=False,
                                     alpha=self.getAlpha(),
                                     symbolsize=self.getSymbolSize())
-        else:  # 'lines', 'solid'
+        else:  # 'solid'
             # TODO cache + avoid duplicate with plot3d + fallback to matplotlib?
             coordinates = numpy.array((xFiltered, yFiltered)).T
 
@@ -109,7 +109,6 @@ class Scatter(Points, ColormapMixIn, LineMixIn):
                 triangles = numpy.array(
                     [[0, 1, 2]], dtype=numpy.int32) % len(coordinates)
 
-            visualization = 'edges' if mode == 'lines' else 'fill'
             return backend.addTriangles(xFiltered, yFiltered, triangles,
                                         legend=self.getLegend(),
                                         color=rgbacolors,
@@ -117,10 +116,9 @@ class Scatter(Points, ColormapMixIn, LineMixIn):
                                         linestyle=self.getLineStyle(),
                                         z=self.getZValue(),
                                         selectable=self.isSelectable(),
-                                        alpha=self.getAlpha(),
-                                        visualization=visualization)
+                                        alpha=self.getAlpha())
 
-    # TODO visualization mix-in??
+    # TODO scatter visualization mix-in
     # TODO use enum for visualization mode + str compatibility
 
     @staticmethod
@@ -131,7 +129,7 @@ class Scatter(Points, ColormapMixIn, LineMixIn):
 
         :rtype: tuple of str
         """
-        return 'points', 'lines', 'solid'
+        return 'points', 'solid'
 
     def setVisualization(self, mode):
         """Set the visualization mode to use.

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -139,7 +139,7 @@ class Scatter(Points, ColormapMixIn, LineMixIn):
         :param str mode:
         """
         mode = str(mode)
-        assert mode in self.supportedVisualizationMode()
+        assert mode in self.supportedVisualization()
 
         if mode != self.__mode:
             self.__mode = mode

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -31,7 +31,6 @@ __date__ = "29/03/2017"
 
 
 import logging
-import sys
 
 import numpy
 
@@ -62,14 +61,23 @@ class Scatter(Points, ColormapMixIn, LineMixIn):
         xFiltered, yFiltered, valueFiltered, xerror, yerror = self.getData(
             copy=False, displayed=True)
 
+        # Remove not finite numbers (this includes filtered out x, y <= 0)
+        mask = numpy.logical_and(numpy.isfinite(xFiltered), numpy.isfinite(yFiltered))
+        xFiltered = xFiltered[mask]
+        yFiltered = yFiltered[mask]
+
         if len(xFiltered) == 0:
             return None  # No data to display, do not add renderer to backend
 
+        # Compute colors
         cmap = self.getColormap()
         rgbacolors = cmap.applyToData(self._value)
 
         if self.__alpha is not None:
             rgbacolors[:, -1] = (rgbacolors[:, -1] * self.__alpha).astype(numpy.uint8)
+
+        # Apply mask to colrs
+        rgbacolors = rgbacolors[mask]
 
         mode = self.getVisualization()
         if mode == 'points':

--- a/silx/gui/plot/test/testItem.py
+++ b/silx/gui/plot/test/testItem.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -194,14 +194,17 @@ class TestSigItemChangedSignal(PlotWidgetTestCase):
 
         # ColormapMixIn
         scatter.getColormap().setName('viridis')
-        data2 = data + 10
 
         # Test of signals in Scatter class
-        scatter.setData(data2, data2, data2)
+        scatter.setData((0, 1, 2), (1, 0, 2), (0, 1, 2))
+
+        # Visualization mode changed
+        scatter.setVisualization('solid')
 
         self.assertEqual(listener.arguments(),
                          [(ItemChangedType.COLORMAP,),
-                          (ItemChangedType.DATA,)])
+                          (ItemChangedType.DATA,),
+                          (ItemChangedType.VISUALIZATION_MODE,)])
 
     def testShapeChanged(self):
         """Test sigItemChanged for shape"""

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -463,7 +463,28 @@ class TestPlotCurve(PlotWidgetTestCase):
         self.plot.addCurve(self.xData, self.yData,
                            legend="curve 2",
                            replace=False, resetzoom=False,
-                           color=color, symbol='o')        
+                           color=color, symbol='o')
+
+
+class TestPlotScatter(PlotWidgetTestCase):
+    """Basic tests for addScatter"""
+
+    def testScatter(self):
+        x = numpy.arange(100)
+        y = numpy.arange(100)
+        value = numpy.arange(100)
+        self.plot.addScatter(x, y, value)
+        self.plot.resetZoom()
+
+    def testScatterVisualization(self):
+        self.plot.addScatter((0, 1, 2, 3), (2, 0, 2, 1), (0, 1, 2, 3))
+        self.plot.resetZoom()
+        self.qapp.processEvents()
+
+        scatter = self.plot.getItems()[0]
+        scatter.setVisualization('solid')
+        self.qapp.processEvents()
+
 
 class TestPlotMarker(PlotWidgetTestCase):
     """Basic tests for add*Marker"""
@@ -1524,11 +1545,19 @@ class TestPlotItemLog(PlotWidgetTestCase):
 
 
 def suite():
-    testClasses = (TestPlotWidget, TestPlotImage, TestPlotCurve,
-                   TestPlotMarker, TestPlotItem, TestPlotAxes,
+    testClasses = (TestPlotWidget,
+                   TestPlotImage,
+                   TestPlotCurve,
+                   TestPlotScatter,
+                   TestPlotMarker,
+                   TestPlotItem,
+                   TestPlotAxes,
                    TestPlotActiveCurveImage,
-                   TestPlotEmptyLog, TestPlotCurveLog, TestPlotImageLog,
-                   TestPlotMarkerLog, TestPlotItemLog)
+                   TestPlotEmptyLog,
+                   TestPlotCurveLog,
+                   TestPlotImageLog,
+                   TestPlotMarkerLog,
+                   TestPlotItemLog)
 
     test_suite = unittest.TestSuite()
 

--- a/silx/gui/plot3d/items/scatter.py
+++ b/silx/gui/plot3d/items/scatter.py
@@ -589,7 +589,7 @@ class Scatter2D(DataItem3D, ColormapMixIn, SymbolMixIn):
                 triangles = triangulation(x, y, dtype=numpy.uint32)
                 if triangles is None:
                     return None
-                self._cachedTrianglesIndices = triangles
+                self._cachedTrianglesIndices = numpy.ravel(triangles)
 
             if mode == 'lines' and self._cachedLinesIndices is None:
                 # Compute line indices


### PR DESCRIPTION
This PR extends the 'scatter' item of the `PlotWidget` to support Delaunay triangulation based display of scatter plots.

It adds `set|getVisualization` and `supportedVisualizations` methods to `scatter` items.
It avoids code duplication with `plot3d` through a `triangulation` function.

Related to #2324 but not closing it:
- OpenGL backend implementation is not done yet (to do in another PR).
- `get|setVisualization` API needs to be reworked for consistency with `plot3d` (issue #2554)