### PR TITLE
[plot] Allow to use plot OpenGL without matplotlib

### DIFF
--- a/silx/_config.py
+++ b/silx/_config.py
@@ -38,7 +38,7 @@ class Config(object):
     .. versionadded:: 0.8
     """
 
-    DEFAULT_PLOT_BACKEND = "matplotlib"
+    DEFAULT_PLOT_BACKEND = "matplotlib", "opengl"
     """Default plot backend.
 
     It will be used as default backend for all the next created PlotWidget.
@@ -50,6 +50,8 @@ class Config(object):
     - 'none'
     - A :class:`silx.gui.plot.backend.BackendBase.BackendBase` class
     - A callable returning backend class or binding name
+
+    If multiple backends are provided, the first available one is used.
 
     .. versionadded:: 0.8
     """

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -887,7 +887,11 @@ def preferredColormaps():
     global _PREFERRED_COLORMAPS
     if _PREFERRED_COLORMAPS is None:
         # Initialize preferred colormaps
-        default_preferred = [k for k in _AVAILABLE_LUTS.keys() if _AVAILABLE_LUTS[k].preferred]
+        default_preferred = []
+        for name, info in _AVAILABLE_LUTS.items():
+            if (info.preferred and
+                    (info.source != 'matplotlib' or _matplotlib_cm is not None)):
+                default_preferred.append(name)
         setPreferredColormaps(default_preferred)
     return tuple(_PREFERRED_COLORMAPS)
 

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -33,12 +33,15 @@ __authors__ = ["V.A. Sole", "T. Vincent"]
 __license__ = "MIT"
 __date__ = "21/12/2018"
 
+import logging
+
+_logger = logging.getLogger(__name__)
+
 
 from collections import OrderedDict, namedtuple
 from contextlib import contextmanager
 import datetime as dt
 import itertools
-import logging
 
 import numpy
 
@@ -46,8 +49,12 @@ import silx
 from silx.utils.weakref import WeakMethodProxy
 from silx.utils.property import classproperty
 from silx.utils.deprecation import deprecated
-# Import matplotlib backend here to init matplotlib our way
-from .backends.BackendMatplotlib import BackendMatplotlibQt
+try:
+    # Import matplotlib backend here to init matplotlib our way
+    from . import matplotlib
+except ImportError:
+    _logger.warning(
+        "matplotlib not available: matplotlib backend not available")
 
 from ..colors import Colormap
 from .. import colors
@@ -64,7 +71,6 @@ from .. import qt
 from ._utils.panzoom import ViewConstraints
 from ...gui.plot._utils.dtime_ticklayout import timestamp
 
-_logger = logging.getLogger(__name__)
 
 
 _COLORDICT = colors.COLORDICT
@@ -300,6 +306,7 @@ class PlotWidget(qt.QMainWindow):
         elif hasattr(backend, "lower"):
             lowerCaseString = backend.lower()
             if lowerCaseString in ("matplotlib", "mpl"):
+                from .backends.BackendMatplotlib import BackendMatplotlibQt
                 backendClass = BackendMatplotlibQt
             elif lowerCaseString in ('gl', 'opengl'):
                 from .backends.BackendOpenGL import BackendOpenGL

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -305,6 +305,7 @@ class PlotWidget(qt.QMainWindow):
             The name of the backend or its class or an iterable of those.
         :rtype: BackendBase
         :raise ValueError: In case the backend is not supported
+        :raise RuntimeError: If a backend is not available
         """
         if callable(backend):
             return backend
@@ -316,14 +317,14 @@ class PlotWidget(qt.QMainWindow):
                     from .backends.BackendMatplotlib import \
                         BackendMatplotlibQt as backendClass
                 except ImportError:
-                    raise ValueError("matplotlib backend is not available")
+                    raise RuntimeError("matplotlib backend is not available")
 
             elif backend in ('gl', 'opengl'):
                 try:
                     from .backends.BackendOpenGL import \
                         BackendOpenGL as backendClass
                 except ImportError:
-                    raise ValueError("OpenGL backend is not available")
+                    raise RuntimeError("OpenGL backend is not available")
 
             elif backend == 'none':
                 from .backends.BackendBase import BackendBase as backendClass

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -50,7 +50,7 @@ from silx.utils.weakref import WeakMethodProxy
 from silx.utils.property import classproperty
 from silx.utils.deprecation import deprecated
 try:
-    # Import matplotlib backend here to init matplotlib our way
+    # Import matplotlib now to init matplotlib our way
     from . import matplotlib
 except ImportError:
     _logger.warning(

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -317,14 +317,14 @@ class PlotWidget(qt.QMainWindow):
                     from .backends.BackendMatplotlib import \
                         BackendMatplotlibQt as backendClass
                 except ImportError:
-                    raise RuntimeError("matplotlib backend is not available")
+                    raise ImportError("matplotlib backend is not available")
 
             elif backend in ('gl', 'opengl'):
                 try:
                     from .backends.BackendOpenGL import \
                         BackendOpenGL as backendClass
                 except ImportError:
-                    raise RuntimeError("OpenGL backend is not available")
+                    raise ImportError("OpenGL backend is not available")
 
             elif backend == 'none':
                 from .backends.BackendBase import BackendBase as backendClass
@@ -338,7 +338,7 @@ class PlotWidget(qt.QMainWindow):
             for b in backend:
                 try:
                     return self.__getBackendClass(b)
-                except ValueError:
+                except ImportError:
                     pass
             else:  # No backend was found
                 raise ValueError("No backends supported: " % str(backend))

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -317,6 +317,7 @@ class PlotWidget(qt.QMainWindow):
                     from .backends.BackendMatplotlib import \
                         BackendMatplotlibQt as backendClass
                 except ImportError:
+                    _logger.debug("Backtrace", exc_info=True)
                     raise ImportError("matplotlib backend is not available")
 
             elif backend in ('gl', 'opengl'):
@@ -324,6 +325,7 @@ class PlotWidget(qt.QMainWindow):
                     from .backends.BackendOpenGL import \
                         BackendOpenGL as backendClass
                 except ImportError:
+                    _logger.debug("Backtrace", exc_info=True)
                     raise ImportError("OpenGL backend is not available")
 
             elif backend == 'none':


### PR DESCRIPTION
This PR makes `matplotlib` an optional dependencies when using the `PlotWidget` OpenGL backend.

I'm not really for optional dependencies, but it's actually a small change set (actually there were places where it was already handled).