### PR TITLE
Improve TestLogging API

### DIFF
--- a/silx/utils/test/test_testutils.py
+++ b/silx/utils/test/test_testutils.py
@@ -59,6 +59,13 @@ class TestTestLogging(unittest.TestCase):
                 logger.error("expected")
                 logger.error("not expected")
 
+    def testManyErrors(self):
+        logger = logging.getLogger(__name__ + "testManyErrors")
+        listener = testutils.TestLogging(logger, error=1, warning=2)
+        with self.assertRaises(RuntimeError):
+            with listener:
+                pass
+
 
 def suite():
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase

--- a/silx/utils/test/test_testutils.py
+++ b/silx/utils/test/test_testutils.py
@@ -66,6 +66,18 @@ class TestTestLogging(unittest.TestCase):
             with listener:
                 pass
 
+    def testCanBeChecked(self):
+        logger = logging.getLogger(__name__ + "testCanBreak")
+        listener = testutils.TestLogging(logger, error=1, warning=2)
+        with self.assertRaises(RuntimeError):
+            with listener:
+                logger.error("aaa")
+                logger.warning("aaa")
+                self.assertFalse(listener.can_be_checked())
+                logger.error("aaa")
+                # Here we know that it's already wrong without a big cost
+                self.assertTrue(listener.can_be_checked())
+
 
 def suite():
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase

--- a/silx/utils/test/test_testutils.py
+++ b/silx/utils/test/test_testutils.py
@@ -78,6 +78,12 @@ class TestTestLogging(unittest.TestCase):
                 # Here we know that it's already wrong without a big cost
                 self.assertTrue(listener.can_be_checked())
 
+    def testWithAs(self):
+        logger = logging.getLogger(__name__ + "testCanBreak")
+        with testutils.TestLogging(logger) as listener:
+            logger.error("aaa")
+            self.assertIsNotNone(listener)
+
 
 def suite():
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase

--- a/silx/utils/test/test_testutils.py
+++ b/silx/utils/test/test_testutils.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,36 +22,50 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-__authors__ = ["T. Vincent", "P. Knobel"]
+"""Tests for testutils module"""
+
+__authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "08/03/2019"
+__date__ = "18/11/2019"
 
 
 import unittest
-from . import test_weakref
-from . import test_html
-from . import test_array_like
-from . import test_launcher
-from . import test_deprecation
-from . import test_proxy
-from . import test_debug
-from . import test_number
-from . import test_external_resources
-from . import test_enum
-from . import test_testutils
+import logging
+from .. import testutils
+
+
+class TestTestLogging(unittest.TestCase):
+    """Tests for TestLogging."""
+
+    def testRight(self):
+        logger = logging.getLogger(__name__ + "testRight")
+        listener = testutils.TestLogging(logger, error=1)
+        with listener:
+            logger.error("expected")
+            logger.info("ignored")
+
+    def testCustomLevel(self):
+        logger = logging.getLogger(__name__ + "testCustomLevel")
+        listener = testutils.TestLogging(logger, error=1)
+        with listener:
+            logger.error("expected")
+            logger.log(666, "custom level have to be ignored")
+
+    def testWrong(self):
+        logger = logging.getLogger(__name__ + "testWrong")
+        listener = testutils.TestLogging(logger, error=1)
+        with self.assertRaises(RuntimeError):
+            with listener:
+                logger.error("expected")
+                logger.error("not expected")
 
 
 def suite():
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
     test_suite = unittest.TestSuite()
-    test_suite.addTest(test_weakref.suite())
-    test_suite.addTest(test_html.suite())
-    test_suite.addTest(test_array_like.suite())
-    test_suite.addTest(test_launcher.suite())
-    test_suite.addTest(test_deprecation.suite())
-    test_suite.addTest(test_proxy.suite())
-    test_suite.addTest(test_debug.suite())
-    test_suite.addTest(test_number.suite())
-    test_suite.addTest(test_external_resources.suite())
-    test_suite.addTest(test_enum.suite())
-    test_suite.addTest(test_testutils.suite())
+    test_suite.addTest(loadTests(TestTestLogging))
     return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/silx/utils/testutils.py
+++ b/silx/utils/testutils.py
@@ -141,7 +141,7 @@ class TestLogging(logging.Handler):
 
         self.records = []
 
