### PR TITLE
silx view: keep the same axes selection whenever possible

### DIFF
--- a/silx/gui/data/DataViewer.py
+++ b/silx/gui/data/DataViewer.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -198,6 +198,9 @@ class DataViewer(qt.QFrame):
         Update the numpy-selector according to the needed axis names
         """
         previous = self.__numpySelection.blockSignals(True)
+        previousPermutation = self.__numpySelection.permutation()
+        previousSelection = self.__numpySelection.selection()
+
         self.__numpySelection.clear()
         info = self._getInfo()
         axisNames = self.__currentView.axesNames(self.__data, info)
@@ -207,6 +210,13 @@ class DataViewer(qt.QFrame):
             self.__numpySelection.setCustomAxis(self.__currentView.customAxisNames())
             data = self.normalizeData(self.__data)
             self.__numpySelection.setData(data)
+
+            # Try to restore previous permutation and selection
+            try:
+                self.__numpySelection.setSelection(previousSelection, previousPermutation)
+            except ValueError as e:
+                _logger.debug("Not restoring selection because: %s", e)
+
             if hasattr(data, "shape"):
                 isVisible = not (len(axisNames) == 1 and len(data.shape) == 1)
             else:

--- a/silx/gui/data/NumpyAxesSelector.py
+++ b/silx/gui/data/NumpyAxesSelector.py
@@ -467,6 +467,7 @@ class NumpyAxesSelector(qt.QWidget):
                         index += 1
                 else:
                     _logger.warning("No axis corresponding to: %s", name)
+                    return None
             return tuple(indices)
 
     def selection(self):

--- a/silx/gui/data/NumpyAxesSelector.py
+++ b/silx/gui/data/NumpyAxesSelector.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -31,11 +31,15 @@ __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "29/01/2018"
 
+import logging
 import numpy
 import functools
 from silx.gui.widgets.FrameBrowser import HorizontalSliderWithBrowser
 from silx.gui import qt
 import silx.utils.weakref
+
+
+_logger = logging.getLogger(__name__)
 
 
 class _Axis(qt.QWidget):
@@ -174,6 +178,13 @@ class _Axis(qt.QWidget):
         """
         return self.__slider.value()
 
+    def setValue(self, value):
+        """Set the currently selected position in the axis.
+
+        :param int value:
+        """
+        self.__slider.setValue(value)
+
     def __sliderValueChanged(self, value):
         """Called when the selected position in the axis change.
 
@@ -236,7 +247,6 @@ class NumpyAxesSelector(qt.QWidget):
 
         self.__data = None
         self.__selectedData = None
-        self.__selection = tuple()
         self.__axis = []
         self.__axisNames = []
         self.__customAxisNames = set([])
@@ -402,48 +412,20 @@ class NumpyAxesSelector(qt.QWidget):
 
         It fires a `selectionChanged` event.
         """
-        if self.__data is None:
+        data = self.data()
+        permutation = self.permutation()
+
+        if data is None or permutation is None:
+            # No data or not all the expected axes are there
             if self.__selectedData is not None:
                 self.__selectedData = None
-                self.__selection = tuple()
                 self.selectionChanged.emit()
             return
 
-        selection = []
-        axisNames = []
-        for slider in self.__axis:
-            name = slider.axisName()
-            if name == "":
-                selection.append(slider.value())
-            else:
-                selection.append(slice(None))
-                axisNames.append(name)
-        self.__selection = tuple(selection)
         # get a view with few fixed dimensions
         # with a h5py dataset, it create a copy
         # TODO we can reuse the same memory in case of a copy
-        view = self.__data[self.__selection]
-
-        if set(self.__axisNames) - set(axisNames) != set([]):
-            # Not all the expected axis are there
-            if self.__selectedData is not None:
-                self.__selectedData = None
-                self.__selection = tuple()
-                self.selectionChanged.emit()
-            return
-
-        # order axis as expected
-        source = []
-        destination = []
-        order = []
-        for index, name in enumerate(self.__axisNames):
-            destination.append(index)
-            source.append(axisNames.index(name))
-        for _, s in sorted(zip(destination, source)):
-            order.append(s)
-        view = numpy.transpose(view, order)
-
-        self.__selectedData = view
+        self.__selectedData = numpy.transpose(data[self.selection()], permutation)
         self.selectionChanged.emit()
 
     def data(self):
@@ -456,16 +438,137 @@ class NumpyAxesSelector(qt.QWidget):
     def selectedData(self):
         """Returns the output data.
 
-        :rtype: numpy.ndarray
+        This is equivalent to::
+
+        numpy.transpose(self.data()[self.selection()], self.permutation())
+
+        :rtype: Union[numpy.ndarray,None]
         """
         return self.__selectedData
