### PR TITLE
[GUI[ Remove warning concerning PySide2 usage.

### DIFF
--- a/silx/gui/qt/_qt.py
+++ b/silx/gui/qt/_qt.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -210,8 +210,6 @@ elif BINDING == 'PyQt5':
 
 elif BINDING == 'PySide2':
     _logger.debug('Using PySide2 bindings')
-    _logger.warning(
-        'Using PySide2 Qt binding: PySide2 support in silx is experimental!')
 
     import PySide2 as QtBinding  # noqa
 


### PR DESCRIPTION
When using PySide PySide2 is proposed as replacement. However, there is a warning when using PySide2.

closes #2565