### PR TITLE
[dataurl] add a test on the type of other in `__eq__`

### DIFF
--- a/silx/io/url.py
+++ b/silx/io/url.py
@@ -107,6 +107,8 @@ class DataUrl(object):
             self.__check_validity()
 
     def __eq__(self, other):
+        if not isinstance(other, DataUrl):
+            return False
         if self.is_valid() != other.is_valid():
             return False
         if self.is_valid():


### PR DESCRIPTION
A small modification to be able to compare other type with Dataurl type.
Previously was failing with 

``` python
url = DataUrl(...)
url == None
```