### PR TITLE
[plot] Refactor picking

### DIFF
--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -1263,7 +1263,6 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
         assert dataPos is not None
 
         item = None if self.draggedItemRef is None else self.draggedItemRef()
-        print('drag', item, self.draggedItemRef, self._lastPos, dataPos)
         if item is not None:
             item.drag(self._lastPos, dataPos)
 

--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -1,7 +1,7 @@
 #  coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1079,7 +1079,9 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
             applyZoomToPlot(self.machine.plot, scaleF, (x, y))
 
         def onMove(self, x, y):
-            marker = self.machine.plot._pickMarker(x, y)
+            marker = self.machine.plot._pickTopMost(
+                    x, y, lambda item: isinstance(item, items.MarkerBase))[0]
+
             if marker is not None:
                 dataPos = self.machine.plot.pixelToData(x, y)
                 assert dataPos is not None
@@ -1151,69 +1153,54 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
         """
 
         if btn == LEFT_BTN:
-            marker = self.plot._pickMarker(
-                x, y, lambda m: m.isSelectable())
-            if marker is not None:
-                xData, yData = marker.getPosition()
+            item, indices = self.plot._pickTopMost(
+                x, y, lambda i: i.isSelectable())
+
+            if isinstance(item, items.MarkerBase):
+                xData, yData = item.getPosition()
                 if xData is None:
-                    xData = [0, 1]
+                    xData = [0, 1]  # TODO why?
                 if yData is None:
-                    yData = [0, 1]
+                    yData = [0, 1]  # TODO why?
 
                 eventDict = prepareMarkerSignal('markerClicked',
                                                 'left',
-                                                marker.getLegend(),
+                                                item.getLegend(),
                                                 'marker',
-                                                marker.isDraggable(),
-                                                marker.isSelectable(),
+                                                item.isDraggable(),
+                                                item.isSelectable(),
                                                 (xData, yData),
                                                 (x, y), None)
                 return eventDict
 
-            else:
-                picked = self.plot._pickImageOrCurve(
-                    x, y, lambda item: item.isSelectable())
+            elif isinstance(item, items.Curve):
+                dataPos = self.plot.pixelToData(x, y)
+                assert dataPos is not None
 
-                if picked is None:
-                    pass
+                xData = item.getXData(copy=False)
+                yData = item.getYData(copy=False)
 
-                elif picked[0] == 'curve':
-                    curve = picked[1]
-                    indices = picked[2]
+                eventDict = prepareCurveSignal('left',
+                                               item.getLegend(),
+                                               'curve',
+                                               xData[indices],
+                                               yData[indices],
+                                               dataPos[0], dataPos[1],
+                                               x, y)
+                return eventDict
 
-                    dataPos = self.plot.pixelToData(x, y)
-                    assert dataPos is not None
+            elif isinstance(item, items.ImageBase):
+                dataPos = self.plot.pixelToData(x, y)
+                assert dataPos is not None
 
-                    xData = curve.getXData(copy=False)
-                    yData = curve.getYData(copy=False)
-
-                    eventDict = prepareCurveSignal('left',
-                                                   curve.getLegend(),
-                                                   'curve',
-                                                   xData[indices],
-                                                   yData[indices],
-                                                   dataPos[0], dataPos[1],
-                                                   x, y)
-                    return eventDict
-
-                elif picked[0] == 'image':
-                    image = picked[1]
-
-                    dataPos = self.plot.pixelToData(x, y)
-                    assert dataPos is not None
-
-                    # Get corresponding coordinate in image
-                    origin = image.getOrigin()
-                    scale = image.getScale()
-                    column = int((dataPos[0] - origin[0]) / float(scale[0]))
-                    row = int((dataPos[1] - origin[1]) / float(scale[1]))
-                    eventDict = prepareImageSignal('left',
-                                                   image.getLegend(),
-                                                   'image',
-                                                   column, row,
-                                                   dataPos[0], dataPos[1],
-                                                   x, y)
-                    return eventDict
+                row, column = indices[0]
+                eventDict = prepareImageSignal('left',
+                                               item.getLegend(),
+                                               'image',
+                                               column, row,
+                                               dataPos[0], dataPos[1],
+                                               x, y)
+                return eventDict
 
         return None
 
@@ -1240,6 +1227,15 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
                                         posDataCursor)
         self.plot.notify(**eventDict)
 
+    @staticmethod
+    def __isDraggableItem(item):
+        return isinstance(item, items.DraggableMixIn) and item.isDraggable()
+
+    def __terminateDrag(self):
+        """Finalize a drag operation by reseting to initial state"""
+        self.plot.setGraphCursorShape()
+        self.draggedItemRef = None
+
     def beginDrag(self, x, y):
         """Handle begining of drag interaction
 
