### PR TITLE
Fix scatterview profile interaction

### DIFF
--- a/silx/gui/plot/ScatterView.py
+++ b/silx/gui/plot/ScatterView.py
@@ -79,7 +79,7 @@ class ScatterView(qt.QMainWindow):
         self._plot = weakref.ref(plot)
 
         # Add an empty scatter
-        plot.addScatter(x=(), y=(), value=(), legend=self._SCATTER_LEGEND)
+        self.__createEmptyScatter()
 
         # Create colorbar widget with white background
         self._colorbar = ColorBarWidget(parent=self, plot=plot)
@@ -144,6 +144,21 @@ class ScatterView(qt.QMainWindow):
             self.addToolBar(toolbar)
             for action in toolbar.actions():
                 self.addAction(action)
+
+
+    def __createEmptyScatter(self):
+        """Create an empty scatter item that is used to display the data
+
+        :rtype: ~silx.gui.plot.items.Scatter
+        """
+        plot = self.getPlotWidget()
+        plot.addScatter(x=(), y=(), value=(), legend=self._SCATTER_LEGEND)
+        scatter = plot._getItem(
+            kind='scatter', legend=self._SCATTER_LEGEND)
+        # Profile is not selectable,
+        # so it does not interfere with profile interaction
+        scatter._setSelectable(False)
+        return scatter
 
     def _pickScatterData(self, x, y):
         """Get data and index and value of top most scatter plot at position (x, y)
@@ -345,9 +360,7 @@ class ScatterView(qt.QMainWindow):
         plot = self.getPlotWidget()
         scatter = plot._getItem(kind='scatter', legend=self._SCATTER_LEGEND)
         if scatter is None:  # Resilient to call to PlotWidget API (e.g., clear)
-            plot.addScatter(x=(), y=(), value=(), legend=self._SCATTER_LEGEND)
-            scatter = plot._getItem(
-                kind='scatter', legend=self._SCATTER_LEGEND)
+            scatter = self.__createEmptyScatter()
         return scatter
 
     # Convenient proxies

--- a/silx/gui/plot/tools/profile/_BaseProfileToolBar.py
+++ b/silx/gui/plot/tools/profile/_BaseProfileToolBar.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -321,7 +321,7 @@ class _BaseProfileToolBar(qt.QToolBar):
 
     def __roiAdded(self, roi):
         """Handle new ROI"""
-        roi.setLabel('Profile')
+        roi.setName('Profile')
         roi.setEditable(True)
 
         # Remove any other ROI


### PR DESCRIPTION
This PR fixes an issue in the `ScatterView` with the profile tool.
Initially raised here: https://github.com/silx-kit/silx/pull/2810#issuecomment-562220610

It was not possible to start a profile while hovering a point of the scatter plot (this was due to the scatter item being selectable and so taking focus of the mouse press event).

The scatter item is no longer selectable and so no longer takes the focus of mouse events
