### PR TITLE
Fix deprecation warnings from numpy/python/pkg_resources/h5py

### DIFF
--- a/silx/app/view/About.py
+++ b/silx/app/view/About.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,6 +27,7 @@ __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "05/07/2018"
 
+import os
 import sys
 
 from silx.gui import qt
@@ -208,7 +209,7 @@ class About(qt.QDialog):
             pass
 
         # Access to the logo in SVG or PNG
-        logo = icons.getQFile("../logo/silx")
+        logo = icons.getQFile("silx:" + os.path.join("gui", "logo", "silx"))
 
         info = dict(
             application_name=self.__applicationName,

--- a/silx/gui/data/ArrayTableModel.py
+++ b/silx/gui/data/ArrayTableModel.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -245,8 +245,7 @@ class ArrayTableModel(qt.QAbstractTableModel):
         if index.isValid() and role == qt.Qt.EditRole:
             try:
                 # cast value to same type as array
-                v = numpy.asscalar(
-                        numpy.array(value, dtype=self._array.dtype))
+                v = numpy.array(value, dtype=self._array.dtype).item()
             except ValueError:
                 return False
 

--- a/silx/gui/data/test/test_textformatter.py
+++ b/silx/gui/data/test/test_textformatter.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -48,7 +48,7 @@ class TestTextFormatter(TestCaseQt):
         self.assertIsNot(formatter, copy)
         copy.setFloatFormat("%.3f")
         self.assertEqual(formatter.integerFormat(), copy.integerFormat())
-        self.assertNotEquals(formatter.floatFormat(), copy.floatFormat())
+        self.assertNotEqual(formatter.floatFormat(), copy.floatFormat())
         self.assertEqual(formatter.useQuoteForText(), copy.useQuoteForText())
         self.assertEqual(formatter.imaginaryUnit(), copy.imaginaryUnit())
 

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -224,7 +224,7 @@ class TestHdf5TreeModel(TestCaseQt):
 
     def testSupportedDrop(self):
         model = hdf5.Hdf5TreeModel()
-        self.assertNotEquals(model.supportedDropActions(), 0)
+        self.assertNotEqual(model.supportedDropActions(), 0)
 
         model.setFileMoveEnabled(False)
         model.setFileDropEnabled(False)
@@ -232,11 +232,11 @@ class TestHdf5TreeModel(TestCaseQt):
 
         model.setFileMoveEnabled(False)
         model.setFileDropEnabled(True)
-        self.assertNotEquals(model.supportedDropActions(), 0)
+        self.assertNotEqual(model.supportedDropActions(), 0)
 
         model.setFileMoveEnabled(True)
         model.setFileDropEnabled(False)
-        self.assertNotEquals(model.supportedDropActions(), 0)
+        self.assertNotEqual(model.supportedDropActions(), 0)
 
     def testCloseFile(self):
         """A file inserted as a filename is open and closed internally."""

--- a/silx/gui/test/test_colors.py
+++ b/silx/gui/test/test_colors.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -445,7 +445,7 @@ class TestRegisteredLut(unittest.TestCase):
     def testLut(self):
         colormap = Colormap("test_8")
         colors = colormap.getNColors(8)
-        self.assertEquals(len(colors), 8)
+        self.assertEqual(len(colors), 8)
 
     def testUint8(self):
         lut = numpy.array([[255, 0, 0], [200, 0, 0], [150, 0, 0]], dtype="uint")

--- a/silx/io/fabioh5.py
+++ b/silx/io/fabioh5.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -474,7 +474,7 @@ class FabioReader(object):
             while len(location) < max_dim:
                 location.append(0)
             normalized_image = numpy.zeros(max_shape, dtype=image.dtype)
-            normalized_image[location] = image
+            normalized_image[tuple(location)] = image
             images[index] = normalized_image
 
         # create a cube

--- a/silx/io/test/test_specfile.py
+++ b/silx/io/test/test_specfile.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -224,14 +224,21 @@ class TestSpecFile(unittest.TestCase):
         with self.assertRaises(specfile.SfErrScanNotFound):
             self.sf.index(99)
 
+    def assertRaisesRegex(self, *args, **kwargs):
+        # Python 2 compatibility
+        if sys.version_info.major >= 3:
+            return super(TestSpecFile, self).assertRaisesRegex(*args, **kwargs)
+        else:
+            return self.assertRaisesRegexp(*args, **kwargs)
+
     def test_getitem(self):
         self.assertIsInstance(self.sf[2], Scan)
         self.assertIsInstance(self.sf["1.2"], Scan)
         # int out of range
-        with self.assertRaisesRegexp(IndexError, 'Scan index must be in ran'):
+        with self.assertRaisesRegex(IndexError, 'Scan index must be in ran'):
             self.sf[107]
         # float indexing not allowed
-        with self.assertRaisesRegexp(TypeError, 'The scan identification k'):
+        with self.assertRaisesRegex(TypeError, 'The scan identification k'):
             self.sf[1.2]
         # non existant scan with "N.M" indexing
         with self.assertRaises(KeyError):

--- a/silx/io/test/test_spech5.py
+++ b/silx/io/test/test_spech5.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -272,6 +272,13 @@ class TestSpecH5(unittest.TestCase):
         self.assertEqual(self.sfh5["25.1/start_time"],
                          u"2015-03-14T03:53:50")
 
+    def assertRaisesRegex(self, *args, **kwargs):
+        # Python 2 compatibility
+        if sys.version_info.major >= 3:
+            return super(TestSpecH5, self).assertRaisesRegex(*args, **kwargs)
+        else:
+            return self.assertRaisesRegexp(*args, **kwargs)
+
     def testDatasetInstanceAttr(self):
         """The SpecH5Dataset objects must implement some dummy attributes
         to improve compatibility with widgets dealing with h5py datasets."""
@@ -279,7 +286,7 @@ class TestSpecH5(unittest.TestCase):
         self.assertIsNone(self.sfh5["1.1"]["measurement"]["MRTSlit UP"].chunks)
 
         # error message must be explicit
-        with self.assertRaisesRegexp(
+        with self.assertRaisesRegex(
                 AttributeError,
                 "SpecH5Dataset has no attribute tOTo"):
             dummy = self.sfh5["/1.1/start_time"].tOTo

--- a/silx/io/test/test_spectoh5.py
+++ b/silx/io/test/test_spectoh5.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -132,7 +132,7 @@ class TestConvertSpecHDF5(unittest.TestCase):
 
     def testTitle(self):
         """Test the value of a dataset"""
-        title12 = self.h5f["/1.2/title"].value
+        title12 = self.h5f["/1.2/title"][()]
         self.assertEqual(title12,
                          u"aaaaaa")
 

--- a/silx/io/test/test_utils.py
+++ b/silx/io/test/test_utils.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,7 @@ import re
 import shutil
 import tempfile
 import unittest
+import sys
 
 from .. import utils
 import silx.io.url
@@ -102,6 +103,13 @@ class TestSave(unittest.TestCase):
             os.unlink(self.npy_fname)
         shutil.rmtree(self.tempdir)
 
+    def assertRegex(self, *args, **kwargs):
+        # Python 2 compatibility
+        if sys.version_info.major >= 3:
+            return super(TestSave, self).assertRegex(*args, **kwargs)
+        else:
+            return self.assertRegexpMatches(*args, **kwargs)
+
     def test_save_csv(self):
         utils.save1D(self.csv_fname, self.x, self.y,
                      xlabel=self.xlab, ylabels=self.ylabs,
@@ -112,7 +120,7 @@ class TestSave(unittest.TestCase):
         actual_csv = csvf.read()
         csvf.close()
 
-        self.assertRegexpMatches(actual_csv, expected_csv)
+        self.assertRegex(actual_csv, expected_csv)
 
     def test_save_npy(self):
         """npy file is saved with numpy.save after building a numpy array
@@ -138,7 +146,7 @@ class TestSave(unittest.TestCase):
         actual_spec = specf.read()
         specf.close()
 
-        self.assertRegexpMatches(actual_spec, expected_spec1)
+        self.assertRegex(actual_spec, expected_spec1)
 
     def test_savespec_file_handle(self):
         """Save SpecFile using savespec(), passing a file handle"""
@@ -158,7 +166,7 @@ class TestSave(unittest.TestCase):
         actual_spec = specf.read()
         specf.close()
 
-        self.assertRegexpMatches(actual_spec, expected_spec2)
+        self.assertRegex(actual_spec, expected_spec2)
 
     def test_save_spec(self):
         """Save SpecFile using save()"""
@@ -168,7 +176,7 @@ class TestSave(unittest.TestCase):
         specf = open(self.spec_fname)
         actual_spec = specf.read()
         specf.close()
-        self.assertRegexpMatches(actual_spec, expected_spec2)
+        self.assertRegex(actual_spec, expected_spec2)
 
     def test_save_csv_no_labels(self):
         """Save csv using save(), with autoheader=True but
@@ -189,7 +197,7 @@ class TestSave(unittest.TestCase):
         csvf = open(self.csv_fname)
         actual_csv = csvf.read()
         csvf.close()
-        self.assertRegexpMatches(actual_csv, expected_csv2)
+        self.assertRegex(actual_csv, expected_csv2)
 
 
 def assert_match_any_string_in_list(test, pattern, list_of_strings):

--- a/silx/math/test/test_HistogramndLut_nominal.py
+++ b/silx/math/test/test_HistogramndLut_nominal.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -112,6 +112,7 @@ class _TestHistogramndLut_nominal(unittest.TestCase):
             def fill_histo(h, v, dim, op=None):
                 idx = [self.other_axes_index]*len(h.shape)
                 idx[dim] = slice(0, None)
+                idx = tuple(idx)
                 if op:
                     h[idx] = op(h[idx], v)
                 else:

--- a/silx/math/test/test_histogramnd_nominal.py
+++ b/silx/math/test/test_histogramnd_nominal.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -113,6 +113,7 @@ class _Test_chistogramnd_nominal(unittest.TestCase):
             def fill_histo(h, v, dim, op=None):
                 idx = [self.other_axes_index]*len(h.shape)
                 idx[dim] = slice(0, None)
+                idx = tuple(idx)
                 if op:
                     h[idx] = op(h[idx], v)
                 else:
@@ -366,9 +367,9 @@ class _Test_chistogramnd_nominal(unittest.TestCase):
 
         sample_2 = self.sample[:]
         if len(sample_2.shape) == 1:
-            idx = [slice(0, None)]
+            idx = (slice(0, None),)
         else:
-            idx = [slice(0, None), self.tested_dim]
+            idx = slice(0, None), self.tested_dim
 
         sample_2[idx] += 2
 
@@ -402,9 +403,9 @@ class _Test_chistogramnd_nominal(unittest.TestCase):
 
         sample_2 = self.sample[:]
         if len(sample_2.shape) == 1:
-            idx = [slice(0, None)]
+            idx = (slice(0, None),)
         else:
-            idx = [slice(0, None), self.tested_dim]
+            idx = slice(0, None), self.tested_dim
 
         sample_2[idx] += 2
 
@@ -443,9 +444,9 @@ class _Test_chistogramnd_nominal(unittest.TestCase):
 
         sample_2 = self.sample[:]
         if len(sample_2.shape) == 1:
-            idx = [slice(0, None)]
+            idx = (slice(0, None),)
         else:
-            idx = [slice(0, None), self.tested_dim]
+            idx = slice(0, None), self.tested_dim
 
         sample_2[idx] += 2
 
@@ -787,9 +788,9 @@ class _Test_Histogramnd_nominal(unittest.TestCase):
 
         sample_2 = self.sample[:]
         if len(sample_2.shape) == 1:
-            idx = [slice(0, None)]
+            idx = (slice(0, None),)
         else:
-            idx = [slice(0, None), self.tested_dim]
+            idx = slice(0, None), self.tested_dim
 
         sample_2[idx] += 2
 
@@ -824,9 +825,9 @@ class _Test_Histogramnd_nominal(unittest.TestCase):
 
         sample_2 = self.sample[:]
         if len(sample_2.shape) == 1:
-            idx = [slice(0, None)]
+            idx = (slice(0, None),)
         else:
-            idx = [slice(0, None), self.tested_dim]
+            idx = slice(0, None), self.tested_dim
 
         sample_2[idx] += 2
 
@@ -863,9 +864,9 @@ class _Test_Histogramnd_nominal(unittest.TestCase):
 
         sample_2 = self.sample[:]
         if len(sample_2.shape) == 1:
-            idx = [slice(0, None)]
+            idx = (slice(0, None),)
         else:
-            idx = [slice(0, None), self.tested_dim]
+            idx = slice(0, None), self.tested_dim
 
         sample_2[idx] += 2
 

--- a/silx/utils/test/test_weakref.py
+++ b/silx/utils/test/test_weakref.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -304,10 +304,10 @@ class TestWeakList(unittest.TestCase):
         self.assertEqual(len(new_list), 1)
 
     def testStr(self):
-        self.assertNotEquals(self.list.__str__(), "[]")
+        self.assertNotEqual(self.list.__str__(), "[]")
 
     def testRepr(self):
-        self.assertNotEquals(self.list.__repr__(), "[]")
+        self.assertNotEqual(self.list.__repr__(), "[]")
 
     def testSort(self):
         # only a coverage


### PR DESCRIPTION
This PR aims at avoiding (most if not all) deprecation warnings from our dependencies during the tests.
Check commit messages for the issue that it fixes.

related to #2609