### PR TITLE
[Opencl] Move non-opencl utilities

### DIFF
--- a/silx/image/utils.py
+++ b/silx/image/utils.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# /*##########################################################################
+# Copyright (C) 2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+
+import numpy as np
+from math import ceil
+
+def gaussian_kernel(sigma, cutoff=4, force_odd_size=False):
+    """
+    Generates a Gaussian convolution kernel.
+
+    :param sigma: Standard Deviation of the Gaussian curve.
+    :param cutoff: Parameter tuning the truncation of the Gaussian.
+        The higher cutoff, the biggest the array will be (and the closest to
+        a "true" Gaussian function).
+    :param force_odd_size: when set to True, the resulting array will always
+        have an odd size, regardless of the values of "sigma" and "cutoff".
+    :return: a numpy.ndarray containing the truncated Gaussian function.
+        The array size is 2*c*s+1 where c=cutoff, s=sigma.
+
+    Nota: due to the quick decay of the Gaussian function, small values of the
+        "cutoff" parameter are usually fine. The energy difference between a
+        Gaussian truncated to [-c, c] and a "true" one is
+            erfc(c/(sqrt(2)*s))
+        so choosing cutoff=4*sigma keeps the truncation error below 1e-4.
+    """
+    size = int(ceil(2 * cutoff * sigma + 1))
+    if force_odd_size and size % 2 == 0:
+        size += 1
+    x = np.arange(size) - (size - 1.0) / 2.0
+    g = np.exp(-(x / sigma) ** 2 / 2.0)
+    g /= g.sum()
+    return g

--- a/silx/opencl/convolution.py
+++ b/silx/opencl/convolution.py
@@ -32,96 +32,11 @@ __license__ = "MIT"
 __date__ = "01/08/2019"
 
 import numpy as np
-from math import ceil
 from copy import copy  # python2
 from .common import pyopencl as cl
 import pyopencl.array as parray
 from .processing import OpenclProcessing, EventDescription
-
-
-class ConvolutionInfos(object):
-    allowed_axes = {
-        "1D": [None],
-        "separable_2D_1D_2D": [None, (0, 1), (1, 0)],
-        "batched_1D_2D": [(0,), (1,)],
-        "separable_3D_1D_3D": [
-            None,
-            (0, 1, 2),
-            (1, 2, 0),
-            (2, 0, 1),
-            (2, 1, 0),
-            (1, 0, 2),
-            (0, 2, 1)
-        ],
-        "batched_1D_3D": [(0,), (1,), (2,)],
-        "batched_separable_2D_1D_3D": [(0,), (1,), (2,)], # unsupported (?)
-        "2D": [None],
-        "batched_2D_3D": [(0,), (1,), (2,)],
-        "separable_3D_2D_3D": [
-            (1, 0),
-            (0, 1),
-            (2, 0),
-            (0, 2),
-            (1, 2),
-            (2, 1),
-        ],
-        "3D": [None],
-    }
-    use_cases = {
-        (1, 1): {
-            "1D": {
-                "name": "1D convolution on 1D data",
-                "kernels": ["convol_1D_X"],
-            },
-        },
-        (2, 2): {
-            "2D": {
-                "name": "2D convolution on 2D data",
-                "kernels": ["convol_2D_XY"],
-            },
-        },
-        (3, 3): {
-            "3D": {
-                "name": "3D convolution on 3D data",
-                "kernels": ["convol_3D_XYZ"],
-            },
-        },
-        (2, 1): {
-            "separable_2D_1D_2D": {
-                "name": "Separable (2D->1D) convolution on 2D data",
-                "kernels": ["convol_1D_X", "convol_1D_Y"],
-            },
-            "batched_1D_2D": {
-                "name": "Batched 1D convolution on 2D data",
-                "kernels": ["convol_1D_X", "convol_1D_Y"],
-            },
-        },
-        (3, 1): {
-            "separable_3D_1D_3D": {
-                "name": "Separable (3D->1D) convolution on 3D data",
-                "kernels": ["convol_1D_X", "convol_1D_Y", "convol_1D_Z"],
-            },
-            "batched_1D_3D": {
-                "name": "Batched 1D convolution on 3D data",
-                "kernels": ["convol_1D_X", "convol_1D_Y", "convol_1D_Z"],
-            },
-            "batched_separable_2D_1D_3D": {
-                "name": "Batched separable (2D->1D) convolution on 3D data",
-                "kernels": ["convol_1D_X", "convol_1D_Y", "convol_1D_Z"],
-            },
-        },
-        (3, 2): {
-            "separable_3D_2D_3D": {
-                "name": "Separable (3D->2D) convolution on 3D data",
-                "kernels": ["convol_2D_XY", "convol_2D_XZ", "convol_2D_YZ"],
-            },
-            "batched_2D_3D": {
-                "name": "Batched 2D convolution on 3D data",
-                "kernels": ["convol_2D_XY", "convol_2D_XZ", "convol_2D_YZ"],
-            },
-        },
-    }
-
+from .utils import ConvolutionInfos
 
 class Convolution(OpenclProcessing):
     """
@@ -528,29 +443,3 @@ class Convolution(OpenclProcessing):
     __call__ = convolve
 
 
-def gaussian_kernel(sigma, cutoff=4, force_odd_size=False):
-    """
-    Generates a Gaussian convolution kernel.
-
-    :param sigma: Standard Deviation of the Gaussian curve.
-    :param cutoff: Parameter tuning the truncation of the Gaussian.
-        The higher cutoff, the biggest the array will be (and the closest to
-        a "true" Gaussian function).
-    :param force_odd_size: when set to True, the resulting array will always
-        have an odd size, regardless of the values of "sigma" and "cutoff".
-    :return: a numpy.ndarray containing the truncated Gaussian function.
-        The array size is 2*c*s+1 where c=cutoff, s=sigma.
-
-    Nota: due to the quick decay of the Gaussian function, small values of the
-        "cutoff" parameter are usually fine. The energy difference between a
-        Gaussian truncated to [-c, c] and a "true" one is
-            erfc(c/(sqrt(2)*s))
-        so choosing cutoff=4*sigma keeps the truncation error below 1e-4.
-    """
-    size = int(ceil(2 * cutoff * sigma + 1))
-    if force_odd_size and size % 2 == 0:
-        size += 1
-    x = np.arange(size) - (size - 1.0) / 2.0
-    g = np.exp(-(x / sigma) ** 2 / 2.0)
-    g /= g.sum()
-    return g

--- a/silx/opencl/test/test_convolution.py
+++ b/silx/opencl/test/test_convolution.py
@@ -40,6 +40,7 @@ import logging
 from itertools import product
 import numpy as np
 from silx.utils.testutils import parameterize
+from silx.image.utils import gaussian_kernel
 try:
     from scipy.ndimage import convolve, convolve1d
     from scipy.misc import ascent
@@ -52,7 +53,7 @@ from ..common import ocl
 if ocl:
     import pyopencl as cl
     import pyopencl.array as parray
-    from ..convolution import Convolution, gaussian_kernel
+    from silx.opencl.convolution import Convolution
 logger = logging.getLogger(__name__)
 
 

--- a/silx/opencl/utils.py
+++ b/silx/opencl/utils.py
@@ -119,3 +119,96 @@ def concatenate_cl_kernel(filenames):
     this method concatenates all the kernel from the list
     """
     return os.linesep.join(read_cl_file(fn) for fn in filenames)
