### PR TITLE
Add action to save stack of images

### DIFF
--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -257,7 +257,7 @@ class StackView(qt.QMainWindow):
             self._plot.profile.clearProfile)
 
     def _saveImageStack(self, plot, filename, nameFilter):
-        """Save a volume from a StackView.
+        """Save all images from the stack into a volume.
 
         :param str filename: The name of the file to write
         :param str nameFilter: The selected name filter

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -85,6 +85,8 @@ from .Profile import Profile3DToolBar
 from ..widgets.FrameBrowser import HorizontalSliderWithBrowser
 
 from silx.gui.plot.actions import control as actions_control
+from silx.gui.plot.actions import io as silx_io
+from silx.io.nxdata import save_NXdata
 from silx.utils.array_like import DatasetView, ListOfImages
 from silx.math import calibration
 from silx.utils.deprecation import deprecated_warning
@@ -226,6 +228,7 @@ class StackView(qt.QMainWindow):
         self._plot.getXAxis().setLabel('Columns')
         self._plot.getYAxis().setLabel('Rows')
         self._plot.sigPlotSignal.connect(self._plotCallback)
+        self._plot.getSaveAction().setFileFilter('image', silx_io.IMAGE_STACK_FILTER_NXDATA, func=self._saveImageStack)
 
         self.__planeSelection = PlanesWidget(self._plot)
         self.__planeSelection.sigPlaneSelectionChanged.connect(self.setPerspective)

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -253,6 +253,25 @@ class StackView(qt.QMainWindow):
         self.__planeSelection.sigPlaneSelectionChanged.connect(
             self._plot.profile.clearProfile)
 
+    def _saveImageStack(self, plot, filename, nameFilter):
+        """Save a volume from a StackView.
+
+        :param str filename: The name of the file to write
+        :param str nameFilter: The selected name filter
+        :return: False if format is not supported or save failed,
+                 True otherwise.
+        :raises: ValueError if nameFilter is invalid
+        """
+        if not nameFilter == silx_io.IMAGE_STACK_FILTER_NXDATA:
+            raise ValueError('Wrong callback')
+        entryPath = silx_io.SaveAction._selectWriteableOutputGroup(filename, parent=self)
+        if entryPath is None:
+            return False
+        return save_NXdata(filename,
+                           nxentry_name=entryPath,
+                           signal=self.getStack(copy=False, returnNumpyArray=True)[0],
+                           signal_name="image_stack")
+
     def _addColorBarAction(self):
         self._plot.getColorBarWidget().setVisible(True)
         actions = self._plot.toolBar().actions()

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -228,7 +228,7 @@ class StackView(qt.QMainWindow):
         self._plot.getXAxis().setLabel('Columns')
         self._plot.getYAxis().setLabel('Rows')
         self._plot.sigPlotSignal.connect(self._plotCallback)
-        self._plot.getSaveAction().setFileFilter('image', silx_io.IMAGE_STACK_FILTER_NXDATA, func=self._saveImageStack)
+        self._plot.getSaveAction().setFileFilter('image', silx_io.SaveAction.IMAGE_STACK_FILTER_NXDATA, func=self._saveImageStack)
 
         self.__planeSelection = PlanesWidget(self._plot)
         self.__planeSelection.sigPlaneSelectionChanged.connect(self.setPerspective)
@@ -265,7 +265,7 @@ class StackView(qt.QMainWindow):
                  True otherwise.
         :raises: ValueError if nameFilter is invalid
         """
-        if not nameFilter == silx_io.IMAGE_STACK_FILTER_NXDATA:
+        if not nameFilter == silx_io.SaveAction.IMAGE_STACK_FILTER_NXDATA:
             raise ValueError('Wrong callback')
         entryPath = silx_io.SaveAction._selectWriteableOutputGroup(filename, parent=self)
         if entryPath is None:

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -162,6 +162,9 @@ class StackView(qt.QMainWindow):
     This signal provides the current frame number.
     """
 
