### PR TITLE
[Plot] add "baseline" option in addCurve

### DIFF
--- a/examples/exampleBaseline.py
+++ b/examples/exampleBaseline.py
@@ -40,7 +40,7 @@ import argparse
 
 def stacked_histogran(plot, edges, histograms, colors, legend):
     # check that we have the same number of histogram, color and baseline
-    current_baseline = numpy.zeros(len(edges))
+    current_baseline = numpy.zeros_like(edges)
 
     for histogram, color, layer_index in zip(histograms, colors, range(len(colors))):
         stacked_histo = histogram + current_baseline

--- a/examples/exampleBaseline.py
+++ b/examples/exampleBaseline.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This example illustrates some usage possible with the baseline parameter
+"""
+
+__authors__ = ["H. Payno"]
+__license__ = "MIT"
+__date__ = "12/09/2019"
+
+
+from silx.gui import qt
+from silx.gui.plot import Plot1D
+import numpy
+import sys
+import argparse
+
+
+def stacked_histogran(plot, edges, histograms, colors, legend):
+    # check that we have the same number of histogram, color and baseline
+    current_baseline = numpy.zeros(len(edges))
+
+    for histogram, color, layer_index in zip(histograms, colors, range(len(colors))):
+        stacked_histo = histogram + current_baseline
+        plot.addHistogram(histogram=stacked_histo,
+                          edges=edges,
+                          legend='_'.join((legend, str(layer_index))),
+                          color=color,
+                          baseline=current_baseline,
+                          z=len(histograms)-layer_index,
+                          fill=True)
+        current_baseline = stacked_histo
+
+
+def get_plot_std(backend):
+    x = numpy.arange(0, 10, step=0.1)
+    my_sin = numpy.sin(x)
+    y = numpy.arange(-4, 6, step=0.1) + my_sin
+    mean = numpy.arange(-5, 5, step=0.1) + my_sin
+    baseline = numpy.arange(-6, 4, step=0.1) + my_sin
+    edges = x[y >= 3.0]
+    histo = mean[y >= 3.0] - 1.8
+
+    plot = Plot1D(backend=backend)
+    plot.addCurve(x=x, y=y, baseline=baseline, color='grey',
+                  legend='std-curve', fill=True)
+    plot.addCurve(x=x, y=mean, color='red', legend='mean')
+    plot.addHistogram(histogram=histo, edges=edges, color='red',
+                      legend='mean2', fill=True)
+    return plot
+
+
+def get_plot_stacked_histogram(backend):
+    plot = Plot1D(backend=backend)
+    # first histogram
+    edges = numpy.arange(-6, 6, step=0.5)
+    histo_1 = numpy.random.random(len(edges))
+    histo_2 = numpy.random.random(len(edges))
+    histo_3 = numpy.random.random(len(edges))
+    histo_4 = numpy.random.random(len(edges))
+    stacked_histogran(plot=plot,
+                      edges=edges,
+                      histograms=(histo_1, histo_2, histo_3, histo_4),
+                      colors=('blue', 'green', 'red', 'yellow'),
+                      legend='first_stacked_histo')
+
+    # second histogram
+    edges = numpy.arange(10, 25, step=1.0)
+    histo_1 = -numpy.random.random(len(edges))
+    histo_2 = -numpy.random.random(len(edges))
+    stacked_histogran(plot=plot, histograms=(histo_1, histo_2),
+                      edges=edges,
+                      colors=('gray', 'black'),
+                      legend='second_stacked_histo')
+
+    # last histogram
+    edges = [30, 40]
+    histograms = [
+        [0.2, 0.3],
+        [0.0, 1.0],
+        [0.1, 0.4],
+        [0.2, 0.0],
+        [0.6, 0.4],
+    ]
+    stacked_histogran(plot=plot,
+                      histograms=histograms,
+                      edges=edges,
+                      colors=('blue', 'green', 'red', 'yellow', 'cyan'),
+                      legend='third_stacked_histo')
+
+    return plot
+
+
+def get_plot_mean_baseline(backend):
+    plot = Plot1D(backend=backend)
+    x = numpy.arange(0, 10, step=0.1)
+    y = numpy.sin(x)
+    plot.addCurve(x=x, y=y, baseline=0, fill=True)
+    plot.setYAxisLogarithmic(True)
+    return plot
+
+
+def get_plot_log(backend):
+    plot = Plot1D(backend=backend)
+    x = numpy.arange(0, 10, step=0.01)
+    y = numpy.exp2(x)
+    baseline = numpy.exp(x)
+    plot.addCurve(x=x, y=y, baseline=baseline, fill=True)
+    plot.setYAxisLogarithmic(True)
+    return plot
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--backend',
+        dest="backend",
+        action="store",
+        default=None,
+        help='Set plot backend. Should be "matplotlib" (default) or "opengl"')
+
+    options = parser.parse_args(argv[1:])
+    assert options.backend in (None, 'matplotlib', 'opengl')
+    qapp = qt.QApplication([])
+
+    plot_std = get_plot_std(backend=options.backend)
+    plot_std.show()
+
+    plot_mean = get_plot_mean_baseline(backend=options.backend)
+    plot_mean.show()
+
+    plot_stacked_histo = get_plot_stacked_histogram(backend=options.backend)
+    plot_stacked_histo.show()
+
+    plot_log = get_plot_log(backend=options.backend)
+    plot_log.show()
+
+    qapp.exec_()
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -848,7 +848,7 @@ class PlotWidget(qt.QMainWindow):
             curve.setColor(default_color)
             curve.setLineStyle(default_linestyle)
             curve.setSymbol(self._defaultPlotPoints)
-            curve.setBaseline(baseline=baseline)
+            curve._setBaseline(baseline=baseline)
 
         # Do not emit sigActiveCurveChanged,
         # it will be sent once with _setActiveItem

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -987,10 +987,8 @@ class PlotWidget(qt.QMainWindow):
             histo.setZValue(z=z)
 
         # Set histogram data
-        histo.setData(histogram, edges, align=align, copy=copy)
-        # set baseline
-        if baseline is not None:
-            histo.setBaseline(baseline=baseline)
+        histo.setData(histogram=histogram, edges=edges, baseline=baseline,
+                      align=align, copy=copy)
 
         if mustBeAdded:
             self._add(histo)

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -710,7 +710,8 @@ class PlotWidget(qt.QMainWindow):
                  xlabel=None, ylabel=None, yaxis=None,
                  xerror=None, yerror=None, z=None, selectable=None,
                  fill=None, resetzoom=True,
-                 histogram=None, copy=True):
+                 histogram=None, copy=True,
+                 baseline=None):
         """Add a 1D curve given by x an y to the graph.
 
         Curves are uniquely identified by their legend.
