### PR TITLE
Support more marker symbols

### DIFF
--- a/examples/compositeline.py
+++ b/examples/compositeline.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""
+Example to show the the use of markers to draw head and tail of lines.
+
+``./bootstrap.py python examples/compositeline.py``
+"""
+from __future__ import division
+
+__license__ = "MIT"
+
+import logging
+from silx.gui.plot import Plot1D
+from silx.gui import qt
+import numpy
+
+
+logging.basicConfig()
+logger = logging.getLogger(__name__)
+
+
+def main(argv=None):
+    """Display few lines with markers.
+    """
+    global app  # QApplication must be global to avoid seg fault on quit
+    app = qt.QApplication([])
+    sys.excepthook = qt.exceptionHandler
+
+    mainWindow = Plot1D(backend="gl")
+    mainWindow.setAttribute(qt.Qt.WA_DeleteOnClose)
+    plot = mainWindow
+    plot.setDataMargins(0.1, 0.1, 0.1, 0.1)
+
+    plot.addCurve(x=[-10,0,0,-10,-10], y=[90,90,10,10,90], legend="box1", color="gray")
+    plot.addCurve(x=[110,100,100,110,110], y=[90,90,10,10,90], legend="box2", color="gray")
+    plot.addCurve(y=[-10,0,0,-10,-10], x=[90,90,10,10,90], legend="box3", color="gray")
+    plot.addCurve(y=[110,100,100,110,110], x=[90,90,10,10,90], legend="box4", color="gray")
+
+    def addLine(source, destination, symbolSource, symbolDestination, legend, color):
+        line = numpy.array([source, destination]).T
+        plot.addCurve(x=line[0,:], y=line[1,:], color=color, legend=legend)
+        plot.addMarker(x=source[0], y=source[1], symbol=symbolSource, color=color)
+        plot.addMarker(x=destination[0], y=destination[1], symbol=symbolDestination, color=color)
+
+    addLine([0, 50], [100, 50], "caretleft", "caretright", "l1", "red")
+    addLine([0, 30], [100, 30], "tickup", "tickdown", "l2", "blue")
+    addLine([0, 70], [100, 70], "|", "|", "l3", "black")
+
+    addLine([50, 0], [50, 100], "caretdown", "caretup", "l4", "red")
+    addLine([30, 0], [30, 100], "tickleft", "tickright", "l5", "blue")
+    addLine([70, 0], [70, 100], "_", "_", "l6", "black")
+
+    mainWindow.setVisible(True)
+    return app.exec_()
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main(argv=sys.argv[1:]))

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -76,6 +76,17 @@ _PATCH_LINESTYLE = {
 _MARKER_PATHS = {}
 """Store cached extra marker paths"""
 
+_SPECIAL_MARKERS = {
+    'tickleft': 0,
+    'tickright': 1,
+    'tickup': 2,
+    'tickdown': 3,
+    'caretleft': 4,
+    'caretright': 5,
+    'caretup': 6,
+    'caretdown': 7,
+}
+
 
 def normalize_linestyle(linestyle):
     """Normalize known old-style linestyle, else return the provided value."""
@@ -423,14 +434,16 @@ class BackendMatplotlib(BackendBase.BackendBase):
         """Returns a marker that can be displayed by matplotlib.
 
         :param str symbol: A symbol description used by silx
-        :rtype: Union[str,matplotlib.path.Path]
+        :rtype: Union[str,int,matplotlib.path.Path]
         """
         path = get_path_from_symbol(symbol)
-        if path is None:
-            # This symbol must be supported by matplotlib
-            return symbol
-        else:
+        if path is not None:
             return path
+        num = _SPECIAL_MARKERS.get(symbol, None)
+        if num is not None:
+            return num
+        # This symbol must be supported by matplotlib
+        return symbol
 
     def addCurve(self, x, y,
                  color, symbol, linewidth, linestyle,

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -56,6 +56,7 @@ from matplotlib.collections import PathCollection, LineCollection
 from matplotlib.ticker import Formatter, ScalarFormatter, Locator
 from matplotlib.tri import Triangulation
 from matplotlib.collections import TriMesh
+from matplotlib import path as mpath
 
 from . import BackendBase
 from .. import items
@@ -72,11 +73,43 @@ _PATCH_LINESTYLE = {
 }
 """Patches do not uses the same matplotlib syntax"""
 
+_MARKER_PATHS = {}
+"""Store cached extra marker paths"""
+
 
 def normalize_linestyle(linestyle):
     """Normalize known old-style linestyle, else return the provided value."""
     return _PATCH_LINESTYLE.get(linestyle, linestyle)
 
+def get_path_from_symbol(symbol):
+    """Get the path representation of a symbol, else None if
+    it is not provided.
+
+    :param str symbol: Symbol description used by silx
+    :rtype: Union[None,matplotlib.path.Path]
+    """
+    if symbol == u'\u2665':
+        path = _MARKER_PATHS.get(symbol, None)
+        if path is not None:
+            return path
+        vertices = numpy.array([
+            [0,-99],
+            [31,-73], [47,-55], [55,-46],
+            [63,-37], [94,-2], [94,33],
+            [94,69], [71,89], [47,89],
+            [24,89], [8,74], [0,58],
+            [-8,74], [-24,89], [-47,89],
+            [-71,89], [-94,69], [-94,33],
+            [-94,-2], [-63,-37], [-55,-46],
+            [-47,-55], [-31,-73], [0,-99],
+            [0,-99]])
+        codes = [mpath.Path.CURVE4] * len(vertices)
+        codes[0] = mpath.Path.MOVETO
+        codes[-1] = mpath.Path.CLOSEPOLY
+        path = mpath.Path(vertices, codes)
+        _MARKER_PATHS[symbol] = path
+        return path
+    return None
 
 class NiceDateLocator(Locator):
     """
