### PR TITLE
Make reading NX_class from silx.gui.hdf5 a bit more robust to errors

### DIFF
--- a/silx/gui/hdf5/Hdf5Item.py
+++ b/silx/gui/hdf5/Hdf5Item.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -367,7 +367,13 @@ class Hdf5Item(Hdf5Node):
                 text = ""
             else:
                 text = self._getFormatter().textFormatter().toString(obj)
-            self.__nx_class = text.strip('"')
+                text = text.strip('"')
+                lower = text.lower()
+                if lower.startswith('nx'):
+                    text = 'NX' + lower[2:]
+                if lower == 'nxcansas':
+                    text = 'NXcanSAS'  # That's the only class with capital letters...
+            self.__nx_class = text
         return self.__nx_class
 
     def dataName(self, role):

--- a/silx/gui/hdf5/Hdf5Item.py
+++ b/silx/gui/hdf5/Hdf5Item.py
@@ -368,11 +368,18 @@ class Hdf5Item(Hdf5Node):
             else:
                 text = self._getFormatter().textFormatter().toString(obj)
                 text = text.strip('"')
+                # Check NX_class formatting
                 lower = text.lower()
                 if lower.startswith('nx'):
-                    text = 'NX' + lower[2:]
+                    formatedNX_class = 'NX' + lower[2:]
                 if lower == 'nxcansas':
-                    text = 'NXcanSAS'  # That's the only class with capital letters...
+                    formatedNX_class = 'NXcanSAS'  # That's the only class with capital letters...
+                if text != formatedNX_class:
+                    _logger.error("NX_class: %s is malformed (should be %s)",
+                                  text,
+                                  formatedNX_class)
+                text = formatedNX_class
+
             self.__nx_class = text
         return self.__nx_class
 


### PR DESCRIPTION
This PR adds makes `silx.gui.hdf5` and so `silx view` a bit more robust against malformed `NX_class` by making it case-insensitive.

No sure we want to go into this direction... but I encountered this case.
What do you think?

I'm fine to drop this.