-        self.count_by_level = {
+        self.expected_count_by_level = {
             logging.CRITICAL: critical,
             logging.ERROR: error,
             logging.WARNING: warning,
@@ -163,6 +163,23 @@ class TestLogging(logging.Handler):
         self.entry_disabled = self.logger.disabled
         self.logger.disabled = False
 
+    def get_count_by_level(self):
+        """Returns the current message count by level.
+        """
+        count = {
+            logging.CRITICAL: 0,
+            logging.ERROR: 0,
+            logging.WARNING: 0,
+            logging.INFO: 0,
+            logging.DEBUG: 0,
+            logging.NOTSET: 0
+        }
+        for record in self.records:
+            level = record.levelno
+            if level in count:
+                count[level] = count[level] + 1
+        return count
+
     def __exit__(self, exc_type, exc_value, traceback):
         """Context (i.e., with) support"""
         self.logger.removeHandler(self)
@@ -170,20 +187,28 @@ class TestLogging(logging.Handler):
         self.logger.setLevel(self.entry_level)
         self.logger.disabled = self.entry_disabled
 
-        for level, expected_count in self.count_by_level.items():
-            if expected_count is None:
-                continue
+        count_by_level = self.get_count_by_level()
 
-            # Number of records for the specified level_str
-            count = len([r for r in self.records if r.levelno == level])
-            if count != expected_count:  # That's an error
-                # Resend record logs through logger as they where masked
-                # to help debug
-                for record in self.records:
-                    self.logger.handle(record)
-                raise RuntimeError(
-                    'Expected %d %s logging messages, got %d' % (
-                        expected_count, logging.getLevelName(level), count))
+        # Remove keys which does not matter
+        ignored = [r for r, v in self.expected_count_by_level.items() if v is None]
+        expected_count_by_level = dict(self.expected_count_by_level)
+        for i in ignored:
+            del count_by_level[i]
+            del expected_count_by_level[i]
+
+        if count_by_level != expected_count_by_level:
+            # Re-send record logs through logger as they where masked
+            # to help debug
+            message = ""
+            for level in count_by_level.keys():
+                if message != "":
+                    message += ", "
+                count = count_by_level[level]
+                expected_count = expected_count_by_level[level]
+                message += "%d %s (got %d)" % (expected_count, logging.getLevelName(level), count)
+
+            raise RuntimeError(
+                'Expected %s' % message)
 
     def emit(self, record):
         """Override :meth:`logging.Handler.emit`"""

--- a/silx/utils/testutils.py
+++ b/silx/utils/testutils.py
@@ -165,6 +165,7 @@ class TestLogging(logging.Handler):
         self.logger.setLevel(logging.DEBUG)
         self.entry_disabled = self.logger.disabled
         self.logger.disabled = False
+        return self
 
     def can_be_checked(self):
         """Returns True if this listener have received enough messages to

--- a/silx/utils/testutils.py
+++ b/silx/utils/testutils.py
@@ -150,6 +150,9 @@ class TestLogging(logging.Handler):
             logging.NOTSET: notset
         }
 
+        self._expected_count = sum([v for k, v in self.expected_count_by_level.items() if v is not None])
+        """Amount of any logging expected"""
+
         super(TestLogging, self).__init__()
 
     def __enter__(self):
@@ -162,6 +165,15 @@ class TestLogging(logging.Handler):
         self.logger.setLevel(logging.DEBUG)
         self.entry_disabled = self.logger.disabled
         self.logger.disabled = False
+
+    def can_be_checked(self):
+        """Returns True if this listener have received enough messages to
+        be valid, and then checked.
+
+        This can be useful for asynchronous wait of messages. It allows process
+        an early break, instead of waiting much time in an active loop.
+        """
+        return len(self.records) >= self._expected_count
 
     def get_count_by_level(self):
         """Returns the current message count by level.


### PR DESCRIPTION
This PR improves few things of the `TestLogging `

- Add unittests
- A single exception to summarize all the problems
- Add function for early break of active loops (it could be improved, but it is good enough for valid usecase)
- Create a `get_count_by_level` method
- Support `with as` syntax

I also break the attribute `count_by_level`, to rename it as `expected_count_by_level`. 

A `count_by_level` could be re-defined for compatibility, but i expect no body was using it. Let me know what you prefer.