### PR TITLE
Improve legend widget

### DIFF
--- a/examples/simplewidget.py
+++ b/examples/simplewidget.py
@@ -165,13 +165,23 @@ class SimpleWidgetExample(qt.QMainWindow):
         # Symbol and colormap
         legend = LegendIconWidget(panel)
         legend.setSymbol("o")
-        legend.setColormap("viridis")
+        legend.setSymbolColormap("viridis")
         layout.addWidget(legend)
 
         # Symbol (without surface) and colormap
         legend = LegendIconWidget(panel)
         legend.setSymbol("+")
-        legend.setColormap("plasma")
+        legend.setSymbolColormap("plasma")
+        layout.addWidget(legend)
+
+        # Colormap + Line + Symbol
+        legend = LegendIconWidget(panel)
+        legend.setColormap("gray")
+        legend.setLineStyle("-")
+        legend.setLineColor("white")
+        legend.setLineWidth(3)
+        legend.setSymbol(".")
+        legend.setSymbolColormap("red")
         layout.addWidget(legend)
 
         return panel

--- a/examples/simplewidget.py
+++ b/examples/simplewidget.py
@@ -44,6 +44,7 @@ from silx.gui.colors import Colormap
 from silx.gui.widgets.WaitingPushButton import WaitingPushButton
 from silx.gui.widgets.ThreadPoolPushButton import ThreadPoolPushButton
 from silx.gui.widgets.RangeSlider import RangeSlider
+from silx.gui.widgets.LegendIconWidget import LegendIconWidget
 
 
 class SimpleWidgetExample(qt.QMainWindow):
@@ -68,6 +69,10 @@ class SimpleWidgetExample(qt.QMainWindow):
         layout.addWidget(qt.QLabel("RangeSlider"))
         layout.addWidget(self.createRangeSlider())
         layout.addWidget(self.createRangeSliderWithBackground())
+
+        panel = self.createLegendIconPanel(self)
+        layout.addWidget(qt.QLabel("LegendIconWidget"))
+        layout.addWidget(panel)
 
         self.setCentralWidget(main_panel)
 
@@ -121,6 +126,38 @@ class SimpleWidgetExample(qt.QMainWindow):
         colormap = Colormap("viridis")
         widget.setGroovePixmapFromProfile(background, colormap)
         return widget
+
+    def createLegendIconPanel(self, parent):
+        panel = qt.QWidget(parent)
+        layout = qt.QVBoxLayout(panel)
+
+        # Empty
+        legend = LegendIconWidget(panel)
+        layout.addWidget(legend)
+
+        # Line
+        legend = LegendIconWidget(panel)
+        legend.setLineStyle("-")
+        legend.setLineColor("blue")
+        legend.setLineWidth(2)
+        layout.addWidget(legend)
+
+        # Symbol
+        legend = LegendIconWidget(panel)
+        legend.setSymbol("o")
+        legend.setSymbolColor("red")
+        layout.addWidget(legend)
+
+        # Line and symbol
+        legend = LegendIconWidget(panel)
+        legend.setLineStyle(":")
+        legend.setLineColor("green")
+        legend.setLineWidth(2)
+        legend.setSymbol("x")
+        legend.setSymbolColor("violet")
+        layout.addWidget(legend)
+
+        return panel
 
 
 def main():

--- a/examples/simplewidget.py
+++ b/examples/simplewidget.py
@@ -162,6 +162,18 @@ class SimpleWidgetExample(qt.QMainWindow):
         legend.setColormap("viridis")
         layout.addWidget(legend)
 
+        # Symbol and colormap
+        legend = LegendIconWidget(panel)
+        legend.setSymbol("o")
+        legend.setColormap("viridis")
+        layout.addWidget(legend)
+
+        # Symbol (without surface) and colormap
+        legend = LegendIconWidget(panel)
+        legend.setSymbol("+")
+        legend.setColormap("plasma")
+        layout.addWidget(legend)
+
         return panel
 
 

--- a/examples/simplewidget.py
+++ b/examples/simplewidget.py
@@ -157,6 +157,11 @@ class SimpleWidgetExample(qt.QMainWindow):
         legend.setSymbolColor("violet")
         layout.addWidget(legend)
 
+        # Colormap
+        legend = LegendIconWidget(panel)
+        legend.setColormap("viridis")
+        layout.addWidget(legend)
+
         return panel
 
 

--- a/silx/gui/plot/LegendSelector.py
+++ b/silx/gui/plot/LegendSelector.py
@@ -38,14 +38,14 @@ import weakref
 import numpy
 
 from .. import qt, colors
-from ..widgets import LegendIconWidget
+from ..widgets.LegendIconWidget import LegendIconWidget
 from . import items
 
 
 _logger = logging.getLogger(__name__)
 
 
