### PR TITLE
Scatter plot regular grid visualization mode

### DIFF
--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -922,7 +922,7 @@ class ScatterVisualizationMixIn(ItemMixInBase):
         This is based on Delaunay triangulation
         """
 
-        REGULAR_GRID = 'regular grid'
+        REGULAR_GRID = 'regular_grid'
         """Display scatter plot as an image.
 
         It expects the points to be the intersection of a regular grid,

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -922,6 +922,15 @@ class ScatterVisualizationMixIn(ItemMixInBase):
         This is based on Delaunay triangulation
         """
 
+        REGULAR_GRID = 'regular grid'
+        """Display scatter plot as an image.
+
+        It expects the points to be the intersection of a regular grid,
+        and the order of points following that of an image.
+        First line, then second one, and always in the same direction
+        (either all lines from left to right or all from right to left).
+        """
+
     def __init__(self):
         self.__visualization = self.Visualization.POINTS
 

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -355,6 +355,8 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
             if guess.order == 'F':
                 image = numpy.transpose(image, axes=(1, 0, 2))
 
+            self.__cacheRegularGridInfo = guess
+
             return backend.addImage(
                 data=image,
                 origin=guess.origin,
@@ -387,10 +389,15 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
             if self.__cacheRegularGridInfo is None:
                 return None
 
-            origin, scale, size = self.__cacheRegularGridInfo
+            origin = self.__cacheRegularGridInfo.origin
+            scale = self.__cacheRegularGridInfo.scale
             column = int((dataPos[0] - origin[0]) / scale[0])
             row = int((dataPos[1] - origin[1]) / scale[1])
-            index = row * size[0] + column
+
+            if self.__cacheRegularGridInfo.order == 'C':
+                index = row * self.__cacheRegularGridInfo.size[0] + column
+            else:
+                index = row + column *self.__cacheRegularGridInfo.size[1]
             if index >= len(self.getXData(copy=False)):  # OK as long as not log scale
                 return None  # Image can be larger than scatter
 

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -87,7 +87,7 @@ class _GreedyThreadPoolExecutor(ThreadPoolExecutor):
 
 # Functions to guess grid size from coordinates
 
-def get_Z_line_length(array):
+def _get_z_line_length(array):
     """Return length of line if array is a Z-like 2D regular grid.
 
     :param numpy.ndarray array: The 1D array of coordinates to check
@@ -109,7 +109,7 @@ def get_Z_line_length(array):
     return 0
 
 
-def guess_Z_grid_size(x, y):
+def _guess_z_grid_size(x, y):
     """Guess the size of a grid from (x, y) coordinates.
 
     The grid might contain more elements than x and y,
@@ -123,7 +123,7 @@ def guess_Z_grid_size(x, y):
         direction is either 1 or -1
     :rtype: Union[List(str,int),None]
     """
-    width = get_Z_line_length(x)
+    width = _get_z_line_length(x)
     if width != 0:
         height = int(numpy.ceil(len(x) / width))
         dir_x = numpy.sign(x[width - 1] - x[0])
@@ -133,7 +133,7 @@ def guess_Z_grid_size(x, y):
         else:
             return 'C', (width, height), (dir_x, dir_y)
     else:
-        height = get_Z_line_length(y)
+        height = _get_z_line_length(y)
         if height != 0:
             width = int(numpy.ceil(len(y) / height))
             dir_x = numpy.sign(x[-1] - x[0])
@@ -167,7 +167,7 @@ GuessedGrid = namedtuple('GuessedGrid',
                          ['origin', 'scale', 'size', 'order'])
 
 
-def guess_grid(x, y):
+def _guess_grid(x, y):
     """Guess a regular grid from the points.
 
     Result convention is (x, y)
@@ -181,7 +181,7 @@ def guess_grid(x, y):
     x_min, x_max = min_max(x)
     y_min, y_max = min_max(y)
 
-    guess = guess_Z_grid_size(x, y)
+    guess = _guess_z_grid_size(x, y)
     if guess is not None:
         order, size, directions = guess
 
@@ -334,7 +334,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
                 # regular grid visualization is not available with log scaled axes
                 return None
 
-            guess = guess_grid(xFiltered, yFiltered)
+            guess = _guess_grid(xFiltered, yFiltered)
             if guess is None:
                 _logger.warning(
                     'Cannot guess a grid: Cannot display as regular grid image')

--- a/silx/gui/plot3d/items/scatter.py
+++ b/silx/gui/plot3d/items/scatter.py
@@ -234,6 +234,9 @@ class Scatter2D(DataItem3D, ColormapMixIn, SymbolMixIn,
     }
     """Dict {visualization mode: property names used in this mode}"""
 
+    _SUPPORTED_SCATTER_VISUALIZATION = tuple(_VISUALIZATION_PROPERTIES.keys())
+    """Overrides supported Visualizations"""
+
     def __init__(self, parent=None):
         DataItem3D.__init__(self, parent=parent)
         ColormapMixIn.__init__(self)


### PR DESCRIPTION
This PR provides an extra visualization of scatter plots as image for cases where the points are on a regular grid.

related to #2743

TODOs: Better guessing of the image dimension, including handling points on a single line, backward direction for both axes, y as fast moving dimension