### PR TITLE
Point roi symbol

### DIFF
--- a/examples/plotInteractiveImageROI.py
+++ b/examples/plotInteractiveImageROI.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -77,7 +77,6 @@ def updateAddedRegionOfInterest(roi):
         roi.setLineWidth(2)
         roi.setLineStyle('--')
     if isinstance(roi, SymbolMixIn):
-        roi.setSymbol('o')
         roi.setSymbolSize(5)
 
 

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -466,7 +466,10 @@ class PointROI(RegionOfInterest, items.SymbolMixIn):
     """Plot shape which is used for the first interaction"""
 
     _DEFAULT_SYMBOL = '+'
-    """Default symbol of the PointROI"""
+    """Default symbol of the PointROI
+
+    It overwrite the `SymbolMixIn` class attribte.
+    """
 
     def __init__(self, parent=None):
         items.SymbolMixIn.__init__(self)

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -465,6 +465,9 @@ class PointROI(RegionOfInterest, items.SymbolMixIn):
     _plotShape = "point"
     """Plot shape which is used for the first interaction"""
 
+    _DEFAULT_SYMBOL = '+'
+    """Default symbol of the PointROI"""
+
     def __init__(self, parent=None):
         items.SymbolMixIn.__init__(self)
         RegionOfInterest.__init__(self, parent=parent)


### PR DESCRIPTION
This PR changes the default symbol used for `PointROI` in `plot` back to '+', and updates the ROI example script.

Some changes made the default symbol used for `PointROI` a 'o' as a side effect.
'+' sounds better and this PR restores it as a default.