@@ -845,6 +846,7 @@ class PlotWidget(qt.QMainWindow):
             curve.setColor(default_color)
             curve.setLineStyle(default_linestyle)
             curve.setSymbol(self._defaultPlotPoints)
+            curve.setBaseline(baseline=baseline)
 
         # Do not emit sigActiveCurveChanged,
         # it will be sent once with _setActiveItem

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -927,6 +927,7 @@ class PlotWidget(qt.QMainWindow):
                      align='center',
                      resetzoom=True,
                      copy=True,
+                     z=None,
                      baseline=None):
         """Add an histogram to the graph.
 
@@ -958,6 +959,7 @@ class PlotWidget(qt.QMainWindow):
         :param bool resetzoom: True (the default) to reset the zoom.
         :param bool copy: True make a copy of the data (default),
                           False to use provided arrays.
+        :param int z: Layer on which to draw the histogram
         :param int baseline: baseline value
         :returns: The key string identify this histogram
         """
@@ -978,6 +980,8 @@ class PlotWidget(qt.QMainWindow):
             histo.setColor(color)
         if fill is not None:
             histo.setFill(fill)
+        if z is not None:
+            histo.setZValue(z=z)
 
         # Set histogram data
         histo.setData(histogram, edges, align=align, copy=copy)

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -891,7 +891,7 @@ class PlotWidget(qt.QMainWindow):
             if len(x) > 0 and isinstance(x[0], dt.datetime):
                 x = [timestamp(d) for d in x]
 
-            curve.setData(x, y, xerror, yerror, copy=copy)
+            curve.setData(x, y, xerror, yerror, baseline=baseline, copy=copy)
 
         if replace:  # Then remove all other curves
             for c in self.getAllCurves(withhidden=True):

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -926,7 +926,8 @@ class PlotWidget(qt.QMainWindow):
                      fill=None,
                      align='center',
                      resetzoom=True,
-                     copy=True):
+                     copy=True,
+                     baseline=None):
         """Add an histogram to the graph.
 
         This is NOT computing the histogram, this method takes as parameter
@@ -957,6 +958,7 @@ class PlotWidget(qt.QMainWindow):
         :param bool resetzoom: True (the default) to reset the zoom.
         :param bool copy: True make a copy of the data (default),
                           False to use provided arrays.
+        :param int baseline: baseline value
         :returns: The key string identify this histogram
         """
         legend = 'Unnamed histogram' if legend is None else str(legend)
@@ -979,6 +981,9 @@ class PlotWidget(qt.QMainWindow):
 
         # Set histogram data
         histo.setData(histogram, edges, align=align, copy=copy)
+        # set baseline
+        if baseline is not None:
+            histo.setBaseline(baseline=baseline)
 
         if mustBeAdded:
             self._add(histo)

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -792,6 +792,8 @@ class PlotWidget(qt.QMainWindow):
             - 'center'
         :param bool copy: True make a copy of the data (default),
                           False to use provided arrays.