@@ -1250,78 +1246,55 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
         self._lastPos = self.plot.pixelToData(x, y)
         assert self._lastPos is not None
 
-        self.imageLegend = None
-        self.markerLegend = None
-        marker = self.plot._pickMarker(
-            x, y, lambda m: m.isDraggable())
+        item = self.plot._pickTopMost(x, y, self.__isDraggableItem)[0]
+        self.draggedItemRef = None if item is None else weakref.ref(item)
 
-        if marker is not None:
-            self.markerLegend = marker.getLegend()
-            self._signalMarkerMovingEvent('markerMoving', marker, x, y)
-        else:
-            picked = self.plot._pickImageOrCurve(
-                x,
-                y,
-                lambda item:
-                    hasattr(item, 'isDraggable') and item.isDraggable())
-            if picked is None:
-                self.imageLegend = None
-                self.plot.setGraphCursorShape()
-                return False
-            else:
-                assert picked[0] == 'image'  # For now only drag images
-                self.imageLegend = picked[1].getLegend()
+        if item is None:
+            self.__terminateDrag()
+            return False
+
+        if isinstance(item, items.MarkerBase):
+            self._signalMarkerMovingEvent('markerMoving', item, x, y)
+
         return True
 
     def drag(self, x, y):
         dataPos = self.plot.pixelToData(x, y)
         assert dataPos is not None
-        xData, yData = dataPos
 
-        if self.markerLegend is not None:
-            marker = self.plot._getMarker(self.markerLegend)
-            if marker is not None:
-                marker.setPosition(xData, yData)
+        item = None if self.draggedItemRef is None else self.draggedItemRef()
+        print('drag', item, self.draggedItemRef, self._lastPos, dataPos)
+        if item is not None:
+            item.drag(self._lastPos, dataPos)
 
-                self._signalMarkerMovingEvent(
-                    'markerMoving', marker, x, y)
+            if isinstance(item, items.MarkerBase):
+                 self._signalMarkerMovingEvent('markerMoving', item, x, y)
 
-        if self.imageLegend is not None:
-            image = self.plot.getImage(self.imageLegend)
-            origin = image.getOrigin()
-            xImage = origin[0] + xData - self._lastPos[0]
-            yImage = origin[1] + yData - self._lastPos[1]
-            image.setOrigin((xImage, yImage))
-
-        self._lastPos = xData, yData
+        self._lastPos = dataPos
 
     def endDrag(self, startPos, endPos):
-        if self.markerLegend is not None:
-            marker = self.plot._getMarker(self.markerLegend)
-            posData = list(marker.getPosition())
+        item = None if self.draggedItemRef is None else self.draggedItemRef()
+        if item is not None and isinstance(item, items.MarkerBase):
+            posData = list(item.getPosition())
             if posData[0] is None:
-                posData[0] = [0, 1]
+                posData[0] = [0, 1]  # TODO issue? should be a float?
             if posData[1] is None:
-                posData[1] = [0, 1]
+                posData[1] = [0, 1]  # TODO issue? should be a float?
 
             eventDict = prepareMarkerSignal(
                 'markerMoved',
                 'left',
-                marker.getLegend(),
+                item.getLegend(),
                 'marker',
-                marker.isDraggable(),
-                marker.isSelectable(),
+                item.isDraggable(),
+                item.isSelectable(),
                 posData)
             self.plot.notify(**eventDict)
 
-        self.plot.setGraphCursorShape()
-
-        del self.markerLegend
-        del self.imageLegend
-        del self._lastPos
+        self.__terminateDrag()
 
     def cancel(self):
-        self.plot.setGraphCursorShape()
+        self.__terminateDrag()
 
 
 class ItemsInteractionForCombo(ItemsInteraction):
