### PR TITLE
[plot] Points item base class made accessible

### DIFF
--- a/silx/gui/plot/items/__init__.py
+++ b/silx/gui/plot/items/__init__.py
@@ -35,7 +35,7 @@ __date__ = "22/06/2017"
 from .core import (Item, LabelsMixIn, DraggableMixIn, ColormapMixIn,  # noqa
                    SymbolMixIn, ColorMixIn, YAxisMixIn, FillMixIn,  # noqa
                    AlphaMixIn, LineMixIn, ScatterVisualizationMixIn,  # noqa
-                   ComplexMixIn, ItemChangedType)  # noqa
+                   ComplexMixIn, ItemChangedType, PointsBase)  # noqa
 from .complex import ImageComplexData  # noqa
 from .curve import Curve, CurveStyle  # noqa
 from .histogram import Histogram  # noqa

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -922,7 +922,7 @@ class ScatterVisualizationMixIn(ItemMixInBase):
         return self.__visualization
 
 
-class Points(Item, SymbolMixIn, AlphaMixIn):
+class PointsBase(Item, SymbolMixIn, AlphaMixIn):
     """Base class for :class:`Curve` and :class:`Scatter`"""
     # note: _logFilterData must be overloaded if you overload
     #       getData to change its signature
@@ -1071,8 +1071,7 @@ class Points(Item, SymbolMixIn, AlphaMixIn):
         if (xPositive, yPositive) not in self._boundsCache:
             # use the getData class method because instance method can be
             # overloaded to return additional arrays
-            data = Points.getData(self, copy=False,
-                                  displayed=True)
+            data = PointsBase.getData(self, copy=False, displayed=True)
             if len(data) == 5:
                 # hack to avoid duplicating caching mechanism in Scatter
                 # (happens when cached data is used, caching done using

--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -37,7 +37,7 @@ import six
 
 from ....utils.deprecation import deprecated
 from ... import colors
-from .core import (Points, LabelsMixIn, ColorMixIn, YAxisMixIn,
+from .core import (PointsBase, LabelsMixIn, ColorMixIn, YAxisMixIn,
                    FillMixIn, LineMixIn, SymbolMixIn, ItemChangedType)
 
 
@@ -151,7 +151,7 @@ class CurveStyle(object):
             return False
 
 
-class Curve(Points, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixIn):
+class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixIn):
     """Description of a curve"""
 
     _DEFAULT_Z_LAYER = 1
@@ -170,7 +170,7 @@ class Curve(Points, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixIn):
     """Default highlight style of the item"""
 
     def __init__(self):
-        Points.__init__(self)
+        PointsBase.__init__(self)
         ColorMixIn.__init__(self)
         YAxisMixIn.__init__(self)
         FillMixIn.__init__(self)

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -35,13 +35,13 @@ import logging
 import numpy
 
 from .._utils.delaunay import triangulation
-from .core import Points, ColormapMixIn, ScatterVisualizationMixIn
+from .core import PointsBase, ColormapMixIn, ScatterVisualizationMixIn
 
 
 _logger = logging.getLogger(__name__)
 
 
-class Scatter(Points, ColormapMixIn, ScatterVisualizationMixIn):
+class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
     """Description of a scatter"""
 
     _DEFAULT_SELECTABLE = True
@@ -53,7 +53,7 @@ class Scatter(Points, ColormapMixIn, ScatterVisualizationMixIn):
     """Overrides supported Visualizations"""
 
     def __init__(self):
-        Points.__init__(self)
+        PointsBase.__init__(self)
         ColormapMixIn.__init__(self)
         ScatterVisualizationMixIn.__init__(self)
         self._value = ()
@@ -139,7 +139,7 @@ class Scatter(Points, ColormapMixIn, ScatterVisualizationMixIn):
         :return: The filtered arrays or unchanged object if not filtering needed
         :rtype: (x, y, value, xerror, yerror)
         """
-        # overloaded from Points to filter also value.
+        # overloaded from PointsBase to filter also value.
         value = self.getValueData(copy=False)
 
         if xPositive or yPositive:
@@ -150,7 +150,7 @@ class Scatter(Points, ColormapMixIn, ScatterVisualizationMixIn):
                 value = numpy.array(value, copy=True, dtype=numpy.float)
                 value[clipped] = numpy.nan
 
-        x, y, xerror, yerror = Points._logFilterData(self, xPositive, yPositive)
+        x, y, xerror, yerror = PointsBase._logFilterData(self, xPositive, yPositive)
 
         return x, y, value, xerror, yerror
 
@@ -196,7 +196,7 @@ class Scatter(Points, ColormapMixIn, ScatterVisualizationMixIn):
                 self.getXErrorData(copy),
                 self.getYErrorData(copy))
 
-    # reimplemented from Points to handle `value`
+    # reimplemented from PointsBase to handle `value`
     def setData(self, x, y, value, xerror=None, yerror=None, alpha=None, copy=True):
         """Set the data of the scatter.
 
@@ -237,4 +237,4 @@ class Scatter(Points, ColormapMixIn, ScatterVisualizationMixIn):
         # set x, y, xerror, yerror
 
         # call self._updated + plot._invalidateDataRange()
-        Points.setData(self, x, y, xerror, yerror, copy)
+        PointsBase.setData(self, x, y, xerror, yerror, copy)

--- a/silx/gui/plot/test/testItem.py
+++ b/silx/gui/plot/test/testItem.py
@@ -54,7 +54,7 @@ class TestSigItemChangedSignal(PlotWidgetTestCase):
         curve.setVisible(True)
         curve.setZValue(100)
 
-        # Test for signals in Points class
+        # Test for signals in PointsBase class
         curve.setData(numpy.arange(100), numpy.arange(100))
 
         # SymbolMixIn


### PR DESCRIPTION
This PR renames the `Points` item base class to `PointsBase` and make it available in the items `__init__.py`.