### PR TITLE
Fix float32

### DIFF
--- a/silx/io/fabioh5.py
+++ b/silx/io/fabioh5.py
@@ -614,12 +614,16 @@ class FabioReader(object):
         converted = []
         types = set([])
         has_none = False
+        is_array = False
+
         for v in values:
             if v is None:
                 converted.append(None)
                 has_none = True
             else:
                 c = self._convert_value(v)
+                if c.shape != tuple():
+                    is_array = True
                 converted.append(c)
                 types.add(c.dtype)
 
@@ -661,8 +665,13 @@ class FabioReader(object):
                 if r is not None:
                     continue
                 result[index] = none_value
+                values[index] = none_value
 
-        return numpy.array(result, dtype=result_type)
+        if is_array:
+            return numpy.array(result, dtype=result_type)
+        if len(types) == 1:
+            return numpy.array(result, dtype=result_type)
+        return numpy.array(values, dtype=result_type)
 
     def _convert_value(self, value):
         """Convert a string into a numpy object (scalar or array).

--- a/silx/io/fabioh5.py
+++ b/silx/io/fabioh5.py
@@ -732,7 +732,10 @@ class FabioReader(object):
                 # use the raw data to create the result
                 return numpy.unicode_(value)
             else:
-                return numpy.array(numpy_values, dtype=result_type)
+                if len(types) == 1:
+                    return numpy.array(numpy_values, dtype=result_type)
+                else:
+                    return numpy.array(values, dtype=result_type)
         except ValueError:
             return numpy.string_(value)
 

--- a/silx/io/test/test_fabioh5.py
+++ b/silx/io/test/test_fabioh5.py
@@ -238,6 +238,26 @@ class TestFabioH5(unittest.TestCase):
         self.assertIn(data.dtype.kind, ['d', 'f'])
         self.assertGreaterEqual(data.dtype.itemsize, 64 / 8)
 
+    def test_mixed_float_size__scalar(self):
+        # We expect to have a precision of 32 bits
+        float_list = [u'1.2', u'1.3001']
+        expected_float_result = [1.2, 1.3001]
+        data = numpy.array([[0, 0], [0, 0]], dtype=numpy.int8)
+        fabio_image = None
+        for float_item in float_list:
+            header = {"float_item": float_item}
+            if fabio_image is None:
+                fabio_image = fabio.edfimage.EdfImage(data=data, header=header)
+            else:
+                fabio_image.appendFrame(data=data, header=header)
+        h5_image = fabioh5.File(fabio_image=fabio_image)
+        data = h5_image["/scan_0/instrument/detector_0/others/float_item"]
+        # At worst a float32
+        self.assertIn(data.dtype.kind, ['d', 'f'])
+        self.assertLessEqual(data.dtype.itemsize, 32 / 8)
+        for computed, expected in zip(data, expected_float_result):
+            numpy.testing.assert_almost_equal(computed, expected, 5)
+
     def test_mixed_float_size__list(self):
         # We expect to have a precision of 32 bits
         float_list = [u'1.2 1.3001']

--- a/silx/io/test/test_fabioh5.py
+++ b/silx/io/test/test_fabioh5.py
@@ -261,7 +261,27 @@ class TestFabioH5(unittest.TestCase):
     def test_mixed_float_size__list(self):
         # We expect to have a precision of 32 bits
         float_list = [u'1.2 1.3001']
-        expected_float_result = numpy.array([1.2, 1.3001])
+        expected_float_result = numpy.array([[1.2, 1.3001]])
+        data = numpy.array([[0, 0], [0, 0]], dtype=numpy.int8)
+        fabio_image = None
+        for float_item in float_list:
+            header = {"float_item": float_item}
+            if fabio_image is None:
+                fabio_image = fabio.edfimage.EdfImage(data=data, header=header)
+            else:
+                fabio_image.appendFrame(data=data, header=header)
+        h5_image = fabioh5.File(fabio_image=fabio_image)
+        data = h5_image["/scan_0/instrument/detector_0/others/float_item"]
+        # At worst a float32
+        self.assertIn(data.dtype.kind, ['d', 'f'])
+        self.assertLessEqual(data.dtype.itemsize, 32 / 8)
+        for computed, expected in zip(data, expected_float_result):
+            numpy.testing.assert_almost_equal(computed, expected, 5)
+
+    def test_mixed_float_size__list_of_list(self):
+        # We expect to have a precision of 32 bits
+        float_list = [u'1.2 1.3001', u'1.3001 1.3001']
+        expected_float_result = numpy.array([[1.2, 1.3001], [1.3001, 1.3001]])
         data = numpy.array([[0, 0], [0, 0]], dtype=numpy.int8)
         fabio_image = None
         for float_item in float_list:

--- a/silx/io/test/test_fabioh5.py
+++ b/silx/io/test/test_fabioh5.py
@@ -238,6 +238,26 @@ class TestFabioH5(unittest.TestCase):
         self.assertIn(data.dtype.kind, ['d', 'f'])
         self.assertGreaterEqual(data.dtype.itemsize, 64 / 8)
 
+    def test_mixed_float_size__list(self):
+        # We expect to have a precision of 32 bits
+        float_list = [u'1.2 1.3001']
+        expected_float_result = numpy.array([1.2, 1.3001])
+        data = numpy.array([[0, 0], [0, 0]], dtype=numpy.int8)
+        fabio_image = None
+        for float_item in float_list:
+            header = {"float_item": float_item}
+            if fabio_image is None:
+                fabio_image = fabio.edfimage.EdfImage(data=data, header=header)
+            else:
+                fabio_image.appendFrame(data=data, header=header)
+        h5_image = fabioh5.File(fabio_image=fabio_image)
+        data = h5_image["/scan_0/instrument/detector_0/others/float_item"]
+        # At worst a float32
+        self.assertIn(data.dtype.kind, ['d', 'f'])
+        self.assertLessEqual(data.dtype.itemsize, 32 / 8)
+        for computed, expected in zip(data, expected_float_result):
+            numpy.testing.assert_almost_equal(computed, expected, 5)
+
     def test_ub_matrix(self):
         """Data from mediapix.edf"""
         header = {}

--- a/silx/utils/number.py
+++ b/silx/utils/number.py
@@ -68,8 +68,8 @@ def is_longdouble_64bits():
 
 def min_numerical_convertible_type(string, check_accuracy=True):
     """
