### PR TITLE
[PlotWindow] fix call to getStatsWidget.

### DIFF
--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -561,9 +561,9 @@ class PlotWindow(PlotWidget):
             self._statsDockWidget.setWindowTitle("Curves stats")
             self._statsDockWidget.layout().setContentsMargins(0, 0, 0, 0)
             statsWidget = BasicStatsWidget(parent=self, plot=self)
+            self._statsDockWidget.setWidget(statsWidget)
             statsWidget.sigVisibilityChanged.connect(
                 self.getStatsAction().setChecked)
-            self._statsDockWidget.setWidget(statsWidget)
             self._statsDockWidget.hide()
             self._statsDockWidget.visibilityChanged.connect(
                 self.__handleFirstDockWidgetShow)


### PR DESCRIPTION
When we try to call the getStatsWidget() the _statsDockWidget.widget() is None. This came from the merge of PR #2674 because `self._statsDockWidget.setWidget(statsWidget)` need to be set before any other call to `getStatsWidget()` which is made by getStatsAction() and bring some incoherence.

this PR fix it