### PR TITLE
Silent/avoid irrelevant RuntimeWarning

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -46,6 +46,7 @@ except ImportError:  # Python2 support
 from contextlib import contextmanager
 import datetime as dt
 import itertools
+import warnings
 
 import numpy
 
@@ -543,16 +544,25 @@ class PlotWidget(qt.QMainWindow):
             if item.isVisible():
                 bounds = item.getBounds()
                 if bounds is not None:
-                    xMin = numpy.nanmin([xMin, bounds[0]])
-                    xMax = numpy.nanmax([xMax, bounds[1]])
+                    with warnings.catch_warnings():
+                        warnings.simplefilter('ignore', category=RuntimeWarning)
+                        # Ignore All-NaN slice encountered
+                        xMin = numpy.nanmin([xMin, bounds[0]])
+                        xMax = numpy.nanmax([xMax, bounds[1]])
                     # Take care of right axis
                     if (isinstance(item, items.YAxisMixIn) and
                             item.getYAxis() == 'right'):
-                        yMinRight = numpy.nanmin([yMinRight, bounds[2]])
-                        yMaxRight = numpy.nanmax([yMaxRight, bounds[3]])
+                        with warnings.catch_warnings():
+                            warnings.simplefilter('ignore', category=RuntimeWarning)
+                            # Ignore All-NaN slice encountered
+                            yMinRight = numpy.nanmin([yMinRight, bounds[2]])
+                            yMaxRight = numpy.nanmax([yMaxRight, bounds[3]])
                     else:
-                        yMinLeft = numpy.nanmin([yMinLeft, bounds[2]])
-                        yMaxLeft = numpy.nanmax([yMaxLeft, bounds[3]])
+                        with warnings.catch_warnings():
+                            warnings.simplefilter('ignore', category=RuntimeWarning)
+                            # Ignore All-NaN slice encountered
+                            yMinLeft = numpy.nanmin([yMinLeft, bounds[2]])
+                            yMaxLeft = numpy.nanmax([yMaxLeft, bounds[3]])
 
         def lGetRange(x, y):
             return None if numpy.isnan(x) and numpy.isnan(y) else (x, y)

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -32,6 +32,7 @@ __date__ = "21/12/2018"
 
 from collections import OrderedDict, namedtuple
 import logging
+import warnings
 import weakref
 
 import numpy
@@ -884,7 +885,10 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                     xErrorMinus, xErrorPlus = xerror[0], xerror[1]
                 else:
                     xErrorMinus, xErrorPlus = xerror, xerror
-                xErrorMinus = logX - numpy.log10(x - xErrorMinus)
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore', category=RuntimeWarning)
+                    # Ignore divide by zero, invalid value encountered in log10
+                    xErrorMinus = logX - numpy.log10(x - xErrorMinus)
                 xErrorPlus = numpy.log10(x + xErrorPlus) - logX
                 xerror = numpy.array((xErrorMinus, xErrorPlus),
                                      dtype=numpy.float32)
@@ -904,7 +908,10 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                     yErrorMinus, yErrorPlus = yerror[0], yerror[1]
                 else:
                     yErrorMinus, yErrorPlus = yerror, yerror
-                yErrorMinus = logY - numpy.log10(y - yErrorMinus)
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore', category=RuntimeWarning)
+                    # Ignore divide by zero, invalid value encountered in log10
+                    yErrorMinus = logY - numpy.log10(y - yErrorMinus)
                 yErrorPlus = numpy.log10(y + yErrorPlus) - logY
                 yerror = numpy.array((yErrorMinus, yErrorPlus),
                                      dtype=numpy.float32)

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -1088,12 +1088,15 @@ class PointsBase(Item, SymbolMixIn, AlphaMixIn):
             else:
                 x, y, _xerror, _yerror = data
 
-            self._boundsCache[(xPositive, yPositive)] = (
-                numpy.nanmin(x),
-                numpy.nanmax(x),
-                numpy.nanmin(y),
-                numpy.nanmax(y)
-            )
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', category=RuntimeWarning)
+                # Ignore All-NaN slice encountered
+                self._boundsCache[(xPositive, yPositive)] = (
+                    numpy.nanmin(x),
+                    numpy.nanmax(x),
+                    numpy.nanmin(y),
+                    numpy.nanmax(y)
+                )
         return self._boundsCache[(xPositive, yPositive)]
 
     def _getCachedData(self):

--- a/silx/math/test/test_colormap.py
+++ b/silx/math/test/test_colormap.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -34,6 +34,7 @@ __date__ = "16/05/2018"
 import logging
 import sys
 import unittest
+import warnings
 
 import numpy
 
@@ -66,7 +67,10 @@ class TestColormap(ParametricTestCase):
                           'sqrt': numpy.sqrt}
 
         norm_function = norm_functions[normalization]
-        norm_data, vmin, vmax = map(norm_function, (data, vmin, vmax))
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=RuntimeWarning)
+            # Ignore divide by zero and invalid value encountered in log10, sqrt
+            norm_data, vmin, vmax = map(norm_function, (data, vmin, vmax))
 
         if normalization == 'arcsinh' and sys.platform == 'win32':
             # There is a difference of behavior of numpy.arcsinh

--- a/silx/math/test/test_combo.py
+++ b/silx/math/test/test_combo.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -31,6 +31,7 @@ __date__ = "17/01/2018"
 
 
 import unittest
+import warnings
 
 import numpy
 
@@ -73,22 +74,24 @@ class TestMinMax(ParametricTestCase):
             filtered_data = data
 
         if filtered_data.size > 0:
-            minimum = numpy.nanmin(filtered_data)
-            if numpy.isnan(minimum):
+            if numpy.all(numpy.isnan(filtered_data)):
+                minimum = numpy.nan
                 argmin = 0
-            else:
-                # nanargmin equivalent
-                argmin = numpy.where(data == minimum)[0][0]
-
-            maximum = numpy.nanmax(filtered_data)
-            if numpy.isnan(maximum):
+                maximum = numpy.nan
                 argmax = 0
             else:
+                minimum = numpy.nanmin(filtered_data)
+                # nanargmin equivalent
+                argmin = numpy.where(data == minimum)[0][0]
+                maximum = numpy.nanmax(filtered_data)
                 # nanargmax equivalent
                 argmax = numpy.where(data == maximum)[0][0]
 
             if min_positive:
-                pos_data = filtered_data[filtered_data > 0]
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore', category=RuntimeWarning)
+                    # Ignore invalid value encountered in greater
+                    pos_data = filtered_data[filtered_data > 0]
                 if pos_data.size > 0:
                     min_pos = numpy.min(pos_data)
                     argmin_pos = numpy.where(data == min_pos)[0][0]


### PR DESCRIPTION
This PR avoids some (not all) `numpy` `RuntimeWarning` related to NaNs or divide by zero, while those cases are acceptable in the condition they are used.

related to #2609