### PR TITLE
[plot] Fix ROI actions unchecking with PySide2

### DIFF
--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -106,6 +106,9 @@ class RegionOfInterestManager(qt.QObject):
         self._rois = []  # List of ROIs
         self._drawnROI = None  # New ROI being currently drawn
 
+        # Handle unique selection of interaction mode action
+        self._actionGroup = qt.QActionGroup(self)
+
         self._roiClass = None
         self._color = rgba('red')
 
@@ -158,6 +161,8 @@ class RegionOfInterestManager(qt.QObject):
             action.setChecked(self.getCurrentInteractionModeRoiClass() is roiClass)
             action.setToolTip(text)
 
+            self._actionGroup.addAction(action)
+
             action.triggered[bool].connect(functools.partial(
                 WeakMethodProxy(self._modeActionTriggered), roiClass=roiClass))
             self._modeActions[roiClass] = action
@@ -171,10 +176,6 @@ class RegionOfInterestManager(qt.QObject):
         """
         if checked:
             self.start(roiClass)
-        else:  # Keep action checked
-            action = self.sender()
-            if isinstance(action, qt.QAction):
-                action.setChecked(True)
 
     def _updateModeActions(self):
         """Check/Uncheck action corresponding to current mode"""


### PR DESCRIPTION
This PR uses a `QActionGroup` to handle ROI drawing mode action selection.
This is a better implementation and it avoids an issue with PySide2.
More refactoring can probably be done to base the access to actions and roiClass on the `QActionGroup`.

I leave you the decision of taking it into 0.11 or not.

closes #2655