@@ -1329,22 +1302,16 @@ class ItemsInteractionForCombo(ItemsInteraction):
     """
 
     class Idle(ItemsInteraction.Idle):
+        @staticmethod
+        def __isItemSelectableOrDraggable(item):
+            return (item.isSelectable() or (
+                    isinstance(item, items.DraggableMixIn) and item.isDraggable()))
+
         def onPress(self, x, y, btn):
             if btn == LEFT_BTN:
-                def test(item):
-                    return (item.isSelectable() or
-                            (isinstance(item, items.DraggableMixIn) and
-                             item.isDraggable()))
-
-                picked = self.machine.plot._pickMarker(x, y, test)
-                if picked is not None:
-                    itemInteraction = True
-
-                else:
-                    picked = self.machine.plot._pickImageOrCurve(x, y, test)
-                    itemInteraction = picked is not None
-
-                if itemInteraction:  # Request focus and handle interaction
+                item = self.machine.plot._pickTopMost(
+                    x, y, self.__isItemSelectableOrDraggable)[0]
+                if item is not None:  # Request focus and handle interaction
                     self.goto('clickOrDrag', x, y)
                     return True
                 else:  # Do not request focus

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2692,6 +2692,14 @@ class PlotWidget(qt.QMainWindow):
         """Redraw the plot immediately."""
         for item in self._contentToUpdate:
             item._update(self._backend)
+
+            # Move updated item to end of content for order
+            # to follow the backend order.
+            key = self._itemKey(item)
+            # OrderedDict.move_to_end equivalent for python2 support
+            # self._content.move_to_end(key)
+            self._content[key] = self._content.pop(key)
+
         self._contentToUpdate = []
         self._backend.replot()
         self._dirty = False  # reset dirty flag
@@ -2880,29 +2888,6 @@ class PlotWidget(qt.QMainWindow):
         """
         self._backend.setGraphCursorShape(cursor)
 
-    def _pickMarker(self, x, y, test=None):
-        """Pick a marker at the given position.
-
-        To use for interaction implementation.
-
-        :param float x: X position in pixels.
-        :param float y: Y position in pixels.
-        :param test: A callable to call for each picked marker to filter
-                     picked markers. If None (default), do not filter markers.
-        """
-        if test is None:
-            def test(mark):
-                return True
-
-        markers = self._backend.pickItems(x, y, kinds=('marker',))
-        legends = [m['legend'] for m in markers if m['kind'] == 'marker']
-
-        for legend in reversed(legends):
-            marker = self._getMarker(legend)
-            if marker is not None and test(marker):
-                return marker
-        return None
-
     def _getAllMarkers(self, just_legend=False):
         """Returns all markers' legend or objects
 
@@ -2924,73 +2909,50 @@ class PlotWidget(qt.QMainWindow):
         """
         return self._getItem(kind='marker', legend=legend)
 
-    def _pickImageOrCurve(self, x, y, test=None):
-        """Pick an image or a curve at the given position.
+    def _itemsFrontToBack(self):
+        """Iterator of plot items ordered from front to back
 
-        To use for interaction implementation.
-
-        :param float x: X position in pixels
-        :param float y: Y position in pixels
-        :param test: A callable to call for each picked item to filter
-                     picked items. If None (default), do not filter items.
+        :return:
         """
-        if test is None:
-            def test(i):
-                return True
+        # TODO handle from front to back, handle z value and right axis
+        for item in reversed(list((self._content.values()))):
+            yield item
 
-        allItems = self._backend.pickItems(x, y, kinds=('curve', 'image'))
-        allItems = [item for item in allItems
-                    if item['kind'] in ['curve', 'image']]
+    def _pick(self, x, y, prefilter=None):
+        """Generator of picked items in the plot at given position.
 
-        for item in reversed(allItems):
-            kind, legend = item['kind'], item['legend']
-            if kind == 'curve':
-                curve = self.getCurve(legend)
-                if curve is not None and test(curve):
-                    return kind, curve, item['indices']
-
-            elif kind == 'image':
-                image = self.getImage(legend)
-                if image is not None and test(image):
-                    return kind, image, None
-
-            else:
-                _logger.warning('Unsupported kind: %s', kind)
-
-        return None
-
-    def _pick(self, x, y):
-        """Pick items in the plot at given position.
+        Items are returned from front to back.
 
         :param float x: X position in pixels
         :param float y: Y position in pixels
+        :param callable prefilter:
+           Callable taking an item as input and returning False for items
+           to skip during picking. If None (default) no item is skipped.
         :return: Iterable of (plot item, indices) at picked position.
-            Items are ordered from back to front.
+            Items are ordered from front to back.
         """
