### PR TITLE
Make ROI inherit from QObject + provide sigItemChanged

### DIFF
--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -46,7 +46,6 @@ from silx.utils.proxy import docstring
 from .. import icons, qt
 from silx.gui.plot.items.curve import Curve
 from silx.math.combo import min_max
-from .items.roi import _RegionOfInterestBase
 import weakref
 from silx.gui.widgets.TableWidget import TableWidget
 from .items.roi import _RegionOfInterestBase

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -44,10 +44,10 @@ from silx.utils import deprecation
 from silx.utils.weakref import WeakMethodProxy
 from silx.utils.proxy import docstring
 from .. import icons, qt
-from silx.gui.plot.items.curve import Curve
 from silx.math.combo import min_max
 import weakref
 from silx.gui.widgets.TableWidget import TableWidget
+from . import items
 from .items.roi import _RegionOfInterestBase
 
 
@@ -1075,6 +1075,13 @@ class ROI(_RegionOfInterestBase):
         self._todata = todata
         self._type = type_ or 'Default'
 
+        self.sigItemChanged.connect(self.__itemChanged)
+
+    def __itemChanged(self, event):
+        """Handle name change"""
+        if event == items.ItemChangedType.NAME:
+            self.sigChanged.emit()
+
     def getID(self):
         """
 
@@ -1097,17 +1104,6 @@ class ROI(_RegionOfInterestBase):
         :return str: the type of the ROI.
         """
         return self._type
-
-    @docstring(_RegionOfInterestBase)
-    def setName(self, name):
-        """
-        Set the name of the :class:`ROI`
-
-        :param str name:
-        """
-        if self.getName() != name:
-            _RegionOfInterestBase.setName(self, name)
-            self.sigChanged.emit()
 
     def setFrom(self, frm):
         """
@@ -1202,7 +1198,7 @@ class ROI(_RegionOfInterestBase):
         :param CurveItem curve:
         :return tuple: rawCount, netCount
         """
-        assert isinstance(curve, Curve) or curve is None
+        assert isinstance(curve, items.Curve) or curve is None
 
         if curve is None:
             return None, None
@@ -1245,7 +1241,7 @@ class ROI(_RegionOfInterestBase):
         :param CurveItem curve:
         :return tuple: rawArea, netArea
         """
-        assert isinstance(curve, Curve) or curve is None
+        assert isinstance(curve, items.Curve) or curve is None
 
         if curve is None:
             return None, None

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -1048,7 +1048,7 @@ class ROITable(TableWidget):
 _indexNextROI = 0
 
 
-class ROI(_RegionOfInterestBase, qt.QObject):
+class ROI(_RegionOfInterestBase):
     """The Region Of Interest is defined by:
 
     - A name
@@ -1067,7 +1067,6 @@ class ROI(_RegionOfInterestBase, qt.QObject):
     """Signal emitted when the ROI is edited"""
 
     def __init__(self, name, fromdata=None, todata=None, type_=None):
-        qt.QObject.__init__(self)
         _RegionOfInterestBase.__init__(self, name=name)
         global _indexNextROI
         self._id = _indexNextROI

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -137,6 +137,9 @@ class ItemChangedType(enum.Enum):
     COMPLEX_MODE = 'complexModeChanged'
     """Item's complex data visualization mode changed flag."""
 
+    NAME = 'nameChanged'
+    """Item's name changed flag."""
+
 
 class Item(qt.QObject):
     """Description of an item of the plot"""

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -47,11 +47,14 @@ from silx.utils.proxy import docstring
 logger = logging.getLogger(__name__)
 
 
-class _RegionOfInterestBase(object):
+class _RegionOfInterestBase(qt.QObject):
+    """Base class of 1D and 2D region of interest
+
+    :param QObject parent: See QObject
+    :param str name: The name of the ROI
     """
-    Base class of 1D and 2D region of interest
-    """
-    def __init__(self, name):
+    def __init__(self, parent=None, name=''):
+        qt.QObject.__init__(self)
         self.__name = name
 
     def getName(self):
@@ -70,7 +73,7 @@ class _RegionOfInterestBase(object):
         self.__name = name
 
 
-class RegionOfInterest(_RegionOfInterestBase, qt.QObject):
+class RegionOfInterest(_RegionOfInterestBase):
     """Object describing a region of interest in a plot.
 
     :param QObject parent:
@@ -90,8 +93,7 @@ class RegionOfInterest(_RegionOfInterestBase, qt.QObject):
         # Avoid circular dependancy
         from ..tools import roi as roi_tools
         assert parent is None or isinstance(parent, roi_tools.RegionOfInterestManager)
-        qt.QObject.__init__(self, parent)
-        _RegionOfInterestBase.__init__(self, '')
+        _RegionOfInterestBase.__init__(self, parent, '')
         self._color = rgba('red')
         self._items = WeakList()
         self._editAnchors = WeakList()

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -112,6 +112,12 @@ class RegionOfInterest(_RegionOfInterestBase):
         self._labelItem = None
         self._editable = False
         self._visible = True
+        self.sigItemChanged.connect(self.__itemChanged)
+
+    def __itemChanged(self, event):
+        """Handle name change"""
+        if event == items.ItemChangedType.NAME:
+            self._updateLabelItem(self.getName())
 
     def __del__(self):
         # Clean-up plot items
@@ -197,13 +203,6 @@ class RegionOfInterest(_RegionOfInterestBase):
         :param str label: The text label to display
         """
         self.setName(name=label)
-
-    @docstring(_RegionOfInterestBase)
-    def setName(self, name):
-        name = str(name)
-        if name != self.getName():
-            _RegionOfInterestBase.setName(self, name)
-            self._updateLabelItem(name)
 
     def isEditable(self):
         """Returns whether the ROI is editable by the user or not.

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -58,7 +58,7 @@ class _RegionOfInterestBase(qt.QObject):
         self.__name = name
 
     def getName(self):
-        """
+        """Returns the name of the ROI
 
         :return: name of the region of interest
         :rtype: str
@@ -66,11 +66,11 @@ class _RegionOfInterestBase(qt.QObject):
         return self.__name
 
     def setName(self, name):
-        """
+        """Set the name of the ROI
 
         :param str name: name of the region of interest
         """
-        self.__name = name
+        self.__name = str(name)
 
 
 class RegionOfInterest(_RegionOfInterestBase):

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -53,9 +53,17 @@ class _RegionOfInterestBase(qt.QObject):
     :param QObject parent: See QObject
     :param str name: The name of the ROI
     """
+
+    sigItemChanged = qt.Signal(object)
+    """Signal emitted when item has changed.
+
+    It provides a flag describing which property of the item has changed.
+    See :class:`ItemChangedType` for flags description.
+    """
+
     def __init__(self, parent=None, name=''):
         qt.QObject.__init__(self)
-        self.__name = name
+        self.__name = str(name)
 
     def getName(self):
         """Returns the name of the ROI
@@ -70,7 +78,10 @@ class _RegionOfInterestBase(qt.QObject):
 
         :param str name: name of the region of interest
         """
-        self.__name = str(name)
+        name = str(name)
+        if self.__name != name:
+            self.__name = name
+            self.sigItemChanged.emit(items.ItemChangedType.NAME)
 
 
 class RegionOfInterest(_RegionOfInterestBase):


### PR DESCRIPTION
This PR is a follow-up of PR #2684 to make ROI base class a QObject and provide a `sigItemChanged` signal as plot items.