### PR TITLE
Fixes bootstrap.py starting IPython the wrong way

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -236,14 +236,14 @@ def main(argv):
         logger.info("Patch the sys.argv: %s", sys.argv)
         sys.path.insert(2, "")
         try:
-            from IPython import embed
+            from IPython import start_ipython
         except Exception as err:
             logger.error("Unable to execute iPython, using normal Python")
             logger.error(err)
             import code
             code.interact()
         else:
-            embed()
+            start_ipython(argv=[])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes issues with `bootstrap.py` and IPython (e.g., defined variables not available in `globals()`).
It was using `embed` while `start_ipython` is preferable.