+        :param baseline: curve baseline
+        :type: Union[None,float,numpy.ndarray]
         :returns: The key string identify this curve
         """
         # This is an histogram, use addHistogram
@@ -960,7 +962,8 @@ class PlotWidget(qt.QMainWindow):
         :param bool copy: True make a copy of the data (default),
                           False to use provided arrays.
         :param int z: Layer on which to draw the histogram
-        :param int baseline: baseline value
+        :param baseline: histogram baseline
+        :type: Union[None,float,numpy.ndarray]
         :returns: The key string identify this histogram
         """
         legend = 'Unnamed histogram' if legend is None else str(legend)

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -101,7 +101,7 @@ class BackendBase(object):
                  color, symbol, linewidth, linestyle,
                  yaxis,
                  xerror, yerror, z, selectable,
-                 fill, alpha, symbolsize):
+                 fill, alpha, symbolsize, baseline):
         """Add a 1D curve given by x an y to the graph.
 
         :param numpy.ndarray x: The data corresponding to the x axis

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -454,9 +454,13 @@ class BackendMatplotlib(BackendBase.BackendBase):
                                    s=symbolsize**2)
             artists.append(scatter)
 
-            if fill:
+            if fill or baseline is not None:
+                if baseline is None:
+                    _baseline = FLOAT32_MINPOS
+                else:
+                    _baseline = baseline
                 artists.append(axes.fill_between(
-                    x, FLOAT32_MINPOS, y, facecolor=actualColor[0], linestyle=''))
+                    x, _baseline, y, facecolor=actualColor[0], linestyle=''))
 
         else:  # Curve
             curveList = axes.plot(x, y,
@@ -468,9 +472,13 @@ class BackendMatplotlib(BackendBase.BackendBase):
                                   markersize=symbolsize)
             artists += list(curveList)
 
-            if fill:
+            if fill or baseline is not None:
+                if baseline is None:
+                    _baseline = FLOAT32_MINPOS
+                else:
+                    _baseline = baseline
                 artists.append(
-                    axes.fill_between(x, FLOAT32_MINPOS, y, facecolor=color))
+                    axes.fill_between(x, _baseline, y, facecolor=color))
 
         for artist in artists:
             artist.set_animated(True)

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -454,7 +454,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                                    s=symbolsize**2)
             artists.append(scatter)
 
-            if fill or baseline is not None:
+            if fill:
                 if baseline is None:
                     _baseline = FLOAT32_MINPOS
                 else:
@@ -472,7 +472,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                                   markersize=symbolsize)
             artists += list(curveList)
 
-            if fill or baseline is not None:
+            if fill:
                 if baseline is None:
                     _baseline = FLOAT32_MINPOS
                 else:

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -389,7 +389,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                  color, symbol, linewidth, linestyle,
                  yaxis,
                  xerror, yerror, z, selectable,
-                 fill, alpha, symbolsize):
+                 fill, alpha, symbolsize, baseline):
         for parameter in (x, y, color, symbol, linewidth, linestyle,
                           yaxis, z, selectable, fill, alpha, symbolsize):
             assert parameter is not None

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -822,7 +822,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                 color = color[0], color[1], color[2], color[3] * alpha
 
         fillColor = None
-        if fill is True or baseline is not None:
+        if fill is True:
             fillColor = color
         curve = GLPlotCurve2D(x, y, colorArray,
                               xError=xerror,

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -821,6 +821,9 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             if color is not None:
                 color = color[0], color[1], color[2], color[3] * alpha
 
+        fillColor = None
+        if fill is True or baseline is not None:
+            fillColor = color
         curve = GLPlotCurve2D(x, y, colorArray,
                               xError=xerror,
                               yError=yerror,
@@ -830,7 +833,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                               marker=symbol,
                               markerColor=color,
                               markerSize=symbolsize,
-                              fillColor=color if fill else None,
+                              fillColor=fillColor,
+                              baseline=baseline,
                               isYLog=isYLog)
         curve.info = {
             'yAxis': 'left' if yaxis is None else yaxis,

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -727,7 +727,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                  color, symbol, linewidth, linestyle,
                  yaxis,
                  xerror, yerror, z, selectable,
-                 fill, alpha, symbolsize):
+                 fill, alpha, symbolsize, baseline):
         for parameter in (x, y, color, symbol, linewidth, linestyle,
                           yaxis, z, selectable, fill, symbolsize):
             assert parameter is not None

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -122,6 +122,8 @@ class _Fill2D(object):
         self._yFillVboData = None
         self.color = color
         self.offset = offset
+
+        # Offset baseline
         self.baseline = baseline - self.offset[1]
 
     def prepare(self):

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -122,14 +122,7 @@ class _Fill2D(object):
         self._yFillVboData = None
         self.color = color
         self.offset = offset
-
-        # Offset baseline
-        if not isinstance(baseline, numpy.ndarray):
-            self._base_is_a_single_pt = True
-            self.baseline = numpy.repeat(baseline - self.offset[1], len(self.xData))
-        else:
-            self._base_is_a_single_pt = False
-            self.baseline = baseline - self.offset[1]
+        self.baseline = baseline - self.offset[1]
 
     def prepare(self):
         """Rendering preparation: build indices and bounding box vertices"""
@@ -147,27 +140,34 @@ class _Fill2D(object):
                 end = numpy.append(end, len(isnan))
             slices = numpy.transpose((start, end))
             # discard slices with less than length values
-            # slices = slices[numpy.diff(slices, axis=1).reshape(-1) >= 2]
+            slices = slices[numpy.diff(slices, axis=1).reshape(-1) >= 2]
+
             # Number of points: slice + 2 * leading and trailing points
             # Twice leading and trailing points to produce degenerated triangles
-            # nbPoints = numpy.sum(numpy.diff(slices, axis=1)) + 4 * len(slices)
-
-            nbPoints = len(notnan) * 4
+            nbPoints = numpy.sum(numpy.diff(slices, axis=1)) * 2 + 4 * len(slices)
             points = numpy.empty((nbPoints, 2), dtype=numpy.float32)
 
             offset = 0
             # invert baseline for filling
-            inv_baseline = self.baseline[::-1]
-            inv_xData = self.xData[::-1]
-
+            new_y_data = numpy.append(self.yData, self.baseline)
             for start, end in slices:
-                for x, y in zip(self.xData[start:end], self.yData[start:end]):
-                    points[offset] = x, y
-                    offset += 2
+                # Duplicate first point for connecting degenerated triangle
+                points[offset:offset+2] = self.xData[start], new_y_data[start]
 
-                for x, y in zip(inv_xData[start:end], inv_baseline[start:end]):
-                    points[offset] = x, y
-                    offset += 2
+                # 2nd point of the polygon is last point
+                points[offset+2] = self.xData[start], self.baseline[start]
+
+                indices = numpy.append(numpy.arange(start, end),
+                                       numpy.arange(len(self.xData) + end-1, len(self.xData) + start-1, -1))
+                indices = indices[buildFillMaskIndices(len(indices))]
+
+                points[offset+3:offset+3+len(indices), 0] = self.xData[indices % len(self.xData)]
+                points[offset+3:offset+3+len(indices), 1] = new_y_data[indices]
+
+                # Duplicate last point for connecting degenerated triangle
+                points[offset+3+len(indices)] = points[offset+3+len(indices)-1]
+
+                offset += len(indices) + 4
 
             self._xFillVboData, self._yFillVboData = vertexBuffer(points.T)
 
@@ -1004,11 +1004,25 @@ class GLPlotCurve2D(object):
             self.offset = 0., 0.
             self.xData = xData
             self.yData = yData
-
         if fillColor is not None:
-            _baseline = -38 if isYLog else 0
-            if baseline is not None:
-                _baseline = baseline
+            def deduce_baseline(baseline):
+                if baseline is None:
+                    _baseline = 0
+                else:
+                    _baseline = baseline
+                if not isinstance(_baseline, numpy.ndarray):
+                    _baseline = numpy.repeat(_baseline,
+                                             len(self.xData))
+                if isYLog is True:
+                    with warnings.catch_warnings():  # Ignore NaN comparison warnings
+                        warnings.simplefilter('ignore',
+                                              category=RuntimeWarning)
+                        log_val = numpy.log10(_baseline)
+                    _baseline = numpy.where(_baseline>0.0, log_val, -38)
+                return _baseline
+
+            _baseline = deduce_baseline(baseline)
+
             # Use different baseline depending of Y log scale
             self.fill = _Fill2D(self.xData, self.yData,
                                 baseline=_baseline,

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -1252,7 +1252,7 @@ class BaselineMixIn(object):
     def __init__(self, baseline=None):
         self._baseline = baseline
 
-    def setBaseline(self, baseline):
+    def _setBaseline(self, baseline):
         """
         Set baseline value
 

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -1245,3 +1245,30 @@ class PointsBase(Item, SymbolMixIn, AlphaMixIn):
             if plot is not None:
                 plot._invalidateDataRange()
         self._updated(ItemChangedType.DATA)