-class LegendIcon(LegendIconWidget.LegendIconWidget):
+class LegendIcon(LegendIconWidget):
     """Object displaying a curve linestyle and symbol.
 
     :param QWidget parent: See :class:`QWidget`
@@ -281,7 +281,7 @@ class LegendModel(qt.QAbstractListModel):
         new = []
         for (legend, icon) in llist:
             linestyle = icon.get('linestyle', None)
-            if linestyle in LegendIconWidget.NoLineStyle:
+            if LegendIconWidget.isEmptyLineStyle(linestyle):
                 # Curve had no line, give it one and hide it
                 # So when toggle line, it will display a solid line
                 showLine = False
@@ -290,7 +290,7 @@ class LegendModel(qt.QAbstractListModel):
                 showLine = True
 
             symbol = icon.get('symbol', None)
-            if symbol in LegendIconWidget.NoSymbols:
+            if LegendIconWidget.isEmptySymbol(symbol):
                 # Curve had no symbol, give it one and hide it
                 # So when toggle symbol, it will display 'o'
                 showSymbol = False
@@ -764,7 +764,7 @@ class LegendListContextMenu(qt.QMenu):
         }
         flag = modelIndex.data(LegendModel.showSymbolRole)
         symbol = modelIndex.data(LegendModel.iconSymbolRole)
-        visible = not flag or symbol in LegendIconWidget.NoSymbols
+        visible = not flag or LegendIconWidget.isEmptySymbol(symbol)
         _logger.debug(
             'togglePointsAction -- Symbols visible: %s', str(visible))
 

--- a/silx/gui/plot/LegendSelector.py
+++ b/silx/gui/plot/LegendSelector.py
@@ -38,63 +38,14 @@ import weakref
 import numpy
 
 from .. import qt, colors
+from ..widgets import LegendIconWidget
 from . import items
 
 
 _logger = logging.getLogger(__name__)
 
-# Build all symbols
-# Courtesy of the pyqtgraph project
-Symbols = dict([(name, qt.QPainterPath())
-                for name in ['o', 's', 't', 'd', '+', 'x', '.', ',']])
-Symbols['o'].addEllipse(qt.QRectF(.1, .1, .8, .8))
-Symbols['.'].addEllipse(qt.QRectF(.3, .3, .4, .4))
-Symbols[','].addEllipse(qt.QRectF(.4, .4, .2, .2))
-Symbols['s'].addRect(qt.QRectF(.1, .1, .8, .8))
 
-coords = {
-    't': [(0.5, 0.), (.1, .8), (.9, .8)],
-    'd': [(0.1, 0.5), (0.5, 0.), (0.9, 0.5), (0.5, 1.)],
-    '+': [(0.0, 0.40), (0.40, 0.40), (0.40, 0.), (0.60, 0.),
-          (0.60, 0.40), (1., 0.40), (1., 0.60), (0.60, 0.60),
-          (0.60, 1.), (0.40, 1.), (0.40, 0.60), (0., 0.60)],
-    'x': [(0.0, 0.40), (0.40, 0.40), (0.40, 0.), (0.60, 0.),
-          (0.60, 0.40), (1., 0.40), (1., 0.60), (0.60, 0.60),
-          (0.60, 1.), (0.40, 1.), (0.40, 0.60), (0., 0.60)]
-}
-for s, c in coords.items():
-    Symbols[s].moveTo(*c[0])
-    for x, y in c[1:]:
-        Symbols[s].lineTo(x, y)
-    Symbols[s].closeSubpath()
-tr = qt.QTransform()
-tr.rotate(45)
-Symbols['x'].translate(qt.QPointF(-0.5, -0.5))
-Symbols['x'] = tr.map(Symbols['x'])
-Symbols['x'].translate(qt.QPointF(0.5, 0.5))
-
-NoSymbols = (None, 'None', 'none', '', ' ')
-"""List of values resulting in no symbol being displayed for a curve"""
-
-
-LineStyles = {
-    None: qt.Qt.NoPen,
-    'None': qt.Qt.NoPen,
-    'none': qt.Qt.NoPen,
-    '': qt.Qt.NoPen,
-    ' ': qt.Qt.NoPen,
-    '-': qt.Qt.SolidLine,
-    '--': qt.Qt.DashLine,
-    ':': qt.Qt.DotLine,
-    '-.': qt.Qt.DashDotLine
-}
-"""Conversion from matplotlib-like linestyle to Qt"""
-
-NoLineStyle = (None, 'None', 'none', '', ' ')
-"""List of style values resulting in no line being displayed for a curve"""
-
-
-class LegendIcon(qt.QWidget):
+class LegendIcon(LegendIconWidget.LegendIconWidget):
     """Object displaying a curve linestyle and symbol.
 
     :param QWidget parent: See :class:`QWidget`
@@ -105,34 +56,7 @@ class LegendIcon(qt.QWidget):
     def __init__(self, parent=None, curve=None):
         super(LegendIcon, self).__init__(parent)
         self._curveRef = None
