### PR TITLE
[plot] Add option to provide an alpha image in plot image item

### DIFF
--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -273,7 +273,7 @@ class ImageData(ImageBase, ColormapMixIn):
             return None
 
         if (self.getAlternativeImageData(copy=False) is not None or
-                self.getAlphaImage(copy=False) is not None):
+                self.getAlphaData(copy=False) is not None):
             dataToUse = self.getRgbaImageData(copy=False)
         else:
             dataToUse = self.getData(copy=False)
@@ -315,7 +315,7 @@ class ImageData(ImageBase, ColormapMixIn):
             # Apply colormap, in this case an new array is always returned
             colormap = self.getColormap()
             image = colormap.applyToData(self.getData(copy=False))
-            alphaImage = self.getAlphaImage(copy=False)
+            alphaImage = self.getAlphaData(copy=False)
             if alphaImage is not None:
                 # Apply transparency
                 image[:, :, 3] = image[:, :, 3] * alphaImage

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -378,7 +378,8 @@ class ImageData(ImageBase, ColormapMixIn):
         self._alternativeImage = alternative
 
         if alpha is not None:
-            alpha = numpy.array(alpha, copy=copy)
+            alpha = numpy.array(alpha, copy=False, dtype=numpy.float32)
+            alpha = numpy.clip(alpha, 0, 1)  # This makes a copy
             assert alpha.shape == data.shape
         self._alphaImage = alpha
 

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -386,6 +386,16 @@ class TestPlotImage(PlotWidgetTestCase, ParametricTestCase):
         self.assertTrue(numpy.all(numpy.equal(retrievedData, data)))
         self.assertIs(retrievedData.dtype.type, numpy.int8)
 
+    def testPlotAlphaImage(self):
+        """Test with an alpha image layer"""
+        data = numpy.random.random((10, 10))
+        alpha = numpy.linspace(0, 1, 100).reshape(10, 10)
+        self.plot.addImage(data, legend='image')
+        image = self.plot.getActiveImage()
+        image.setData(data, alpha=alpha)
+        self.qapp.processEvents()
+        self.assertTrue(numpy.array_equal(alpha, image.getAlphaData()))
+
 
 class TestPlotCurve(PlotWidgetTestCase):
     """Basic tests for addCurve."""


### PR DESCRIPTION
This PR adds the option to provide an alpha image to plot `Image` items.
This is available through `Image.setData`.

Sample code:
```

import numpy
from silx import sx

data = numpy.random.random((10, 10))
alpha = numpy.linspace(0, 1, 100).reshape(10, 10)

plot = sx.Plot2D()
plot.addImage([()], legend='image')  # Create an empty image
image = plot.getActiveImage()
image.setData(data, alpha=alpha) # Fill the image with data and transparency

plot.resetZoom()
plot.show()
app.exec_()
```

closes #2620 