+
+
+class BaselineMixIn(object):
+    """Base class for Baseline mix-in"""
+    def __init__(self, baseline=None):
+        self._baseline = baseline
+
+    def setBaseline(self, baseline):
+        """
+        Set baseline value
+
+        :param baseline: baseline value(s)
+        :type: Union[None,float,numpy.ndarray]
+        """
+        self._baseline = baseline
+
+    def getBaseline(self, copy=True):
+        """
+
+        :param bool copy:
+        :return: histogram baseline
+        :rtype: Union[None,float,numpy.ndarray]
+        """
+        if isinstance(self._baseline, numpy.ndarray):
+            return numpy.array(self._baseline, copy=True)
+        else:
+            return self._baseline

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -1259,6 +1259,8 @@ class BaselineMixIn(object):
         :param baseline: baseline value(s)
         :type: Union[None,float,numpy.ndarray]
         """
+        if (isinstance(baseline, abc.Iterable)):
+            baseline = numpy.array(baseline)
         self._baseline = baseline
 
     def getBaseline(self, copy=True):

--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -382,6 +382,8 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn,
                       row 1 for negative errors.
         :param yerror: Values with the uncertainties on the y values.
         :type yerror: A float, or a numpy.ndarray of float32. See xerror.
+        :param baseline: curve baseline
+        :type baseline: Union[None,float,numpy.ndarray]
         :param bool copy: True make a copy of the data (default),
                           False to use provided arrays.
         """

