### PR TITLE
[plot] Change the handling of default y axis limits

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2665,9 +2665,11 @@ class PlotWidget(qt.QMainWindow):
         xmin, xmax = (1., 100.) if ranges.x is None else ranges.x
         ymin, ymax = (1., 100.) if ranges.y is None else ranges.y
         if ranges.yright is None:
-            ymin2, ymax2 = None, None
+            ymin2, ymax2 = ymin, ymax
         else:
             ymin2, ymax2 = ranges.yright
+            if ranges.y is None:
+                ymin, ymax = ranges.yright
 
         # Add margins around data inside the plot area
         newLimits = list(_utils.addMarginsToLimits(


### PR DESCRIPTION
This PR changes the way to handle Y axes limits when the Y axes have no content displayed.
When the Y axis on the left has no content while the right Y axis as some curves, the limits on the left defaults to the one on the right. This is meant to avoid missleading [0, 100] limits displayed on the left.

closes #2563