-
-        # Visibilities
-        self.showLine = True
-        self.showSymbol = True
-
-        # Line attributes
-        self.lineStyle = qt.Qt.NoPen
-        self.lineWidth = 1.
-        self.lineColor = qt.Qt.green
-
-        self.symbol = ''
-        # Symbol attributes
-        self.symbolStyle = qt.Qt.SolidPattern
-        self.symbolColor = qt.Qt.green
-        self.symbolOutlineBrush = qt.QBrush(qt.Qt.white)
-
-        # Control widget size: sizeHint "is the only acceptable
-        # alternative, so the widget can never grow or shrink"
-        # (c.f. Qt Doc, enum QSizePolicy::Policy)
-        self.setSizePolicy(qt.QSizePolicy.Fixed,
-                           qt.QSizePolicy.Fixed)
-
         self.setCurve(curve)
-
-    def sizeHint(self):
-        return qt.QSize(50, 15)
-
-    # Synchronize with a curve
 
     def getCurve(self):
         """Returns curve associated to this widget
@@ -205,125 +129,6 @@ class LegendIcon(qt.QWidget):
                      items.ItemChangedType.HIGHLIGHTED,
                      items.ItemChangedType.HIGHLIGHTED_STYLE):
             self._update()
-
-    # Modify Symbol
-    def setSymbol(self, symbol):
-        symbol = str(symbol)
-        if symbol not in NoSymbols:
-            if symbol not in Symbols:
-                raise ValueError("Unknown symbol: <%s>" % symbol)
-        self.symbol = symbol
-        # self.update() after set...?
-        # Does not seem necessary
-
-    def setSymbolColor(self, color):
-        """
-        :param color: determines the symbol color
-        :type style: qt.QColor
-        """
-        self.symbolColor = qt.QColor(color)
-
-    # Modify Line
-
-    def setLineColor(self, color):
-        self.lineColor = qt.QColor(color)
-
-    def setLineWidth(self, width):
-        self.lineWidth = float(width)
-
-    def setLineStyle(self, style):
-        """Set the linestyle.
-
-        Possible line styles:
-
-        - '', ' ', 'None': No line
-        - '-': solid
-        - '--': dashed
-        - ':': dotted
-        - '-.': dash and dot
-
-        :param str style: The linestyle to use
-        """
-        if style not in LineStyles:
-            raise ValueError('Unknown style: %s', style)
-        self.lineStyle = LineStyles[style]
-
-    # Paint
-
-    def paintEvent(self, event):
-        """
-        :param event: event
-        :type event: QPaintEvent
-        """
-        painter = qt.QPainter(self)
-        self.paint(painter, event.rect(), self.palette())
-
-    def paint(self, painter, rect, palette):
-        painter.save()
-        painter.setRenderHint(qt.QPainter.Antialiasing)
-        # Scale painter to the icon height
-        # current -> width = 2.5, height = 1.0
-        scale = float(self.height())
-        ratio = float(self.width()) / scale
-        painter.scale(scale,
-                      scale)
-        symbolOffset = qt.QPointF(.5 * (ratio - 1.), 0.)
-        # Determine and scale offset
-        offset = qt.QPointF(float(rect.left()) / scale, float(rect.top()) / scale)
-
-        # Override color when disabled
-        if self.isEnabled():
-            overrideColor = None
-        else:
-            overrideColor = palette.color(qt.QPalette.Disabled,
-                                          qt.QPalette.WindowText)
-
-        # Draw BG rectangle (for debugging)
-        # bottomRight = qt.QPointF(
-        #    float(rect.right())/scale,
-        #    float(rect.bottom())/scale)
-        # painter.fillRect(qt.QRectF(offset, bottomRight),
-        #                 qt.QBrush(qt.Qt.green))
-        llist = []
-        if self.showLine:
-            linePath = qt.QPainterPath()
-            linePath.moveTo(0., 0.5)
-            linePath.lineTo(ratio, 0.5)
-            # linePath.lineTo(2.5, 0.5)
-            lineBrush = qt.QBrush(
-                self.lineColor if overrideColor is None else overrideColor)
-            linePen = qt.QPen(
-                lineBrush,
-                (self.lineWidth / self.height()),
-                self.lineStyle,
-                qt.Qt.FlatCap
-            )
-            llist.append((linePath, linePen, lineBrush))
-        if (self.showSymbol and len(self.symbol) and
-                self.symbol not in NoSymbols):
-            # PITFALL ahead: Let this be a warning to others
-            # symbolPath = Symbols[self.symbol]
-            # Copy before translate! Dict is a mutable type
-            symbolPath = qt.QPainterPath(Symbols[self.symbol])
-            symbolPath.translate(symbolOffset)
-            symbolBrush = qt.QBrush(
-                self.symbolColor if overrideColor is None else overrideColor,
-                self.symbolStyle)
-            symbolPen = qt.QPen(
-                self.symbolOutlineBrush,  # Brush
-                1. / self.height(),       # Width
-                qt.Qt.SolidLine           # Style
-            )
-            llist.append((symbolPath,
-                          symbolPen,
-                          symbolBrush))
-        # Draw
-        for path, pen, brush in llist:
-            path.translate(offset)
-            painter.setPen(pen)
-            painter.setBrush(brush)
-            painter.drawPath(path)
-        painter.restore()
 
 
 class LegendModel(qt.QAbstractListModel):
@@ -476,7 +281,7 @@ class LegendModel(qt.QAbstractListModel):
         new = []
         for (legend, icon) in llist:
             linestyle = icon.get('linestyle', None)
-            if linestyle in NoLineStyle:
+            if linestyle in LegendIconWidget.NoLineStyle:
                 # Curve had no line, give it one and hide it
                 # So when toggle line, it will display a solid line
                 showLine = False
@@ -485,7 +290,7 @@ class LegendModel(qt.QAbstractListModel):
                 showLine = True
 
             symbol = icon.get('symbol', None)
-            if symbol in NoSymbols:
+            if symbol in LegendIconWidget.NoSymbols:
                 # Curve had no symbol, give it one and hide it
                 # So when toggle symbol, it will display 'o'
                 showSymbol = False
@@ -959,7 +764,7 @@ class LegendListContextMenu(qt.QMenu):
         }
         flag = modelIndex.data(LegendModel.showSymbolRole)
         symbol = modelIndex.data(LegendModel.iconSymbolRole)
-        visible = not flag or symbol in NoSymbols
+        visible = not flag or symbol in LegendIconWidget.NoSymbols
         _logger.debug(
             'togglePointsAction -- Symbols visible: %s', str(visible))
 

--- a/silx/gui/widgets/LegendIconWidget.py
+++ b/silx/gui/widgets/LegendIconWidget.py
@@ -265,11 +265,8 @@ class LegendIconWidget(qt.QWidget):
             pixmap = self._colormapPixmap
             if pixmap is not None:
                 pixmapRect = qt.QRect(0, 0, _COLORMAP_PIXMAP_SIZE, 1)
-                widthMargin = 4
-                if self.symbol is None:
-                    halfHeight = 4
-                else:
-                    halfHeight = 2
+                widthMargin = 0
+                halfHeight = 4
                 dest = qt.QRect(
                     rect.left() + widthMargin,
                     rect.center().y() - halfHeight + 1,

--- a/silx/gui/widgets/LegendIconWidget.py
+++ b/silx/gui/widgets/LegendIconWidget.py
@@ -44,33 +44,9 @@ _logger = logging.getLogger(__name__)
 # Build all symbols
 # Courtesy of the pyqtgraph project
 
-_Symbols = dict([(name, qt.QPainterPath())
-                for name in ['o', 's', 't', 'd', '+', 'x', '.', ',']])
-_Symbols['o'].addEllipse(qt.QRectF(.1, .1, .8, .8))
-_Symbols['.'].addEllipse(qt.QRectF(.3, .3, .4, .4))
-_Symbols[','].addEllipse(qt.QRectF(.4, .4, .2, .2))
-_Symbols['s'].addRect(qt.QRectF(.1, .1, .8, .8))
+_Symbols = None
+""""Cache supported symbols as Qt paths"""
 