+    IMAGE_STACK_FILTER_NXDATA = 'Stack of images as NXdata (%s)' % silx_io._NEXUS_HDF5_EXT_STR
+
+
     def __init__(self, parent=None, resetzoom=True, backend=None,
                  autoScale=False, logScale=False, grid=False,
                  colormap=True, aspectRatio=True, yinverted=True,
@@ -228,7 +231,7 @@ class StackView(qt.QMainWindow):
         self._plot.getXAxis().setLabel('Columns')
         self._plot.getYAxis().setLabel('Rows')
         self._plot.sigPlotSignal.connect(self._plotCallback)
-        self._plot.getSaveAction().setFileFilter('image', silx_io.SaveAction.IMAGE_STACK_FILTER_NXDATA, func=self._saveImageStack)
+        self._plot.getSaveAction().setFileFilter('image', self.IMAGE_STACK_FILTER_NXDATA, func=self._saveImageStack, appendToFile=True)
 
         self.__planeSelection = PlanesWidget(self._plot)
         self.__planeSelection.sigPlaneSelectionChanged.connect(self.setPerspective)
@@ -265,7 +268,7 @@ class StackView(qt.QMainWindow):
                  True otherwise.
         :raises: ValueError if nameFilter is invalid
         """
-        if not nameFilter == silx_io.SaveAction.IMAGE_STACK_FILTER_NXDATA:
+        if not nameFilter == self.IMAGE_STACK_FILTER_NXDATA:
             raise ValueError('Wrong callback')
         entryPath = silx_io.SaveAction._selectWriteableOutputGroup(filename, parent=self)
         if entryPath is None:

--- a/silx/gui/plot/actions/io.py
+++ b/silx/gui/plot/actions/io.py
@@ -509,7 +509,7 @@ class SaveAction(PlotAction):
                 axes_errors=[xerror, yerror],
                 title=plot.getGraphTitle())
 
-    def setFileFilter(self, dataKind, nameFilter, func, index=None):
+    def setFileFilter(self, dataKind, nameFilter, func, index=None, appendToFile=False):
         """Set a name filter to add/replace a file format support
 
         :param str dataKind:
@@ -520,9 +520,14 @@ class SaveAction(PlotAction):
         :param callable func: The function to call to perform saving.
             Expected signature is:
             bool func(PlotWidget plot, str filename, str nameFilter)
+        :param bool appendToFile: True to append the data into the selected
+            file.
         :param integer index: Index of the filter in the final list (or None)
         """
         assert dataKind in ('all', 'curve', 'curves', 'image', 'scatter')
+
+        if appendToFile:
+            self._appendFilters.append(nameFilter)
 
         # first append or replace the new filter to prevent colissions
         self._filters[dataKind][nameFilter] = func

--- a/silx/gui/plot/actions/io.py
+++ b/silx/gui/plot/actions/io.py
@@ -237,7 +237,7 @@ class SaveAction(PlotAction):
             # create new entry in new file
             return "/entry"
         else:
-            self._errorMessage('Save failed (file access issue)\n', parent=parent)
+            SaveAction._errorMessage('Save failed (file access issue)\n', parent=parent)
             return None
 
     def _saveCurveAsNXdata(self, curve, filename):

--- a/silx/gui/plot/actions/io.py
+++ b/silx/gui/plot/actions/io.py
@@ -185,10 +185,11 @@ class SaveAction(PlotAction):
         self.setShortcut(qt.QKeySequence.Save)
         self.setShortcutContext(qt.Qt.WidgetShortcut)
 
-    def _errorMessage(self, informativeText=''):
+    @staticmethod
+    def _errorMessage(informativeText='', parent=None):
         """Display an error message."""
         # TODO issue with QMessageBox size fixed and too small
-        msg = qt.QMessageBox(self.plot)
+        msg = qt.QMessageBox(parent)
         msg.setIcon(qt.QMessageBox.Critical)
         msg.setInformativeText(informativeText + ' ' + str(sys.exc_info()[1]))
         msg.setDetailedText(traceback.format_exc())
@@ -220,7 +221,8 @@ class SaveAction(PlotAction):
         ylabel = item.getYLabel() or self.plot.getYAxis().getLabel()
         return xlabel, ylabel
 
-    def _selectWriteableOutputGroup(self, filename):
+    @staticmethod
+    def _selectWriteableOutputGroup(filename, parent):
         if os.path.exists(filename) and os.path.isfile(filename) \
                 and os.access(filename, os.W_OK):
             entryPath = selectOutputGroup(filename)
@@ -232,11 +234,11 @@ class SaveAction(PlotAction):
             # create new entry in new file
             return "/entry"
         else:
-            self._errorMessage('Save failed (file access issue)\n')
+            self._errorMessage('Save failed (file access issue)\n', parent=parent)
             return None
 
     def _saveCurveAsNXdata(self, curve, filename):
-        entryPath = self._selectWriteableOutputGroup(filename)
+        entryPath = self._selectWriteableOutputGroup(filename, parent=self.plot)
         if entryPath is None:
             return False
 
@@ -273,7 +275,7 @@ class SaveAction(PlotAction):
         if curve is None:
             curves = plot.getAllCurves()
             if not curves:
-                self._errorMessage("No curve to be saved")
+                self._errorMessage("No curve to be saved", parent=self.plot)
                 return False
             curve = curves[0]
 
@@ -299,7 +301,7 @@ class SaveAction(PlotAction):
                    fmt=fmt, csvdelim=csvdelim,
                    autoheader=autoheader)
         except IOError:
-            self._errorMessage('Save failed\n')
+            self._errorMessage('Save failed\n', parent=self.plot)
             return False
 
         return True
@@ -317,7 +319,7 @@ class SaveAction(PlotAction):
 
         curves = plot.getAllCurves()
         if not curves:
-            self._errorMessage("No curves to be saved")
+            self._errorMessage("No curves to be saved", parent=self.plot)
             return False
 
         curve = curves[0]
@@ -334,7 +336,7 @@ class SaveAction(PlotAction):
                                 write_file_header=True,
                                 close_file=False)
         except IOError:
-            self._errorMessage('Save failed\n')
+            self._errorMessage('Save failed\n', parent=self.plot)
             return False
 
         for curve in curves[1:]:
@@ -351,7 +353,7 @@ class SaveAction(PlotAction):
                                     write_file_header=False,
                                     close_file=False)
             except IOError:
-                self._errorMessage('Save failed\n')
+                self._errorMessage('Save failed\n', parent=self.plot)
                 return False
         specfile.close()
 
@@ -391,12 +393,12 @@ class SaveAction(PlotAction):
             try:
                 numpy.save(filename, data)
             except IOError:
-                self._errorMessage('Save failed\n')
+                self._errorMessage('Save failed\n', parent=self.plot)
                 return False
             return True
 
         elif nameFilter == self.IMAGE_FILTER_NXDATA:
-            entryPath = self._selectWriteableOutputGroup(filename)
+            entryPath = self._selectWriteableOutputGroup(filename, parent=self.plot)
             if entryPath is None:
                 return False
             xorigin, yorigin = image.getOrigin()
@@ -438,7 +440,7 @@ class SaveAction(PlotAction):
                        autoheader=True)
 
             except IOError:
-                self._errorMessage('Save failed\n')
+                self._errorMessage('Save failed\n', parent=self.plot)
                 return False
             return True
 
@@ -471,7 +473,7 @@ class SaveAction(PlotAction):
             return False
 
         if nameFilter == self.SCATTER_FILTER_NXDATA:
-            entryPath = self._selectWriteableOutputGroup(filename)
+            entryPath = self._selectWriteableOutputGroup(filename, parent=self.plot)
             if entryPath is None:
                 return False
             scatter = plot.getScatter()

--- a/silx/gui/plot/actions/io.py
+++ b/silx/gui/plot/actions/io.py
@@ -131,6 +131,7 @@ class SaveAction(PlotAction):
     IMAGE_FILTER_CSV_TAB = 'Image data as tab-separated CSV (*.csv)'
     IMAGE_FILTER_RGB_PNG = 'Image as PNG (*.png)'
     IMAGE_FILTER_NXDATA = 'Image as NXdata (%s)' % _NEXUS_HDF5_EXT_STR
+
     DEFAULT_IMAGE_FILTERS = (IMAGE_FILTER_EDF,
                              IMAGE_FILTER_TIFF,
                              IMAGE_FILTER_NUMPY,
@@ -144,9 +145,11 @@ class SaveAction(PlotAction):
     SCATTER_FILTER_NXDATA = 'Scatter as NXdata (%s)' % _NEXUS_HDF5_EXT_STR
     DEFAULT_SCATTER_FILTERS = (SCATTER_FILTER_NXDATA,)
 
+    IMAGE_STACK_FILTER_NXDATA = 'Stack of images as NXdata (%s)' % _NEXUS_HDF5_EXT_STR
+
     # filters for which we don't want an "overwrite existing file" warning
     DEFAULT_APPEND_FILTERS = (CURVE_FILTER_NXDATA, IMAGE_FILTER_NXDATA,
-                              SCATTER_FILTER_NXDATA)
+                              SCATTER_FILTER_NXDATA, IMAGE_STACK_FILTER_NXDATA)
 
     def __init__(self, plot, parent=None):
         self._filters = {

--- a/silx/gui/plot/actions/io.py
+++ b/silx/gui/plot/actions/io.py
@@ -613,7 +613,7 @@ class SaveAction(PlotAction):
         def onFilterSelection(filt_):
             # disable overwrite confirmation for NXdata types,
             # because we append the data to existing files
-            if filt_ in self.DEFAULT_APPEND_FILTERS:
+            if filt_ in self._appendFilters:
                 dialog.setOption(dialog.DontConfirmOverwrite)
             else:
                 dialog.setOption(dialog.DontConfirmOverwrite, False)

--- a/silx/gui/plot/actions/io.py
+++ b/silx/gui/plot/actions/io.py
@@ -159,6 +159,8 @@ class SaveAction(PlotAction):
             'image': OrderedDict(),
             'scatter': OrderedDict()}
 
+        self._appendFilters = list(self.DEFAULT_APPEND_FILTERS)
+
         # Initialize filters
         for nameFilter in self.DEFAULT_ALL_FILTERS:
             self.setFileFilter(

--- a/silx/gui/plot/actions/io.py
+++ b/silx/gui/plot/actions/io.py
@@ -145,11 +145,9 @@ class SaveAction(PlotAction):
     SCATTER_FILTER_NXDATA = 'Scatter as NXdata (%s)' % _NEXUS_HDF5_EXT_STR
     DEFAULT_SCATTER_FILTERS = (SCATTER_FILTER_NXDATA,)
 
-    IMAGE_STACK_FILTER_NXDATA = 'Stack of images as NXdata (%s)' % _NEXUS_HDF5_EXT_STR
-
     # filters for which we don't want an "overwrite existing file" warning
     DEFAULT_APPEND_FILTERS = (CURVE_FILTER_NXDATA, IMAGE_FILTER_NXDATA,
-                              SCATTER_FILTER_NXDATA, IMAGE_STACK_FILTER_NXDATA)
+                              SCATTER_FILTER_NXDATA)
 
     def __init__(self, plot, parent=None):
         self._filters = {


### PR DESCRIPTION
This PR adds a filter in the `SaveAction` of `StackView` which makes possible to save all the stack in an hdf5 file.
We need to specify that the 'IMAGE_STACK_FILTER_NXDATA' is an 'Append' action to the file.
If 'IMAGE_STACK_FILTER_NXDATA' should be stored in StackView then we need to add an 'addAppendFilter' function.

/close #2812 