### PR TITLE
[plot3d] Improve reset zoom with 2D (and 1D) data sets

### DIFF
--- a/silx/gui/plot3d/scene/camera.py
+++ b/silx/gui/plot3d/scene/camera.py
@@ -292,6 +292,8 @@ class Camera(transform.Transform):
 
         center = 0.5 * (bounds[0] + bounds[1])
         radius = numpy.linalg.norm(0.5 * (bounds[1] - bounds[0]))
+        if radius == 0.:  # bounds are all collapsed
+            radius = 1.
 
         if isinstance(self.intrinsic, transform.Perspective):
             # Get the viewpoint distance from the bounds center

--- a/silx/gui/plot3d/scene/viewport.py
+++ b/silx/gui/plot3d/scene/viewport.py
@@ -413,15 +413,9 @@ class Viewport(event.Notifier):
         Camera sight direction and up are not affected.
         """
         bounds = self.scene.bounds(transformed=True)
-        if bounds is None or numpy.all(numpy.equal(bounds, bounds[0, 0])):
+        if bounds is None:
             bounds = numpy.array(((0., 0., 0.), (1., 1., 1.)),
                                  dtype=numpy.float32)
-        elif numpy.any(numpy.diff(bounds, axis=0) == 0):
-            # At least on dimension is collapsed, use [0, 1]
-            for index in range(3):
-                if bounds[0, index] == bounds[1, index]:
-                    bounds[:, index] = 0., 1.
-
         self.camera.resetCamera(bounds)
 
     def orbitCamera(self, direction, angle=1.):


### PR DESCRIPTION
This PR improves the handling of reset zoom when one or more dimension is null.