### PR TITLE
Fix issue reopening FitWidget after dismiss (issue #2664)

### DIFF
--- a/silx/gui/plot/actions/PlotToolAction.py
+++ b/silx/gui/plot/actions/PlotToolAction.py
@@ -125,7 +125,8 @@ class PlotToolAction(PlotAction):
             if self._toolWindow is not None:
                 window = self._toolWindow()
                 self._previousGeometry = window.geometry()
-                window.hide()
+                window.deleteLater()
+                self._toolWindow = None
             self.setChecked(False)
 
         return PlotAction.eventFilter(self, qobject, event)


### PR DESCRIPTION
Dear silx team,

Please refer to issue #2664

If FitWidget is closed with the dismiss button, nothing is displayed on the screen the next time you open it again. The problem seems to be solved by using the method of deleting and re-creating the window.

