### PR TITLE
Testing if pyopencl can be used on the machine after importation

### DIFF
--- a/silx/opencl/common.py
+++ b/silx/opencl/common.py
@@ -56,6 +56,15 @@ if os.environ.get("SILX_OPENCL") in ["0", "False"]:
 else:
     try:
         import pyopencl
+        if pyopencl:
+            try:
+                pyopencl.get_platforms()
+            except pyopen._cl.LogicError:
+                logger.warning("The module pyopenCL has been imported but can't be used here")
+                pyopencl = None
+            else:
+                pass
+
     except ImportError:
         logger.warning("Unable to import pyOpenCl. Please install it from: http://pypi.python.org/pypi/pyopencl")
         pyopencl = None

--- a/silx/opencl/common.py
+++ b/silx/opencl/common.py
@@ -56,21 +56,18 @@ if os.environ.get("SILX_OPENCL") in ["0", "False"]:
 else:
     try:
         import pyopencl
-        if pyopencl:
-            try:
-                pyopencl.get_platforms()
-            except pyopen._cl.LogicError:
-                logger.warning("The module pyopenCL has been imported but can't be used here")
-                pyopencl = None
-            else:
-                pass
-
     except ImportError:
         logger.warning("Unable to import pyOpenCl. Please install it from: http://pypi.python.org/pypi/pyopencl")
         pyopencl = None
     else:
-        import pyopencl.array as array
-        mf = pyopencl.mem_flags
+        try:
+            pyopencl.get_platforms()
+        except pyopencl.LogicError:
+            logger.warning("The module pyOpenCL has been imported but can't be used here")
+            pyopencl = None
+        else:
+            import pyopencl.array as array
+            mf = pyopencl.mem_flags
 
 if pyopencl is None:
     # Define default mem flags


### PR DESCRIPTION
Hello,

I am trying to deal with the issue number #1272 of silx-kit/pyFAI.
We get this : 

```LogicError: clGetPlatformIDs failed: PLATFORM_NOT_FOUND_KHR```

when using pyopencl even if  it is not possible to use it.
Thus I tried to fix this issue with a test being ran just after the importation of pyopencl.
Tell me what you think about it.

Cheers,

Alex