### PR TITLE
Make plot/plot3d scatter visualization mode consistent

### DIFF
--- a/silx/gui/plot/items/__init__.py
+++ b/silx/gui/plot/items/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,8 @@ __date__ = "22/06/2017"
 
 from .core import (Item, LabelsMixIn, DraggableMixIn, ColormapMixIn,  # noqa
                    SymbolMixIn, ColorMixIn, YAxisMixIn, FillMixIn,  # noqa
-                   AlphaMixIn, LineMixIn, ItemChangedType)  # noqa
+                   AlphaMixIn, LineMixIn, ScatterVisualizationMixIn,  # noqa
+                   ComplexMixIn, ItemChangedType)  # noqa
 from .complex import ImageComplexData  # noqa
 from .curve import Curve, CurveStyle  # noqa
 from .histogram import Histogram  # noqa

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -895,7 +895,11 @@ class ScatterVisualizationMixIn(ItemMixInBase):
     def setVisualization(self, mode):
         """Set the scatter plot visualization mode to use.
 
+        See :class:`Visualization` for all possible values,
+        and :meth:`supportedVisualizations` for supported ones.
+
         :param Union[str,Visualization] mode:
+            The visualization mode to use.
         :return: True if value was set, False if is was already set
         :rtype: bool
         """

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -766,7 +766,7 @@ class AlphaMixIn(ItemMixInBase):
 
 
 class ComplexMixIn(ItemMixInBase):
-    """Mix-in class for converting complex data to scalar value"""
+    """Mix-in class for complex data mode"""
 
     _SUPPORTED_COMPLEX_MODES = None
     """Override to only support a subset of all ComplexMode"""
@@ -849,6 +849,73 @@ class ComplexMixIn(ItemMixInBase):
             return cls.ComplexMode.members()
         else:
             return cls._SUPPORTED_COMPLEX_MODES
+
+
+class ScatterVisualizationMixIn(ItemMixInBase):
+    """Mix-in class for scatter plot visualization modes"""
+
+    _SUPPORTED_SCATTER_VISUALIZATION = None
+    """Allows to override supported Visualizations"""
+
+    @enum.unique
+    class Visualization(_Enum):
+        """Different modes of scatter plot visualizations"""
+
+        POINTS = 'points'
+        """Display scatter plot as a point cloud"""
+
+        LINES = 'lines'
+        """Display scatter plot as a wireframe.
+
+        This is based on Delaunay triangulation
+        """
+
+        SURFACE = 'surface'
+        """Display scatter plot as a set of filled triangles.
+
+        This is based on Delaunay triangulation
+        """
+
+    def __init__(self):
+        self.__visualization = self.Visualization.POINTS
+
+    @classmethod
+    def supportedVisualizations(cls):
+        """Returns the list of supported scatter visualization modes.
+
+        See :meth:`setVisualization`
+
+        :rtype: List[Visualization]
+        """
+        if cls._SUPPORTED_SCATTER_VISUALIZATION is None:
+            return cls.Visualization.members()
+        else:
+            return cls._SUPPORTED_SCATTER_VISUALIZATION
+
+    def setVisualization(self, mode):
+        """Set the scatter plot visualization mode to use.
+
+        :param Union[str,Visualization] mode:
+        :return: True if value was set, False if is was already set
+        :rtype: bool
+        """
+        mode = self.Visualization.from_value(mode)
+        assert mode in self.supportedVisualizations()
+
+        if mode != self.__visualization:
+            self.__visualization = mode
+
+            self._updated(ItemChangedType.VISUALIZATION_MODE)
+            return True
+        else:
+            return False
+
+    def getVisualization(self):
+        """Returns the scatter plot visualization mode in use.
+
+        :rtype: Visualization
+        """
+        return self.__visualization
 
 
 class Points(Item, SymbolMixIn, AlphaMixIn):

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -870,7 +870,7 @@ class ScatterVisualizationMixIn(ItemMixInBase):
         This is based on Delaunay triangulation
         """
 
-        SURFACE = 'surface'
+        SOLID = 'solid'
         """Display scatter plot as a set of filled triangles.
 
         This is based on Delaunay triangulation

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -782,14 +782,14 @@ class ComplexMixIn(ItemMixInBase):
         SQUARE_AMPLITUDE = 'square_amplitude'
 
     def __init__(self):