-        items = []
+        for item in self._itemsFrontToBack():
+            if prefilter is None or prefilter(item):
+                indices = item.pick(x, y)
+                if indices is not None:
+                    yield item, indices
 
-        # Convert backend result to plot items
-        for itemInfo in self._backend.pickItems(
-                x, y, kinds=('marker', 'curve', 'image')):
-            kind, legend = itemInfo['kind'], itemInfo['legend']
+    def _pickTopMost(self, x, y, prefilter=None):
+        """Returns top-most picked item in the plot at given position.
 
-            if kind in ('marker', 'image'):
-                item = self._getItem(kind=kind, legend=legend)
-                indices = None  # TODO compute indices for images
+        Items are checked from front to back.
 
-            else:  # backend kind == 'curve'
-                for kind in ('curve', 'histogram', 'scatter'):
-                    item = self._getItem(kind=kind, legend=legend)
-                    if item is not None:
-                        indices = itemInfo['indices']
-                        break
-                else:
-                    _logger.error(
-                        'Cannot find corresponding picked item')
-                    continue
-            items.append((item, indices))
-
-        return tuple(items)
+        :param float x: X position in pixels
+        :param float y: Y position in pixels
+        :param callable prefilter:
+           Callable taking an item as input and returning False for items
+           to skip during picking. If None (default) no item is skipped.
+        :return: (plot item, indices) at picked position or
+           If no item is picked, it returns (None, None)
+        """
+        for item, indices in self._pick(x, y, prefilter):
+            return item, indices
+        return None, None
 
     # User event handling #
 

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2918,39 +2918,39 @@ class PlotWidget(qt.QMainWindow):
         for item in reversed(list((self._content.values()))):
             yield item
 
-    def _pick(self, x, y, prefilter=None):
+    def pickItems(self, x, y, condition=None):
         """Generator of picked items in the plot at given position.
 
         Items are returned from front to back.
 
         :param float x: X position in pixels
         :param float y: Y position in pixels
-        :param callable prefilter:
+        :param callable condition:
            Callable taking an item as input and returning False for items
            to skip during picking. If None (default) no item is skipped.
         :return: Iterable of (plot item, indices) at picked position.
             Items are ordered from front to back.
         """
         for item in self._itemsFrontToBack():
-            if prefilter is None or prefilter(item):
+            if condition is None or condition(item):
                 indices = item.pick(x, y)
                 if indices is not None:
                     yield item, indices
 
-    def _pickTopMost(self, x, y, prefilter=None):
+    def _pickTopMost(self, x, y, condition=None):
         """Returns top-most picked item in the plot at given position.
 
         Items are checked from front to back.
 
         :param float x: X position in pixels
         :param float y: Y position in pixels
-        :param callable prefilter:
+        :param callable condition:
            Callable taking an item as input and returning False for items
            to skip during picking. If None (default) no item is skipped.
         :return: (plot item, indices) at picked position or
            If no item is picked, it returns (None, None)
         """
-        for item, indices in self._pick(x, y, prefilter):
+        for item, indices in self.pickItems(x, y, condition):
             return item, indices
         return None, None
 

--- a/silx/gui/plot/ScatterView.py
+++ b/silx/gui/plot/ScatterView.py
@@ -162,17 +162,18 @@ class ScatterView(qt.QMainWindow):
                 pixelPos = plot.dataToPixel(x, y)
                 if pixelPos is not None:
                     # Start from top-most item
