### PR TITLE
[Opencl] Convolution: allow for extra option allocate_X_array=False

### DIFF
--- a/silx/opencl/convolution.py
+++ b/silx/opencl/convolution.py
@@ -336,8 +336,7 @@ class Convolution(OpenclProcessing):
         kernel_args = [
             self.queue,
             self.ndrange, self.wg,
-            data_in_ref,
-            # ~ self.data_out.data,
+            None,
             None,
             d_kernel_ref,
             np.int32(self.kernel.shape[0]),

--- a/silx/opencl/convolution.py
+++ b/silx/opencl/convolution.py
@@ -321,11 +321,9 @@ class Convolution(OpenclProcessing):
                 str("-DIMAGE_DIMS=%d" % self.data_ndim),
                 str("-DFILTER_DIMS=%d" % self.kernel_ndim),
             ])
-            data_in_ref = self.data_in_tex
             d_kernel_ref = self.d_kernel_tex
         else:
             kernel_files = ["convolution.cl"]
-            data_in_ref = self.data_in.data
             d_kernel_ref = self.d_kernel.data
         self.compile_kernels(
             kernel_files=kernel_files,

--- a/silx/opencl/convolution.py
+++ b/silx/opencl/convolution.py
@@ -337,7 +337,8 @@ class Convolution(OpenclProcessing):
             self.queue,
             self.ndrange, self.wg,
             data_in_ref,
-            self.data_out.data,
+            # ~ self.data_out.data,
+            None,
             d_kernel_ref,
             np.int32(self.kernel.shape[0]),
             self.Nx, self.Ny, self.Nz


### PR DESCRIPTION
Fix a bug when we don't want to allocate any memory outside of necessary temporary buffer.