-coords = {
-    't': [(0.5, 0.), (.1, .8), (.9, .8)],
-    'd': [(0.1, 0.5), (0.5, 0.), (0.9, 0.5), (0.5, 1.)],
-    '+': [(0.0, 0.40), (0.40, 0.40), (0.40, 0.), (0.60, 0.),
-          (0.60, 0.40), (1., 0.40), (1., 0.60), (0.60, 0.60),
-          (0.60, 1.), (0.40, 1.), (0.40, 0.60), (0., 0.60)],
-    'x': [(0.0, 0.40), (0.40, 0.40), (0.40, 0.), (0.60, 0.),
-          (0.60, 0.40), (1., 0.40), (1., 0.60), (0.60, 0.60),
-          (0.60, 1.), (0.40, 1.), (0.40, 0.60), (0., 0.60)]
-}
-for s, c in coords.items():
-    _Symbols[s].moveTo(*c[0])
-    for x, y in c[1:]:
-        _Symbols[s].lineTo(x, y)
-    _Symbols[s].closeSubpath()
-tr = qt.QTransform()
-tr.rotate(45)
-_Symbols['x'].translate(qt.QPointF(-0.5, -0.5))
-_Symbols['x'] = tr.map(_Symbols['x'])
-_Symbols['x'].translate(qt.QPointF(0.5, 0.5))
 
 _NoSymbols = (None, 'None', 'none', '', ' ')
 """List of values resulting in no symbol being displayed for a curve"""
@@ -101,6 +77,43 @@ _COLORMAP_PIXMAP_SIZE = 32
 """Size of the cached pixmaps for the colormaps"""
 
 