--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -38,7 +38,8 @@ import six
 from ....utils.deprecation import deprecated
 from ... import colors
 from .core import (PointsBase, LabelsMixIn, ColorMixIn, YAxisMixIn,
-                   FillMixIn, LineMixIn, SymbolMixIn, ItemChangedType)
+                   FillMixIn, LineMixIn, SymbolMixIn, ItemChangedType,
+                   BaselineMixIn)
 
 
 _logger = logging.getLogger(__name__)
@@ -151,7 +152,8 @@ class CurveStyle(object):
             return False
 
 
-class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixIn):
+class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn,
+            LineMixIn, BaselineMixIn):
     """Description of a curve"""
 
     _DEFAULT_Z_LAYER = 1
@@ -178,10 +180,11 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixI
         FillMixIn.__init__(self)
         LabelsMixIn.__init__(self)
         LineMixIn.__init__(self)
+        BaselineMixIn.__init__(self)
 
         self._highlightStyle = self._DEFAULT_HIGHLIGHT_STYLE
         self._highlighted = False
-        self._baseline = Curve._DEFAULT_BASELINE
+        self.setBaseline(Curve._DEFAULT_BASELINE)
 
         self.sigItemChanged.connect(self.__itemChanged)
 
@@ -216,7 +219,7 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixI
                                 fill=self.isFill(),
                                 alpha=self.getAlpha(),
                                 symbolsize=style.getSymbolSize(),
-                                baseline=self.getBaseline())
+                                baseline=self.getBaseline(copy=False))
 
     def __getitem__(self, item):
         """Compatibility with PyMca and silx <= 0.4.0"""
@@ -324,15 +327,6 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixI
                      one of the predefined color names defined in colors.py
         """
         self.setHighlightedStyle(CurveStyle(color))
-
-    def setBaseline(self, baseline):
-        self._baseline = baseline
-
-    def getBaseline(self, copy=True):
-        if copy is True and isinstance(self._baseline, numpy.ndarray):
-            return self._baseline.copy()
-        else:
-            return self._baseline
 
     def getCurrentStyle(self):
         """Returns the current curve style.

--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -246,7 +246,6 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixI
                 'z': self.getZValue(),
                 'selectable': self.isSelectable(),
                 'fill': self.isFill(),
-                'baseline': self.getBaseline(copy=False),
             }
             return params
         else:

--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -169,6 +169,8 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixI
     _DEFAULT_HIGHLIGHT_STYLE = CurveStyle(color='black')
     """Default highlight style of the item"""
 
+    _DEFAULT_BASELINE = None
+
     def __init__(self):
         PointsBase.__init__(self)
         ColorMixIn.__init__(self)
@@ -179,6 +181,7 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixI
 
         self._highlightStyle = self._DEFAULT_HIGHLIGHT_STYLE
         self._highlighted = False
+        self._baseline = None
 
         self.sigItemChanged.connect(self.__itemChanged)
 
@@ -212,7 +215,8 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixI
                                 selectable=self.isSelectable(),
                                 fill=self.isFill(),
                                 alpha=self.getAlpha(),
-                                symbolsize=style.getSymbolSize())
+                                symbolsize=style.getSymbolSize(),
+                                baseline=self.getBaseline())
 
     def __getitem__(self, item):
         """Compatibility with PyMca and silx <= 0.4.0"""
@@ -241,7 +245,8 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixI
                 'yerror': self.getYErrorData(copy=False),
                 'z': self.getZValue(),
                 'selectable': self.isSelectable(),
-                'fill': self.isFill()
+                'fill': self.isFill(),
+                'baseline': self.getBaseline(copy=False),
             }
             return params
         else:
@@ -320,6 +325,15 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixI
                      one of the predefined color names defined in colors.py
         """
         self.setHighlightedStyle(CurveStyle(color))
+
+    def setBaseline(self, baseline):
+        self._baseline = baseline
+
+    def getBaseline(self, copy=True):
+        if copy is True and isinstance(self._baseline, numpy.ndarray):
+            return self._baseline.copy()
+        else:
+            return self._baseline
 
     def getCurrentStyle(self):
         """Returns the current curve style.

--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -184,7 +184,7 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn,
 
         self._highlightStyle = self._DEFAULT_HIGHLIGHT_STYLE
         self._highlighted = False
