### PR TITLE
GenericScanKernel: use pyopencl.sparse instead of pyopencl.algorithm

### DIFF
--- a/silx/opencl/sparse.py
+++ b/silx/opencl/sparse.py
@@ -34,7 +34,7 @@ __date__ = "07/06/2019"
 import numpy
 import pyopencl.array as parray
 from collections import namedtuple
-from pyopencl.algorithm import GenericScanKernel
+from pyopencl.scan import GenericScanKernel
 from .common import pyopencl as cl
 from .processing import OpenclProcessing, EventDescription, BufferDescription
 mf = cl.mem_flags


### PR DESCRIPTION
Fix import error on old versions of pyopencl.