+def _initSymbols():
+    """Init the cached symbol structure if not yet done."""
+    global _Symbols
+    if _Symbols is not None:
+        return
+
+    symbols = dict([(name, qt.QPainterPath())
+                    for name in ['o', 's', 't', 'd', '+', 'x', '.', ',']])
+    symbols['o'].addEllipse(qt.QRectF(.1, .1, .8, .8))
+    symbols['.'].addEllipse(qt.QRectF(.3, .3, .4, .4))
+    symbols[','].addEllipse(qt.QRectF(.4, .4, .2, .2))
+    symbols['s'].addRect(qt.QRectF(.1, .1, .8, .8))
+
+    coords = {
+        't': [(0.5, 0.), (.1, .8), (.9, .8)],
+        'd': [(0.1, 0.5), (0.5, 0.), (0.9, 0.5), (0.5, 1.)],
+        '+': [(0.0, 0.40), (0.40, 0.40), (0.40, 0.), (0.60, 0.),
+              (0.60, 0.40), (1., 0.40), (1., 0.60), (0.60, 0.60),
+              (0.60, 1.), (0.40, 1.), (0.40, 0.60), (0., 0.60)],
+        'x': [(0.0, 0.40), (0.40, 0.40), (0.40, 0.), (0.60, 0.),
+              (0.60, 0.40), (1., 0.40), (1., 0.60), (0.60, 0.60),
+              (0.60, 1.), (0.40, 1.), (0.40, 0.60), (0., 0.60)]
+    }
+    for s, c in coords.items():
+        symbols[s].moveTo(*c[0])
+        for x, y in c[1:]:
+            symbols[s].lineTo(x, y)
+        symbols[s].closeSubpath()
+    tr = qt.QTransform()
+    tr.rotate(45)
+    symbols['x'].translate(qt.QPointF(-0.5, -0.5))
+    symbols['x'] = tr.map(symbols['x'])
+    symbols['x'].translate(qt.QPointF(0.5, 0.5))
+
+    _Symbols = symbols
+
+
 class LegendIconWidget(qt.QWidget):
     """Object displaying linestyle and symbol of plots.
 
@@ -109,6 +122,7 @@ class LegendIconWidget(qt.QWidget):
 
     def __init__(self, parent=None):
         super(LegendIconWidget, self).__init__(parent)
+        _initSymbols()
 
         # Visibilities
         self.showLine = True

--- a/silx/gui/widgets/LegendIconWidget.py
+++ b/silx/gui/widgets/LegendIconWidget.py
@@ -159,8 +159,7 @@ class LegendIconWidget(qt.QWidget):
             if symbol not in _Symbols:
                 raise ValueError("Unknown symbol: <%s>" % symbol)
         self.symbol = symbol
-        # self.update() after set...?
-        # Does not seem necessary
+        self.update()
 
     def setSymbolColor(self, color):
         """
@@ -168,14 +167,17 @@ class LegendIconWidget(qt.QWidget):
         :type style: qt.QColor
         """
         self.symbolColor = qt.QColor(color)
+        self.update()
 
     # Modify Line
 
     def setLineColor(self, color):
         self.lineColor = qt.QColor(color)
+        self.update()
 
     def setLineWidth(self, width):
         self.lineWidth = float(width)
+        self.update()
 
     def setLineStyle(self, style):
         """Set the linestyle.
@@ -193,6 +195,7 @@ class LegendIconWidget(qt.QWidget):
         if style not in _LineStyles:
             raise ValueError('Unknown style: %s', style)
         self.lineStyle = _LineStyles[style]
+        self.update()
 
     def setColormap(self, colormap):
         """Set the colormap to display
@@ -212,7 +215,10 @@ class LegendIconWidget(qt.QWidget):
             colormap = c
 
         if colormap is None:
+            if self.colormap is None:
+                return
             self.colormap = None
+            self.update()
             return
 
         if numpy.array_equal(self.colormap, colormap):
@@ -220,6 +226,7 @@ class LegendIconWidget(qt.QWidget):
             return
 
         self.colormap = colormap
+        self.update()
 
     def getColormap(self):
         """Returns the used colormap.

--- a/silx/gui/widgets/LegendIconWidget.py
+++ b/silx/gui/widgets/LegendIconWidget.py
@@ -220,12 +220,6 @@ class LegendIconWidget(qt.QWidget):
             return
 
         self.colormap = colormap
-        if isinstance(colormap, numpy.ndarray):
-            name = None
-            colorArray = colormap
-        else:
-            name = colormap
-            colorArray = None
 
     def getColormap(self):
         """Returns the used colormap.

--- a/silx/gui/widgets/LegendIconWidget.py
+++ b/silx/gui/widgets/LegendIconWidget.py
@@ -354,6 +354,18 @@ class LegendIconWidget(qt.QWidget):
     # Helpers
 
     @staticmethod
+    def isEmptySymbol(symbol):
+        """Returns True if this symbol description will result in an empty
+        symbol."""
+        return symbol in NoSymbols
+
+    @staticmethod
+    def isEmptyLineStyle(lineStyle):
+        """Returns True if this line style description will result in an empty
+        line."""
+        return lineStyle in NoLineStyle
+
+    @staticmethod
     def _getColormapKey(colormap):
         """
         Returns the key used to store the image in the data storage