-        self.setBaseline(Curve._DEFAULT_BASELINE)
+        self._setBaseline(Curve._DEFAULT_BASELINE)
 
         self.sigItemChanged.connect(self.__itemChanged)
 

--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -181,7 +181,7 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn, LineMixI
 
         self._highlightStyle = self._DEFAULT_HIGHLIGHT_STYLE
         self._highlighted = False
-        self._baseline = None
+        self._baseline = Curve._DEFAULT_BASELINE
 
         self.sigItemChanged.connect(self.__itemChanged)
 

--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -368,3 +368,23 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn,
         :rtype: 4-tuple of float in [0, 1]
         """
         return self.getCurrentStyle().getColor()
+
+    def setData(self, x, y, xerror=None, yerror=None, baseline=None, copy=True):
+        """Set the data of the curve.
+
+        :param numpy.ndarray x: The data corresponding to the x coordinates.
+        :param numpy.ndarray y: The data corresponding to the y coordinates.
+        :param xerror: Values with the uncertainties on the x values
+        :type xerror: A float, or a numpy.ndarray of float32.
+                      If it is an array, it can either be a 1D array of
+                      same length as the data or a 2D array with 2 rows
+                      of same length as the data: row 0 for positive errors,
+                      row 1 for negative errors.
+        :param yerror: Values with the uncertainties on the y values.
+        :type yerror: A float, or a numpy.ndarray of float32. See xerror.
+        :param bool copy: True make a copy of the data (default),
+                          False to use provided arrays.
+        """
+        PointsBase.setData(self, x=x, y=y, xerror=xerror, yerror=yerror,
+                           copy=copy)
+        self._setBaseline(baseline=baseline)

--- a/silx/gui/plot/items/histogram.py
+++ b/silx/gui/plot/items/histogram.py
@@ -32,6 +32,11 @@ __date__ = "28/08/2018"
 import logging
 
 import numpy
+from collections import OrderedDict, namedtuple
+try:
+    from collections import abc
+except ImportError:  # Python2 support
+    import collections as abc
 
 from .core import (Item, AlphaMixIn, BaselineMixIn, ColorMixIn, FillMixIn,
                    LineMixIn, YAxisMixIn, ItemChangedType)
@@ -296,11 +301,13 @@ class Histogram(Item, AlphaMixIn, ColorMixIn, FillMixIn,
             edgesDiff = numpy.diff(edges)
             assert numpy.all(edgesDiff >= 0) or numpy.all(edgesDiff <= 0)
             # manage baseline
-            if (isinstance(baseline, numpy.ndarray) and
-                    baseline.size == histogram.size):
-                baseline = numpy.empty(baseline.shape[0] * 2)
-                for i_value, value in enumerate(baseline):
-                    baseline[i_value*2:i_value*2+2] = value
+            if (isinstance(baseline, abc.Iterable)):
+                baseline = numpy.array(baseline)
+                if baseline.size == histogram.size:
+                    new_baseline = numpy.empty(baseline.shape[0] * 2)
+                    for i_value, value in enumerate(baseline):
+                        new_baseline[i_value*2:i_value*2+2] = value
+                    baseline = new_baseline
             self._histogram = histogram
             self._edges = edges
             self._alignement = align

--- a/silx/gui/plot/items/histogram.py
+++ b/silx/gui/plot/items/histogram.py
@@ -165,6 +165,7 @@ class Histogram(Item, AlphaMixIn, ColorMixIn, FillMixIn,
                                 selectable=self.isSelectable(),
                                 fill=self.isFill(),
                                 alpha=self.getAlpha(),
+                                baseline=None,
                                 symbolsize=1)
 
     def _getBounds(self):

--- a/silx/gui/plot/items/histogram.py
+++ b/silx/gui/plot/items/histogram.py
@@ -111,6 +111,8 @@ class Histogram(Item, AlphaMixIn, ColorMixIn, FillMixIn,
     _DEFAULT_LINESTYLE = '-'
     """Default line style of the histogram"""
 
+    _DEFAULT_BASELINE = None
+
     def __init__(self):
         Item.__init__(self)
         AlphaMixIn.__init__(self)
@@ -121,6 +123,7 @@ class Histogram(Item, AlphaMixIn, ColorMixIn, FillMixIn,
 
         self._histogram = ()
         self._edges = ()
+        self._baseline = Histogram._DEFAULT_BASELINE
 
     def _addBackendRenderer(self, backend):
         """Update backend renderer"""
@@ -165,7 +168,7 @@ class Histogram(Item, AlphaMixIn, ColorMixIn, FillMixIn,
                                 selectable=self.isSelectable(),
                                 fill=self.isFill(),
                                 alpha=self.getAlpha(),
-                                baseline=None,
+                                baseline=self._baseline,
                                 symbolsize=1)
 
     def _getBounds(self):
@@ -297,6 +300,20 @@ class Histogram(Item, AlphaMixIn, ColorMixIn, FillMixIn,
                 plot._invalidateDataRange()
 
         self._updated(ItemChangedType.DATA)
+
+    def setBaseline(self, baseline):
+        if isinstance(baseline, numpy.ndarray):
+            self._baseline = numpy.empty(baseline.shape[0] * 2)
+            for i_value, value in enumerate(baseline):
+                self._baseline[i_value*2:i_value*2+2] = value
+        else:
+            self._baseline = baseline
+
+    def getBaseline(self, copy=True):
+        if copy is True and isinstance(self._baseline, numpy.ndarray):
+            return self._baseline.copy()
+        else:
+            return self._baseline
 
     def getAlignment(self):
         """

