### PR TITLE
[plot] OpenGL implementation of scatter plot displayed as surface

### DIFF
--- a/silx/gui/_glutils/__init__.py
+++ b/silx/gui/_glutils/__init__.py
@@ -40,3 +40,4 @@ from .Program import Program  # noqa
 from .Texture import Texture  # noqa
 from .VertexBuffer import VertexBuffer, VertexBufferAttrib, vertexBuffer  # noqa
 from .utils import sizeofGLType, isSupportedGLType, numpyToGLType  # noqa
+from .utils import segmentTrianglesIntersection  # noqa

--- a/silx/gui/_glutils/utils.py
+++ b/silx/gui/_glutils/utils.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -68,3 +68,74 @@ def isSupportedGLType(type_):
 def numpyToGLType(type_):
     """Returns the GL type corresponding the provided numpy type or dtype."""
     return _TYPE_CONVERTER[numpy.dtype(type_)]
+
+
+def segmentTrianglesIntersection(segment, triangles):
+    """Check for segment/triangles intersection.
+
+    This is based on signed tetrahedron volume comparison.
+
+    See A. Kensler, A., Shirley, P.
+    Optimizing Ray-Triangle Intersection via Automated Search.
+    Symposium on Interactive Ray Tracing, vol. 0, p33-38 (2006)
+
+    :param numpy.ndarray segment:
+        Segment end points as a 2x3 array of coordinates
+    :param numpy.ndarray triangles:
+        Nx3x3 array of triangles
+    :return: (triangle indices, segment parameter, barycentric coord)
+        Indices of intersected triangles, "depth" along the segment
+        of the intersection point and barycentric coordinates of intersection
+        point in the triangle.
+    :rtype: List[numpy.ndarray]
+    """
+    # TODO triangles from vertices + indices
+    # TODO early rejection? e.g., check segment bbox vs triangle bbox
+    segment = numpy.asarray(segment)
+    assert segment.ndim == 2
+    assert segment.shape == (2, 3)
+
+    triangles = numpy.asarray(triangles)
+    assert triangles.ndim == 3
+    assert triangles.shape[1] == 3
+
+    # Test line/triangles intersection
+    d = segment[1] - segment[0]
+    t0s0 = segment[0] - triangles[:, 0, :]
+    edge01 = triangles[:, 1, :] - triangles[:, 0, :]
+    edge02 = triangles[:, 2, :] - triangles[:, 0, :]
+
+    dCrossEdge02 = numpy.cross(d, edge02)
+    t0s0CrossEdge01 = numpy.cross(t0s0, edge01)
+    volume = numpy.sum(dCrossEdge02 * edge01, axis=1)
+    del edge01
+    subVolumes = numpy.empty((len(triangles), 3), dtype=triangles.dtype)
+    subVolumes[:, 1] = numpy.sum(dCrossEdge02 * t0s0, axis=1)
+    del dCrossEdge02
+    subVolumes[:, 2] = numpy.sum(t0s0CrossEdge01 * d, axis=1)
+    subVolumes[:, 0] = volume - subVolumes[:, 1] - subVolumes[:, 2]
+    intersect = numpy.logical_or(
+        numpy.all(subVolumes >= 0., axis=1),  # All positive
+        numpy.all(subVolumes <= 0., axis=1))  # All negative
+    intersect = numpy.where(intersect)[0]  # Indices of intersected triangles
+
+    # Get barycentric coordinates
+    barycentric = subVolumes[intersect] / volume[intersect].reshape(-1, 1)
+    del subVolumes
+
+    # Test segment/triangles intersection
+    volAlpha = numpy.sum(t0s0CrossEdge01[intersect] * edge02[intersect], axis=1)
+    t = volAlpha / volume[intersect]  # segment parameter of intersected triangles
+    del t0s0CrossEdge01
+    del edge02
+    del volAlpha
+    del volume
+
+    inSegmentMask = numpy.logical_and(t >= 0., t <= 1.)
+    intersect = intersect[inSegmentMask]
+    t = t[inSegmentMask]
+    barycentric = barycentric[inSegmentMask]
+
+    # Sort intersecting triangles by t
+    indices = numpy.argsort(t)
+    return intersect[indices], t[indices], barycentric[indices]

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -182,7 +182,7 @@ class BackendBase(object):
         :param numpy.ndarray color: color(s) as (npoints, 4) array
         :param int z: Layer on which to draw the cuve
         :param bool selectable: indicate if the curve can be selected
