### PR TITLE
silx.gui.utils.blockSignals helper

### DIFF
--- a/silx/gui/qt/_utils.py
+++ b/silx/gui/qt/_utils.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,6 +29,8 @@ __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "30/11/2016"
 
+
+import contextlib as _contextlib
 import sys
 from . import _qt as qt
 
@@ -64,3 +66,19 @@ def silxGlobalThreadPool():
         tp.setMaxThreadCount(tp.maxThreadCount())
         __globalThreadPoolInstance = tp
     return __globalThreadPoolInstance
+
+
+@_contextlib.contextmanager
+def blockSignals(obj):
+    """Context manager blocking signals of a QObject.
+
+    It restores previous state when leaving.
+
+    :param qt.QObject obj: QObject for which to block signals
+    """
+    method = getattr(obj, "blockSignals")
+    previous = method(True)
+    try:
+        yield
+    finally:
+        method(previous)

--- a/silx/gui/qt/_utils.py
+++ b/silx/gui/qt/_utils.py
@@ -31,21 +31,21 @@ __date__ = "30/11/2016"
 
 
 import contextlib as _contextlib
-import sys
-from . import _qt as qt
+import sys as _sys
+from . import _qt
 
 
 def supportedImageFormats():
     """Return a set of string of file format extensions supported by the
     Qt runtime."""
-    if sys.version_info[0] < 3 or qt.BINDING == 'PySide':
+    if _sys.version_info[0] < 3 or _qt.BINDING == 'PySide':
         convert = str
-    elif qt.BINDING == 'PySide2':
+    elif _qt.BINDING == 'PySide2':
         def convert(data):
             return str(data.data(), 'ascii')
     else:
         convert = lambda data: str(data, 'ascii')
-    formats = qt.QImageReader.supportedImageFormats()
+    formats = _qt.QImageReader.supportedImageFormats()
     return set([convert(data) for data in formats])
 
 
@@ -61,7 +61,7 @@ def silxGlobalThreadPool():
     """
     global __globalThreadPoolInstance
     if __globalThreadPoolInstance is  None:
-        tp = qt.QThreadPool()
+        tp = _qt.QThreadPool()
         # This pointless command fixes a segfault with PyQt 5.9.1 on Windows
         tp.setMaxThreadCount(tp.maxThreadCount())
         __globalThreadPoolInstance = tp

--- a/silx/gui/qt/_utils.py
+++ b/silx/gui/qt/_utils.py
@@ -69,16 +69,16 @@ def silxGlobalThreadPool():
 
 
 @_contextlib.contextmanager
-def blockSignals(obj):
-    """Context manager blocking signals of a QObject.
+def blockSignals(*objs):
+    """Context manager blocking signals of QObjects.
 
     It restores previous state when leaving.
 
-    :param qt.QObject obj: QObject for which to block signals
+    :param qt.QObject objs: QObjects for which to block signals
     """
-    method = getattr(obj, "blockSignals")
-    previous = method(True)
+    blocked = [(obj, obj.blockSignals(True)) for obj in objs]
     try:
         yield
     finally:
-        method(previous)
+        for obj, previous in blocked:
+            obj.blockSignals(previous)

--- a/silx/gui/qt/_utils.py
+++ b/silx/gui/qt/_utils.py
@@ -30,7 +30,6 @@ __license__ = "MIT"
 __date__ = "30/11/2016"
 
 
-import contextlib as _contextlib
 import sys as _sys
 from . import _qt
 
@@ -66,19 +65,3 @@ def silxGlobalThreadPool():
         tp.setMaxThreadCount(tp.maxThreadCount())
         __globalThreadPoolInstance = tp
     return __globalThreadPoolInstance
-
-
-@_contextlib.contextmanager
-def blockSignals(*objs):
-    """Context manager blocking signals of QObjects.
-
-    It restores previous state when leaving.
-
-    :param qt.QObject objs: QObjects for which to block signals
-    """
-    blocked = [(obj, obj.blockSignals(True)) for obj in objs]
-    try:
-        yield
-    finally:
-        for obj, previous in blocked:
-            obj.blockSignals(previous)

--- a/silx/gui/utils/__init__.py
+++ b/silx/gui/utils/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,3 +27,22 @@
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "09/03/2018"
+
+
+import contextlib as _contextlib
+
+
+@_contextlib.contextmanager
+def blockSignals(*objs):
+    """Context manager blocking signals of QObjects.
+
+    It restores previous state when leaving.
+
+    :param qt.QObject objs: QObjects for which to block signals
+    """
+    blocked = [(obj, obj.blockSignals(True)) for obj in objs]
+    try:
+        yield
+    finally:
+        for obj, previous in blocked:
+            obj.blockSignals(previous)

--- a/silx/gui/utils/test/test.py
+++ b/silx/gui/utils/test/test.py
@@ -54,10 +54,12 @@ class TestBlockSignals(TestCaseQt):
 
         self.assertEqual(listener.arguments(), [("received",)] * len(objs))
 
+    @unittest.skipUnless(qt.BINDING in ('PyQt5', 'PySide2'), 'Qt5 only test')
     def testManyObjects(self):
         """Test blockSignals with 2 QObjects"""
         self._test(qt.QObject(), qt.QObject())
 
+    @unittest.skipUnless(qt.BINDING in ('PyQt5', 'PySide2'), 'Qt5 only test')
     def testOneObject(self):
         """Test blockSignals context manager with a single QObject"""
         self._test(qt.QObject())

--- a/silx/gui/utils/test/test.py
+++ b/silx/gui/utils/test/test.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,27 +22,51 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-"""silx.gui.utils tests"""
+"""Test of functions available in silx.gui.utils module."""
 
+from __future__ import absolute_import
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "24/04/2018"
+__date__ = "01/08/2019"
 
 
 import unittest
+from silx.gui import qt
+from silx.gui.utils.testutils import TestCaseQt, SignalListener
 
-from . import test_async
-from . import test_image
-from . import test
+from silx.gui.utils import blockSignals
+
+
+class TestBlockSignals(TestCaseQt):
+    """Test blockSignals context manager"""
+
+    def _test(self, *objs):
+        """Test for provided objects"""
+        listener = SignalListener()
+        for obj in objs:
+            obj.objectNameChanged.connect(listener)
+            obj.setObjectName("received")
+
+        with blockSignals(*objs):
+            for obj in objs:
+                obj.setObjectName("silent")
+
+        self.assertEqual(listener.arguments(), [("received",)] * len(objs))
+
+    def testManyObjects(self):
+        """Test blockSignals with 2 QObjects"""
+        self._test(qt.QObject(), qt.QObject())
+
+    def testOneObject(self):
+        """Test blockSignals context manager with a single QObject"""
+        self._test(qt.QObject())
 
 
 def suite():
-    """Test suite for module silx.image.test"""
     test_suite = unittest.TestSuite()
-    test_suite.addTest(test.suite())
-    test_suite.addTest(test_async.suite())
-    test_suite.addTest(test_image.suite())
+    test_suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(
+        TestBlockSignals))
     return test_suite
 
 


### PR DESCRIPTION
This PR adds a `blockSignals` context manager that allows to block signals for one or many `QObject`s.

This is not much code, but it allows to replace:
```
previous = obj.blockSignals(True)
# do stuff
obj.blockSignals(previous)
```
with:
```
with blockSignals(obj):
    # do stuff
```
which makes it more readable.