--- a/silx/gui/widgets/LegendIconWidget.py
+++ b/silx/gui/widgets/LegendIconWidget.py
@@ -1,0 +1,245 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Widget displaying a symbol (marker symbol, line style and color) to identify
+an item displayed by a plot.
+"""
+
+__authors__ = ["V.A. Sole", "T. Rueter", "T. Vincent"]
+__license__ = "MIT"
+__data__ = "11/11/2019"
+
+
+import logging
+
+import numpy
+
+from .. import qt, colors
+
+
+_logger = logging.getLogger(__name__)
+
+
+# Build all symbols
+# Courtesy of the pyqtgraph project
+Symbols = dict([(name, qt.QPainterPath())
+                for name in ['o', 's', 't', 'd', '+', 'x', '.', ',']])
+Symbols['o'].addEllipse(qt.QRectF(.1, .1, .8, .8))
+Symbols['.'].addEllipse(qt.QRectF(.3, .3, .4, .4))
+Symbols[','].addEllipse(qt.QRectF(.4, .4, .2, .2))
+Symbols['s'].addRect(qt.QRectF(.1, .1, .8, .8))
+
+coords = {
+    't': [(0.5, 0.), (.1, .8), (.9, .8)],
+    'd': [(0.1, 0.5), (0.5, 0.), (0.9, 0.5), (0.5, 1.)],
+    '+': [(0.0, 0.40), (0.40, 0.40), (0.40, 0.), (0.60, 0.),
+          (0.60, 0.40), (1., 0.40), (1., 0.60), (0.60, 0.60),
+          (0.60, 1.), (0.40, 1.), (0.40, 0.60), (0., 0.60)],
+    'x': [(0.0, 0.40), (0.40, 0.40), (0.40, 0.), (0.60, 0.),
+          (0.60, 0.40), (1., 0.40), (1., 0.60), (0.60, 0.60),
+          (0.60, 1.), (0.40, 1.), (0.40, 0.60), (0., 0.60)]
+}
+for s, c in coords.items():
+    Symbols[s].moveTo(*c[0])
+    for x, y in c[1:]:
+        Symbols[s].lineTo(x, y)
+    Symbols[s].closeSubpath()
+tr = qt.QTransform()
+tr.rotate(45)
+Symbols['x'].translate(qt.QPointF(-0.5, -0.5))
+Symbols['x'] = tr.map(Symbols['x'])
+Symbols['x'].translate(qt.QPointF(0.5, 0.5))
+
+NoSymbols = (None, 'None', 'none', '', ' ')
+"""List of values resulting in no symbol being displayed for a curve"""
+
+
+LineStyles = {
+    None: qt.Qt.NoPen,
+    'None': qt.Qt.NoPen,
+    'none': qt.Qt.NoPen,
+    '': qt.Qt.NoPen,
+    ' ': qt.Qt.NoPen,
+    '-': qt.Qt.SolidLine,
+    '--': qt.Qt.DashLine,
+    ':': qt.Qt.DotLine,
+    '-.': qt.Qt.DashDotLine
+}
+"""Conversion from matplotlib-like linestyle to Qt"""
+
+NoLineStyle = (None, 'None', 'none', '', ' ')
+"""List of style values resulting in no line being displayed for a curve"""
+
+
+class LegendIconWidget(qt.QWidget):
+    """Object displaying linestyle and symbol of plots.
+
+    :param QWidget parent: See :class:`QWidget`
+    """
+
+    def __init__(self, parent=None):
+        super(LegendIconWidget, self).__init__(parent)
+
+        # Visibilities
+        self.showLine = True
+        self.showSymbol = True
+
+        # Line attributes
+        self.lineStyle = qt.Qt.NoPen
+        self.lineWidth = 1.
+        self.lineColor = qt.Qt.green
+
+        self.symbol = ''
+        # Symbol attributes
+        self.symbolStyle = qt.Qt.SolidPattern
+        self.symbolColor = qt.Qt.green
+        self.symbolOutlineBrush = qt.QBrush(qt.Qt.white)
+
+        # Control widget size: sizeHint "is the only acceptable
+        # alternative, so the widget can never grow or shrink"
+        # (c.f. Qt Doc, enum QSizePolicy::Policy)
+        self.setSizePolicy(qt.QSizePolicy.Fixed,
+                           qt.QSizePolicy.Fixed)
+
+    def sizeHint(self):
+        return qt.QSize(50, 15)
+
+    def setSymbol(self, symbol):
+        """Set the symbol"""
+        symbol = str(symbol)
+        if symbol not in NoSymbols:
+            if symbol not in Symbols:
+                raise ValueError("Unknown symbol: <%s>" % symbol)
+        self.symbol = symbol
+        # self.update() after set...?
+        # Does not seem necessary
+
+    def setSymbolColor(self, color):
+        """
+        :param color: determines the symbol color
+        :type style: qt.QColor
+        """
+        self.symbolColor = qt.QColor(color)
+
+    # Modify Line
+
+    def setLineColor(self, color):
+        self.lineColor = qt.QColor(color)
+
+    def setLineWidth(self, width):
+        self.lineWidth = float(width)
+
+    def setLineStyle(self, style):
+        """Set the linestyle.
+
+        Possible line styles:
+
+        - '', ' ', 'None': No line
+        - '-': solid
+        - '--': dashed
+        - ':': dotted
+        - '-.': dash and dot
+
+        :param str style: The linestyle to use
+        """
+        if style not in LineStyles:
+            raise ValueError('Unknown style: %s', style)
+        self.lineStyle = LineStyles[style]
+
+    # Paint
+
+    def paintEvent(self, event):
+        """
+        :param event: event
+        :type event: QPaintEvent
+        """
+        painter = qt.QPainter(self)
+        self.paint(painter, event.rect(), self.palette())
+
+    def paint(self, painter, rect, palette):
+        painter.save()
+        painter.setRenderHint(qt.QPainter.Antialiasing)
+        # Scale painter to the icon height
+        # current -> width = 2.5, height = 1.0
+        scale = float(self.height())
+        ratio = float(self.width()) / scale
+        painter.scale(scale,
+                      scale)
+        symbolOffset = qt.QPointF(.5 * (ratio - 1.), 0.)
+        # Determine and scale offset
+        offset = qt.QPointF(float(rect.left()) / scale, float(rect.top()) / scale)
+
+        # Override color when disabled
+        if self.isEnabled():
+            overrideColor = None
+        else:
+            overrideColor = palette.color(qt.QPalette.Disabled,
+                                          qt.QPalette.WindowText)
+
+        # Draw BG rectangle (for debugging)
+        # bottomRight = qt.QPointF(
+        #    float(rect.right())/scale,
+        #    float(rect.bottom())/scale)
+        # painter.fillRect(qt.QRectF(offset, bottomRight),
+        #                 qt.QBrush(qt.Qt.green))
+        llist = []
+        if self.showLine:
+            linePath = qt.QPainterPath()
+            linePath.moveTo(0., 0.5)
+            linePath.lineTo(ratio, 0.5)
+            # linePath.lineTo(2.5, 0.5)
+            lineBrush = qt.QBrush(
+                self.lineColor if overrideColor is None else overrideColor)
+            linePen = qt.QPen(
+                lineBrush,
+                (self.lineWidth / self.height()),
+                self.lineStyle,
+                qt.Qt.FlatCap
+            )
+            llist.append((linePath, linePen, lineBrush))
+        if (self.showSymbol and len(self.symbol) and
+                self.symbol not in NoSymbols):
+            # PITFALL ahead: Let this be a warning to others
+            # symbolPath = Symbols[self.symbol]
+            # Copy before translate! Dict is a mutable type
+            symbolPath = qt.QPainterPath(Symbols[self.symbol])
+            symbolPath.translate(symbolOffset)
+            symbolBrush = qt.QBrush(
+                self.symbolColor if overrideColor is None else overrideColor,
+                self.symbolStyle)
+            symbolPen = qt.QPen(
+                self.symbolOutlineBrush,  # Brush
+                1. / self.height(),       # Width
+                qt.Qt.SolidLine           # Style
+            )
+            llist.append((symbolPath,
+                          symbolPen,
+                          symbolBrush))
+        # Draw
+        for path, pen, brush in llist:
+            path.translate(offset)
+            painter.setPen(pen)
+            painter.setBrush(brush)
+            painter.drawPath(path)
+        painter.restore()

--- a/silx/gui/widgets/LegendIconWidget.py
+++ b/silx/gui/widgets/LegendIconWidget.py
@@ -43,12 +43,13 @@ _logger = logging.getLogger(__name__)
 
 # Build all symbols
 # Courtesy of the pyqtgraph project
-Symbols = dict([(name, qt.QPainterPath())
+
+_Symbols = dict([(name, qt.QPainterPath())
                 for name in ['o', 's', 't', 'd', '+', 'x', '.', ',']])
-Symbols['o'].addEllipse(qt.QRectF(.1, .1, .8, .8))
-Symbols['.'].addEllipse(qt.QRectF(.3, .3, .4, .4))
-Symbols[','].addEllipse(qt.QRectF(.4, .4, .2, .2))
-Symbols['s'].addRect(qt.QRectF(.1, .1, .8, .8))
+_Symbols['o'].addEllipse(qt.QRectF(.1, .1, .8, .8))
+_Symbols['.'].addEllipse(qt.QRectF(.3, .3, .4, .4))
+_Symbols[','].addEllipse(qt.QRectF(.4, .4, .2, .2))
+_Symbols['s'].addRect(qt.QRectF(.1, .1, .8, .8))
 
 coords = {
     't': [(0.5, 0.), (.1, .8), (.9, .8)],
@@ -61,21 +62,21 @@ coords = {
           (0.60, 1.), (0.40, 1.), (0.40, 0.60), (0., 0.60)]
 }
 for s, c in coords.items():
-    Symbols[s].moveTo(*c[0])
+    _Symbols[s].moveTo(*c[0])
     for x, y in c[1:]:
-        Symbols[s].lineTo(x, y)
-    Symbols[s].closeSubpath()
+        _Symbols[s].lineTo(x, y)
+    _Symbols[s].closeSubpath()
 tr = qt.QTransform()
 tr.rotate(45)
-Symbols['x'].translate(qt.QPointF(-0.5, -0.5))
-Symbols['x'] = tr.map(Symbols['x'])
-Symbols['x'].translate(qt.QPointF(0.5, 0.5))
+_Symbols['x'].translate(qt.QPointF(-0.5, -0.5))
+_Symbols['x'] = tr.map(_Symbols['x'])
+_Symbols['x'].translate(qt.QPointF(0.5, 0.5))
 
-NoSymbols = (None, 'None', 'none', '', ' ')
+_NoSymbols = (None, 'None', 'none', '', ' ')
 """List of values resulting in no symbol being displayed for a curve"""
 
 
-LineStyles = {
+_LineStyles = {
     None: qt.Qt.NoPen,
     'None': qt.Qt.NoPen,
     'none': qt.Qt.NoPen,
@@ -88,7 +89,7 @@ LineStyles = {
 }
 """Conversion from matplotlib-like linestyle to Qt"""
 
-NoLineStyle = (None, 'None', 'none', '', ' ')
+_NoLineStyle = (None, 'None', 'none', '', ' ')
 """List of style values resulting in no line being displayed for a curve"""
 
 
@@ -140,8 +141,8 @@ class LegendIconWidget(qt.QWidget):
     def setSymbol(self, symbol):
         """Set the symbol"""
         symbol = str(symbol)
-        if symbol not in NoSymbols:
-            if symbol not in Symbols:
+        if symbol not in _NoSymbols:
+            if symbol not in _Symbols:
                 raise ValueError("Unknown symbol: <%s>" % symbol)
         self.symbol = symbol
         # self.update() after set...?
@@ -175,9 +176,9 @@ class LegendIconWidget(qt.QWidget):
 
         :param str style: The linestyle to use
         """
