### PR TITLE
[Opencl] CSR: add support for data types other than float32

### DIFF
--- a/silx/opencl/sparse.py
+++ b/silx/opencl/sparse.py
@@ -224,8 +224,8 @@ class CSR(OpenclProcessing):
         assert isinstance(csr_data, CSRData)
         for arr in [csr_data.data, csr_data.indices, csr_data.indptr]:
             assert arr.ndim == 1
-        assert csr_data.data.size == self.max_nnz
-        assert csr_data.indices.size == self.max_nnz
+        assert csr_data.data.size <= self.max_nnz
+        assert csr_data.indices.size <= self.max_nnz
         assert csr_data.indptr.size == self.shape[0]+1
         assert csr_data.data.dtype == self.dtype
         assert csr_data.indices.dtype == self.indice_dtype
@@ -263,7 +263,7 @@ class CSR(OpenclProcessing):
                 setattr(self, name, arr)
             # The current array is a numpy.ndarray: copy H2D
             elif isinstance(arr, numpy.ndarray):
-                getattr(self, name)[:] = arr[:]
+                getattr(self, name)[:arr.size] = arr[:]
             else:
                 raise ValueError("Unsupported array type: %s" % type(arr))
 

--- a/silx/opencl/test/test_sparse.py
+++ b/silx/opencl/test/test_sparse.py
@@ -82,35 +82,38 @@ class TestCSR(unittest.TestCase):
     """Test CSR format"""
 
     def setUp(self):
-        self.array = generate_sparse_random_data(shape=(512, 511))
-        # Compute reference sparsification
-        a_s = sp.csr_matrix(self.array)
-        self.ref_data = a_s.data
-        self.ref_indices = a_s.indices
-        self.ref_indptr = a_s.indptr
-        self.ref_nnz = a_s.nnz
         # Test possible configurations
         input_on_device = [False, True]
         output_on_device = [False, True]
-        self._test_configs = list(product(input_on_device, output_on_device))
+        dtypes = [np.float32, np.int32, np.uint16]
+        self._test_configs = list(product(input_on_device, output_on_device, dtypes))
+
+
+    def compute_ref_sparsification(self, array):
+        ref_sparse = sp.csr_matrix(array)
+        return ref_sparse
 
 
     def test_sparsification(self):
