### PR TITLE
Take into account optional sift module (for debian packaging)

### DIFF
--- a/silx/gui/plot/CompareImages.py
+++ b/silx/gui/plot/CompareImages.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -48,7 +48,11 @@ _logger = logging.getLogger(__name__)
 
 from silx.opencl import ocl
 if ocl is not None:
-    from silx.opencl import sift
+    try:
+        from silx.opencl import sift
+    except ImportError:
+        # sift module is not available (e.g., in official Debian packages)
+        sift = None
 else:  # No OpenCL device or no pyopencl
     sift = None
 


### PR DESCRIPTION
This PR makes `CompareImage` taking into account the optional availability of the `sift` package (under Debian).

closes #2605