### PR TITLE
h5todict asarray=True argument

### DIFF
--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -263,7 +263,7 @@ def _name_contains_string_in_list(name, strlist):
     return False
 
 
-def h5todict(h5file, path="/", exclude_names=None):
+def h5todict(h5file, path="/", exclude_names=None, asarray=True):
     """Read a HDF5 file and return a nested dictionary with the complete file
     structure and all data.
 
@@ -299,6 +299,8 @@ def h5todict(h5file, path="/", exclude_names=None):
         to read only a sub-group in the file
     :param List[str] exclude_names: Groups and datasets whose name contains
         a string in this list will be ignored. Default is None (ignore nothing)
+    :param bool asarray: True (default) to read scalar as arrays, False to
+        read them as scalar
     :return: Nested dictionary
     """
     with _SafeH5FileRead(h5file) as h5f:
@@ -311,8 +313,11 @@ def h5todict(h5file, path="/", exclude_names=None):
                                       path + "/" + key,
                                       exclude_names=exclude_names)
             else:
-                # Convert HDF5 dataset to numpy array
-                ddict[key] = h5f[path + "/" + key][...]
+                # Read HDF5 datset
+                data = h5f[path + "/" + key][()]
+                if asarray:  # Convert HDF5 dataset to numpy array
+                    data = numpy.array(data, copy=False)
+                ddict[key] = data
 
     return ddict
 

--- a/silx/io/test/test_dictdump.py
+++ b/silx/io/test/test_dictdump.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -49,9 +49,11 @@ def tree():
     return defaultdict(tree)
 
 
+inhabitants = 160215
+
 city_attrs = tree()
 city_attrs["Europe"]["France"]["Grenoble"]["area"] = "18.44 km2"
-city_attrs["Europe"]["France"]["Grenoble"]["inhabitants"] = 160215
+city_attrs["Europe"]["France"]["Grenoble"]["inhabitants"] = inhabitants
 city_attrs["Europe"]["France"]["Grenoble"]["coordinates"] = [45.1830, 5.7196]
 city_attrs["Europe"]["France"]["Tourcoing"]["area"]
 
@@ -128,6 +130,16 @@ class TestH5ToDict(unittest.TestCase):
         self.assertNotIn("inhabitants", ddict["Grenoble"])
         self.assertIn("coordinates", ddict["Grenoble"])
         self.assertIn("area", ddict["Grenoble"])
+
+    def testAsArrayTrue(self):
+        """Test with asarray=True, the default"""
+        ddict = h5todict(self.h5_fname, path="/Europe/France/Grenoble")
+        self.assertTrue(numpy.array_equal(ddict["inhabitants"], numpy.array(inhabitants)))
+
+    def testAsArrayFalse(self):
+        """Test with asarray=False"""
+        ddict = h5todict(self.h5_fname, path="/Europe/France/Grenoble", asarray=False)
+        self.assertEqual(ddict["inhabitants"], inhabitants)
 
 
 class TestDictToJson(unittest.TestCase):


### PR DESCRIPTION
This PR adds an `asarray` argument to `h5todict` which is `True` by default and keeps the legacy behavior, but when set to `False` provides the behavior that for me should have been the only one: scalars are converted to scalars in the output `dict` rather than arrays.

closes #2689