-    Parse the string and return the smallest numerical type to use for a safe
-    conversion.
+    Parse the string and try to return the smallest numerical type to use for
+    a safe conversion. It has some known issues: precission loss.
 
     :param str string: Representation of a float/integer with text
     :param bool check_accuracy: If true, a warning is pushed on the logger

--- a/silx/utils/number.py
+++ b/silx/utils/number.py
@@ -104,7 +104,7 @@ def min_numerical_convertible_type(string, check_accuracy=True):
         exponent = "0"
 
     nb_precision_digits = int(exponent) - len(decimal) - 1
-    precision = _biggest_float(10) ** nb_precision_digits
+    precision = _biggest_float(10) ** nb_precision_digits * 1.2
     previous_type = _biggest_float
     for numpy_type in _float_types:
         if numpy_type == _biggest_float:

--- a/silx/utils/number.py
+++ b/silx/utils/number.py
@@ -104,7 +104,7 @@ def min_numerical_convertible_type(string, check_accuracy=True):
         exponent = "0"
 
     nb_precision_digits = int(exponent) - len(decimal) - 1
-    precision = _biggest_float(10) ** nb_precision_digits * 2.5
+    precision = _biggest_float(10) ** nb_precision_digits
     previous_type = _biggest_float
     for numpy_type in _float_types:
         if numpy_type == _biggest_float:

--- a/silx/utils/test/test_number.py
+++ b/silx/utils/test/test_number.py
@@ -101,6 +101,10 @@ class TestConversionTypes(testutils.ParametricTestCase):
         dtype = number.min_numerical_convertible_type("1.50")
         self.assertEqual(dtype, numpy.float16)
 
+    def testFloat32(self):
+        dtype = number.min_numerical_convertible_type("-23.172")
+        self.assertEqual(dtype, numpy.float32)
+
     def testMantissa32(self):
         dtype = number.min_numerical_convertible_type("1400.50")
         self.assertEqual(dtype, numpy.float32)


### PR DESCRIPTION
- Tune magic coef to allow to discrete float precision expected more than 16bit but less than 64bit bits
- Fix precision for scalar in many frames (1)
- Fix precision for list of numbers (2)
- Fix precision for list of numbers in many frames (3)

Add regression test.

Spotted by @juliagarriga 

It would be good to rework this code to allow to take care of the three use cases (1) (2) (3) in specialized functions. This could create a more readable code.

Closes #2736
Closes #2737