--- a/silx/gui/plot/items/histogram.py
+++ b/silx/gui/plot/items/histogram.py
@@ -129,7 +129,7 @@ class Histogram(Item, AlphaMixIn, ColorMixIn, FillMixIn,
 
         self._histogram = ()
         self._edges = ()
-        self.setBaseline(Histogram._DEFAULT_BASELINE)
+        self._setBaseline(Histogram._DEFAULT_BASELINE)
 
     def _addBackendRenderer(self, backend):
         """Update backend renderer"""
@@ -311,7 +311,7 @@ class Histogram(Item, AlphaMixIn, ColorMixIn, FillMixIn,
             self._histogram = histogram
             self._edges = edges
             self._alignement = align
-            self.setBaseline(baseline)
+            self._setBaseline(baseline)
 
         if self.isVisible():
             plot = self.getPlot()

--- a/silx/gui/plot/items/histogram.py
+++ b/silx/gui/plot/items/histogram.py
@@ -302,14 +302,31 @@ class Histogram(Item, AlphaMixIn, ColorMixIn, FillMixIn,
         self._updated(ItemChangedType.DATA)
 
     def setBaseline(self, baseline):
+        """
+        Set histogram baseline baseline
+
+        :param baseline: histogram baseline
+        :type: Union[float,numpy.ndarray]
+        :return:
+        """
         if isinstance(baseline, numpy.ndarray):
-            self._baseline = numpy.empty(baseline.shape[0] * 2)
-            for i_value, value in enumerate(baseline):
-                self._baseline[i_value*2:i_value*2+2] = value
+            # manage the case user give only one value par histogram value
+            if len(self._baseline) != len(self._edges):
+                self._baseline = numpy.empty(baseline.shape[0] * 2)
+                for i_value, value in enumerate(baseline):
+                    self._baseline[i_value*2:i_value*2+2] = value
+            else:
+                self._baseline = baseline
         else:
             self._baseline = baseline
 
     def getBaseline(self, copy=True):
+        """
+
+        :param bool copy:
+        :return: histogram baseline
+        :rtype: Union[float,None,numpy.ndarray]
+        """
         if copy is True and isinstance(self._baseline, numpy.ndarray):
             return self._baseline.copy()
         else:

--- a/silx/gui/plot/items/histogram.py
+++ b/silx/gui/plot/items/histogram.py
@@ -174,7 +174,7 @@ class Histogram(Item, AlphaMixIn, ColorMixIn, FillMixIn,
                                 selectable=self.isSelectable(),
                                 fill=self.isFill(),
                                 alpha=self.getAlpha(),
-                                baseline=self._baseline,
+                                baseline=baseline,
                                 symbolsize=1)
 
     def _getBounds(self):

--- a/silx/gui/plot/items/histogram.py
+++ b/silx/gui/plot/items/histogram.py
@@ -8,7 +8,7 @@
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
+# furnished to do so, subject to the following conditions::t
 #
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
@@ -278,7 +278,7 @@ class Histogram(Item, AlphaMixIn, ColorMixIn, FillMixIn,
             the N+1 bin edges are computed according to the alignment in:
             'center' (default), 'left', 'right'.
         :param baseline: histogram baseline
-        :type: Union[None,float,numpy.ndarray]
+        :type baseline: Union[None,float,numpy.ndarray]
         :param bool copy: True make a copy of the data (default),
                           False to use provided arrays.
         """

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -142,7 +142,8 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
                                     selectable=self.isSelectable(),
                                     fill=False,
                                     alpha=self.getAlpha(),
-                                    symbolsize=self.getSymbolSize())
+                                    symbolsize=self.getSymbolSize(),
+                                    baseline=None)
 
         else:  # 'solid'
             plot = self.getPlot()

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -475,7 +475,7 @@ class TestPlotCurve(PlotWidgetTestCase):
                            replace=False, resetzoom=False,
                            color=color, symbol='o')
 
-    def testPlotBaseline(self):
+    def testPlotBaselineNumpyArray(self):
         """simple test of the API with baseline as a numpy array"""
         x = numpy.arange(0, 10, step=0.1)
         my_sin = numpy.sin(x)
@@ -485,7 +485,7 @@ class TestPlotCurve(PlotWidgetTestCase):
         self.plot.addCurve(x=x, y=y, color='grey', legend='curve1', fill=True,
                            baseline=baseline)
 
-    def testPlotBaseline(self):
+    def testPlotBaselineScalar(self):
         """simple test of the API with baseline as an int"""
         x = numpy.arange(0, 10, step=0.1)
         my_sin = numpy.sin(x)
@@ -493,6 +493,15 @@ class TestPlotCurve(PlotWidgetTestCase):
 
         self.plot.addCurve(x=x, y=y, color='grey', legend='curve1', fill=True,
                            baseline=0)
+
+    def testPlotBaselineList(self):
+        """simple test of the API with baseline as an int"""
+        x = numpy.arange(0, 10, step=0.1)
+        my_sin = numpy.sin(x)
+        y = numpy.arange(-4, 6, step=0.1) + my_sin
+
+        self.plot.addCurve(x=x, y=y, color='grey', legend='curve1', fill=True,
+                           baseline=list(range(0, 100, 1)))
 
 
 class TestPlotHistogram(PlotWidgetTestCase):

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -475,6 +475,47 @@ class TestPlotCurve(PlotWidgetTestCase):
                            replace=False, resetzoom=False,
                            color=color, symbol='o')
 
+    def testPlotBaseline(self):
+        """simple test of the API with baseline as a numpy array"""
+        x = numpy.arange(0, 10, step=0.1)
+        my_sin = numpy.sin(x)
+        y = numpy.arange(-4, 6, step=0.1) + my_sin
+        baseline = y - 1.0
+
+        self.plot.addCurve(x=x, y=y, color='grey', legend='curve1', fill=True,
+                           baseline=baseline)
+
+    def testPlotBaseline(self):
+        """simple test of the API with baseline as an int"""
+        x = numpy.arange(0, 10, step=0.1)
+        my_sin = numpy.sin(x)
+        y = numpy.arange(-4, 6, step=0.1) + my_sin
+
+        self.plot.addCurve(x=x, y=y, color='grey', legend='curve1', fill=True,
+                           baseline=0)
+
+
+class TestPlotHistogram(PlotWidgetTestCase):
+    """Basic tests for add Histogram"""
+    def setUp(self):
+        super(TestPlotHistogram, self).setUp()
+        self.edges = numpy.arange(0, 10, step=1)
+        self.histogram = numpy.random.random(len(self.edges))
+
+    def testPlot(self):
+        self.plot.addHistogram(histogram=self.histogram,
+                               edges=self.edges,
+                               legend='histogram1')
+
+    def testPlotBaseline(self):
+        self.plot.addHistogram(histogram=self.histogram,
+                               edges=self.edges,
+                               legend='histogram1',
+                               color='blue',
+                               baseline=-2,
+                               z=2,
+                               fill=True)
+
 
 class TestPlotScatter(PlotWidgetTestCase, ParametricTestCase):
     """Basic tests for addScatter"""
@@ -1564,6 +1605,7 @@ def suite():
     testClasses = (TestPlotWidget,
                    TestPlotImage,
                    TestPlotCurve,
+                   TestPlotHistogram,
                    TestPlotScatter,
                    TestPlotMarker,
                    TestPlotItem,


### PR DESCRIPTION
This is the PR related to #2714 to add a baseline parameter.

this include
- [x] matlab backend
- [x] opengl backend
- [x] unittest
- [x] example of usage -> not sure this is mandatory

If such a parameter is added then we could reconsider the usage of the 'fill parameter'.
/close #2714 


small script to test, for now fails in the addHistogram, with the current values:
``` python
from silx.gui import qt
from silx.gui.plot import Plot1D
import numpy

qapp = qt.QApplication([])

x = numpy.arange(0, 10, step=0.1)
my_sin = numpy.sin(x)
y = numpy.arange(-4, 6, step=0.1) + my_sin
mean = numpy.arange(-5, 5, step=0.1) + my_sin
baseline = numpy.arange(-6, 4, step=0.1) + my_sin
edges = x[y>=3.2]
histo = mean[y>=3.2] - 1.8

# opengl plot
plot_ogl = Plot1D(backend='opengl')
plot_ogl.addCurve(x=x, y=y, baseline=baseline, color='grey', legend='std-curve', fill=True)
plot_ogl.addCurve(x=x, y=mean, color='red', legend='mean')
plot_ogl.addHistogram(histogram=histo, edges=edges, color='red', legend='mean2', fill=True)

# matplotlib plot
plot_mtl = Plot1D()
plot_mtl.addCurve(x=x, y=y, baseline=baseline, color='grey', legend='std-curve')
plot_mtl.addCurve(x=x, y=mean, color='red', legend='mean')
plot_mtl.addHistogram(histogram=histo, edges=edges, color='red', legend='mean2', fill=True)

plot_mtl.show()
plot_ogl.show()

qapp.exec_()
```