@@ -386,6 +419,19 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
     # Add methods
 
+    def _getMarkerFromSymbol(self, symbol):
+        """Returns a marker that can be displayed by matplotlib.
+
+        :param str symbol: A symbol description used by silx
+        :rtype: Union[str,matplotlib.path.Path]
+        """
+        path = get_path_from_symbol(symbol)
+        if path is None:
+            # This symbol must be supported by matplotlib
+            return symbol
+        else:
+            return path
+
     def addCurve(self, x, y,
                  color, symbol, linewidth, linestyle,
                  yaxis,
@@ -448,9 +494,10 @@ class BackendMatplotlib(BackendBase.BackendBase):
                                       marker=None)
                 artists += list(curveList)
 
+            marker = self._getMarkerFromSymbol(symbol)
             scatter = axes.scatter(x, y,
                                    color=actualColor,
-                                   marker=symbol,
+                                   marker=marker,
                                    picker=picker,
                                    s=symbolsize**2)
             artists.append(scatter)
@@ -661,11 +708,12 @@ class BackendMatplotlib(BackendBase.BackendBase):
         else:
             assert(False)
 
+        marker = self._getMarkerFromSymbol(symbol)
         if x is not None and y is not None:
             line = ax.plot(x, y,
                            linestyle=" ",
                            color=color,
-                           marker=symbol,
+                           marker=marker,
                            markersize=10.)[-1]
 
             if text is not None:

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -530,6 +530,15 @@ DIAMOND, CIRCLE, SQUARE, PLUS, X_MARKER, POINT, PIXEL, ASTERISK = \
 
 H_LINE, V_LINE, HEART = '_', '|', u'\u2665'
 
+TICK_LEFT = "tickleft"
+TICK_RIGHT = "tickright"
+TICK_UP = "tickup"
+TICK_DOWN = "tickdown"
+CARET_LEFT = "caretleft"
+CARET_RIGHT = "caretright"
+CARET_UP = "caretup"
+CARET_DOWN = "caretdown"
+
 
 class _Points2D(object):
     """Object rendering curve markers
@@ -544,7 +553,8 @@ class _Points2D(object):
     """
 
     MARKERS = (DIAMOND, CIRCLE, SQUARE, PLUS, X_MARKER, POINT, PIXEL, ASTERISK,
-               H_LINE, V_LINE, HEART)
+               H_LINE, V_LINE, HEART, TICK_LEFT, TICK_RIGHT, TICK_UP, TICK_DOWN,
+               CARET_LEFT, CARET_RIGHT, CARET_UP, CARET_DOWN)
     """List of supported markers"""
 
     _VERTEX_SHADER = """
@@ -657,7 +667,95 @@ class _Points2D(object):
             res = smoothstep(0.1, 0.001, res);
             return res;
         }
-        """
+        """,
+            TICK_LEFT: """
+        float alphaSymbol(vec2 coord, float size) {
+            coord  = size * (coord - 0.5);
+            float dy = abs(coord.y);
+            if (dy < 0.5 && coord.x < 0.5) {
+                return 1.0;
+            } else {
+                return 0.0;
+            }
+        }
+        """,
+            TICK_RIGHT: """
+        float alphaSymbol(vec2 coord, float size) {
+            coord  = size * (coord - 0.5);
+            float dy = abs(coord.y);
+            if (dy < 0.5 && coord.x > -0.5) {
+                return 1.0;
+            } else {
+                return 0.0;
+            }
+        }
+        """,
+            TICK_UP: """
+        float alphaSymbol(vec2 coord, float size) {
+            coord  = size * (coord - 0.5);
+            float dx = abs(coord.x);
+            if (dx < 0.5 && coord.y < 0.5) {
+                return 1.0;
+            } else {
+                return 0.0;
+            }
+        }
+        """,
+            TICK_DOWN: """
+        float alphaSymbol(vec2 coord, float size) {
+            coord  = size * (coord - 0.5);
+            float dx = abs(coord.x);
+            if (dx < 0.5 && coord.y > -0.5) {
+                return 1.0;
+            } else {
+                return 0.0;
+            }
+        }
+        """,
+            CARET_LEFT: """
+        float alphaSymbol(vec2 coord, float size) {
+            coord  = size * (coord - 0.5);
+            float d = abs(coord.x) - abs(coord.y);
+            if (d >= -0.1 && coord.x > 0.5) {
+                return smoothstep(-0.1, 0.1, d);
+            } else {
+                return 0.0;
+            }
+        }
+        """,
+            CARET_RIGHT: """
+        float alphaSymbol(vec2 coord, float size) {
+            coord  = size * (coord - 0.5);
+            float d = abs(coord.x) - abs(coord.y);
+            if (d >= -0.1 && coord.x < 0.5) {
+                return smoothstep(-0.1, 0.1, d);
+            } else {
+                return 0.0;
+            }
+        }
+        """,
+            CARET_UP: """
+        float alphaSymbol(vec2 coord, float size) {
+            coord  = size * (coord - 0.5);
+            float d = abs(coord.y) - abs(coord.x);
+            if (d >= -0.1 && coord.y > 0.5) {
+                return smoothstep(-0.1, 0.1, d);
+            } else {
+                return 0.0;
+            }
+        }
+        """,
+            CARET_DOWN: """
+        float alphaSymbol(vec2 coord, float size) {
+            coord  = size * (coord - 0.5);
+            float d = abs(coord.y) - abs(coord.x);
+            if (d >= -0.1 && coord.y < 0.5) {
+                return smoothstep(-0.1, 0.1, d);
+            } else {
+                return 0.0;
+            }
+        }
+        """,
     }
 
     _FRAGMENT_SHADER_TEMPLATE = """

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -528,7 +528,7 @@ def distancesFromArrays(xData, yData):
 DIAMOND, CIRCLE, SQUARE, PLUS, X_MARKER, POINT, PIXEL, ASTERISK = \
     'd', 'o', 's', '+', 'x', '.', ',', '*'
 
