### PR TITLE
Add margin around data for readability

### DIFF
--- a/silx/gui/plot/actions/histogram.py
+++ b/silx/gui/plot/actions/histogram.py
@@ -134,6 +134,7 @@ class PixelIntensitiesHistoAction(PlotToolAction):
         window = Plot1D(parent=self.plot)
         window.setWindowFlags(qt.Qt.Window)
         window.setWindowTitle('Image Intensity Histogram')
+        window.setDataMargins(0.1, 0.1, 0.1, 0.1)
         window.getXAxis().setLabel("Value")
         window.getYAxis().setLabel("Count")
         return window


### PR DESCRIPTION
For a very high peak in at the min data, and mostly nothings for other bins, the plot looks empty (basically a black image with a small beam).

This PR make the result a little more readable by introducing a margin around the data.