-        :param float alpha: Curve opacity, as a float in [0., 1.]
+        :param float alpha: Opacity as a float in [0., 1.]
         :returns: The triangles' unique identifier used by the backend
         """
         return legend

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1033,6 +1033,13 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
     def addTriangles(self, x, y, triangles, legend,
                      color, z, selectable, alpha):
+
+        # Handle axes log scale: convert data
+        if self._plotFrame.xAxis.isLog:
+            x = numpy.log10(x)
+        if self._plotFrame.yAxis.isLog:
+            y = numpy.log10(y)
+
         triangles = GLPlotTriangles(x, y, color, triangles, alpha)
         triangles.info = {
             'legend': legend,

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -106,7 +106,7 @@ class PlotDataContent(object):
     This class is only meant to work with _OpenGLPlotCanvas.
     """
 
-    _PRIMITIVE_TYPES = 'curve', 'image'
+    _PRIMITIVE_TYPES = 'curve', 'image', 'triangles'
 
     def __init__(self):
         self._primitives = OrderedDict()  # For images and curves
@@ -1041,7 +1041,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         }
         self._plotContent.add(triangles)
 
-        return legend, 'triangles'  # TODO curve?
+        return legend, 'triangles'
 
     def addItem(self, x, y, legend, shape, color, fill, overlay, z,
                 linestyle, linewidth, linebgcolor):
@@ -1132,10 +1132,10 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
                 self._glGarbageCollector.append(curve)
 
-        elif kind == 'image':
-            image = self._plotContent.pop('image', legend)
-            if image is not None:
-                self._glGarbageCollector.append(image)
+        elif kind in ('image', 'triangles'):
+            item = self._plotContent.pop(kind, legend)
+            if item is not None:
+                self._glGarbageCollector.append(item)
 
         elif kind == 'marker':
             self._markers.pop(legend, False)

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1030,31 +1030,15 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         return legend, 'image'
 
     def addTriangles(self, x, y, triangles, legend,
-                     color, linewidth, linestyle,
-                     z, selectable,
-                     alpha):
-
-        # Check and convert input data
-        x = numpy.ravel(x)
-        y = numpy.ravel(y)
-        color = numpy.array(color, copy=False)
-
-        assert x.size == y.size
-        assert x.size == len(color)
-        assert color.ndim == 2 and color.shape[1] in (3, 4)
-        if numpy.issubdtype(color.dtype, numpy.floating):
-            color = numpy.array(color, dtype=numpy.float32, copy=False)
-        elif numpy.issubdtype(color.dtype, numpy.integer):
-            color = numpy.array(color, dtype=numpy.uint8, copy=False)
-        else:
-            raise ValueError('Unsupported color type')
-
-        triangles = GLPlotTriangles(x, y, triangles, color)
+                     color, z, selectable, alpha):
+        triangles = GLPlotTriangles(x, y, color, triangles, alpha)
         triangles.info = {
             'legend': legend,
             'zOrder': z,
             'behaviors': set(['selectable']) if selectable else set(),
         }
