### PR TITLE
[OpenCL] CSR utilities

### DIFF
--- a/silx/opencl/sparse.py
+++ b/silx/opencl/sparse.py
@@ -139,7 +139,13 @@ class CSR(OpenclProcessing):
             self.kernel_files,
             compile_options=["-DIMAGE_WIDTH=%d" % self.shape[1]]
         )
-        self._decomp_wg = (32, 1) # TODO tune
+        device = self.ctx.devices[0]
+        wg_x = min(
+            device.max_work_group_size,
+            32,
+            self.kernels.max_workgroup_size("densify_csr")
+        )
+        self._decomp_wg = (wg_x, 1)
         self._decomp_grid = (self._decomp_wg[0], self.shape[0])
 
 

--- a/silx/opencl/sparse.py
+++ b/silx/opencl/sparse.py
@@ -99,6 +99,7 @@ class CSR(OpenclProcessing):
         self.allocate_buffers(use_array=True)
         for arr_name in ["array", "data", "indices", "indptr"]:
             setattr(self, arr_name, self.cl_mem[arr_name])
+            self.cl_mem[arr_name].fill(0) # allocate_buffers() uses empty()
         self._old_array = self.array
         self._old_data = self.data
         self._old_indices = self.indices
@@ -309,7 +310,4 @@ class CSR(OpenclProcessing):
         res = self.get_array(output)
         self._recover_arrays_references()
         return res
-
-
-
 

--- a/silx/opencl/test/__init__.py
+++ b/silx/opencl/test/__init__.py
@@ -39,6 +39,7 @@ from . import test_image
 from . import test_kahan
 from . import test_stats
 from . import test_convolution
+from . import test_sparse
 
 
 def suite():
@@ -54,6 +55,7 @@ def suite():
     test_suite.addTests(test_kahan.suite())
     test_suite.addTests(test_stats.suite())
     test_suite.addTests(test_convolution.suite())
+    test_suite.addTests(test_sparse.suite())
     # Allow to remove sift from the project
     test_base_dir = os.path.dirname(__file__)
     sift_dir = os.path.join(test_base_dir, "..", "sift")