-        if style not in LineStyles:
+        if style not in _LineStyles:
             raise ValueError('Unknown style: %s', style)
-        self.lineStyle = LineStyles[style]
+        self.lineStyle = _LineStyles[style]
 
     def setColormap(self, colormap):
         """Set the colormap to display
@@ -259,7 +260,7 @@ class LegendIconWidget(qt.QWidget):
 
         isSymbol = (self.showSymbol and
                     len(self.symbol) and
-                    self.symbol not in NoSymbols)
+                    self.symbol not in _NoSymbols)
         isColormap = self.colormap is not None
         isSymbolColormap = isSymbol and isColormap
         if isSymbolColormap:
@@ -304,7 +305,7 @@ class LegendIconWidget(qt.QWidget):
             # PITFALL ahead: Let this be a warning to others
             # symbolPath = Symbols[self.symbol]
             # Copy before translate! Dict is a mutable type
-            symbolPath = qt.QPainterPath(Symbols[self.symbol])
+            symbolPath = qt.QPainterPath(_Symbols[self.symbol])
             symbolPath.translate(symbolOffset)
             symbolBrush = qt.QBrush(
                 self.symbolColor if overrideColor is None else overrideColor,
@@ -330,7 +331,7 @@ class LegendIconWidget(qt.QWidget):
                 color = image.pixelColor(pos, 0)
                 delta = qt.QPointF(ratio * ((i - (nbSymbols-1)/2) / nbSymbols), 0)
 
-                symbolPath = qt.QPainterPath(Symbols[self.symbol])
+                symbolPath = qt.QPainterPath(_Symbols[self.symbol])
                 symbolPath.translate(symbolOffset + delta)
                 symbolBrush = qt.QBrush(color, self.symbolStyle)
                 symbolPen = qt.QPen(
@@ -357,13 +358,13 @@ class LegendIconWidget(qt.QWidget):
     def isEmptySymbol(symbol):
         """Returns True if this symbol description will result in an empty
         symbol."""
-        return symbol in NoSymbols
+        return symbol in _NoSymbols
 
     @staticmethod
     def isEmptyLineStyle(lineStyle):
         """Returns True if this line style description will result in an empty
         line."""
-        return lineStyle in NoLineStyle
+        return lineStyle in _NoLineStyle
 
     @staticmethod
     def _getColormapKey(colormap):


### PR DESCRIPTION
- Create a dedicated module for the `LegendIcon` -> `silx.gui.widgets.LegendIconWidget`
    - It was created to have no dependency with plot objects
- Support `colormap` (including grayed when disabled)
- Support `symbolColormap` to display style for scatters (including grayed when disabled)
- `LegendIcon` still exists, it provides the link between plot items and `LegendIconWidget`.
- Update of the `simplewidget` example
- Module attributes was set private
- Accesses (from `LegendModel`) like `linestyle in LegendIconWidget.NoLineStyle` was replaced by `isEmptySymbol` and `isEmptyLineStyle`
- Automatically call `update` when an attribute was changed, instead of forcing the user to do so

### Todo
- Some unittest or code coverage?

### Preview

![Screenshot (115)](https://user-images.githubusercontent.com/7579321/67587493-48ab2500-f754-11e9-821a-9d77f4b72f5a.png)


- line
- symbol
- line + symbol
- colormap
- symbol using colormap
- line-based symbol using colormap
- colormap + line + symbol using colormap

### Could be a problem:
- `NoLineStyle`, `Symbols`... are not anymore part of `silx.gui.plot.LegendSelector`. It maybe breaks external code

Closes #2774 