### PR TITLE
plot/plot3 complex visualization mode API consistency

### DIFF
--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -947,10 +947,10 @@ class _ComplexImageView(DataView):
     def createWidget(self, parent):
         from silx.gui.plot.ComplexImageView import ComplexImageView
         widget = ComplexImageView(parent=parent)
-        widget.setColormap(self.defaultColormap(), mode=ComplexImageView.Mode.ABSOLUTE)
-        widget.setColormap(self.defaultColormap(), mode=ComplexImageView.Mode.SQUARE_AMPLITUDE)
-        widget.setColormap(self.defaultColormap(), mode=ComplexImageView.Mode.REAL)
-        widget.setColormap(self.defaultColormap(), mode=ComplexImageView.Mode.IMAGINARY)
+        widget.setColormap(self.defaultColormap(), mode=ComplexImageView.ComplexMode.ABSOLUTE)
+        widget.setColormap(self.defaultColormap(), mode=ComplexImageView.ComplexMode.SQUARE_AMPLITUDE)
+        widget.setColormap(self.defaultColormap(), mode=ComplexImageView.ComplexMode.REAL)
+        widget.setColormap(self.defaultColormap(), mode=ComplexImageView.ComplexMode.IMAGINARY)
         widget.getPlot().getColormapAction().setColorDialog(self.defaultColorDialog())
         widget.getPlot().getIntensityHistogramAction().setVisible(True)
         widget.getPlot().setKeepDataAspectRatio(True)

--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -532,10 +532,10 @@ class ArrayComplexImagePlot(qt.QWidget):
 
         self._plot = ComplexImageView(self)
         if colormap is not None:
-            for mode in (ComplexImageView.Mode.ABSOLUTE,
-                         ComplexImageView.Mode.SQUARE_AMPLITUDE,
-                         ComplexImageView.Mode.REAL,
-                         ComplexImageView.Mode.IMAGINARY):
+            for mode in (ComplexImageView.ComplexMode.ABSOLUTE,
+                         ComplexImageView.ComplexMode.SQUARE_AMPLITUDE,
+                         ComplexImageView.ComplexMode.REAL,
+                         ComplexImageView.ComplexMode.IMAGINARY):
                 self._plot.setColormap(colormap, mode)
 
         self._plot.getPlot().getIntensityHistogramAction().setVisible(True)

--- a/silx/gui/plot/ComplexImageView.py
+++ b/silx/gui/plot/ComplexImageView.py
@@ -400,8 +400,10 @@ class ComplexImageView(qt.QWidget):
 
            widget = ComplexImageView()
            widget.setComplexMode(ComplexImageView.ComplexMode.PHASE)
+           # or
+           widget.setComplexMode('phase')
 