-H_LINE, V_LINE = '_', '|'
+H_LINE, V_LINE, HEART = '_', '|', u'\u2665'
 
 
 class _Points2D(object):
@@ -544,7 +544,7 @@ class _Points2D(object):
     """
 
     MARKERS = (DIAMOND, CIRCLE, SQUARE, PLUS, X_MARKER, POINT, PIXEL, ASTERISK,
-               H_LINE, V_LINE)
+               H_LINE, V_LINE, HEART)
     """List of supported markers"""
 
     _VERTEX_SHADER = """
@@ -641,6 +641,21 @@ class _Points2D(object):
             } else {
                 return 0.0;
             }
+        }
+        """,
+            HEART: """
+        float alphaSymbol(vec2 coord, float size) {
+            coord = (coord - 0.5) * 2.;
+            coord *= 0.75;
+            coord.y += 0.25;
+            float a = atan(coord.x,-coord.y)/3.141593;
+            float r = length(coord);
+            float h = abs(a);
+            float d = (13.0*h - 22.0*h*h + 10.0*h*h*h)/(6.0-5.0*h);
+            float res = clamp(r-d, 0., 1.);
+            // antialiasing
+            res = smoothstep(0.1, 0.001, res);
+            return res;
         }
         """
     }

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -492,6 +492,7 @@ class SymbolMixIn(ItemMixInBase):
         ('x', 'Cross'),
         ('.', 'Point'),
         (',', 'Pixel'),
+        (u'\u2665', 'Heart'),
         ('', 'None')))
     """Dict of supported symbols"""
 

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -492,6 +492,16 @@ class SymbolMixIn(ItemMixInBase):
         ('x', 'Cross'),
         ('.', 'Point'),
         (',', 'Pixel'),
+        ('|', 'Vertical line'),
+        ('_', 'Horizontal line'),
+        ('tickleft', 'Tick left'),
+        ('tickright', 'Tick right'),
+        ('tickup', 'Tick up'),
+        ('tickdown', 'Tick down'),
+        ('caretleft', 'Caret left'),
+        ('caretright', 'Caret right'),
+        ('caretup', 'Caret up'),
+        ('caretdown', 'Caret down'),
         (u'\u2665', 'Heart'),
         ('', 'None')))
     """Dict of supported symbols"""


### PR DESCRIPTION
This PR provides more markers for both OpenGL and Matplotlib backend.

It also provides a small example as a usecase.

## Matplotlib
![silx-symbols-matplotlib](https://user-images.githubusercontent.com/7579321/67581375-31fed100-f748-11e9-9f23-8609f04117f2.png)

## OpenGL

There is some glitches cause of the hi-dpi, some lines can be displayed or not according to the screen resolution... But everything is there.

![silx-symbols-opengl](https://user-images.githubusercontent.com/7579321/67581376-31fed100-f748-11e9-92f7-25f72ade98f6.png)


I think it is good enough for me.

Closes  #2740