+
+    def permutation(self):
+        """Returns the axes permutation to convert data subset to selected data.
+
+        If permutation cannot be computer, it returns None.
+
+        :rtype: Union[List[int],None]
+        """
+        if self.__data is None:
+            return None
+        else:
+            indices = []
+            for name in self.__axisNames:
+                index = 0
+                for axis in self.__axis:
+                    if axis.axisName() == name:
+                        indices.append(index)
+                        break
+                    if axis.axisName() != "":
+                        index += 1
+                else:
+                    _logger.warning("No axis corresponding to: %s", name)
+            return tuple(indices)
 
     def selection(self):
         """Returns the selection tuple used to slice the data.
 
         :rtype: tuple
         """
-        return self.__selection
+        if self.__data is None:
+            return tuple()
+        else:
+            return tuple([axis.value() if axis.axisName() == "" else slice(None)
+                          for axis in self.__axis])
+
+    def setSelection(self, selection, permutation=None):
+        """Set the selection along each dimension.
+
+        tuple returned by :meth:`selection` can be provided as input,
+        provided that it is for the same the number of axes and
+        the same number of dimensions of the data.
+
+        :param List[Union[int,slice,None]] selection:
+            The selection tuple with as one element for each dimension of the data.
+            If an element is None, then the whole dimension is selected.
+        :param  Union[List[int],None] permutation:
+            The data axes indices to transpose.
+            If not given, no permutation is applied
+        :raise ValueError:
+            When the selection does not match current data shape and number of axes.
+        """
+        data = self.data()
+        if data is None:
+            data = numpy.empty(())  # Use array with ndim=0
+
+        # Check selection
+        if len(selection) != data.ndim:
+            raise ValueError(
+                "Selection length (%d) and data ndim (%d) mismatch" %
+                (len(selection), data.ndim))
+
+        # Check selection type
+        selectedDataNDim = 0
+        for element, size in zip(selection, data.shape):
+            if isinstance(element, int):
+                if not 0 <= element < size:
+                    raise ValueError(
+                        "Selected index (%d) outside data dimension range [0-%d]" %
+                        (element, size))
+            elif element is None or element == slice(None):
+                selectedDataNDim += 1
+            else:
+                raise ValueError("Unsupported element in selection: %s" % element)
+
+        ndim = len(self.__axisNames)
+        if selectedDataNDim != ndim:
+            raise ValueError(
+                "Selection dimensions (%d) and number of axes (%d) mismatch" %
+                (selectedDataNDim, ndim))
+
+        # check permutation
+        if permutation is None:
+            permutation = tuple(range(ndim))
+
+        if set(permutation) != set(range(ndim)):
+            raise ValueError(
+                "Error in provided permutation: "
+                "Wrong size, elements out of range or duplicates")
+
+        inversePermutation = numpy.argsort(permutation)
+
+        axisNameChanged = False
+        customValueChanged = []
+
+        blocked = [(axis, axis.blockSignals(True)) for axis in self.__axis]
+        index = 0
+        for element, axis in zip(selection, self.__axis):
+            if isinstance(element, int):
+                name = ""
+            else:
+                name = self.__axisNames[inversePermutation[index]]
+                index += 1
+
+            if axis.axisName() != name:
+                axis.setAxisName(name)
+                axisNameChanged = True
+
+        for element, axis in zip(selection, self.__axis):
+            value = element if isinstance(element, int) else 0
+            if axis.value() != value:
+                axis.setValue(value)
+
+                name = axis.axisName()
+                if name in self.__customAxisNames:
+                    customValueChanged.append((name, value))
+        for axis, previous in blocked:
+            axis.blockSignals(previous)
+
+        # Send signals that where disabled
+        if axisNameChanged:
+            self.selectedAxisChanged.emit()
+        for name, value in customValueChanged:
+            self.customAxisChanged.emit(name, value)
+        self.__updateSelectedData()
 
     def setNamedAxesSelectorVisibility(self, visible):
         """Show or hide the combo-boxes allowing to map the plot axes

--- a/silx/gui/data/test/test_numpyaxesselector.py
+++ b/silx/gui/data/test/test_numpyaxesselector.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -76,7 +76,7 @@ class TestNumpyAxesSelector(TestCaseQt):
         widget.setAxisNames(["x", "y", "z", "boum"])
         widget.setData(data[0])
         result = widget.selectedData()
-        self.assertEqual(result, None)
+        self.assertIsNone(result)
         widget.setData(data)
         result = widget.selectedData()
         self.assertTrue(numpy.array_equal(result, expectedResult))


### PR DESCRIPTION
This PR makes the data viewer (and so `silx view`) keeping the same selection of axes when switching between datasets which have the same shape. It also keeps the selection between views with similar dimensions for the same dataset (e.g., between image view and array view).

This is changing quite a bit the internals which are not that simple, so it needs a serious look at it.

related to #2683, but not closing it: (NX)StackView need specific care and this PR is not addressing it.
