### PR TITLE
PlotWidget.pickItems returns objects

### DIFF
--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -1079,8 +1079,9 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
             applyZoomToPlot(self.machine.plot, scaleF, (x, y))
 
         def onMove(self, x, y):
-            marker = self.machine.plot._pickTopMost(
-                    x, y, lambda item: isinstance(item, items.MarkerBase))[0]
+            result = self.machine.plot._pickTopMost(
+                    x, y, lambda item: isinstance(item, items.MarkerBase))
+            marker = result.getItem() if result is not None else None
 
             if marker is not None:
                 dataPos = self.machine.plot.pixelToData(x, y)
@@ -1153,8 +1154,11 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
         """
 
         if btn == LEFT_BTN:
-            item, indices = self.plot._pickTopMost(
-                x, y, lambda i: i.isSelectable())
+            result = self.plot._pickTopMost(x, y, lambda i: i.isSelectable())
+            if result is None:
+                return None
+
+            item = result.getItem()
 
             if isinstance(item, items.MarkerBase):
                 xData, yData = item.getPosition()
@@ -1180,6 +1184,7 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
                 xData = item.getXData(copy=False)
                 yData = item.getYData(copy=False)
 
+                indices = result.getIndices(copy=False)
                 eventDict = prepareCurveSignal('left',
                                                item.getLegend(),
                                                'curve',
@@ -1193,7 +1198,7 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
                 dataPos = self.plot.pixelToData(x, y)
                 assert dataPos is not None
 
-                row, column = indices[0]
+                row, column = result.getIndices(copy=False)[0]
                 eventDict = prepareImageSignal('left',
                                                item.getLegend(),
                                                'image',
@@ -1246,7 +1251,9 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
         self._lastPos = self.plot.pixelToData(x, y)
         assert self._lastPos is not None
 
-        item = self.plot._pickTopMost(x, y, self.__isDraggableItem)[0]
+        result = self.plot._pickTopMost(x, y, self.__isDraggableItem)
+        item = result.getItem() if result is not None else None
+
         self.draggedItemRef = None if item is None else weakref.ref(item)
 
         if item is None:
@@ -1308,9 +1315,9 @@ class ItemsInteractionForCombo(ItemsInteraction):
 
         def onPress(self, x, y, btn):
             if btn == LEFT_BTN:
-                item = self.machine.plot._pickTopMost(
-                    x, y, self.__isItemSelectableOrDraggable)[0]
-                if item is not None:  # Request focus and handle interaction
+                result = self.machine.plot._pickTopMost(
+                    x, y, self.__isItemSelectableOrDraggable)
+                if result is not None:  # Request focus and handle interaction
                     self.goto('clickOrDrag', x, y)
                     return True
                 else:  # Do not request focus

--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -1198,7 +1198,8 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
                 dataPos = self.plot.pixelToData(x, y)
                 assert dataPos is not None
 
-                row, column = result.getIndices(copy=False)[0]
+                indices = result.getIndices(copy=False)
+                row, column = indices[0][0], indices[1][0]
                 eventDict = prepareImageSignal('left',
                                                item.getLegend(),
                                                'image',

--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -1274,7 +1274,7 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
             item.drag(self._lastPos, dataPos)
 
             if isinstance(item, items.MarkerBase):
-                 self._signalMarkerMovingEvent('markerMoving', item, x, y)
+                self._signalMarkerMovingEvent('markerMoving', item, x, y)
 
         self._lastPos = dataPos
 

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2928,14 +2928,14 @@ class PlotWidget(qt.QMainWindow):
         :param callable condition:
            Callable taking an item as input and returning False for items
            to skip during picking. If None (default) no item is skipped.
-        :return: Iterable of (plot item, indices) at picked position.
+        :return: Iterable of :class:`PickingResult` objects at picked position.
             Items are ordered from front to back.
         """
         for item in self._itemsFrontToBack():
             if condition is None or condition(item):
-                indices = item.pick(x, y)
-                if indices is not None:
-                    yield item, indices
+                result = item.pick(x, y)
+                if result is not None:
+                    yield result
 
     def _pickTopMost(self, x, y, condition=None):
         """Returns top-most picked item in the plot at given position.
@@ -2947,12 +2947,13 @@ class PlotWidget(qt.QMainWindow):
         :param callable condition:
            Callable taking an item as input and returning False for items
            to skip during picking. If None (default) no item is skipped.
-        :return: (plot item, indices) at picked position or
-           If no item is picked, it returns (None, None)
+        :return: :class:`PickingResult` object at picked position.
+           If no item is picked, it returns None
+        :rtype: Union[None,PickingResult]
         """
-        for item, indices in self.pickItems(x, y, condition):
-            return item, indices
-        return None, None
+        for result in self.pickItems(x, y, condition):
+            return result
+        return None
 
     # User event handling #
 

