### PR TITLE
[plot] Fix issue in large image display with OpenGL backend

### DIFF
--- a/silx/gui/plot/backends/glutils/GLTexture.py
+++ b/silx/gui/plot/backends/glutils/GLTexture.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -163,7 +163,6 @@ class Image(object):
                                           data[yOrig:yOrig+hData,
                                                xOrig:xOrig+wData],
                                           format_,
-                                          shape=(hData, wData),
                                           texUnit=texUnit,
                                           minFilter=self._MIN_FILTER,
                                           magFilter=self._MAG_FILTER,


### PR DESCRIPTION
This PR fixes an issue in the plot OpenGL backend for large images (when using tiles) where both texture data and shape were provided.

closes #2557