### PR TITLE
Rework PlotWidget rendering/picking order

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2914,8 +2914,8 @@ class PlotWidget(qt.QMainWindow):
            If None (default), no item is skipped.
         :rtpye: List[Item]
         """
-        # Sort items: Overlays and markers first, then others
-        # and in each category ordered by z and by order of addition
+        # Sort items: Overlays first, then others
+        # and in each category ordered by z and then by order of addition
         # as _content keeps this order.
         content = self._content.values()
         if condition is not None:

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2909,8 +2909,7 @@ class PlotWidget(qt.QMainWindow):
         It takes into account overlays, z value and order of addition of items
 
         :param callable condition:
-           Callable taking an item as input and returning False for items
-           to skip.
+           Callable taking an item as input and returning False for items to skip.
            If None (default), no item is skipped.
         :rtpye: List[Item]
         """

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1224,6 +1224,10 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
 
         This is directly called by matplotlib for widget resize.
         """
+        # Hide axes borders to defer rendering
+        for spine in self.ax.spines.values():
+            spine.set_visible(False)
+
         # Starting with mpl 2.1.0, toggling autoscale raises a ValueError
         # in some situations. See #1081, #1136, #1163,
         if self._matplotlibVersion >= _parse_version("2.0.0"):
@@ -1261,6 +1265,14 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
                 self._plot.getYAxis(axis='right')._emitLimitsChanged()
 
         self._drawOverlays()
+
+        # Draw axes borders at last
+        for spine in self.ax.spines.values():
+            spine.set_visible(True)
+            self.ax.draw_artist(spine)
+        # Alternative: redraw what's inside the frame
+        # which ends-up to redraw the border as everything is "animated"
+        #self.ax.redraw_in_frame()
 
     def replot(self):
         BackendMatplotlib.replot(self)

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -727,7 +727,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
             self._graphCursor = lineh, linev
         else:
-            if self._graphCursor is not None:
+            if self._graphCursor:
                 lineh, linev = self._graphCursor
                 lineh.remove()
                 linev.remove()

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1195,16 +1195,18 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
             False (default) to draw all items but overlays,
             True to draw only overlay items.
         """
-        for item in self._plot._itemsFromBackToFront():
-            if (item.isVisible() and
+        def condition(item):
+            return (item.isVisible() and
                     item._backendRenderer is not None and
-                    (item._backendRenderer in self._overlays) == overlay):
-                if (isinstance(item, items.YAxisMixIn) and
-                        item.getYAxis() == 'right'):
-                    axes = self.ax2
-                else:
-                    axes = self.ax
-                axes.draw_artist(item._backendRenderer)
+                    (item._backendRenderer in self._overlays) == overlay)
+
+        for item in self._plot._itemsFromBackToFront(condition=condition):
+            if (isinstance(item, items.YAxisMixIn) and
+                    item.getYAxis() == 'right'):
+                axes = self.ax2
+            else:
+                axes = self.ax
+            axes.draw_artist(item._backendRenderer)
 
     def _drawOverlays(self):
         """Draw overlays if any."""

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1225,8 +1225,9 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
         This is directly called by matplotlib for widget resize.
         """
         # Hide axes borders to defer rendering
-        for spine in self.ax.spines.values():
-            spine.set_visible(False)
+        if self.ax.axison:
+            for spine in self.ax.spines.values():
+                spine.set_visible(False)
 
         # Starting with mpl 2.1.0, toggling autoscale raises a ValueError
         # in some situations. See #1081, #1136, #1163,
@@ -1267,12 +1268,13 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
         self._drawOverlays()
 
         # Draw axes borders at last
-        for spine in self.ax.spines.values():
-            spine.set_visible(True)
-            self.ax.draw_artist(spine)
-        # Alternative: redraw what's inside the frame
-        # which ends-up to redraw the border as everything is "animated"
-        #self.ax.redraw_in_frame()
+        if self.ax.axison:
+            for spine in self.ax.spines.values():
+                spine.set_visible(True)
+                self.ax.draw_artist(spine)
+            # Alternative: redraw what's inside the frame
+            # which ends-up to redraw the border as everything is "animated"
+            #self.ax.redraw_in_frame()
 
     def replot(self):
         BackendMatplotlib.replot(self)

--- a/silx/gui/plot/items/marker.py
+++ b/silx/gui/plot/items/marker.py
@@ -81,13 +81,11 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn):
         self.setPosition(to[0], to[1])
 
     def isOverlay(self):
-        """Return true if marker is drawn as an overlay.
-
-        A marker is an overlay if it is draggable.
+        """Returns True: A marker is always rendered as an overlay.
 
         :rtype: bool
         """
-        return self.isDraggable()
+        return True
 
     def getText(self):
         """Returns marker text.


### PR DESCRIPTION
This PR reworks completely the order in which the plot items are rendered and picked:
- Picking order was not consistent with rendering order after merging PR #2602 which didn't care about the item ordering on screen.
- Rendering order was not ideal because:
  -  for a given z value, the rendering order was defined by the order of updates of items rather than the order of addition to the plot.
  - for overlaid items (i.e., markers and draggable shape items), the z value was not taken into account.

Now the rendering order is defined by:
- first, whether or not the item is an overlay,
- then by the z value,
- and finally by the order of addition of items in the plot.

Rendering order of items is no longer managed by the backend, instead, the backend are asking the order to the PlotWIdget.

Picking order is the reversed order of rendering.

The adaptation is done for the matplotlib backend.
TODO: Make it for the OpenGL backend.

closes  #2682