### PR TITLE
[doc] Update debian version of nightly builds to debian 9

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ Or using Anaconda on Linux and MacOS:
 
 Unofficial packages for different distributions are available:
 
-- Unofficial Debian8 packages are available at http://www.silx.org/pub/debian/
+- Unofficial Debian9 packages are available at http://www.silx.org/pub/debian/
 - CentOS 7 rpm packages are provided by Max IV at: http://pubrepo.maxiv.lu.se/rpm/el7/x86_64/
 - Fedora 23 rpm packages are provided by Max IV at http://pubrepo.maxiv.lu.se/rpm/fc23/x86_64/
 - Arch Linux (AUR) packages are also available: https://aur.archlinux.org/packages/python-silx

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -110,7 +110,7 @@ Linux
 
 Packages are available for a few distributions:
 
-- Debian 8: see `Installing a Debian package`_.
+- Debian 9: see `Installing a Debian package`_.
 - `CentOS 7 RPM packages <http://pubrepo.maxiv.lu.se/rpm/el7/x86_64/>`_ provided by the Max IV institute at Lund, Sweden.
 - `Fedora 23 rpm packages <http://pubrepo.maxiv.lu.se/rpm/fc23/x86_64/>`_ provided by the Max IV institute at Lund, Sweden.
 - `Arch Linux (AUR) package <https://aur.archlinux.org/packages/python-silx>`_ provided by Leonid Bloch.
@@ -125,7 +125,7 @@ You can also follow one of those installation procedures:
 Installing a Debian package
 +++++++++++++++++++++++++++
 
-Debian 8 (Jessie) packages are available on http://www.silx.org/pub/debian/ for amd64 computers.
+Debian 9 (Stretch) packages are available on http://www.silx.org/pub/debian/ for amd64 computers.
 To install it, you need to download this file :
 
 .. code-block:: bash 


### PR DESCRIPTION
This PR changes the debian version that is advertised for packages provided by www.silx.org to debian 9.