### PR TITLE
[Scatter Mask] Prevent unhandled exception

### DIFF
--- a/silx/gui/plot/ScatterMaskToolsWidget.py
+++ b/silx/gui/plot/ScatterMaskToolsWidget.py
@@ -280,7 +280,7 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
             # if the method is not connected this raises a TypeError and there is no way
             # to know the connected slots
             self.plot.sigActiveScatterChanged.disconnect(self._activeScatterChanged)
-        except TypeError:
+        except (RuntimeError, TypeError):
             _logger.info(sys.exc_info()[1])
         if not self.browseAction.isChecked():
             self.browseAction.trigger()  # Disable drawing tool

--- a/silx/gui/plot/ScatterMaskToolsWidget.py
+++ b/silx/gui/plot/ScatterMaskToolsWidget.py
@@ -276,7 +276,12 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
         self.plot.sigActiveScatterChanged.connect(self._activeScatterChanged)
 
     def hideEvent(self, event):
-        self.plot.sigActiveScatterChanged.disconnect(self._activeScatterChanged)
+        try:
+            # if the method is not connected this raises a TypeError and there is no way
+            # to know the connected slots
+            self.plot.sigActiveScatterChanged.disconnect(self._activeScatterChanged)
+        except TypeError:
+            _logger.info(sys.exc_info()[1])
         if not self.browseAction.isChecked():
             self.browseAction.trigger()  # Disable drawing tool
 


### PR DESCRIPTION
Attempting to disconnect a non-connected method raises a type error.

According to this old post, there is no way to know it the slot was connected or not

https://forum.qt.io/topic/6667/i-strongly-need-to-know-slot-where-signal-is-connected-to/11