### PR TITLE
PlotWidget: fix valuerror formating

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -344,7 +344,7 @@ class PlotWidget(qt.QMainWindow):
                 except ImportError:
                     pass
             else:  # No backend was found
-                raise ValueError("No backends supported: " % str(backend))
+                raise ValueError("No supported backend was found")
 
         raise ValueError("Backend not supported %s" % str(backend))
 


### PR DESCRIPTION
Fix "not all items were formated" error in PlotWidget when no supported backend was found.