### PR TITLE
Uses a more precise value to ensure warning is raised

### DIFF
--- a/silx/utils/test/test_number.py
+++ b/silx/utils/test/test_number.py
@@ -148,7 +148,8 @@ class TestConversionTypes(testutils.ParametricTestCase):
         self.skipIfFloat80NotSupported()
         if pkg_resources.parse_version(numpy.version.version) <= pkg_resources.parse_version("1.10.4"):
             self.skipTest("numpy > 1.10.4 expected")
-        value = "1000000000.00001013332"
+        # value does not fit even in a 128 bits mantissa
+        value = "1.0340282366920938463463374607431768211456"
         func = testutils.test_logging(number._logger.name, warning=1)
         func = func(number.min_numerical_convertible_type)
         dtype = func(value)


### PR DESCRIPTION
This PR uses a value to test conversion that does not fit even in a 128 bits mantissa to make sure the warning is raised with any kind of `float128` dtype (which is not necessarily a padded 80 bits float depending on the platform e.g., ppc64, arm64).


closes #2606