-        :param ComplexMode mode: The mode to use.
+        :param Unions[ComplexMode,str] mode: The mode to use.
         """
         self._plotImage.setComplexMode(mode)
 

--- a/silx/gui/plot/ComplexImageView.py
+++ b/silx/gui/plot/ComplexImageView.py
@@ -39,6 +39,7 @@ import logging
 import collections
 import numpy
 
+from ...utils.deprecation import deprecated
 from .. import qt, icons
 from .PlotWindow import Plot2D
 from . import items
@@ -170,16 +171,16 @@ class _ComplexDataToolButton(qt.QToolButton):
     """
 
     _MODES = collections.OrderedDict([
-        (ImageComplexData.Mode.ABSOLUTE, ('math-amplitude', 'Amplitude')),
-        (ImageComplexData.Mode.SQUARE_AMPLITUDE,
+        (ImageComplexData.ComplexMode.ABSOLUTE, ('math-amplitude', 'Amplitude')),
+        (ImageComplexData.ComplexMode.SQUARE_AMPLITUDE,
          ('math-square-amplitude', 'Square amplitude')),
-        (ImageComplexData.Mode.PHASE, ('math-phase', 'Phase')),
-        (ImageComplexData.Mode.REAL, ('math-real', 'Real part')),
-        (ImageComplexData.Mode.IMAGINARY,
+        (ImageComplexData.ComplexMode.PHASE, ('math-phase', 'Phase')),
+        (ImageComplexData.ComplexMode.REAL, ('math-real', 'Real part')),
+        (ImageComplexData.ComplexMode.IMAGINARY,
          ('math-imaginary', 'Imaginary part')),
-        (ImageComplexData.Mode.AMPLITUDE_PHASE,
+        (ImageComplexData.ComplexMode.AMPLITUDE_PHASE,
          ('math-phase-color', 'Amplitude and Phase')),
-        (ImageComplexData.Mode.LOG10_AMPLITUDE_PHASE,
+        (ImageComplexData.ComplexMode.LOG10_AMPLITUDE_PHASE,
          ('math-phase-color-log', 'Log10(Amp.) and Phase'))
     ])
 
@@ -208,7 +209,7 @@ class _ComplexDataToolButton(qt.QToolButton):
 
         self.setPopupMode(qt.QToolButton.InstantPopup)
 
-        self._modeChanged(self._plot2DComplex.getVisualizationMode())
+        self._modeChanged(self._plot2DComplex.getComplexMode())
         self._plot2DComplex.sigVisualizationModeChanged.connect(
             self._modeChanged)
 
@@ -217,7 +218,8 @@ class _ComplexDataToolButton(qt.QToolButton):
         icon, text = self._MODES[mode]
         self.setIcon(icons.getQIcon(icon))
         self.setToolTip('Display the ' + text.lower())
-        self._rangeDialogAction.setEnabled(mode == ImageComplexData.Mode.LOG10_AMPLITUDE_PHASE)
+        self._rangeDialogAction.setEnabled(
+            mode == ImageComplexData.ComplexMode.LOG10_AMPLITUDE_PHASE)
 
     def _triggered(self, action):
         """Handle triggering of menu actions"""
@@ -244,8 +246,8 @@ class _ComplexDataToolButton(qt.QToolButton):
 
         else:  # update mode
             mode = action.data()
-            if isinstance(mode, ImageComplexData.Mode):
-                self._plot2DComplex.setVisualizationMode(mode)
+            if isinstance(mode, ImageComplexData.ComplexMode):
+                self._plot2DComplex.setComplexMode(mode)
 
     def _rangeChanged(self, range_):
         """Handle updates of range in the dialog"""
@@ -258,8 +260,8 @@ class ComplexImageView(qt.QWidget):
     :param parent: See :class:`QMainWindow`
     """
 
-    Mode = ImageComplexData.Mode
-    """Also expose the modes inside the class"""
+    ComplexMode = ImageComplexData.ComplexMode
+    """Complex Modes enumeration"""
 
     sigDataChanged = qt.Signal()
     """Signal emitted when data has changed."""
@@ -301,7 +303,7 @@ class ComplexImageView(qt.QWidget):
         if event is items.ItemChangedType.DATA:
             self.sigDataChanged.emit()
         elif event is items.ItemChangedType.VISUALIZATION_MODE:
-            mode = self.getVisualizationMode()
+            mode = self.getComplexMode()
             self.sigVisualizationModeChanged.emit(mode)
 
     def getPlot(self):
@@ -344,15 +346,34 @@ class ComplexImageView(qt.QWidget):
                           False to return internal data (do not modify!)
         :rtype: numpy.ndarray of float with 2 dims or RGBA image (uint8).
         """
-        mode = self.getVisualizationMode()
-        if mode in (self.Mode.AMPLITUDE_PHASE,
-                    self.Mode.LOG10_AMPLITUDE_PHASE):
+        mode = self.getComplexMode()
+        if mode in (self.ComplexMode.AMPLITUDE_PHASE,
+                    self.ComplexMode.LOG10_AMPLITUDE_PHASE):
             return self._plotImage.getRgbaImageData(copy=copy)
         else:
             return self._plotImage.getData(copy=copy)
 
+    # Backward compatibility
+
+    Mode = ComplexMode
+
+    @classmethod
+    @deprecated(replacement='supportedComplexModes', since_version='0.11.0')
+    def getSupportedVisualizationModes(cls):
+        return cls.supportedComplexModes()
+
+    @deprecated(replacement='setComplexMode', since_version='0.11.0')
+    def setVisualizationMode(self, mode):
+        return self.setComplexMode(mode)
+
+    @deprecated(replacement='getComplexMode', since_version='0.11.0')
+    def getVisualizationMode(self):
+        return self.getComplexMode()
+
+    # Image item proxy
+
     @staticmethod
-    def getSupportedVisualizationModes():
+    def supportedComplexModes():
         """Returns the supported visualization modes.
 
         Supported visualization modes are:
@@ -365,31 +386,31 @@ class ComplexImageView(qt.QWidget):
         - log10_amplitude_phase:
           Color-coded phase with log10(amplitude) as alpha.
 
-        :rtype: List[Mode]
+        :rtype: List[ComplexMode]
         """
-        return tuple(ImageComplexData.Mode)
+        return ImageComplexData.supportedComplexModes()
 
-    def setVisualizationMode(self, mode):
+    def setComplexMode(self, mode):
         """Set the mode of visualization of the complex data.
 
-        See :meth:`getSupportedVisualizationModes` for the list of
+        See :meth:`supportedComplexModes` for the list of
         supported modes.
 
         How-to change visualization mode::
 
            widget = ComplexImageView()
-           widget.setVisualizationMode(ComplexImageView.Mode.PHASE)
+           widget.setComplexMode(ComplexImageView.ComplexMode.PHASE)
 
-        :param Mode mode: The mode to use.
+        :param ComplexMode mode: The mode to use.
         """
-        self._plotImage.setVisualizationMode(mode)
+        self._plotImage.setComplexMode(mode)
 
-    def getVisualizationMode(self):
+    def getComplexMode(self):
         """Get the current visualization mode of the complex data.
 
-        :rtype: Mode
+        :rtype: ComplexMode
         """
-        return self._plotImage.getVisualizationMode()
+        return self._plotImage.getComplexMode()
 
     def _setAmplitudeRangeInfo(self, max_=None, delta=2):
         """Set the amplitude range to display for 'log10_amplitude_phase' mode.
@@ -407,8 +428,6 @@ class ComplexImageView(qt.QWidget):
         :rtype: 2-tuple"""
         return self._plotImage._getAmplitudeRangeInfo()
 
-    # Image item proxy
-
     def setColormap(self, colormap, mode=None):
         """Set the colormap to use for amplitude, phase, real or imaginary.
 
@@ -416,14 +435,14 @@ class ComplexImageView(qt.QWidget):
         amplitude and phase.
 
         :param ~silx.gui.colors.Colormap colormap: The colormap
-        :param Mode mode: If specified, set the colormap of this specific mode
+        :param ComplexMode mode: If specified, set the colormap of this specific mode
         """
         self._plotImage.setColormap(colormap, mode)
 
     def getColormap(self, mode=None):
         """Returns the colormap used to display the data.
 
-        :param Mode mode: If specified, set the colormap of this specific mode
+        :param ComplexMode mode: If specified, set the colormap of this specific mode
         :rtype: ~silx.gui.colors.Colormap
         """
         return self._plotImage.getColormap(mode=mode)

--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -377,11 +377,11 @@ class ColormapAction(PlotAction):
             # Specific init for complex images
             colormap = image.getColormap()
 
-            mode = image.getVisualizationMode()
-            if mode in (items.ImageComplexData.Mode.AMPLITUDE_PHASE,
-                        items.ImageComplexData.Mode.LOG10_AMPLITUDE_PHASE):
+            mode = image.getComplexMode()
+            if mode in (items.ImageComplexData.ComplexMode.AMPLITUDE_PHASE,
+                        items.ImageComplexData.ComplexMode.LOG10_AMPLITUDE_PHASE):
                 data = image.getData(
-                    copy=False, mode=items.ImageComplexData.Mode.PHASE)
+                    copy=False, mode=items.ImageComplexData.ComplexMode.PHASE)
             else:
                 data = image.getData(copy=False)
 

--- a/silx/gui/plot/items/complex.py
+++ b/silx/gui/plot/items/complex.py
@@ -33,12 +33,13 @@ __date__ = "14/06/2018"
 
 
 import logging
-import enum
 
 import numpy
 
+from ....utils.proxy import docstring
+from ....utils.deprecation import deprecated
 from ...colors import Colormap
-from .core import ColormapMixIn, ItemChangedType
+from .core import ColormapMixIn, ComplexMixIn, ItemChangedType
 from .image import ImageBase
 
 
@@ -105,29 +106,19 @@ def _complex2rgbalin(phaseColormap, data, gamma=1.0, smax=None):
     return rgba
 
 
-class ImageComplexData(ImageBase, ColormapMixIn):
+class ImageComplexData(ImageBase, ColormapMixIn, ComplexMixIn):
     """Specific plot item to force colormap when using complex colormap.
 
     This is returning the specific colormap when displaying
     colored phase + amplitude.
     """
 
-    class Mode(enum.Enum):
-        """Identify available display mode for complex"""
-        ABSOLUTE = 'absolute'
-        PHASE = 'phase'
-        REAL = 'real'
-        IMAGINARY = 'imaginary'
-        AMPLITUDE_PHASE = 'amplitude_phase'
-        LOG10_AMPLITUDE_PHASE = 'log10_amplitude_phase'
-        SQUARE_AMPLITUDE = 'square_amplitude'
-
     def __init__(self):
         ImageBase.__init__(self)
         ColormapMixIn.__init__(self)
+        ComplexMixIn.__init__(self)
         self._data = numpy.zeros((0, 0), dtype=numpy.complex64)
         self._dataByModesCache = {}
-        self._mode = self.Mode.ABSOLUTE
         self._amplitudeRangeInfo = None, 2
 
         # Use default from ColormapMixIn
@@ -139,13 +130,13 @@ class ImageComplexData(ImageBase, ColormapMixIn):
             vmax=numpy.pi)
 
         self._colormaps = {  # Default colormaps for all modes
-            self.Mode.ABSOLUTE: colormap,
-            self.Mode.PHASE: phaseColormap,
-            self.Mode.REAL: colormap,
-            self.Mode.IMAGINARY: colormap,
-            self.Mode.AMPLITUDE_PHASE: phaseColormap,
-            self.Mode.LOG10_AMPLITUDE_PHASE: phaseColormap,
-            self.Mode.SQUARE_AMPLITUDE: colormap,
+            self.ComplexMode.ABSOLUTE: colormap,
+            self.ComplexMode.PHASE: phaseColormap,
+            self.ComplexMode.REAL: colormap,
+            self.ComplexMode.IMAGINARY: colormap,
+            self.ComplexMode.AMPLITUDE_PHASE: phaseColormap,
+            self.ComplexMode.LOG10_AMPLITUDE_PHASE: phaseColormap,
+            self.ComplexMode.SQUARE_AMPLITUDE: colormap,
         }
 
     def _addBackendRenderer(self, backend):
@@ -156,9 +147,9 @@ class ImageComplexData(ImageBase, ColormapMixIn):
             # Do not render with non linear scales
             return None
 
-        mode = self.getVisualizationMode()
-        if mode in (self.Mode.AMPLITUDE_PHASE,
-                    self.Mode.LOG10_AMPLITUDE_PHASE):
+        mode = self.getComplexMode()
+        if mode in (self.ComplexMode.AMPLITUDE_PHASE,
+                    self.ComplexMode.LOG10_AMPLITUDE_PHASE):
             # For those modes, compute RGBA image here
             colormap = None
             data = self.getRgbaImageData(copy=False)
@@ -179,17 +170,11 @@ class ImageComplexData(ImageBase, ColormapMixIn):
                                 colormap=colormap,
                                 alpha=self.getAlpha())
 
-    def setVisualizationMode(self, mode):
-        """Set the visualization mode to use.
-
-        :param Mode mode:
-        """
-        assert isinstance(mode, self.Mode)
-        assert mode in self._colormaps
-
-        if mode != self._mode:
-            self._mode = mode
-
+    @docstring(ComplexMixIn)
+    def setComplexMode(self, mode):
+        changed = super(ImageComplexData, self).setComplexMode(mode)
+        if changed:
+            # Backward compatibility
             self._updated(ItemChangedType.VISUALIZATION_MODE)
 
             # Send data updated as value returned by getData has changed
@@ -199,13 +184,7 @@ class ImageComplexData(ImageBase, ColormapMixIn):
             colormap = self._colormaps[self._mode]
             if colormap is not super(ImageComplexData, self).getColormap():
                 super(ImageComplexData, self).setColormap(colormap)
-
-    def getVisualizationMode(self):
-        """Returns the visualization mode in use.
-
-        :rtype: Mode
-        """
-        return self._mode
+        return changed
 
     def _setAmplitudeRangeInfo(self, max_=None, delta=2):
         """Set the amplitude range to display for 'log10_amplitude_phase' mode.
@@ -228,15 +207,17 @@ class ImageComplexData(ImageBase, ColormapMixIn):
         """Set the colormap for this specific mode.
 
         :param ~silx.gui.colors.Colormap colormap: The colormap
-        :param Mode mode:
+        :param Union[ComplexMode,str] mode:
             If specified, set the colormap of this specific mode.
             Default: current mode.
         """
         if mode is None:
-            mode = self.getVisualizationMode()
+            mode = self.getComplexMode()
+        else:
+            mode = self.ComplexMode.from_value(mode)
 
         self._colormaps[mode] = colormap
-        if mode is self.getVisualizationMode():
+        if mode is self.getComplexMode():
             super(ImageComplexData, self).setColormap(colormap)
         else:
             self._updated(ItemChangedType.COLORMAP)
@@ -244,13 +225,15 @@ class ImageComplexData(ImageBase, ColormapMixIn):
     def getColormap(self, mode=None):
         """Get the colormap for the (current) mode.
 
-        :param Mode mode:
+        :param Union[ComplexMode,str] mode:
             If specified, get the colormap of this specific mode.
             Default: current mode.
         :rtype: ~silx.gui.colors.Colormap
         """
         if mode is None:
-            mode = self.getVisualizationMode()
+            mode = self.getComplexMode()
+        else:
+            mode = self.ComplexMode.from_value(mode)
 
         return self._colormaps[mode]
 
@@ -296,28 +279,30 @@ class ImageComplexData(ImageBase, ColormapMixIn):
 
         :param bool copy: True (Default) to get a copy,
                           False to use internal representation (do not modify!)
-        :param Mode mode:
+        :param Union[ComplexMode,str] mode:
             If specified, get data corresponding to the mode.
             Default: Current mode.
         :rtype: numpy.ndarray of float
         """
         if mode is None:
-            mode = self.getVisualizationMode()
+            mode = self.getComplexMode()
+        else:
+            mode = self.ComplexMode.from_value(mode)
 
         if mode not in self._dataByModesCache:
             # Compute data for mode and store it in cache
             complexData = self.getComplexData(copy=False)
-            if mode is self.Mode.PHASE:
+            if mode is self.ComplexMode.PHASE:
                 data = numpy.angle(complexData)
-            elif mode is self.Mode.REAL:
+            elif mode is self.ComplexMode.REAL:
                 data = numpy.real(complexData)
-            elif mode is self.Mode.IMAGINARY:
+            elif mode is self.ComplexMode.IMAGINARY:
                 data = numpy.imag(complexData)
-            elif mode in (self.Mode.ABSOLUTE,
-                          self.Mode.LOG10_AMPLITUDE_PHASE,
-                          self.Mode.AMPLITUDE_PHASE):
+            elif mode in (self.ComplexMode.ABSOLUTE,
+                          self.ComplexMode.LOG10_AMPLITUDE_PHASE,
+                          self.ComplexMode.AMPLITUDE_PHASE):
                 data = numpy.absolute(complexData)
-            elif mode is self.Mode.SQUARE_AMPLITUDE:
+            elif mode is self.ComplexMode.SQUARE_AMPLITUDE:
                 data = numpy.absolute(complexData) ** 2
             else:
                 _logger.error(
@@ -333,22 +318,36 @@ class ImageComplexData(ImageBase, ColormapMixIn):
         """Get the displayed RGB(A) image for (current) mode
 
         :param bool copy: Ignored for this class
-        :param Mode mode:
+        :param Union[ComplexMode,str] mode:
             If specified, get data corresponding to the mode.
             Default: Current mode.
         :rtype: numpy.ndarray of uint8 of shape (height, width, 4)
         """
         if mode is None:
-            mode = self.getVisualizationMode()
+            mode = self.getComplexMode()
+        else:
+            mode = self.ComplexMode.from_value(mode)
 
         colormap = self.getColormap(mode=mode)
-        if mode is self.Mode.AMPLITUDE_PHASE:
+        if mode is self.ComplexMode.AMPLITUDE_PHASE:
             data = self.getComplexData(copy=False)
             return _complex2rgbalin(colormap, data)
-        elif mode is self.Mode.LOG10_AMPLITUDE_PHASE:
+        elif mode is self.ComplexMode.LOG10_AMPLITUDE_PHASE:
             data = self.getComplexData(copy=False)
             max_, delta = self._getAmplitudeRangeInfo()
             return _complex2rgbalog(colormap, data, dlogs=delta, smax=max_)
         else:
             data = self.getData(copy=False, mode=mode)
             return colormap.applyToData(data)
+
+    # Backward compatibility
+
+    Mode = ComplexMixIn.ComplexMode
+
+    @deprecated(replacement='setComplexMode', since_version='0.11.0')
+    def setVisualizationMode(self, mode):
+        return self.setComplexMode(mode)
+
+    @deprecated(replacement='getComplexMode', since_version='0.11.0')
+    def getVisualizationMode(self):
+        return self.getComplexMode()

--- a/silx/gui/plot/items/complex.py
+++ b/silx/gui/plot/items/complex.py
@@ -181,7 +181,7 @@ class ImageComplexData(ImageBase, ColormapMixIn, ComplexMixIn):
             self._updated(ItemChangedType.DATA)
 
             # Update ColormapMixIn colormap
-            colormap = self._colormaps[self._mode]
+            colormap = self._colormaps[self.getComplexMode()]
             if colormap is not super(ImageComplexData, self).getColormap():
                 super(ImageComplexData, self).setColormap(colormap)
         return changed

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -793,6 +793,8 @@ class ComplexMixIn(ItemMixInBase):
 
         :param ComplexMode mode: The visualization mode in:
             'real', 'imaginary', 'phase', 'amplitude'
+        :return: True if value was set, False if is was already set
+        :rtype: bool
         """
         mode = self.ComplexMode.from_value(mode)
         assert mode in self.supportedComplexModes()
@@ -800,6 +802,9 @@ class ComplexMixIn(ItemMixInBase):
         if mode != self._mode:
             self._mode = mode
             self._updated(ItemChangedType.COMPLEX_MODE)
+            return True
+        else:
+            return False
 
     def _convertComplexData(self, data, mode=None):
         """Convert complex data to the specific mode.

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -768,6 +768,9 @@ class AlphaMixIn(ItemMixInBase):
 class ComplexMixIn(ItemMixInBase):
     """Mix-in class for converting complex data to scalar value"""
 
+    _SUPPORTED_COMPLEX_MODES = None
+    """Override to only support a subset of all ComplexMode"""
+
     class ComplexMode(_Enum):
         """Identify available display mode for complex"""
         ABSOLUTE = 'amplitude'
@@ -838,11 +841,14 @@ class ComplexMixIn(ItemMixInBase):
     def supportedComplexModes(cls):
         """Returns the list of supported complex visualization modes.
 
-        See :meth:`setComplexMode`.
+        See :class:`ComplexMode` and :meth:`setComplexMode`.
 
         :rtype: List[ComplexMode]
         """
-        return cls.ComplexMode.members()
+        if cls._SUPPORTED_COMPLEX_MODES is None:
+            return cls.ComplexMode.members()
+        else:
+            return cls._SUPPORTED_COMPLEX_MODES
 
 
 class Points(Item, SymbolMixIn, AlphaMixIn):

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -133,6 +133,9 @@ class ItemChangedType(enum.Enum):
     VISUALIZATION_MODE = 'visualizationModeChanged'
     """Item's visualization mode changed flag."""
 
+    COMPLEX_MODE = 'complexModeChanged'
+    """Item's complex data visualization mode changed flag."""
+
 
 class Item(qt.QObject):
     """Description of an item of the plot"""
@@ -796,7 +799,7 @@ class ComplexMixIn(ItemMixInBase):
 
         if mode != self._mode:
             self._mode = mode
-            self._updated(ItemChangedType.VISUALIZATION_MODE)
+            self._updated(ItemChangedType.COMPLEX_MODE)
 
     def _convertComplexData(self, data, mode=None):
         """Convert complex data to the specific mode.

--- a/silx/gui/plot/test/testComplexImageView.py
+++ b/silx/gui/plot/test/testComplexImageView.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -63,10 +63,10 @@ class TestComplexImageView(PlotWidgetTestCase, ParametricTestCase):
         self.qWait(100)
 
         # Test all modes
-        modes = self.plot.getSupportedVisualizationModes()
+        modes = self.plot.supportedComplexModes()
         for mode in modes:
             with self.subTest(mode=mode):
-                self.plot.setVisualizationMode(mode)
+                self.plot.setComplexMode(mode)
                 self.qWait(100)
 
         # Test origin and scale API

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -1063,7 +1063,7 @@ class ComplexModeRow(ItemProxyRow):
             name='Mode',
             fget=item.getComplexMode,
             fset=item.setComplexMode,
-            events=items.ItemChangedType.VISUALIZATION_MODE,
+            events=items.ItemChangedType.COMPLEX_MODE,
             toModelData=lambda data: data.value.replace('_', ' ').title(),
             fromModelData=lambda data: data.lower().replace(' ', '_'),
             editorHint=names)

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -35,10 +35,12 @@ import numpy
 
 from silx.math.combo import min_max
 
+from ....utils.proxy import docstring
 from ....utils.enum import Enum as _Enum
 from ...plot.items.core import ItemMixInBase
 from ...plot.items.core import ColormapMixIn as _ColormapMixIn
 from ...plot.items.core import SymbolMixIn as _SymbolMixIn
+from ...plot.items.core import ComplexMixIn as _ComplexMixIn
 from ...colors import rgba
 
 from ..scene import primitives
@@ -175,83 +177,17 @@ class ColormapMixIn(_ColormapMixIn):
             self.__sceneColormap.range_ = range_
 
 
-class ComplexMixIn(ItemMixInBase):
-    """Mix-in class for converting complex data to scalar value"""
-
-    class Mode(_Enum):
-        """Identify available display mode for complex"""
-        ABSOLUTE = 'amplitude'
-        PHASE = 'phase'
-        REAL = 'real'
-        IMAGINARY = 'imaginary'
-        AMPLITUDE_PHASE = 'amplitude_phase'
-        LOG10_AMPLITUDE_PHASE = 'log10_amplitude_phase'
-        SQUARE_AMPLITUDE = 'square_amplitude'
-
-    def __init__(self):
-        self._mode = self.Mode.ABSOLUTE
-
-    def getComplexMode(self):
-        """Returns the current complex visualization mode.
-
-        :rtype: Mode
-        """
-        return self._mode
-
-    def setComplexMode(self, mode):
-        """Set the complex visualization mode.
-
-        :param Mode mode: The visualization mode in:
-            'real', 'imaginary', 'phase', 'amplitude'
-        """
-        mode = self.Mode.from_value(mode)
-        assert mode in self.supportedComplexModes()
-
-        if mode != self._mode:
-            self._mode = mode
-            self._updated(ItemChangedType.VISUALIZATION_MODE)
-
-    def _convertComplexData(self, data, mode=None):
-        """Convert complex data to the specific mode.
-
-        :param Union[Mode,None] mode:
-            The kind of value to compute.
-            If None (the default), the current complex mode is used.
-        :return: The converted dataset
-        :rtype: Union[numpy.ndarray[float],None]
-        """
-        if data is None:
-            return None
-
-        if mode is None:
-            mode = self.getComplexMode()
-
-        if mode is self.Mode.REAL:
-            return numpy.real(data)
-        elif mode is self.Mode.IMAGINARY:
-            return numpy.imag(data)
-        elif mode is self.Mode.ABSOLUTE:
-            return numpy.absolute(data)
-        elif mode is self.Mode.PHASE:
-            return numpy.angle(data)
-        elif mode is self.Mode.SQUARE_AMPLITUDE:
-            return numpy.absolute(data) ** 2
-        else:
-            raise ValueError('Unsupported conversion mode: %s', str(mode))
+@docstring(_ComplexMixIn)
+class ComplexMixIn(_ComplexMixIn):
 
     @classmethod
+    @docstring(_ComplexMixIn)
     def supportedComplexModes(cls):
-        """Returns the list of supported complex visualization modes.
-
-        See :meth:`setComplexMode`.
-
-        :rtype: List[Mode]
-        """
-        return (cls.Mode.REAL,
-                cls.Mode.IMAGINARY,
-                cls.Mode.ABSOLUTE,
-                cls.Mode.PHASE,
-                cls.Mode.SQUARE_AMPLITUDE)
+        return (cls.ComplexMode.REAL,
+                cls.ComplexMode.IMAGINARY,
+                cls.ComplexMode.ABSOLUTE,
+                cls.ComplexMode.PHASE,
+                cls.ComplexMode.SQUARE_AMPLITUDE)
 
 
 class SymbolMixIn(_SymbolMixIn):

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -36,7 +36,6 @@ import numpy
 from silx.math.combo import min_max
 
 from ....utils.proxy import docstring
-from ....utils.enum import Enum as _Enum
 from ...plot.items.core import ItemMixInBase
 from ...plot.items.core import ColormapMixIn as _ColormapMixIn
 from ...plot.items.core import SymbolMixIn as _SymbolMixIn

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -179,14 +179,13 @@ class ColormapMixIn(_ColormapMixIn):
 @docstring(_ComplexMixIn)
 class ComplexMixIn(_ComplexMixIn):
 
-    @classmethod
-    @docstring(_ComplexMixIn)
-    def supportedComplexModes(cls):
-        return (cls.ComplexMode.REAL,
-                cls.ComplexMode.IMAGINARY,
-                cls.ComplexMode.ABSOLUTE,
-                cls.ComplexMode.PHASE,
-                cls.ComplexMode.SQUARE_AMPLITUDE)
+    _SUPPORTED_COMPLEX_MODES = (
+        _ComplexMixIn.ComplexMode.REAL,
+        _ComplexMixIn.ComplexMode.IMAGINARY,
+        _ComplexMixIn.ComplexMode.ABSOLUTE,
+        _ComplexMixIn.ComplexMode.PHASE,
+        _ComplexMixIn.ComplexMode.SQUARE_AMPLITUDE)
+    """Overrides supported ComplexMode"""
 
 
 class SymbolMixIn(_SymbolMixIn):

--- a/silx/gui/plot3d/items/volume.py
+++ b/silx/gui/plot3d/items/volume.py
@@ -672,7 +672,7 @@ class ComplexCutPlane(CutPlane, ComplexMixIn):
 
         :param Union[None,ItemChangedType] event: The kind of update
         """
-        if event == ItemChangedType.VISUALIZATION_MODE:
+        if event == ItemChangedType.COMPLEX_MODE:
             self._syncDataWithParent()
         super(ComplexCutPlane, self)._updated(event)
 
@@ -698,7 +698,7 @@ class ComplexIsosurface(Isosurface):
 
     def _parentChanged(self, event):
         """Handle data change in the parent this isosurface belongs to"""
-        if event == ItemChangedType.VISUALIZATION_MODE:
+        if event == ItemChangedType.COMPLEX_MODE:
             self._syncDataWithParent()
         super(ComplexIsosurface, self)._parentChanged(event)
 

--- a/silx/gui/plot3d/test/testSceneWidgetPicking.py
+++ b/silx/gui/plot3d/test/testSceneWidgetPicking.py
@@ -135,13 +135,13 @@ class TestSceneWidgetPicking(TestCaseQt, ParametricTestCase):
                 refData = numpy.arange(10**3, dtype=dtype).reshape(10, 10, 10)
                 volume = self.widget.addVolume(refData)
                 if dtype == numpy.complex64:
-                    volume.setComplexMode(volume.Mode.REAL)
+                    volume.setComplexMode(volume.ComplexMode.REAL)
                     refData = numpy.real(refData)
                 self.widget.resetZoom('front')
 
                 cutplane = volume.getCutPlanes()[0]
                 if dtype == numpy.complex64:
-                    cutplane.setComplexMode(volume.Mode.REAL)
+                    cutplane.setComplexMode(volume.ComplexMode.REAL)
                 cutplane.getColormap().setVRange(0, 100)
                 cutplane.setNormal((0, 0, 1))
 

--- a/silx/gui/plot3d/test/testSceneWindow.py
+++ b/silx/gui/plot3d/test/testSceneWindow.py
@@ -106,7 +106,7 @@ class TestSceneWindow(TestCaseQt, ParametricTestCase):
             numpy.arange(10**3).reshape(10, 10, 10).astype(numpy.complex64))
         volume.setTranslation(10, 0, 10)
         volume.setRotation(45, (0, 0, 1))
-        volume.setComplexMode(volume.Mode.REAL)
+        volume.setComplexMode(volume.ComplexMode.REAL)
         volume.addIsosurface(500, (1., 0., 0., .5))
         items.append(volume)
         self.assertEqual(sceneWidget.getItems(), tuple(items))

--- a/silx/utils/proxy.py
+++ b/silx/utils/proxy.py
@@ -206,21 +206,21 @@ class Proxy(object):
     __call__ = property(lambda self: self.__obj.__call__)
 
 
-def _docstring(func, origin):
+def _docstring(dest, origin):
     """Implementation of docstring decorator.
 
-    It patches func.__doc__.
+    It patches dest.__doc__.
     """
-    if isinstance(origin, type):
-        # This is a class, get the method with the same name
+    if not isinstance(dest, type) and isinstance(origin, type):
+        # func is not a class, but origin is, get the method with the same name
         try:
-            origin = getattr(origin, func.__name__)
+            origin = getattr(origin, dest.__name__)
         except AttributeError:
             raise ValueError(
-                "origin class has no %s method" % func.__name__)
+                "origin class has no %s method" % dest.__name__)
 
-    func.__doc__ = origin.__doc__
-    return func
+    dest.__doc__ = origin.__doc__
+    return dest
 
 
 def docstring(origin):


### PR DESCRIPTION
This PR makes `plot` and `plot3d` items API consistent concerning complex data visualization mode.
It moves the `ComplexMixIn` from `plot3d` to `plot` and uses it in `ImageComplexData` plot item.
API of `ComplexImageView` is updated to be synchronized with `ComplexMixIn`.
Backward compatibility is kept (with deprecation warnings).

Also by using `silx.utils.Enum` it is now possible to set the complex mode with a `str` (e.g., 'phase') as well as an `Enum` member.