-                    for item, indices in reversed(plot._pick(*pixelPos)):
-                        if isinstance(item, items.Scatter):
-                            # Get last index
-                            # with matplotlib it should be the top-most point
-                            dataIndex = indices[-1]
-                            self.__pickingCache = (
-                                dataIndex,
-                                item.getXData(copy=False)[dataIndex],
-                                item.getYData(copy=False)[dataIndex],
-                                item.getValueData(copy=False)[dataIndex])
-                            break
+                    item, indices = plot._pickTopMost(
+                        pixelPos[0], pixelPos[1],
+                        lambda item: isinstance(item, items.Scatter))
+                    if item is not None:
+                        # Get last index
+                        # with matplotlib it should be the top-most point
+                        dataIndex = indices[-1]
+                        self.__pickingCache = (
+                            dataIndex,
+                            item.getXData(copy=False)[dataIndex],
+                            item.getYData(copy=False)[dataIndex],
+                            item.getValueData(copy=False)[dataIndex])
 
         return self.__pickingCache
 

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -307,22 +307,17 @@ class BackendBase(object):
         """
         pass
 
-    def pickItems(self, x, y, kinds):
-        """Get a list of items at a pixel position.
+    def pickItem(self, x, y, item):
+        """Return picked indices if any, or None.
 
         :param float x: The x pixel coord where to pick.
         :param float y: The y pixel coord where to pick.
-        :param List[str] kind: List of item kinds to pick.
-            Supported kinds: 'marker', 'curve', 'image'.
-        :return: All picked items from back to front.
-                 One dict per item,
-                 with 'kind' key in 'curve', 'marker', 'image';
-                 'legend' key, the item legend.
-                 and for curves, 'xdata' and 'ydata' keys storing picked
-                 position on the curve.
-        :rtype: list of dict
+        :param item: A backend item created with add* methods.
+        :return: None if item was not picked, else returns
+            picked indices information.
+        :rtype: Union[None,List]
         """
-        return []
+        return None
 
     # Update curve
 

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1316,7 +1316,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             if isinstance(glItem, (GLPlotColormap, GLPlotRGBAImage, GLPlotTriangles)):
                 return glItem.pick(*dataPos)  # Might be None
 
-            elif isinstance(item, GLPlotCurve2D):
+            elif isinstance(glItem, GLPlotCurve2D):
                 return self.__pickCurves(glItem, x, y)
             else:
                 return None

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1212,8 +1212,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         :param GLPlotCurve2D item:
         :param float x: X position of the mouse in widget coordinates
         :param float y: Y position of the mouse in widget coordinates
