### PR TITLE
add a setVisible method to ROI objects

### DIFF
--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -321,12 +321,14 @@ class RegionOfInterest(qt.QObject):
             if self._labelItem is not None:
                 self._labelItem._setLegend(legendPrefix + "label")
                 plot._add(self._labelItem)
+                self._labelItem.setVisible(self.isVisible())
 
         self._items = WeakList()
         plotItems = self._createShapeItems(controlPoints)
         for item in plotItems:
             item._setLegend(legendPrefix + str(itemIndex))
             plot._add(item)
+            item.setVisible(self.isVisible())
             self._items.append(item)
             itemIndex += 1
 
@@ -338,6 +340,7 @@ class RegionOfInterest(qt.QObject):
             for index, item in enumerate(plotItems):
                 item._setLegend(legendPrefix + str(itemIndex))
                 item.setColor(color)
+                item.setVisible(self.isVisible())
                 plot._add(item)
                 item.sigItemChanged.connect(functools.partial(
                     self._controlPointAnchorChanged, index))

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -73,6 +73,7 @@ class RegionOfInterest(qt.QObject):
         self._label = ''
         self._labelItem = None
         self._editable = False
+        self._visible = True
 
     def __del__(self):
         # Clean-up plot items
@@ -175,6 +176,34 @@ class RegionOfInterest(qt.QObject):
             # Recreate plot items
             # This can be avoided once marker.setDraggable is public
             self._createPlotItems()
+
+    def isVisible(self):
+        """Returns whether the ROI is visible in the plot.
+
+        .. note::
+            This does not take into account whether or not the plot
+            widget itself is visible (unlike :meth:`QWidget.isVisible` which
+            checks the visibility of all its parent widgets up to the window)
+
+        :rtype: bool
+        """
+        return self._visible
+
+    def setVisible(self, visible):
+        """Set whether the plot items associated with this ROI are
+        visible in the plot.
+
+        :param bool visible: True to show the ROI in the plot, False to
+            hide it.
+        """
+        visible = bool(visible)
+        if self._visible == visible:
+            return
+        self._visible = visible
+        if self._labelItem is not None:
+            self._labelItem.setVisible(visible)
+        for item in self._items + self._editAnchors:
+            item.setVisible(visible)
 
     def _getControlPoints(self):
         """Returns the current ROI control points.
@@ -512,10 +541,10 @@ class LineROI(RegionOfInterest, items.LineMixIn):
         return controlPoints
 
     def setEndPoints(self, startPoint, endPoint):
-        """Set this line location using the endding points
+        """Set this line location using the ending points
 
         :param numpy.ndarray startPoint: Staring bounding point of the line
-        :param numpy.ndarray endPoint: Endding bounding point of the line
+        :param numpy.ndarray endPoint: Ending bounding point of the line
         """
         assert(startPoint.shape == (2,) and endPoint.shape == (2,))
         shapePoints = numpy.array([startPoint, endPoint])
@@ -1261,13 +1290,13 @@ class ArcROI(RegionOfInterest, items.LineMixIn):
     def getGeometry(self):
         """Returns a tuple containing the geometry of this ROI
 
-        It is a symetric fonction of :meth:`setGeometry`.
+        It is a symmetric function of :meth:`setGeometry`.
 
         If `startAngle` is smaller than `endAngle` the rotation is clockwise,
         else the rotation is anticlockwise.
 
         :rtype: Tuple[numpy.ndarray,float,float,float,float]
-        :raise ValueError: In case the ROI can't be representaed as section of
+        :raise ValueError: In case the ROI can't be represented as section of
             a circle
         """
         geometry = self._getInternalGeometry()

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -781,9 +781,9 @@ class RegionOfInterestTableWidget(qt.QTableWidget):
         super(RegionOfInterestTableWidget, self).__init__(parent)
         self._roiManagerRef = None
 
-        self.setColumnCount(5)
-        self.setHorizontalHeaderLabels(
-            ['Label', 'Edit', 'Kind', 'Coordinates', ''])
+        headers = ['Label', 'Edit', 'Kind', 'Coordinates', '']
+        self.setColumnCount(len(headers))
+        self.setHorizontalHeaderLabels(headers)
 
         horizontalHeader = self.horizontalHeader()
         horizontalHeader.setDefaultAlignment(qt.Qt.AlignLeft)
@@ -815,9 +815,10 @@ class RegionOfInterestTableWidget(qt.QTableWidget):
             manager = self.getRegionOfInterestManager()
             roi = manager.getRois()[index]
         else:
-            roi = None
+            return
 
         if column == 0:
+            roi.setVisible(item.checkState() == qt.Qt.Checked)
             roi.setLabel(item.text())
         elif column == 1:
             roi.setEditable(
@@ -884,11 +885,13 @@ class RegionOfInterestTableWidget(qt.QTableWidget):
         for index, roi in enumerate(rois):
             baseFlags = qt.Qt.ItemIsSelectable | qt.Qt.ItemIsEnabled
 
-            # Label
+            # Label and visible
             label = roi.getLabel()
             item = qt.QTableWidgetItem(label)
-            item.setFlags(baseFlags | qt.Qt.ItemIsEditable)
+            item.setFlags(baseFlags | qt.Qt.ItemIsEditable | qt.Qt.ItemIsUserCheckable)
             item.setData(qt.Qt.UserRole, index)
+            item.setCheckState(
+                qt.Qt.Checked if roi.isVisible() else qt.Qt.Unchecked)
             self.setItem(index, 0, item)
 
             # Editable


### PR DESCRIPTION
I have a use case where I need multiple sets of ROIs (one set for each image in a list of images) associated with a single PlotWidget. When I change the image in the plot widget, I want to show only the ROIs specific to the new image.

This PR adds a public API to class `RegionOfInterest` to show or hide it in the plot:
`roi.setVisible(False)`

Alternative APIs that would also work for me, in case you don't like this one:

`roimanager.setRoisVisible(False)`   (this works because I have one ROI manager per image)

`item.setVisible(False) for item in roi.getPlotItems()`