+
+
+
+
+class ConvolutionInfos(object):
+    allowed_axes = {
+        "1D": [None],
+        "separable_2D_1D_2D": [None, (0, 1), (1, 0)],
+        "batched_1D_2D": [(0,), (1,)],
+        "separable_3D_1D_3D": [
+            None,
+            (0, 1, 2),
+            (1, 2, 0),
+            (2, 0, 1),
+            (2, 1, 0),
+            (1, 0, 2),
+            (0, 2, 1)
+        ],
+        "batched_1D_3D": [(0,), (1,), (2,)],
+        "batched_separable_2D_1D_3D": [(0,), (1,), (2,)], # unsupported (?)
+        "2D": [None],
+        "batched_2D_3D": [(0,), (1,), (2,)],
+        "separable_3D_2D_3D": [
+            (1, 0),
+            (0, 1),
+            (2, 0),
+            (0, 2),
+            (1, 2),
+            (2, 1),
+        ],
+        "3D": [None],
+    }
+    use_cases = {
+        (1, 1): {
+            "1D": {
+                "name": "1D convolution on 1D data",
+                "kernels": ["convol_1D_X"],
+            },
+        },
+        (2, 2): {
+            "2D": {
+                "name": "2D convolution on 2D data",
+                "kernels": ["convol_2D_XY"],
+            },
+        },
+        (3, 3): {
+            "3D": {
+                "name": "3D convolution on 3D data",
+                "kernels": ["convol_3D_XYZ"],
+            },
+        },
+        (2, 1): {
+            "separable_2D_1D_2D": {
+                "name": "Separable (2D->1D) convolution on 2D data",
+                "kernels": ["convol_1D_X", "convol_1D_Y"],
+            },
+            "batched_1D_2D": {
+                "name": "Batched 1D convolution on 2D data",
+                "kernels": ["convol_1D_X", "convol_1D_Y"],
+            },
+        },
+        (3, 1): {
+            "separable_3D_1D_3D": {
+                "name": "Separable (3D->1D) convolution on 3D data",
+                "kernels": ["convol_1D_X", "convol_1D_Y", "convol_1D_Z"],
+            },
+            "batched_1D_3D": {
+                "name": "Batched 1D convolution on 3D data",
+                "kernels": ["convol_1D_X", "convol_1D_Y", "convol_1D_Z"],
+            },
+            "batched_separable_2D_1D_3D": {
+                "name": "Batched separable (2D->1D) convolution on 3D data",
+                "kernels": ["convol_1D_X", "convol_1D_Y", "convol_1D_Z"],
+            },
+        },
+        (3, 2): {
+            "separable_3D_2D_3D": {
+                "name": "Separable (3D->2D) convolution on 3D data",
+                "kernels": ["convol_2D_XY", "convol_2D_XZ", "convol_2D_YZ"],
+            },
+            "batched_2D_3D": {
+                "name": "Batched 2D convolution on 3D data",
+                "kernels": ["convol_2D_XY", "convol_2D_XZ", "convol_2D_YZ"],
+            },
+        },
+    }
+
+
+
+
+
+
+


### PR DESCRIPTION
In `silx`, importing anything using `silx.opencl.common` creates an OpenCL context on all possible devices on certain machines (see #2703). This is due to `common.py` creating a `OpenCL()` singleton when imported.

However if another module wants to use non-opencl utilities (ex. `ConvolutionInfos`, `gaussian_kernel`), a context should not be created on devices. To ensure so, these features are moved in a module not importing `silx.opencl.common`.