### PR TITLE
fix h5todict with asarray=False

### DIFF
--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -311,7 +311,8 @@ def h5todict(h5file, path="/", exclude_names=None, asarray=True):
             if is_group(h5f[path + "/" + key]):
                 ddict[key] = h5todict(h5f,
                                       path + "/" + key,
-                                      exclude_names=exclude_names)
+                                      exclude_names=exclude_names,
+                                      asarray=asarray)
             else:
                 # Read HDF5 datset
                 data = h5f[path + "/" + key][()]


### PR DESCRIPTION
This PR fixes a bug in `h5todict` with argument `asarray=False` where there was an issue during the recursive calls.