-        self._mode = self.ComplexMode.ABSOLUTE
+        self.__complex_mode = self.ComplexMode.ABSOLUTE
 
     def getComplexMode(self):
         """Returns the current complex visualization mode.
 
         :rtype: ComplexMode
         """
-        return self._mode
+        return self.__complex_mode
 
     def setComplexMode(self, mode):
         """Set the complex visualization mode.
@@ -802,8 +802,8 @@ class ComplexMixIn(ItemMixInBase):
         mode = self.ComplexMode.from_value(mode)
         assert mode in self.supportedComplexModes()
 
-        if mode != self._mode:
-            self._mode = mode
+        if mode != self.__complex_mode:
+            self.__complex_mode = mode
             self._updated(ItemChangedType.COMPLEX_MODE)
             return True
         else:

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -49,7 +49,7 @@ class Scatter(Points, ColormapMixIn, ScatterVisualizationMixIn):
 
     _SUPPORTED_SCATTER_VISUALIZATION = (
         ScatterVisualizationMixIn.Visualization.POINTS,
-        ScatterVisualizationMixIn.Visualization.SURFACE)
+        ScatterVisualizationMixIn.Visualization.SOLID)
     """Overrides supported Visualizations"""
 
     def __init__(self):

--- a/silx/gui/plot/test/testItem.py
+++ b/silx/gui/plot/test/testItem.py
@@ -199,7 +199,7 @@ class TestSigItemChangedSignal(PlotWidgetTestCase):
         scatter.setData((0, 1, 2), (1, 0, 2), (0, 1, 2))
 
         # Visualization mode changed
-        scatter.setVisualization(scatter.Visualization.SURFACE)
+        scatter.setVisualization(scatter.Visualization.SOLID)
 
         self.assertEqual(listener.arguments(),
                          [(ItemChangedType.COLORMAP,),

--- a/silx/gui/plot/test/testItem.py
+++ b/silx/gui/plot/test/testItem.py
@@ -199,7 +199,7 @@ class TestSigItemChangedSignal(PlotWidgetTestCase):
         scatter.setData((0, 1, 2), (1, 0, 2), (0, 1, 2))
 
         # Visualization mode changed
-        scatter.setVisualization('solid')
+        scatter.setVisualization(scatter.Visualization.SURFACE)
 
         self.assertEqual(listener.arguments(),
                          [(ItemChangedType.COLORMAP,),

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -466,7 +466,7 @@ class TestPlotCurve(PlotWidgetTestCase):
                            color=color, symbol='o')
 
 
-class TestPlotScatter(PlotWidgetTestCase):
+class TestPlotScatter(PlotWidgetTestCase, ParametricTestCase):
     """Basic tests for addScatter"""
 
     def testScatter(self):
@@ -482,8 +482,14 @@ class TestPlotScatter(PlotWidgetTestCase):
         self.qapp.processEvents()
 
         scatter = self.plot.getItems()[0]
-        scatter.setVisualization('solid')
-        self.qapp.processEvents()
+
+        for visualization in ('surface',
+                              'points',
+                              scatter.Visualization.SURFACE,
+                              scatter.Visualization.POINTS):
+            with self.subTest(visualization=visualization):
+                scatter.setVisualization(visualization)
+                self.qapp.processEvents()
 
 
 class TestPlotMarker(PlotWidgetTestCase):

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -483,9 +483,9 @@ class TestPlotScatter(PlotWidgetTestCase, ParametricTestCase):
 
         scatter = self.plot.getItems()[0]
 
-        for visualization in ('surface',
+        for visualization in ('solid',
                               'points',
-                              scatter.Visualization.SURFACE,
+                              scatter.Visualization.SOLID,
                               scatter.Visualization.POINTS):
             with self.subTest(visualization=visualization):
                 scatter.setVisualization(visualization)

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -1509,8 +1509,8 @@ def initScatter2DNode(node, item):
         fget=item.getVisualization,
         fset=item.setVisualization,
         events=items.ItemChangedType.VISUALIZATION_MODE,
-        editorHint=[m.title() for m in item.supportedVisualizations()],
-        toModelData=lambda data: data.title(),
+        editorHint=[m.value.title() for m in item.supportedVisualizations()],
+        toModelData=lambda data: data.value.title(),
         fromModelData=lambda data: data.lower()))
 
     node.addRow(ItemProxyRow(

--- a/silx/gui/plot3d/items/scatter.py
+++ b/silx/gui/plot3d/items/scatter.py
@@ -230,7 +230,7 @@ class Scatter2D(DataItem3D, ColormapMixIn, SymbolMixIn,
             ('symbol', 'symbolSize'),
         ScatterVisualizationMixIn.Visualization.LINES:
             ('lineWidth',),
-        ScatterVisualizationMixIn.Visualization.SURFACE: (),
+        ScatterVisualizationMixIn.Visualization.SOLID: (),
     }
     """Dict {visualization mode: property names used in this mode}"""
 

--- a/silx/gui/plot3d/items/scatter.py
+++ b/silx/gui/plot3d/items/scatter.py
@@ -561,12 +561,13 @@ class Scatter2D(DataItem3D, ColormapMixIn, SymbolMixIn,
                     return None
                 self._cachedTrianglesIndices = numpy.ravel(triangles)
 
-            if mode == 'lines' and self._cachedLinesIndices is None:
+            if (mode is self.Visualization.LINES and
+                    self._cachedLinesIndices is None):
                 # Compute line indices
                 self._cachedLinesIndices = utils.triangleToLineIndices(
                     self._cachedTrianglesIndices, unicity=True)
 
-            if mode == 'lines':
+            if mode is self.Visualization.LINES:
                 indices = self._cachedLinesIndices
                 renderMode = 'lines'
             else:
@@ -583,7 +584,7 @@ class Scatter2D(DataItem3D, ColormapMixIn, SymbolMixIn,
 
             # TODO option to enable/disable light, cache normals
             # TODO smooth surface
-            if mode == 'solid':
+            if mode is self.Visualization.SOLID:
                 if heightMap:
                     coordinates = coordinates[indices]
                     if len(value) > 1:

--- a/silx/gui/plot3d/items/scatter.py
+++ b/silx/gui/plot3d/items/scatter.py
@@ -43,6 +43,7 @@ from ... import _glutils as glu
 from ...plot._utils.delaunay import triangulation
 from ..scene import function, primitives, utils
 
+from ...plot.items import ScatterVisualizationMixIn
 from .core import DataItem3D, Item3DChangedType, ItemChangedType
 from .mixins import ColormapMixIn, SymbolMixIn
 from ._pick import PickingResult
@@ -217,16 +218,19 @@ class Scatter3D(DataItem3D, ColormapMixIn, SymbolMixIn):
             return None
 
 
-class Scatter2D(DataItem3D, ColormapMixIn, SymbolMixIn):
+class Scatter2D(DataItem3D, ColormapMixIn, SymbolMixIn,
+                ScatterVisualizationMixIn):
     """2D scatter data with settable visualization mode.
 
     :param parent: The View widget this item belongs to.
     """
 
     _VISUALIZATION_PROPERTIES = {
-        'points': ('symbol', 'symbolSize'),
-        'lines':  ('lineWidth',),
-        'solid': (),
+        ScatterVisualizationMixIn.Visualization.POINTS:
+            ('symbol', 'symbolSize'),
+        ScatterVisualizationMixIn.Visualization.LINES:
+            ('lineWidth',),
+        ScatterVisualizationMixIn.Visualization.SURFACE: (),
     }
     """Dict {visualization mode: property names used in this mode}"""
 
@@ -234,6 +238,7 @@ class Scatter2D(DataItem3D, ColormapMixIn, SymbolMixIn):
         DataItem3D.__init__(self, parent=parent)
         ColormapMixIn.__init__(self)
         SymbolMixIn.__init__(self)
+        ScatterVisualizationMixIn.__init__(self)
 
         self._visualizationMode = 'points'
         self._heightMap = False
@@ -258,48 +263,14 @@ class Scatter2D(DataItem3D, ColormapMixIn, SymbolMixIn):
                     child.marker = symbol
                     child.setAttribute('size', size, copy=True)
 
-        elif event == ItemChangedType.VISIBLE:
+        elif event is ItemChangedType.VISIBLE:
             # TODO smart update?, need dirty flags
             self._updateScene()
 
-        super(Scatter2D, self)._updated(event)
-
-    def supportedVisualizations(self):
-        """Returns the list of supported visualization modes.
-
-        See :meth:`setVisualizationModes`
-
-        :rtype: tuple of str
-        """
-        return tuple(self._VISUALIZATION_PROPERTIES.keys())
-
-    def setVisualization(self, mode):
-        """Set the visualization mode of the data.
-
-        Supported visualization modes are:
-
-        - 'points': For scatter plot representation
-        - 'lines': For Delaunay tessellation-based wireframe representation
-        - 'solid': For Delaunay tessellation-based solid surface representation
-
-        :param str mode: Mode of representation to use
-        """
-        mode = str(mode)
-        assert mode in self.supportedVisualizations()
-
-        if mode != self.getVisualization():
-            self._visualizationMode = mode
+        elif event is ItemChangedType.VISUALIZATION_MODE:
             self._updateScene()
-            self._updated(ItemChangedType.VISUALIZATION_MODE)
 
-    def getVisualization(self):
-        """Returns the current visualization mode.
-
-         See :meth:`setVisualization`
-
-        :rtype: str
-        """
-        return self._visualizationMode
+        super(Scatter2D, self)._updated(event)
 
     def isPropertyEnabled(self, name, visualization=None):
         """Returns true if the property is used with visualization mode.