-        :return: List of indices of picked points
-        :rtype: List[int]
+        :return: List of indices of picked points or None if not picked
+        :rtype: Union[List[int],None]
         """
         offset = self._PICK_OFFSET
         if item.marker is not None:
@@ -1227,14 +1227,14 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         dataPos = self.pixelToData(inAreaPos[0], inAreaPos[1],
                                    axis=yAxis, check=True)
         if dataPos is None:
-            return []
+            return None
         xPick0, yPick0 = dataPos
 
         inAreaPos = self._mouseInPlotArea(x + offset, y + offset)
         dataPos = self.pixelToData(inAreaPos[0], inAreaPos[1],
                                    axis=yAxis, check=True)
         if dataPos is None:
-            return []
+            return None
         xPick1, yPick1 = dataPos
 
         if xPick0 < xPick1:
@@ -1260,69 +1260,66 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         return item.pick(xPickMin, yPickMin,
                          xPickMax, yPickMax)
 
-    def pickItems(self, x, y, kinds):
-        picked = []
+    def pickItem(self, x, y, item):
+        legend, kind = item
 
         dataPos = self.pixelToData(x, y, axis='left', check=True)
-        if dataPos is not None:
-            # Pick markers
-            if 'marker' in kinds:
-                for marker in reversed(list(self._markers.values())):
-                    pixelPos = self.dataToPixel(
-                        marker['x'], marker['y'], axis='left', check=False)
-                    if pixelPos is None:  # negative coord on a log axis
-                        continue
+        if dataPos is None:
+            return None  # Outside plot area
 
-                    if marker['x'] is None:  # Horizontal line
-                        pt1 = self.pixelToData(
-                            x, y - self._PICK_OFFSET, axis='left', check=False)
-                        pt2 = self.pixelToData(
-                            x, y + self._PICK_OFFSET, axis='left', check=False)
-                        isPicked = (min(pt1[1], pt2[1]) <= marker['y'] <=
-                                    max(pt1[1], pt2[1]))
+        # Pick markers
+        if kind == 'marker':
+            marker = self._markers.get(legend)
+            if marker is None:
+                _logger.error(
+                    "Trying to pick a marker that is not in the plot: %s",
+                    item)
+                return None
 
-                    elif marker['y'] is None:  # Vertical line
-                        pt1 = self.pixelToData(
-                            x - self._PICK_OFFSET, y, axis='left', check=False)
-                        pt2 = self.pixelToData(
-                            x + self._PICK_OFFSET, y, axis='left', check=False)
-                        isPicked = (min(pt1[0], pt2[0]) <= marker['x'] <=
-                                    max(pt1[0], pt2[0]))
+            pixelPos = self.dataToPixel(
+                marker['x'], marker['y'], axis='left', check=False)
+            if pixelPos is None:
+                return None  # negative coord on a log axis
 
-                    else:
-                        isPicked = (
-                            numpy.fabs(x - pixelPos[0]) <= self._PICK_OFFSET and
-                            numpy.fabs(y - pixelPos[1]) <= self._PICK_OFFSET)
+            if marker['x'] is None:  # Horizontal line
+                pt1 = self.pixelToData(
+                    x, y - self._PICK_OFFSET, axis='left', check=False)
+                pt2 = self.pixelToData(
+                    x, y + self._PICK_OFFSET, axis='left', check=False)
+                isPicked = (min(pt1[1], pt2[1]) <= marker['y'] <=
+                            max(pt1[1], pt2[1]))
 
-                    if isPicked:
-                        picked.append(dict(kind='marker',
-                                           legend=marker['legend']))
+            elif marker['y'] is None:  # Vertical line
+                pt1 = self.pixelToData(
+                    x - self._PICK_OFFSET, y, axis='left', check=False)
+                pt2 = self.pixelToData(
+                    x + self._PICK_OFFSET, y, axis='left', check=False)
+                isPicked = (min(pt1[0], pt2[0]) <= marker['x'] <=
+                            max(pt1[0], pt2[0]))
 
-            # Pick image and curves
-            if 'image' in kinds or 'curve' in kinds:
-                for item in self._plotContent.zOrderedPrimitives(reverse=True):
-                    if ('image' in kinds and
-                            isinstance(item, (GLPlotColormap, GLPlotRGBAImage))):
-                        pickedPos = item.pick(*dataPos)
-                        if pickedPos is not None:
-                            picked.append(dict(kind='image',
-                                               legend=item.info['legend']))
+            else:
+                isPicked = (
+                    numpy.fabs(x - pixelPos[0]) <= self._PICK_OFFSET and
+                    numpy.fabs(y - pixelPos[1]) <= self._PICK_OFFSET)
 
-                    elif 'curve' in kinds:
-                        if isinstance(item, GLPlotCurve2D):
-                            pickedIndices = self.__pickCurves(item, x, y)
-                            if pickedIndices:
-                                picked.append(dict(kind='curve',
-                                                   legend=item.info['legend'],
-                                                   indices=pickedIndices))
+            return (0,) if isPicked else None
 
-                        elif isinstance(item, GLPlotTriangles):
-                            pickedIndices = item.pick(*dataPos)
-                            if pickedIndices:
-                                picked.append(dict(kind='curve',
-                                                   legend=item.info['legend'],
-                                                   indices=pickedIndices))
-        return picked
+        # Pick image, curve, triangles
+        elif kind in ('image', 'curve', 'triangles'):
+            glItem = self._plotContent.get(kind, legend)
+            if glItem is None:
+                _logger.error(
+                    "Trying to pick an item that is not in the plot: %s",
+                    item)
+                return None
+
+            if isinstance(glItem, (GLPlotColormap, GLPlotRGBAImage, GLPlotTriangles)):
+                return glItem.pick(*dataPos)  # Might be None
+
+            elif isinstance(item, GLPlotCurve2D):
+                return self.__pickCurves(glItem, x, y)
+            else:
+                return None
 
     # Update curve
 

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -1129,7 +1129,7 @@ class GLPlotCurve2D(object):
         and the segment [i-1, i] is not tested for picking.
 
         :return: The indices of the picked data
-        :rtype: list of int
+        :rtype: Union[List[int],None]
         """
         if (self.marker is None and self.lineStyle is None) or \
                 self.xMin > xPickMax or xPickMin > self.xMax or \
@@ -1209,4 +1209,4 @@ class GLPlotCurve2D(object):
                                         (self.yData >= yPickMin) &
                                         (self.yData <= yPickMax))[0].tolist()
 
-        return indices
+        return tuple(indices) if len(indices) > 0 else None

--- a/silx/gui/plot/backends/glutils/GLPlotImage.py
+++ b/silx/gui/plot/backends/glutils/GLPlotImage.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -56,7 +56,7 @@ class _GLPlotData2D(object):
             sx, sy = self.scale
             col = int((x - ox) / sx)
             row = int((y - oy) / sy)
