### PR TITLE
Rework matplotlib backend rendering (and picking)

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2933,28 +2933,6 @@ class PlotWidget(qt.QMainWindow):
         """
         return self._getItem(kind='marker', legend=legend)
 
-    def _itemsFromBackToFront(self, condition=None):
-        """Iterator of plot items ordered from back to front.
-
-        This is the order used for rendering.
-        It takes into account overlays, z value and order of addition of items
-
-        :param callable condition:
-           Callable taking an item as input and returning False for items to skip.
-           If None (default), no item is skipped.
-        :rtpye: List[Item]
-        """
-        # Sort items: Overlays first, then others
-        # and in each category ordered by z and then by order of addition
-        # as _content keeps this order.
-        content = self._content.values()
-        if condition is not None:
-            content = (item for item in content if condition(item))
-
-        return sorted(
-            content,
-            key=lambda i: ((1 if i.isOverlay() else 0), i.getZValue()))
-
     def pickItems(self, x, y, condition=None):
         """Generator of picked items in the plot at given position.
 
@@ -2968,7 +2946,7 @@ class PlotWidget(qt.QMainWindow):
         :return: Iterable of :class:`PickingResult` objects at picked position.
             Items are ordered from front to back.
         """
-        for item in reversed(self._itemsFromBackToFront(condition=condition)):
+        for item in reversed(self._backend.getItemsFromBackToFront(condition=condition)):
             result = item.pick(x, y)
             if result is not None:
                 yield result

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -303,6 +303,29 @@ class BackendBase(object):
         """
         pass
 
+    def getItemsFromBackToFront(self, condition=None):
+        """Returns the list of plot items order as rendered by the backend.
+
+        This is the order used for rendering.
+        By default, it takes into account overlays, z value and order of addition of items,
+        but backends can override it.
+
+        :param callable condition:
+           Callable taking an item as input and returning False for items to skip.
+           If None (default), no item is skipped.
+        :rtype: List[~silx.gui.plot.items.Item]
+        """
+        # Sort items: Overlays first, then others
+        # and in each category ordered by z and then by order of addition
+        # as content keeps this order.
+        content = self._plot.getItems()
+        if condition is not None:
+            content = [item for item in content if condition(item)]
+
+        return sorted(
+            content,
+            key=lambda i: ((1 if i.isOverlay() else 0), i.getZValue()))
+
     def pickItem(self, x, y, item):
         """Return picked indices if any, or None.
 

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -209,15 +209,25 @@ class NiceAutoDateFormatter(Formatter):
 class _PickableContainer(Container):
     """Artists container with a :meth:`contains` method"""
 
+    def __init__(self, *args, **kwargs):
+        Container.__init__(self, *args, **kwargs)
+        self.__zorder = None
+
     def draw(self, *args, **kwargs):
         """artist-like draw to broadcast draw to children"""
         for child in self.get_children():
             child.draw(*args, **kwargs)
 
+    def get_zorder(self):
+        """Mimic Artist.get_zorder"""
+        return self.__zorder
+
     def set_zorder(self, z):
         """Mimic Artist.set_zorder to broadcast to children"""
-        for child in self.get_children():
-            child.set_zorder(z)
+        if z != self.__zorder:
+            self.__zorder = z
+            for child in self.get_children():
+                child.set_zorder(z)
 
     def contains(self, mouseevent):
         """Mimic Artist.contains, and call it on all children.
@@ -887,7 +897,9 @@ class BackendMatplotlib(BackendBase.BackendBase):
             lambda item: item.isVisible() and item._backendRenderer is not None)
         count = len(items)
         for index, item in enumerate(items):
-            item._backendRenderer.set_zorder(1. + index / count)
+            zorder = 1. + index / count
+            if zorder != item._backendRenderer.get_zorder():
+                item._backendRenderer.set_zorder(zorder)
 
     def saveGraph(self, fileName, fileFormat, dpi):
         self.updateZOrder()

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1186,6 +1186,12 @@ class BackendMatplotlib(BackendBase.BackendBase):
                     line.set_color(gridColor)
                 # axes.grid().set_markeredgecolor(gridColor)
 
+    def setBackgroundColors(self, backgroundColor, dataBackgroundColor):
+        self._synchronizeBackgroundColors()
+
+    def setForegroundColors(self, foregroundColor, gridColor):
+        self._synchronizeForegroundColors()
+
 
 class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
     """QWidget matplotlib backend using a QtAgg canvas.
@@ -1394,9 +1400,3 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
         else:
             cursor = self._QT_CURSORS[cursor]
             FigureCanvasQTAgg.setCursor(self, qt.QCursor(cursor))
-
-    def setBackgroundColors(self, backgroundColor, dataBackgroundColor):
-        self._synchronizeBackgroundColors()
-
-    def setForegroundColors(self, foregroundColor, gridColor):
-        self._synchronizeForegroundColors()

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -437,7 +437,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         labels = []
         pixelOffset = 3
 
-        for plotItem in self._plot._itemsFromBackToFront(
+        for plotItem in self.getItemsFromBackToFront(
                 condition=lambda i: i.isVisible() and i.isOverlay() == overlay):
             if plotItem._backendRenderer is None:
                 continue


### PR DESCRIPTION
This PR reworks the `matplotlib` rendering.
The way used in PR #2730 had some short-comings (e.g., see #2785 + when saving as image, the content was different from what the widget displayed...)

The idea here is to decouple the z order in `PlotWidget` from that in `matplotlib`.
Each matplotlib item is given a different z order (which order is set according to this order in the `PlotWidget`).
The drawback of this method it that items associated with left and right axes are no longer interleaved regarding z as matplotlib `Axes` are one on top of the other... but trying to avoid that (as in #2730) is quite tricky and (as shown by the issues it implies) not really robust.

closes #2785