@@ -546,14 +517,14 @@ class Scatter2D(DataItem3D, ColormapMixIn, SymbolMixIn):
                                   numpy.ones_like(xData)))
 
         mode = self.getVisualization()
-        if mode == 'points':
+        if mode is self.Visualization.POINTS:
             # TODO issue with symbol size: using pixel instead of points
             # Get "corrected" symbol size
             _, threshold = self._getSceneSymbol()
             return self._pickPoints(
                 context, points, threshold=max(3., threshold))
 
-        elif mode == 'lines':
+        elif mode is self.Visualization.LINES:
             # Picking only at point
             return self._pickPoints(context, points, threshold=5.)
 
@@ -573,7 +544,7 @@ class Scatter2D(DataItem3D, ColormapMixIn, SymbolMixIn):
         mode = self.getVisualization()
         heightMap = self.isHeightMap()
 
-        if mode == 'points':
+        if mode is self.Visualization.POINTS:
             z = value if heightMap else 0.
             symbol, size = self._getSceneSymbol()
             primitive = primitives.Points(

--- a/silx/gui/plot3d/items/scatter.py
+++ b/silx/gui/plot3d/items/scatter.py
@@ -240,7 +240,6 @@ class Scatter2D(DataItem3D, ColormapMixIn, SymbolMixIn,
         SymbolMixIn.__init__(self)
         ScatterVisualizationMixIn.__init__(self)
 
-        self._visualizationMode = 'points'
         self._heightMap = False
         self._lineWidth = 1.
 


### PR DESCRIPTION
This PR adds a `ScatterVisualizationMixIn` class to have a consistent API for 2D scatter plots in both `plot` and `plot3d` items.

This introduces an API break in `plot3d` 2D scatter items, as `supportedVisualizations` and `getVisualization` methods were returning `str` and now returns the corresponding `Enum`.
The `setVisualization` method is backward compatible.

closes  #2554