-            return col, row
+            return ((row, col),)
         else:
             return None
 

--- a/silx/gui/plot/backends/glutils/GLPlotTriangles.py
+++ b/silx/gui/plot/backends/glutils/GLPlotTriangles.py
@@ -114,11 +114,12 @@ class GLPlotTriangles(object):
         :param float x: X coordinates in plot data frame
         :param float y: Y coordinates in plot data frame
         :return: List of picked data point indices
-        :rtype: numpy.ndarray
+        :rtype: Union[List[int],None]
         """
         if (x < self.xMin or x > self.xMax or
                 y < self.yMin or y > self.yMax):
-            return ()
+            return None
+
         xPts, yPts = self.__x_y_color[:2]
         if self.__picking_triangles is None:
             self.__picking_triangles = numpy.zeros(
@@ -137,7 +138,7 @@ class GLPlotTriangles(object):
         dists = (xPts[indices] - x) ** 2 + (yPts[indices] - y) ** 2
         indices = indices[numpy.flip(numpy.argsort(dists))]
 
-        return tuple(indices)
+        return tuple(indices) if len(indices) > 0 else None
 
     def discard(self):
         """Release resources on the GPU"""

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -330,6 +330,20 @@ class Item(qt.QObject):
             backend.remove(self._backendRenderer)
             self._backendRenderer = None
 
+    def pick(self, x, y):
+        """Run picking test on this item
+
+        :param float x: The x pixel coord where to pick.
+        :param float y: The y pixel coord where to pick.
+        :return: None if not picked, else picked indices
+        """
+        if not self.isVisible() or self._backendRenderer is None:
+            return None
+        plot = self.getPlot()
+        if plot is None:
+            return None
+        return plot._backend.pickItem(x, y, self._backendRenderer)
+
 
 # Mix-in classes ##############################################################
 

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -142,6 +142,25 @@ class ImageBase(Item, LabelsMixIn, DraggableMixIn, AlphaMixIn):
                 plot._invalidateDataRange()
         super(ImageBase, self).setVisible(visible)
 
+    @docstring(Item)
+    def pick(self, x, y):
+        if super(ImageBase, self).pick(x, y) is not None:
+            plot = self.getPlot()
+            if plot is None:
+                return None
+
+            dataPos = plot.pixelToData(x, y)
+            if dataPos is None:
+                return None
+
+            origin = self.getOrigin()
+            scale = self.getScale()
+            column = int((dataPos[0] - origin[0]) / float(scale[0]))
+            row = int((dataPos[1] - origin[1]) / float(scale[1]))
+            return ((row, column),)
+
+        return None
+
     def _isPlotLinear(self, plot):
         """Return True if plot only uses linear scale for both of x and y
         axes."""

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -488,31 +488,31 @@ class PointROI(RegionOfInterest, items.SymbolMixIn):
         return None
 
     def _updateLabelItem(self, label):
-        if self.isEditable():
-            item = self._editAnchors[0]
-        else:
+        self._items[0].setText(label)
+
+    def _updateShape(self):
+        if len(self._items) > 0:
+            controlPoints = self._getControlPoints()
             item = self._items[0]
-        item.setText(label)
+            item.setPosition(*controlPoints[0])
+
+    def __positionChanged(self, event):
+        """Handle position changed events of the marker"""
+        if event is items.ItemChangedType.POSITION:
+            marker = self.sender()
+            if isinstance(marker, items.Marker):
+                self.setPosition(marker.getPosition())
 
     def _createShapeItems(self, points):
-        if self.isEditable():
-            return []
         marker = items.Marker()
         marker.setPosition(points[0][0], points[0][1])
         marker.setText(self.getLabel())
+        marker.setSymbol(self.getSymbol())
+        marker.setSymbolSize(self.getSymbolSize())
         marker.setColor(rgba(self.getColor()))
-        marker.setSymbol(self.getSymbol())
-        marker.setSymbolSize(self.getSymbolSize())
-        marker._setDraggable(False)
-        return [marker]
-
-    def _createAnchorItems(self, points):
-        marker = items.Marker()
-        marker.setPosition(points[0][0], points[0][1])
-        marker.setText(self.getLabel())
         marker._setDraggable(self.isEditable())
-        marker.setSymbol(self.getSymbol())
-        marker.setSymbolSize(self.getSymbolSize())
+        if self.isEditable():
+            marker.sigItemChanged.connect(self.__positionChanged)
         return [marker]
 
     def __str__(self):
@@ -672,38 +672,31 @@ class HorizontalLineROI(RegionOfInterest, items.LineMixIn):
         return None
 
     def _updateLabelItem(self, label):
-        if self.isEditable():
-            item = self._editAnchors[0]
-        else:
-            item = self._items[0]
-        item.setText(label)
+        self._items[0].setText(label)
 
     def _updateShape(self):
-        if not self.isEditable():
-            if len(self._items) > 0:
-                controlPoints = self._getControlPoints()
-                item = self._items[0]
-                item.setPosition(*controlPoints[0])
+        if len(self._items) > 0:
+            controlPoints = self._getControlPoints()
+            item = self._items[0]
+            item.setPosition(*controlPoints[0])
+
+    def __positionChanged(self, event):
+        """Handle position changed events of the marker"""
+        if event is items.ItemChangedType.POSITION:
+            marker = self.sender()
+            if isinstance(marker, items.YMarker):
+                self.setPosition(marker.getYPosition())
 
     def _createShapeItems(self, points):
-        if self.isEditable():
-            return []
         marker = items.YMarker()
         marker.setPosition(points[0][0], points[0][1])
         marker.setText(self.getLabel())
         marker.setColor(rgba(self.getColor()))
-        marker._setDraggable(False)
         marker.setLineWidth(self.getLineWidth())
         marker.setLineStyle(self.getLineStyle())
-        return [marker]
-
-    def _createAnchorItems(self, points):
-        marker = items.YMarker()
-        marker.setPosition(points[0][0], points[0][1])
-        marker.setText(self.getLabel())
         marker._setDraggable(self.isEditable())
-        marker.setLineWidth(self.getLineWidth())
-        marker.setLineStyle(self.getLineStyle())
+        if self.isEditable():
+            marker.sigItemChanged.connect(self.__positionChanged)
         return [marker]
 
     def __str__(self):
@@ -749,38 +742,31 @@ class VerticalLineROI(RegionOfInterest, items.LineMixIn):
         return None
 
     def _updateLabelItem(self, label):
-        if self.isEditable():
-            item = self._editAnchors[0]
-        else:
-            item = self._items[0]
-        item.setText(label)
+        self._items[0].setText(label)
 
     def _updateShape(self):
-        if not self.isEditable():
-            if len(self._items) > 0:
-                controlPoints = self._getControlPoints()
-                item = self._items[0]
-                item.setPosition(*controlPoints[0])
+        if len(self._items) > 0:
+            controlPoints = self._getControlPoints()
+            item = self._items[0]
+            item.setPosition(*controlPoints[0])
+
+    def __positionChanged(self, event):
+        """Handle position changed events of the marker"""
+        if event is items.ItemChangedType.POSITION:
+            marker = self.sender()
+            if isinstance(marker, items.XMarker):
+                self.setPosition(marker.getXPosition())
 
     def _createShapeItems(self, points):
-        if self.isEditable():
-            return []
         marker = items.XMarker()
         marker.setPosition(points[0][0], points[0][1])
         marker.setText(self.getLabel())
         marker.setColor(rgba(self.getColor()))
-        marker._setDraggable(False)
         marker.setLineWidth(self.getLineWidth())
         marker.setLineStyle(self.getLineStyle())
-        return [marker]
-
-    def _createAnchorItems(self, points):
-        marker = items.XMarker()
-        marker.setPosition(points[0][0], points[0][1])
-        marker.setText(self.getLabel())
         marker._setDraggable(self.isEditable())
-        marker.setLineWidth(self.getLineWidth())
-        marker.setLineStyle(self.getLineStyle())
+        if self.isEditable():
+            marker.sigItemChanged.connect(self.__positionChanged)
         return [marker]
 
     def __str__(self):


### PR DESCRIPTION
This PR provides a refactoring of the `PlotWidget` picking machinery to make it more generic.
The initial need for this comes from displaying scatter plot as images (for density plot) which requires a split between plot items and the backend that was not possible with the previous picking implementation.

`PlotWidget` provides 2 methods: `_pick` and `_pickTopMost` to do the picking (to become public at some point and probably return some `PickingResult` objects as in `plot3d` and `sx.ginput`).
Plot items provide a `pick` method returning `None` if not picked and otherwise the indices of the picked data points.
