### PR TITLE
Avoid some synchronization replot in matplotlib backend

### DIFF
--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -818,6 +818,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
         if self._dirtyLimits and self.isKeepDataAspectRatio():
             self.ax.apply_aspect()
             self.ax2.apply_aspect()
+            self._dirtyLimits = False
         return self.ax.get_xbound()
 
     def setGraphXLimits(self, xmin, xmax):
@@ -835,6 +836,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
         if self._dirtyLimits and self.isKeepDataAspectRatio():
             self.ax.apply_aspect()
             self.ax2.apply_aspect()
+            self._dirtyLimits = False
 
         return ax.get_ybound()
 

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -816,7 +816,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
     def getGraphXLimits(self):
         if self._dirtyLimits and self.isKeepDataAspectRatio():
-            self.replot()  # makes sure we get the right limits
+            self.ax.apply_aspect()
+            self.ax2.apply_aspect()
         return self.ax.get_xbound()
 
     def setGraphXLimits(self, xmin, xmax):
@@ -832,7 +833,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
             return None
 
         if self._dirtyLimits and self.isKeepDataAspectRatio():
-            self.replot()  # makes sure we get the right limits
+            self.ax.apply_aspect()
+            self.ax2.apply_aspect()
 
         return ax.get_ybound()
 


### PR DESCRIPTION
This PR uses the matplotlib `Axes.apply_aspect` method to synchronize plot limits rather than doing a full replot.
This avoids to replot when getting the limits of a plot with keep aspect ratio.