### PR TITLE
Add a trilinear interpolator

### DIFF
--- a/silx/math/interpolate.pyx
+++ b/silx/math/interpolate.pyx
@@ -1,0 +1,165 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+"""This module provides :func:`interp3d` to perform trilinear interpolation.
+"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "11/07/2019"
+
+
+import cython
+from cython.parallel import prange
+import numpy
+
+cimport cython
+from libc.math cimport floor
+cimport numpy as cnumpy
+
+
+ctypedef fused _floating:
+    float
+    double
+
+ctypedef fused _floating_pts:
+    float
+    double
+
+
+@cython.initializedcheck(False)
+@cython.boundscheck(False)
+@cython.wraparound(False)
+cdef inline double trilinear_interpolation(
+    _floating[:, :, :] values,
+    _floating_pts pos0,
+    _floating_pts pos1,
+    _floating_pts pos2,
+    double fill_value) nogil:
+    """Evaluate the trilinear interpolation at a given position
+
+    :param values: 3D dataset from which to do the interpolation
+    :param pos0: Dimension 0 coordinate at which to evaluate the interpolation
+    :param pos1: Dimension 1 coordinate at which to evaluate the interpolation
+    :param pos2: Dimension 2 coordinate at which to evaluate the interpolation
+    :param fill_value: Value to return for points outside data
+    """
+    cdef:
+        int i0, i1, i2  # Indices
+        int i0_plus1, i1_plus1, i2_plus1  # Indices+1
+        double delta
+        double c00, c01, c10, c11, c0, c1
+        double c
+
+    if (pos0 < 0. or pos0 > (values.shape[0] -1) or
+            pos1 < 0. or pos1 > (values.shape[1] -1) or
+            pos2 < 0. or pos2 > (values.shape[2] -1)):
+        return fill_value
+
+    i0 = < int > floor(pos0)
+    i1 = < int > floor(pos1)
+    i2 = < int > floor(pos2)
+
+    # Clip i+1 indices to data volume
+    # In this case, corresponding dX is 0.
+    i0_plus1 = min(i0 + 1, values.shape[0] - 1)
+    i1_plus1 = min(i1 + 1, values.shape[1] - 1)
+    i2_plus1 = min(i2 + 1, values.shape[2] - 1)
+
+    if pos2 == i2:  # Avoids multiplication by 0 (which yields to NaN with inf)
+        c00 = <double> values[i0, i1, i2]
+        c10 = <double> values[i0, i1_plus1, i2]
+        c01 = <double> values[i0_plus1, i1, i2]
+        c11 = <double> values[i0_plus1, i1_plus1, i2]
+    else:
+        delta = pos2 - i2
+        c00 = (<double> values[i0, i1, i2]) * (1. - delta) + (<double> values[i0, i1, i2_plus1]) * delta
+        c10 = (<double> values[i0, i1_plus1, i2]) * (1. - delta) + (<double> values[i0, i1_plus1, i2_plus1]) * delta
+        c01 = (<double> values[i0_plus1, i1, i2]) * (1. - delta) + (<double> values[i0_plus1, i1, i2_plus1]) * delta
+        c11 = (<double> values[i0_plus1, i1_plus1, i2]) * (1. - delta) + (<double> values[i0_plus1, i1_plus1, i2_plus1]) * delta
+
+    if pos1 == i1:  # Avoids multiplication by 0 (which yields to NaN with inf)
+        c0 = c00
+        c1 = c01
+    else:
+        delta = pos1 - i1
+        c0 = c00 * (1. - delta) + c10 * delta
+        c1 = c01 * (1. - delta) + c11 * delta
+
+    if pos0 == i0:  # Avoids multiplication by 0 (which yields to NaN with inf)
+        c = c0
+    else:
+        delta = pos0 - i0
+        c = c0 * (1 - delta) + c1 * delta
+
+    return c
+
+
+@cython.boundscheck(False)
+@cython.wraparound(False)
+def interp3d(_floating[:, :, :] values not None,
+             _floating_pts[:, :] xi not None,
+             str method='linear',
+             double fill_value=numpy.nan):
+    """Trilinear interpolation in a regular grid.
+
+    Perform trilinear interpolation of the 3D dataset at given points
+
+    :param numpy.ndarray values: 3D dataset of floating point values
+    :param numpy.ndarray xi: (N, 3) sampling points
+    :param str method: Interpolation method to use in:
+        - 'linear': Trilinear interpolation
+        - 'linear_omp': Trilinear interpolation with OpenMP parallelism
+    :param float fill_value:
+        Value to use for points outside the volume (default: nan)
+    :return: Values evaluated at given input points.
+    :rtype: numpy.ndarray
+    """
+    if _floating is cnumpy.float32_t:
+        dtype = numpy.float32
+    elif _floating is cnumpy.float64_t:
+        dtype = numpy.float64
+    else:  # This should not happen
+        raise ValueError("Unsupported input dtype")
+
+    cdef:
+        int npoints = xi.shape[0]
+        _floating[:] result = numpy.empty((npoints,), dtype=dtype)
+        int index
+        double c_fill_value = fill_value
+
+    if method == 'linear':
+        with nogil:
+            for index in range(npoints):
+                result[index] = < _floating > trilinear_interpolation(
+                    values, xi[index, 0], xi[index, 1], xi[index, 2], c_fill_value)
+
+    elif method == 'linear_omp':
+        for index in prange(npoints, nogil=True):
+            result[index] = < _floating > trilinear_interpolation(
+                values, xi[index, 0], xi[index, 1], xi[index, 2], c_fill_value)
+    else:
+        raise ValueError("Unsupported method: %s" % method)
+
+    return numpy.array(result, copy=False)

--- a/silx/math/setup.py
+++ b/silx/math/setup.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -78,6 +78,13 @@ def configuration(parent_package='', top_path=None):
 
     config.add_extension('colormap',
                          sources=["colormap.pyx"],
+                         language='c',
+                         include_dirs=['include', numpy.get_include()],
+                         extra_link_args=['-fopenmp'],
+                         extra_compile_args=['-fopenmp'])
+
+    config.add_extension('interpolate',
+                         sources=["interpolate.pyx"],
                          language='c',
                          include_dirs=['include', numpy.get_include()],
                          extra_link_args=['-fopenmp'],

--- a/silx/math/test/__init__.py
+++ b/silx/math/test/__init__.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -38,6 +38,7 @@ from ..medianfilter.test import suite as test_medianfilter_suite
 from .test_combo import suite as test_combo_suite
 from .test_calibration import suite as test_calibration_suite
 from .test_colormap import suite as test_colormap_suite
+from .test_interpolate import suite as test_interpolate_suite
 from ..fft.test import suite as test_fft_suite
 
 def suite():
@@ -52,5 +53,6 @@ def suite():
     test_suite.addTest(test_combo_suite())
     test_suite.addTest(test_calibration_suite())
     test_suite.addTest(test_colormap_suite())
+    test_suite.addTest(test_interpolate_suite())
     test_suite.addTest(test_fft_suite())
     return test_suite

--- a/silx/math/test/test_interpolate.py
+++ b/silx/math/test/test_interpolate.py
@@ -71,7 +71,7 @@ class TestInterp3d(ParametricTestCase):
             points = ref_points.astype(dtype)
             ref_result = self.ref_interp3d(data, points)
 
-            for method in ('linear', 'linear_omp'):
+            for method in (u'linear', u'linear_omp'):
                 with self.subTest(method=method):
                     result = interpolate.interp3d(data, points, method=method)
                     self.assertTrue(numpy.allclose(ref_result, result))
@@ -84,7 +84,7 @@ class TestInterp3d(ParametricTestCase):
         points = numpy.array([(0.5, 0.5, 0.5),
                               (1.5, 1.5, 1.5)])
 
-        for method in ('linear', 'linear_omp'):
+        for method in (u'linear', u'linear_omp'):
             with self.subTest(method=method):
                 result = interpolate.interp3d(
                     data, points, method=method)
@@ -99,7 +99,7 @@ class TestInterp3d(ParametricTestCase):
                               (-0.1, 1., 1.),
                               (1., 1., 3.1)])
 
-        for method in ('linear', 'linear_omp'):
+        for method in (u'linear', u'linear_omp'):
             for fill_value in (numpy.nan, 0., -1.):
                 with self.subTest(method=method):
                     result = interpolate.interp3d(
@@ -119,7 +119,7 @@ class TestInterp3d(ParametricTestCase):
 
         ref_result = data[tuple(points.T.astype(numpy.int32))]
 
-        for method in ('linear', 'linear_omp'):
+        for method in (u'linear', u'linear_omp'):
             with self.subTest(method=method):
                 result = interpolate.interp3d(data, points, method=method)
                 self.assertTrue(numpy.allclose(ref_result, result))

--- a/silx/math/test/test_interpolate.py
+++ b/silx/math/test/test_interpolate.py
@@ -1,0 +1,136 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+"""Test for interpolate module"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "11/07/2019"
+
+
+import unittest
+
+import numpy
+try:
+    from scipy.interpolate import interpn
+except ImportError:
+    interpn = None
+
+from silx.utils.testutils import ParametricTestCase
+from silx.math import interpolate
+
+
+@unittest.skipUnless(interpn is not None, "scipy missing")
+class TestInterp3d(ParametricTestCase):
+    """Test silx.math.interpolate.interp3d"""
+
+    @staticmethod
+    def ref_interp3d(data, points):
+        """Reference implementation of interp3d based on scipy
+
+        :param numpy.ndarray data: 3D floating dataset
+        :param numpy.ndarray points: Array of points of shape (N, 3)
+        """
+        return interpn(
+            [numpy.arange(dim, dtype=data.dtype) for dim in data.shape],
+            data,
+            points,
+            method='linear')
+
+    def test_random_data(self):
+        """Test interp3d with random data"""
+        size = 32
+        npoints = 10
+
+        ref_data = numpy.random.random((size, size, size))
+        ref_points = numpy.random.random(npoints*3).reshape(npoints, 3) * (size -1)
+
+        for dtype in (numpy.float32, numpy.float64):
+            data = ref_data.astype(dtype)
+            points = ref_points.astype(dtype)
+            ref_result = self.ref_interp3d(data, points)
+
+            for method in ('linear', 'linear_omp'):
+                with self.subTest(method=method):
+                    result = interpolate.interp3d(data, points, method=method)
+                    self.assertTrue(numpy.allclose(ref_result, result))
+
+    def test_notfinite_data(self):
+        """Test interp3d with NaN and inf"""
+        data = numpy.ones((3, 3, 3), dtype=numpy.float64)
+        data[0, 0, 0] = numpy.nan
+        data[2, 2, 2] = numpy.inf
+        points = numpy.array([(0.5, 0.5, 0.5),
+                              (1.5, 1.5, 1.5)])
+
+        for method in ('linear', 'linear_omp'):
+            with self.subTest(method=method):
+                result = interpolate.interp3d(
+                    data, points, method=method)
+                self.assertTrue(numpy.isnan(result[0]))
+                self.assertTrue(result[1] == numpy.inf)
+
+    def test_points_outside(self):
+        """Test interp3d with points outside the volume"""
+        data = numpy.ones((4, 4, 4), dtype=numpy.float64)
+        points = numpy.array([(-0.1, -0.1, -0.1),
+                              (3.1, 3.1, 3.1),
+                              (-0.1, 1., 1.),
+                              (1., 1., 3.1)])
+
+        for method in ('linear', 'linear_omp'):
+            for fill_value in (numpy.nan, 0., -1.):
+                with self.subTest(method=method):
+                    result = interpolate.interp3d(
+                        data, points, method=method, fill_value=fill_value)
+                    if numpy.isnan(fill_value):
+                        self.assertTrue(numpy.all(numpy.isnan(result)))
+                    else:
+                        self.assertTrue(numpy.all(numpy.equal(result, fill_value)))
+
+    def test_integer_points(self):
+        """Test interp3d with integer points coord"""
+        data = numpy.arange(4**3, dtype=numpy.float64).reshape(4, 4, 4)
+        points = numpy.array([(0., 0., 0.),
+                              (0., 0., 1.),
+                              (2., 3., 0.),
+                              (3., 3., 3.)])
+
+        ref_result = data[tuple(points.T.astype(numpy.int32))]
+
+        for method in ('linear', 'linear_omp'):
+            with self.subTest(method=method):
+                result = interpolate.interp3d(data, points, method=method)
+                self.assertTrue(numpy.allclose(ref_result, result))
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    test_suite.addTest(
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestInterp3d))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
This PR adds a `silx.math.interpolate` module with a `interp3d` function for trilinear interpolation in a regular equally spaced grid.

This functions is similar to [`scipy.interpolate.interpn`](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.interpn.html#scipy.interpolate.interpn) except that the grid is equally spaced and it only handles 3D dataset.
It provides almost a x10 speed-up over `interpn` and almost x50 with OpenMP * (with `method=linear_omp`).

I need it for #2323

*: On my machine