--- a/silx/opencl/test/test_sparse.py
+++ b/silx/opencl/test/test_sparse.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2018-2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Test of the sparse module"""
+
+import numpy as np
+import unittest
+import logging
+from silx.opencl.sparse import CSR
+from ..common import ocl
+try:
+    import scipy.sparse as sp
+except ImportError:
+    sp = None
+logger = logging.getLogger(__name__)
+
+
+
+def generate_sparse_random_data(
+    shape=(1000,),
+    data_min=0, data_max=100,
+    density=0.1,
+    use_only_integers=True,
+    dtype="f"):
+    """
+    Generate random sparse data where.
+
+    Parameters
+    ------------
+    shape: tuple
+        Output data shape.
+    data_min: int or float
+        Minimum value of data
+    data_max: int or float
+        Maximum value of data
+    density: float
+        Density of non-zero elements in the output data.
+        Low value of density mean low number of non-zero elements.
+    use_only_integers: bool
+        If set to True, the output data items will be primarily integers,
+        possibly casted to float if dtype is a floating-point type.
+        This can be used for ease of debugging.
+    dtype: str or numpy.dtype
+        Output data type
+    """
+    mask = np.random.binomial(1, density, size=shape)
+    if use_only_integers:
+        d = np.random.randint(data_min, high=data_max, size=shape)
+    else:
+        d = data_min + (data_max - data_min) * np.random.rand(*shape)
+    return (d * mask).astype(dtype)
+
+
+
+@unittest.skipUnless(ocl and sp, "PyOpenCl/scipy is missing")
+class TestCSR(unittest.TestCase):
+    """Test CSR format"""
+
+    def setUp(self):
+        self.tol = 1e-7
+        self.array = generate_sparse_random_data(shape=(512, 511))
+
+
+    def test_sparsification(self):
+        csr = CSR(self.array.shape)
+        csr.sparsify(self.array)
+
+
+        array_sparse = sp.csr_matrix(self.array)
+
+        #
+        data = csr.data.get()
+        indices = csr.indices.get()
+        indptr = csr.indptr.get()
+        #
+
+
+        # test "data"
+        nnz = array_sparse.nnz
+        import matplotlib.pyplot as plt
+        plt.figure()
+        plt.plot(data[:nnz] - array_sparse.data)
+        plt.show()
+        plt.figure()
+        plt.plot(indices[:nnz] - array_sparse.indices)
+        plt.show()
+        #
+
+        self.assertTrue(True)
+
+
+
+
+def suite():
+    suite = unittest.TestSuite()
+    suite.addTest(
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestCSR)
+    )
+    return suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest="suite")
+
+

--- a/silx/opencl/test/test_sparse.py
+++ b/silx/opencl/test/test_sparse.py
@@ -31,8 +31,10 @@ import logging
 from itertools import product
 from silx.opencl.sparse import CSR
 from ..common import ocl
-if ocl:
+try:
     import pyopencl.array as parray
+except ImportError:
+    ocl = None
 try:
     import scipy.sparse as sp
 except ImportError:

--- a/silx/opencl/test/test_sparse.py
+++ b/silx/opencl/test/test_sparse.py
@@ -79,37 +79,30 @@ class TestCSR(unittest.TestCase):
     """Test CSR format"""
 
     def setUp(self):
-        self.tol = 1e-7
         self.array = generate_sparse_random_data(shape=(512, 511))
 
 
     def test_sparsification(self):
+        # Sparsify on device
         csr = CSR(self.array.shape)
-        csr.sparsify(self.array)
-
-
-        array_sparse = sp.csr_matrix(self.array)
-
-        #
-        data = csr.data.get()
-        indices = csr.indices.get()
-        indptr = csr.indptr.get()
-        #
-
-
-        # test "data"
-        nnz = array_sparse.nnz
-        import matplotlib.pyplot as plt
-        plt.figure()
-        plt.plot(data[:nnz] - array_sparse.data)
-        plt.show()
-        plt.figure()
-        plt.plot(indices[:nnz] - array_sparse.indices)
-        plt.show()
-        #
-
-        self.assertTrue(True)
-
+        data, ind, indptr = csr.sparsify(self.array)
+        # Compute reference sparsification
+        a_s = sp.csr_matrix(self.array)
+        data_ref, ind_ref, indptr_ref = a_s.data, a_s.indices, a_s.indptr
+        # Compare
+        nnz = a_s.nnz
+        self.assertTrue(
+            np.allclose(data[:nnz], data_ref),
+            "something wrong with sparsified data"
+        )
+        self.assertTrue(
+            np.allclose(ind[:nnz], ind_ref),
+            "something wrong with sparsified indices"
+        )
+        self.assertTrue(
+            np.allclose(indptr, indptr_ref),
+            "something wrong with sparsified indices pointers (indptr)"
+        )
 
 
 

--- a/silx/opencl/test/test_sparse.py
+++ b/silx/opencl/test/test_sparse.py
@@ -29,12 +29,10 @@ import numpy as np
 import unittest
 import logging
 from itertools import product
-from silx.opencl.sparse import CSR
 from ..common import ocl
-try:
+if ocl:
     import pyopencl.array as parray
-except ImportError:
-    ocl = None
+    from silx.opencl.sparse import CSR
 try:
     import scipy.sparse as sp
 except ImportError:

--- a/silx/resources/opencl/sparse.cl
+++ b/silx/resources/opencl/sparse.cl
@@ -1,3 +1,48 @@
+/*
+ *   Copyright (C) 2016-2019 European Synchrotron Radiation Facility
+ *                           Grenoble, France
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef IMAGE_WIDTH
+  #error "Please define IMAGE_WIDTH parameter
+#endif
+#ifndef
+
+/**
+ * Densify a matric from CSR format to "dense" 2D format.
+ * The input CSR data consists in 3 arrays: (data, ind, iptr).
+ * The output array is a 2D array of dimensions IMAGE_WIDTH * image_height.
+ *
+ * data: 1D array containing the nonzero data items.
+ * ind: 1D array containing the column indices of the nonzero data items.
+ * iptr: 1D array containing indirection indices, such that range
+ *    [iptr[i], iptr[i+1]-1] of "data" and "ind" contain the relevant data
+ *    of output row "i".
+ * output: 2D array containing the densified data.
+ * image_height: height (number of rows) of the output data.
+**/
+
 kernel void densify_csr(
     const global float* data,
     const global int* ind,

--- a/silx/resources/opencl/sparse.cl
+++ b/silx/resources/opencl/sparse.cl
@@ -25,7 +25,7 @@
  */
 
 #ifndef IMAGE_WIDTH
-  #error "Please define IMAGE_WIDTH parameter
+  #error "Please define IMAGE_WIDTH parameter"
 #endif
 
 /**

--- a/silx/resources/opencl/sparse.cl
+++ b/silx/resources/opencl/sparse.cl
@@ -27,7 +27,6 @@
 #ifndef IMAGE_WIDTH
   #error "Please define IMAGE_WIDTH parameter
 #endif
-#ifndef
 
 /**
  * Densify a matric from CSR format to "dense" 2D format.

--- a/silx/resources/opencl/sparse.cl
+++ b/silx/resources/opencl/sparse.cl
@@ -1,0 +1,40 @@
+kernel void densify_csr(
+    const global float* data,
+    const global int* ind,
+    const global int* iptr,
+    global float* output,
+    int image_height
+)
+{
+    uint tid = get_local_id(0);
+    uint row_idx = get_global_id(1);
+    if ((tid >= IMAGE_WIDTH) || (row_idx >= image_height)) return;
+
+    local float line[IMAGE_WIDTH];
+
+    // Memset
+    //~ #pragma unroll
+    for (int k = 0; tid+k < IMAGE_WIDTH; k += get_local_size(0)) {
+        if (tid+k >= IMAGE_WIDTH) break;
+        line[tid+k] = 0.0f;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+
+    uint start = iptr[row_idx], end = iptr[row_idx+1];
+    //~ #pragma unroll
+    for (int k = start; k < end; k += get_local_size(0)) {
+        // Current work group handles one line of the final array
+        // on the current line, write data[start+tid] at column index ind[start+tid]
+        if (k+tid < end)
+            line[ind[k+tid]] = data[k+tid];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    // write the current line (shared mem) into the output array (global mem)
+    //~ #pragma unroll
+    for (int k = 0; tid+k < IMAGE_WIDTH; k += get_local_size(0)) {
+        output[row_idx*IMAGE_WIDTH + tid+k] = line[tid+k];
+        if (k+tid >= IMAGE_WIDTH) return;
+    }
+}


### PR DESCRIPTION
This PR aims at bringing sparse matrix compaction/decompaction in the Compressed Sparse Row (CSR) format with OpenCL.

Work in progress:
- [x] CSR compaction ("dense" array -> sparse array)
- [x] CSR decompaction (sparse array -> dense array)

Questions:
  - Do we implement generic matrix-vector, matrix-matrix in this processing ?
  - Do we include more specialized code (ex. decompaction of `op(csr1, csr2)` where `op` is an elementwise operation) ?