### PR TITLE
Defensive code for ROI QAction signal handling

### DIFF
--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -173,7 +173,8 @@ class RegionOfInterestManager(qt.QObject):
             self.start(roiClass)
         else:  # Keep action checked
             action = self.sender()
-            action.setChecked(True)
+            if isinstance(action, qt.QAction):
+                action.setChecked(True)
 
     def _updateModeActions(self):
         """Check/Uncheck action corresponding to current mode"""


### PR DESCRIPTION
This PR makes sure we are handling a signal from a QAction when dealing with ROI action.

Related to #2655 (might be closing it).