-        for input_on_device, output_on_device in self._test_configs:
-            self._test_sparsification(input_on_device, output_on_device)
+        for input_on_device, output_on_device, dtype in self._test_configs:
+            self._test_sparsification(input_on_device, output_on_device, dtype)
 
 
-    def _test_sparsification(self, input_on_device, output_on_device):
-        current_config = "input on device: %s, output on device: %s" % (
-            str(input_on_device), str(output_on_device)
+    def _test_sparsification(self, input_on_device, output_on_device, dtype):
+        current_config = "input on device: %s, output on device: %s, dtype: %s" % (
+            str(input_on_device), str(output_on_device), str(dtype)
         )
+        logger.debug("CSR: %s" % current_config)
+        # Generate data and reference CSR
+        array = generate_sparse_random_data(shape=(512, 511), dtype=dtype)
+        ref_sparse = self.compute_ref_sparsification(array)
         # Sparsify on device
-        csr = CSR(self.array.shape)
+        csr = CSR(array.shape, dtype=dtype)
         if input_on_device:
             # The array has to be flattened
-            arr = parray.to_device(csr.queue, self.array.ravel())
+            arr = parray.to_device(csr.queue, array.ravel())
         else:
-            arr = self.array
+            arr = array
         if output_on_device:
             d_data = parray.zeros_like(csr.data)
             d_indices = parray.zeros_like(csr.indices)
@@ -124,43 +127,47 @@ class TestCSR(unittest.TestCase):
             indices = indices.get()
             indptr = indptr.get()
         # Compare
-        nnz = self.ref_nnz
+        nnz = ref_sparse.nnz
         self.assertTrue(
-            np.allclose(data[:nnz], self.ref_data),
+            np.allclose(data[:nnz], ref_sparse.data),
             "something wrong with sparsified data (%s)"
             % current_config
         )
         self.assertTrue(
-            np.allclose(indices[:nnz], self.ref_indices),
+            np.allclose(indices[:nnz], ref_sparse.indices),
             "something wrong with sparsified indices (%s)"
             % current_config
         )
         self.assertTrue(
-            np.allclose(indptr, self.ref_indptr),
+            np.allclose(indptr, ref_sparse.indptr),
             "something wrong with sparsified indices pointers (indptr) (%s)"
             % current_config
         )
 
 
     def test_desparsification(self):
-        for input_on_device, output_on_device in self._test_configs:
-            self._test_desparsification(input_on_device, output_on_device)
+        for input_on_device, output_on_device, dtype in self._test_configs:
+            self._test_desparsification(input_on_device, output_on_device, dtype)
 
 
-    def _test_desparsification(self, input_on_device, output_on_device):
-        current_config = "input on device: %s, output on device: %s" % (
-            str(input_on_device), str(output_on_device)
+    def _test_desparsification(self, input_on_device, output_on_device, dtype):
+        current_config = "input on device: %s, output on device: %s, dtype: %s" % (
+            str(input_on_device), str(output_on_device), str(dtype)
         )
+        logger.debug("CSR: %s" % current_config)
+        # Generate data and reference CSR
+        array = generate_sparse_random_data(shape=(512, 511), dtype=dtype)
+        ref_sparse = self.compute_ref_sparsification(array)
         # De-sparsify on device
-        csr = CSR(self.array.shape, max_nnz=self.ref_nnz)
+        csr = CSR(array.shape, dtype=dtype, max_nnz=ref_sparse.nnz)
         if input_on_device:
-            data = parray.to_device(csr.queue, self.ref_data)
-            indices = parray.to_device(csr.queue, self.ref_indices)
-            indptr = parray.to_device(csr.queue, self.ref_indptr)
+            data = parray.to_device(csr.queue, ref_sparse.data)
+            indices = parray.to_device(csr.queue, ref_sparse.indices)
+            indptr = parray.to_device(csr.queue, ref_sparse.indptr)
         else:
-            data = self.ref_data
-            indices = self.ref_indices
-            indptr = self.ref_indptr
+            data = ref_sparse.data
+            indices = ref_sparse.indices
+            indptr = ref_sparse.indptr
         if output_on_device:
             d_arr = parray.zeros_like(csr.array)
             output = d_arr
@@ -171,7 +178,7 @@ class TestCSR(unittest.TestCase):
             arr = arr.get()
         # Compare
         self.assertTrue(
-            np.allclose(arr.reshape(self.array.shape), self.array),
+            np.allclose(arr.reshape(array.shape), array),
             "something wrong with densified data (%s)"
             % current_config
         )

--- a/silx/resources/opencl/sparse.cl
+++ b/silx/resources/opencl/sparse.cl
@@ -28,6 +28,16 @@
   #error "Please define IMAGE_WIDTH parameter"
 #endif
 
+#ifndef DTYPE
+  #error "Please define DTYPE parameter"
+#endif
+
+#ifndef IDX_DTYPE
+  #error "Please define IDX_DTYPE parameter"
+#endif
+
+
+
 /**
  * Densify a matric from CSR format to "dense" 2D format.
  * The input CSR data consists in 3 arrays: (data, ind, iptr).
@@ -43,10 +53,10 @@
 **/
 
 kernel void densify_csr(
-    const global float* data,
-    const global int* ind,
-    const global int* iptr,
-    global float* output,
+    const global DTYPE* data,
+    const global IDX_DTYPE* ind,
+    const global IDX_DTYPE* iptr,
+    global DTYPE* output,
     int image_height
 )
 {
@@ -54,7 +64,7 @@ kernel void densify_csr(
     uint row_idx = get_global_id(1);
     if ((tid >= IMAGE_WIDTH) || (row_idx >= image_height)) return;
 
-    local float line[IMAGE_WIDTH];
+    local DTYPE line[IMAGE_WIDTH];
 
     // Memset
     //~ #pragma unroll


### PR DESCRIPTION
This PR enables to use the GPU CSR utilities on other data types (float64, (u)int8,16,32,64).
Complex and half float are not supported as data types.  
Due to a pyopencl limitation in `GenericScanKernel`, indices data type must have its size divisible by 4 bytes.