### PR TITLE
[Plot] common API for draggable item

### DIFF
--- a/silx/gui/plot/items/__init__.py
+++ b/silx/gui/plot/items/__init__.py
@@ -42,7 +42,7 @@ from .histogram import Histogram  # noqa
 from .image import ImageBase, ImageData, ImageRgba, MaskImageData  # noqa
 from .shape import Shape  # noqa
 from .scatter import Scatter  # noqa
-from .marker import Marker, XMarker, YMarker  # noqa
+from .marker import MarkerBase, Marker, XMarker, YMarker  # noqa
 from .axis import Axis, XAxis, YAxis, YRightAxis
 
 DATA_ITEMS = ImageComplexData, Curve, Histogram, ImageBase, Scatter

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -412,6 +412,14 @@ class DraggableMixIn(ItemMixInBase):
         """
         self._draggable = bool(draggable)
 
+    def drag(self, from_, to):
+        """Perform a drag of the item.
+
+        :param List[float] from_: (x, y) previous position in data coordinates
+        :param List[float] to: (x, y) current position in data coordinates
+        """
+        raise NotImplementedError("Must be implemented in subclass")
+
 
 class ColormapMixIn(ItemMixInBase):
     """Mix-in class for items with colormap"""

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -39,6 +39,7 @@ import logging
 
 import numpy
 
+from ....utils.proxy import docstring
 from .core import (Item, LabelsMixIn, DraggableMixIn, ColormapMixIn,
                    AlphaMixIn, ItemChangedType)
 
@@ -172,6 +173,12 @@ class ImageBase(Item, LabelsMixIn, DraggableMixIn, AlphaMixIn):
             return None
         else:
             return xmin, xmax, ymin, ymax
+
+    @docstring(DraggableMixIn)
+    def drag(self, from_, to):
+        origin = self.getOrigin()
+        self.setOrigin((origin[0] + to[0] - from_[0],
+                        origin[1] + to[1] - from_[1]))
 
     def getData(self, copy=True):
         """Returns the image data

--- a/silx/gui/plot/items/marker.py
+++ b/silx/gui/plot/items/marker.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +39,7 @@ from .core import (Item, DraggableMixIn, ColorMixIn, LineMixIn, SymbolMixIn,
 _logger = logging.getLogger(__name__)
 
 
-class _BaseMarker(Item, DraggableMixIn, ColorMixIn):
+class MarkerBase(Item, DraggableMixIn, ColorMixIn):
     """Base class for markers"""
 
     _DEFAULT_COLOR = (0., 0., 0., 1.)
@@ -166,14 +166,14 @@ class _BaseMarker(Item, DraggableMixIn, ColorMixIn):
         return args
 
 
-class Marker(_BaseMarker, SymbolMixIn):
+class Marker(MarkerBase, SymbolMixIn):
     """Description of a marker"""
 
     _DEFAULT_SYMBOL = '+'
     """Default symbol of the marker"""
 
     def __init__(self):
-        _BaseMarker.__init__(self)
+        MarkerBase.__init__(self)
         SymbolMixIn.__init__(self)
 
         self._x = 0.
@@ -204,11 +204,11 @@ class Marker(_BaseMarker, SymbolMixIn):
         return x, self.getYPosition()
 
 
-class _LineMarker(_BaseMarker, LineMixIn):
+class _LineMarker(MarkerBase, LineMixIn):
     """Base class for line markers"""
 
     def __init__(self):
-        _BaseMarker.__init__(self)
+        MarkerBase.__init__(self)
         LineMixIn.__init__(self)
 
     def _addBackendRenderer(self, backend):

--- a/silx/gui/plot/items/marker.py
+++ b/silx/gui/plot/items/marker.py
@@ -32,6 +32,7 @@ __date__ = "06/03/2017"
 
 import logging
 
+from ....utils.proxy import docstring
 from .core import (Item, DraggableMixIn, ColorMixIn, LineMixIn, SymbolMixIn,
                    ItemChangedType)
 
@@ -74,6 +75,10 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn):
     def _addBackendRenderer(self, backend):
         """Update backend renderer"""
         raise NotImplementedError()
+
+    @docstring(DraggableMixIn)
+    def drag(self, from_, to):
+        self.setPosition(to[0], to[1])
 
     def isOverlay(self):
         """Return true if marker is drawn as an overlay.


### PR DESCRIPTION
This PR adds a common API (`drag` method) to move `DraggableMixIn` items.
It also make the base class of markers available.

This is to prepare for larger modifications of the plot.

