### PR TITLE
Update the dialog then show

### DIFF
--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -360,8 +360,8 @@ class ColormapAction(PlotAction):
 
         # Run the dialog listening to colormap change
         if checked is True:
-            self._dialog.show()
             self._updateColormap()
+            self._dialog.show()
         else:
             self._dialog.hide()
 


### PR DESCRIPTION
Here is one way to fix #2764

I think the colordialog size is set with a plot size of 0x0.
And then the plot take all the expected size when the colormap is set to the dialog which create the graphical glitch.

In between i think:
- plotwidget sizehint is maybe wrong
- colormap sizeHint is wrong

I think this patch only fix one of the cases. And the problem still exists.

Closes #2764