--- a/silx/gui/plot/ScatterView.py
+++ b/silx/gui/plot/ScatterView.py
@@ -162,13 +162,14 @@ class ScatterView(qt.QMainWindow):
                 pixelPos = plot.dataToPixel(x, y)
                 if pixelPos is not None:
                     # Start from top-most item
-                    item, indices = plot._pickTopMost(
+                    result = plot._pickTopMost(
                         pixelPos[0], pixelPos[1],
                         lambda item: isinstance(item, items.Scatter))
-                    if item is not None:
+                    if result is not None:
                         # Get last index
                         # with matplotlib it should be the top-most point
-                        dataIndex = indices[-1]
+                        dataIndex = result.getIndices(copy=False)[-1]
+                        item = result.getItem()
                         self.__pickingCache = (
                             dataIndex,
                             item.getXData(copy=False)[dataIndex],

--- a/silx/gui/plot/items/_pick.py
+++ b/silx/gui/plot/items/_pick.py
@@ -44,7 +44,7 @@ class PickingResult(object):
         """
         self._item = item
 
-        if indices is None or len(indices == 0):
+        if indices is None or len(indices) == 0:
             self._indices = None
         else:
             self._indices = numpy.array(indices, copy=False, dtype=numpy.int)

--- a/silx/gui/plot/items/_pick.py
+++ b/silx/gui/plot/items/_pick.py
@@ -1,0 +1,70 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This module provides classes supporting item picking."""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "04/06/2019"
+
+import numpy
+
+
+class PickingResult(object):
+    """Class to access picking information in a :class:`PlotWidget`"""
+
+    def __init__(self, item, indices=None):
+        """Init
+
+        :param item: The picked item
+        :param numpy.ndarray indices: Array-like of indices of picked data.
+            Either 1D or 2D with dim0: data dimension and dim1: indices.
+            No copy is made.
+        """
+        self._item = item
+
+        if indices is None or len(indices == 0):
+            self._indices = None
+        else:
+            self._indices = numpy.array(indices, copy=False, dtype=numpy.int)
+
+    def getItem(self):
+        """Returns the item this results corresponds to."""
+        return self._item
+
+    def getIndices(self, copy=True):
+        """Returns indices of picked data.
+
+        If data is 1D, it returns a numpy.ndarray, otherwise
+        it returns a tuple with as many numpy.ndarray as there are
+        dimensions in the data.
+
+        :param bool copy: True (default) to get a copy,
+            False to return internal arrays
+        :rtype: Union[None,numpy.ndarray,List[numpy.ndarray]]
+        """
+        if self._indices is None:
+            return None
+        indices = numpy.array(self._indices, copy=copy)
+        return indices if indices.ndim == 1 else tuple(indices)

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -47,6 +47,7 @@ from ....utils.enum import Enum as _Enum
 from ... import qt
 from ... import colors
 from ...colors import Colormap
+from ._pick import PickingResult
 
 from silx import config
 
@@ -335,14 +336,20 @@ class Item(qt.QObject):
 
         :param float x: The x pixel coord where to pick.
         :param float y: The y pixel coord where to pick.
-        :return: None if not picked, else picked indices
+        :return: None if not picked, else the picked position information
+        :rtype: Union[None,PickingResult]
         """
         if not self.isVisible() or self._backendRenderer is None:
             return None
         plot = self.getPlot()
         if plot is None:
             return None
-        return plot._backend.pickItem(x, y, self._backendRenderer)
+
+        indices = plot._backend.pickItem(x, y, self._backendRenderer)
+        if indices is None:
+            return None
+        else:
+            return PickingResult(self, indices if len(indices) != 0 else None)
 
 
 # Mix-in classes ##############################################################

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -42,6 +42,7 @@ import numpy
 from ....utils.proxy import docstring
 from .core import (Item, LabelsMixIn, DraggableMixIn, ColormapMixIn,
                    AlphaMixIn, ItemChangedType)
+from ._pick import PickingResult
 
 
 _logger = logging.getLogger(__name__)
@@ -157,7 +158,7 @@ class ImageBase(Item, LabelsMixIn, DraggableMixIn, AlphaMixIn):
             scale = self.getScale()
             column = int((dataPos[0] - origin[0]) / float(scale[0]))
             row = int((dataPos[1] - origin[1]) / float(scale[1]))
-            return ((row, column),)
+            return PickingResult(self, ([row], [column]))
 
         return None
 

--- a/silx/gui/plot3d/items/_pick.py
+++ b/silx/gui/plot3d/items/_pick.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -34,6 +34,7 @@ __date__ = "24/09/2018"
 import logging
 import numpy
 
+from ...plot.items._pick import PickingResult as _PickingResult
 from ..scene import Viewport, Base
 
 
@@ -177,9 +178,8 @@ class PickContext(object):
         return rayObject
 
 
-class PickingResult(object):
-    """Class to access picking information in a 3D scene.
-    """
+class PickingResult(_PickingResult):
+    """Class to access picking information in a 3D scene."""
 
     def __init__(self, item, positions, indices=None, fetchdata=None):
         """Init
@@ -194,7 +194,8 @@ class PickingResult(object):
             to provide an alternative function to access item data.
             Default is to use `item.getData`.
         """
-        self._item = item
+        super(PickingResult, self).__init__(item, indices)
+
         self._objectPositions = numpy.array(
             positions, copy=False, dtype=numpy.float)
 
@@ -205,35 +206,7 @@ class PickingResult(object):
         self._scenePositions = None
         self._ndcPositions = None
 
-        if indices is None:
-            self._indices = None
-        else:
-            self._indices = numpy.array(indices, copy=False, dtype=numpy.int)
-
         self._fetchdata = fetchdata
-
-    def getItem(self):
-        """Returns the item this results corresponds to.
-
-        :rtype: ~silx.gui.plot3d.items.Item3D
-        """
-        return self._item
-
-    def getIndices(self, copy=True):
-        """Returns indices of picked data.
-
-        If data is 1D, it returns a numpy.ndarray, otherwise
-        it returns a tuple with as many numpy.ndarray as there are
-        dimensions in the data.
-
-        :param bool copy: True (default) to get a copy,
-            False to return internal arrays
-        :rtype: Union[None,numpy.ndarray,List[numpy.ndarray]]
-        """
-        if self._indices is None:
-            return None
-        indices = numpy.array(self._indices, copy=copy)
-        return indices if indices.ndim == 1 else tuple(indices)
 
     def getData(self, copy=True):
         """Returns picked data values

--- a/silx/sx/_plot.py
+++ b/silx/sx/_plot.py
@@ -532,7 +532,7 @@ class _GInputHandler(roi.InteractiveRegionOfInterestManager):
                                        data=numpy.array((xData, yData)).T)
 
             elif isinstance(item, items.ImageBase):
-                row, column = indices[0]
+                row, column = indices[0][0], indices[1][0]
                 data = item.getData(copy=False)[row, column]
                 result = _GInputResult((x, y),
                                        item=item,

--- a/silx/sx/_plot.py
+++ b/silx/sx/_plot.py
@@ -510,31 +510,34 @@ class _GInputHandler(roi.InteractiveRegionOfInterestManager):
         xPixel, yPixel = plot.dataToPixel(x, y, axis='left', check=False)
 
         # Pick item at selected position
-        item, indices = plot._pickTopMost(
+        pickingResult = plot._pickTopMost(
             xPixel, yPixel,
             lambda item: isinstance(item, (items.ImageBase, items.Curve)))
 
-        if item is None:
+        if pickingResult is None:
             result = _GInputResult((x, y),
                                    item=None,
                                    indices=numpy.array((), dtype=int),
                                    data=None)
+        else:
+            item = pickingResult.getItem()
+            indices = pickingResult.getIndices(copy=True)
 
-        elif isinstance(item, items.Curve):
-            xData = item.getXData(copy=False)[indices]
-            yData = item.getYData(copy=False)[indices]
-            result = _GInputResult((x, y),
-                                   item=item,
-                                   indices=indices,
-                                   data=numpy.array((xData, yData)).T)
+            if isinstance(item, items.Curve):
+                xData = item.getXData(copy=False)[indices]
+                yData = item.getYData(copy=False)[indices]
+                result = _GInputResult((x, y),
+                                       item=item,
+                                       indices=indices,
+                                       data=numpy.array((xData, yData)).T)
 
-        elif isinstance(item, items.ImageBase):
-            row, column = indices[0]
-            data = item.getData(copy=False)[row, column]
-            result = _GInputResult((x, y),
-                                   item=item,
-                                   indices=(row, column),
-                                   data=data)
+            elif isinstance(item, items.ImageBase):
+                row, column = indices[0]
+                data = item.getData(copy=False)[row, column]
+                result = _GInputResult((x, y),
+                                       item=item,
+                                       indices=(row, column),
+                                       data=data)
 
         self.__selections[roi] = result
 


### PR DESCRIPTION
This PR makes `PlotWidget.pickItems` and items' `pick` method returns a `PickingResult` object rather than a tuple (item, indices) or indices. This enables to provide richer picking information in the future without breaking the API and is consistent with the picking API of `plot3d`.

The `PickingResult` class of `plot3d` inherits from the new one of `plot` and extends it as more features are available for now in `plot3d` picking.