+        self._plotContent.add(triangles)
+
         return legend, 'triangles'  # TODO curve?
 
     def addItem(self, x, y, legend, shape, color, fill, overlay, z,

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -44,7 +44,7 @@ from ... import qt
 from ..._glutils import gl
 from ... import _glutils as glu
 from .glutils import (
-    GLLines2D, GLPlotTriangles
+    GLLines2D, GLPlotTriangles,
     GLPlotCurve2D, GLPlotColormap, GLPlotRGBAImage, GLPlotFrame2D,
     mat4Ortho, mat4Identity,
     LEFT, RIGHT, BOTTOM, TOP,
@@ -124,6 +124,8 @@ class PlotDataContent(object):
             primitiveType = 'curve'
         elif isinstance(primitive, (GLPlotColormap, GLPlotRGBAImage)):
             primitiveType = 'image'
+        elif isinstance(primitive, GLPlotTriangles):
+            primitiveType = 'triangles'
         else:
             raise RuntimeError('Unsupported object type: %s', primitive)
 

--- a/silx/gui/plot/backends/glutils/GLPlotTriangles.py
+++ b/silx/gui/plot/backends/glutils/GLPlotTriangles.py
@@ -104,6 +104,16 @@ class GLPlotTriangles(object):
         self.__vbos = None
         self.__indicesVbo = None
 
+    def pick(self, x, y):
+        """Perform picking
+
+        :param float x: X coordinates in plot data frame
+        :param float y: Y coordinates in plot data frame
+        :return: List of picked point indices
+        :rtype: List[int]
+        """
+        return ()
+
     def discard(self):
         """Release resources on the GPU"""
         if self.__vbos is not None:

--- a/silx/gui/plot/backends/glutils/GLPlotTriangles.py
+++ b/silx/gui/plot/backends/glutils/GLPlotTriangles.py
@@ -115,7 +115,6 @@ class GLPlotTriangles(object):
     def prepare(self):
         """Allocate resources on the GPU"""
         if self.__vbos is None:
-            x, y, color = self.__x_y_color
             self.__vbos = glutils.vertexBuffer(self.__x_y_color)
             # Normalization is need for color
             self.__vbos[-1].normalization = True

--- a/silx/gui/plot/backends/glutils/GLPlotTriangles.py
+++ b/silx/gui/plot/backends/glutils/GLPlotTriangles.py
@@ -81,10 +81,11 @@ class GLPlotTriangles(object):
         :param float alpha: Opacity in [0, 1]
         """
         # Check and convert input data
-        x = numpy.ravel(x)
-        y = numpy.ravel(y)
+        x = numpy.ravel(numpy.array(x, dtype=numpy.float32))
+        y = numpy.ravel(numpy.array(y, dtype=numpy.float32))
         color = numpy.array(color, copy=False)
-        triangles = numpy.array(triangles, copy=False)
+        # Cast to uint32
+        triangles = numpy.array(triangles, copy=False, dtype=numpy.uint32)
 
         assert x.size == y.size
         assert x.size == len(color)
@@ -114,17 +115,23 @@ class GLPlotTriangles(object):
     def prepare(self):
         """Allocate resources on the GPU"""
         if self.__vbos is None:
+            x, y, color = self.__x_y_color
             self.__vbos = glutils.vertexBuffer(self.__x_y_color)
+            # Normalization is need for color
+            self.__vbos[-1].normalization = True
+
         if self.__indicesVbo is None:
             self.__indicesVbo = glutils.VertexBuffer(
                 self.__indices,
                 usage=gl.GL_STATIC_DRAW,
                 target=gl.GL_ELEMENT_ARRAY_BUFFER)
 
-    def render(self, matrix):
+    def render(self, matrix, isXLog, isYLog):
         """Perform rendering
 
         :param numpy.ndarray matrix: 4x4 transform matrix to use
+        :param bool isXLog:
+        :param bool isYLog:
         """
         self.prepare()
 

--- a/silx/gui/plot/backends/glutils/GLPlotTriangles.py
+++ b/silx/gui/plot/backends/glutils/GLPlotTriangles.py
@@ -127,6 +127,7 @@ class GLPlotTriangles(object):
         # Point indices
         indices = numpy.unique(numpy.ravel(self.__triangles[indices]))
 
+        # Sorted from furthest to closest point
         dists = (xPts[indices] - x) ** 2 + (yPts[indices] - y) ** 2
         indices = indices[numpy.flip(numpy.argsort(dists))]
 

--- a/silx/gui/plot/backends/glutils/GLPlotTriangles.py
+++ b/silx/gui/plot/backends/glutils/GLPlotTriangles.py
@@ -35,6 +35,7 @@ import ctypes
 
 import numpy
 
+from .....math.combo import min_max
 from .... import _glutils as glutils
 from ...._glutils import gl
 
@@ -99,6 +100,8 @@ class GLPlotTriangles(object):
         assert triangles.ndim == 2 and triangles.shape[1] == 3
 
         self.__x_y_color = x, y, color
+        self.__xBounds = min_max(x, finite=True)
+        self.__yBounds = min_max(y, finite=True)
         self.__triangles = triangles
         self.__alpha = numpy.clip(float(alpha), 0., 1.)
         self.__vbos = None
@@ -113,6 +116,9 @@ class GLPlotTriangles(object):
         :return: List of picked data point indices
         :rtype: numpy.ndarray
         """
+        if (x < self.__xBounds.minimum or x > self.__xBounds.maximum or
+                y < self.__yBounds.minimum or y > self.__yBounds.maximum):
+            return ()
         xPts, yPts = self.__x_y_color[:2]
         if self.__picking_triangles is None:
             self.__picking_triangles = numpy.zeros(
@@ -140,7 +146,6 @@ class GLPlotTriangles(object):
             self.__vbos = None
             self.__indicesVbo.discard()
             self.__indicesVbo = None
-            self.__picking_triangles = None
 
     def prepare(self):
         """Allocate resources on the GPU"""

--- a/silx/gui/plot/backends/glutils/GLPlotTriangles.py
+++ b/silx/gui/plot/backends/glutils/GLPlotTriangles.py
@@ -1,0 +1,103 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+"""
+This module provides a class to render a set of 2D triangles
+"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "03/04/2017"
+
+
+import numpy
+
+
+from ...._glutils import gl, Program, vertexBuffer
+
+
+class GLPlotTriangles(object):
+
+    _PROGRAM = Program(
+        vertexShader="""
+        #version 120
+
+        uniform mat4 matrix;
+        attribute float xPos;
+        attribute float yPos;
+        attribute vec4 color;
+
+        varying vec4 vColor;
+
+        void main(void) {
+            gl_Position = matrix * vec4(xPos, yPos, 0.0, 1.0);
+            vColor = color;
+        }
+        """,
+        fragmentShader="""
+        #version 120
+
+        varying vColor;
+
+        void main(void) {
+            gl_FragColor = vColor;
+        }
+        """,
+        attrib0='xPos')
+
+    def __init__(self, xData=None, yData=None, color=None):
+        self.__x_y_color = xData, yData, color
+        self.__vbos = None
+
+    def discard(self):
+        if self.__vbos is not None:
+            self.__vbos[0].vbo.discard()
+            self.__vbos = None
+
+    def prepare(self):
+        if self.__vbos is None and None not in self.__x_y_color:
+            self.__vbos = vertexBuffer(self.__x_y_color)
+
+    def render(self, matrix):
+        """Perform rendering
+
+        :param numpy.ndarray matrix: 4x4 transform matrix to use
+        """
+        self.prepare()
+
+        if self.__vbos is None:
+            return  # Nothing to display
+
+        self._PROGRAM.use()
+
+        gl.glUniformMatrix4fv(
+            self._PROGRAM.uniforms['matrix'], 1, gl.GL_TRUE,
+            matrix.astype(numpy.float32))
+
+        for index, name in enumerate(('xPos', 'yPos', 'color')):
+            attr = self._PROGRAM.attributes[name]
+            gl.glEnableVertexAttribArray(attr)
+            self.__vbos[index].setVertexAttrib(attr)
+
+        gl.glDrawArrays(gl.GL_TRIANGLE_STRIP, 0, self.__vbos[0].size)

--- a/silx/gui/plot/backends/glutils/__init__.py
+++ b/silx/gui/plot/backends/glutils/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -39,6 +39,7 @@ _logger = logging.getLogger(__name__)
 from .GLPlotCurve import *  # noqa
 from .GLPlotFrame import *  # noqa
 from .GLPlotImage import *  # noqa
+from .GLPlotTriangles import GLPlotTriangles  # noqa
 from .GLSupport import *  # noqa
 from .GLText import *  # noqa
 from .GLTexture import *  # noqa

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -125,8 +125,6 @@ class Scatter(Points, ColormapMixIn):
             # Update cache
             self.__cacheTriangles = (
                 x, y, triangulation(x, y, dtype=numpy.int32))
-        else:
-            print('reuse cache')
         return self.__cacheTriangles[2]
 
     @staticmethod

--- a/silx/gui/plot3d/items/mesh.py
+++ b/silx/gui/plot3d/items/mesh.py
@@ -35,6 +35,7 @@ __date__ = "17/07/2018"
 import logging
 import numpy
 
+from ... import _glutils as glu
 from ..scene import primitives, utils, function
 from ..scene.transform import Rotate
 from .core import DataItem3D, ItemChangedType
@@ -168,7 +169,7 @@ class _MeshBase(DataItem3D):
                 _logger.warning("Unsupported draw mode: %s" % mode)
                 return None
 
-        trianglesIndices, t, barycentric = utils.segmentTrianglesIntersection(
+        trianglesIndices, t, barycentric = glu.segmentTrianglesIntersection(
             rayObject, triangles)
 
         if len(trianglesIndices) == 0:
@@ -494,7 +495,7 @@ class _CylindricalVolume(DataItem3D):
         positions = self._mesh.getAttribute('position', copy=False)
         triangles = positions.reshape(-1, 3, 3)  # 'triangle' draw mode
 
-        trianglesIndices, t = utils.segmentTrianglesIntersection(
+        trianglesIndices, t = glu.segmentTrianglesIntersection(
             rayObject, triangles)[:2]
 
         if len(trianglesIndices) == 0:

--- a/silx/gui/plot3d/items/scatter.py
+++ b/silx/gui/plot3d/items/scatter.py
@@ -36,10 +36,10 @@ try:
 except ImportError:  # Python2 support
     import collections as abc
 import logging
-import sys
 import numpy
 
 from ....utils.deprecation import deprecated
+from ... import _glutils as glu
 from ...plot._utils.delaunay import triangulation
 from ..scene import function, primitives, utils
 
@@ -507,7 +507,7 @@ class Scatter2D(DataItem3D, ColormapMixIn, SymbolMixIn):
 
         trianglesIndices = self._cachedTrianglesIndices.reshape(-1, 3)
         triangles = points[trianglesIndices, :3]
-        selectedIndices, t, barycentric = utils.segmentTrianglesIntersection(
+        selectedIndices, t, barycentric = glu.segmentTrianglesIntersection(
             rayObject, triangles)
         closest = numpy.argmax(barycentric, axis=1)
 

--- a/silx/gui/plot3d/items/volume.py
+++ b/silx/gui/plot3d/items/volume.py
@@ -39,6 +39,7 @@ from silx.math.combo import min_max
 from silx.math.marchingcubes import MarchingCubes
 
 from ....utils.proxy import docstring
+from ... import _glutils as glu
 from ... import qt
 from ...colors import rgba
 
@@ -409,7 +410,7 @@ class Isosurface(Item3D):
             mc = MarchingCubes(data.reshape(2, 2, 2), isolevel=level)
             points = mc.get_vertices() + currentBin
             triangles = points[mc.get_indices()]
-            t = utils.segmentTrianglesIntersection(rayObject, triangles)[1]
+            t = glu.segmentTrianglesIntersection(rayObject, triangles)[1]
             t = numpy.unique(t)  # Duplicates happen on triangle edges
             if len(t) != 0:
                 # Compute intersection points and get closest data point

--- a/silx/gui/plot3d/scene/utils.py
+++ b/silx/gui/plot3d/scene/utils.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -542,77 +542,6 @@ def segmentVolumeIntersect(segment, nbins):
     centers = (points[:-1] + points[1:]) / 2.
     bins = numpy.floor(centers).astype(numpy.int)
     return bins
-
-
-def segmentTrianglesIntersection(segment, triangles):
-    """Check for segment/triangles intersection.
-
-    This is based on signed tetrahedron volume comparison.
-
-    See A. Kensler, A., Shirley, P.
-    Optimizing Ray-Triangle Intersection via Automated Search.
-    Symposium on Interactive Ray Tracing, vol. 0, p33-38 (2006)
-
-    :param numpy.ndarray segment:
-        Segment end points as a 2x3 array of coordinates
-    :param numpy.ndarray triangles:
-        Nx3x3 array of triangles
-    :return: (triangle indices, segment parameter, barycentric coord)
-        Indices of intersected triangles, "depth" along the segment
-        of the intersection point and barycentric coordinates of intersection
-        point in the triangle.
-    :rtype: List[numpy.ndarray]
-    """
-    # TODO triangles from vertices + indices
-    # TODO early rejection? e.g., check segment bbox vs triangle bbox
-    segment = numpy.asarray(segment)
-    assert segment.ndim == 2
-    assert segment.shape == (2, 3)
-
-    triangles = numpy.asarray(triangles)
-    assert triangles.ndim == 3
-    assert triangles.shape[1] == 3
-
-    # Test line/triangles intersection
-    d = segment[1] - segment[0]
-    t0s0 = segment[0] - triangles[:, 0, :]
-    edge01 = triangles[:, 1, :] - triangles[:, 0, :]
-    edge02 = triangles[:, 2, :] - triangles[:, 0, :]
-
-    dCrossEdge02 = numpy.cross(d, edge02)
-    t0s0CrossEdge01 = numpy.cross(t0s0, edge01)
-    volume = numpy.sum(dCrossEdge02 * edge01, axis=1)
-    del edge01
-    subVolumes = numpy.empty((len(triangles), 3), dtype=triangles.dtype)
-    subVolumes[:, 1] = numpy.sum(dCrossEdge02 * t0s0, axis=1)
-    del dCrossEdge02
-    subVolumes[:, 2] = numpy.sum(t0s0CrossEdge01 * d, axis=1)
-    subVolumes[:, 0] = volume - subVolumes[:, 1] - subVolumes[:, 2]
-    intersect = numpy.logical_or(
-        numpy.all(subVolumes >= 0., axis=1),  # All positive
-        numpy.all(subVolumes <= 0., axis=1))  # All negative
-    intersect = numpy.where(intersect)[0]  # Indices of intersected triangles
-
-    # Get barycentric coordinates
-    barycentric = subVolumes[intersect] / volume[intersect].reshape(-1, 1)
-    del subVolumes
-
-    # Test segment/triangles intersection
-    volAlpha = numpy.sum(t0s0CrossEdge01[intersect] * edge02[intersect], axis=1)
-    t = volAlpha / volume[intersect]  # segment parameter of intersected triangles
-    del t0s0CrossEdge01
-    del edge02
-    del volAlpha
-    del volume
-
-    inSegmentMask = numpy.logical_and(t >= 0., t <= 1.)
-    intersect = intersect[inSegmentMask]
-    t = t[inSegmentMask]
-    barycentric = barycentric[inSegmentMask]
-
-    # Sort intersecting triangles by t
-    indices = numpy.argsort(t)
-    return intersect[indices], t[indices], barycentric[indices]
 
 
 # Plane #######################################################################


### PR DESCRIPTION
This PR adds the implementation of `addTriangles` method to the plot OpenGL backend, thus allowing to display scatter plots as surfaces with the OpenGL backend.

Picking still needs to be done.

closes #2324
