### PR TITLE
Allows URL to go through filename expansion

### DIFF
--- a/silx/utils/files.py
+++ b/silx/utils/files.py
@@ -46,7 +46,11 @@ def expand_filenames(filenames):
         if os.path.exists(filename):
             result.append(filename)
         elif glob.has_magic(filename):
-            result += glob.glob(filename)
+            expanded_filenames = glob.glob(filename)
+            if expanded_filenames:
+                result += expanded_filenames
+            else:  # Cannot expand, add as is
+                result.append(filename)
         else:
             result.append(filename)
     return result


### PR DESCRIPTION
This PR makes URL goes through the filename expansing function by adding filenames with magic that cannot extends.
Not sure it is the best (it would be better to check that it is a URL), but at least it keeps it simple.

closes #2749