### PR TITLE
[plot] Make code compatible with numpy 1.12

### DIFF
--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1313,7 +1313,7 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
             # being the top one.
             dists = ((triangulation.x[indices] - x) ** 2 +
                      (triangulation.y[indices] - y) ** 2)
-            return indices[numpy.flip(numpy.argsort(dists))]
+            return indices[numpy.flip(numpy.argsort(dists), axis=0)]
 
         else:  # Returns indices if any
             return info.get('ind', ())

--- a/silx/gui/plot/backends/glutils/GLPlotTriangles.py
+++ b/silx/gui/plot/backends/glutils/GLPlotTriangles.py
@@ -136,7 +136,7 @@ class GLPlotTriangles(object):
 
         # Sorted from furthest to closest point
         dists = (xPts[indices] - x) ** 2 + (yPts[indices] - y) ** 2
-        indices = indices[numpy.flip(numpy.argsort(dists))]
+        indices = indices[numpy.flip(numpy.argsort(dists), axis=0)]
 
         return tuple(indices) if len(indices) > 0 else None
 


### PR DESCRIPTION
This PR makes the plot picking code compatible with numpy 1.12 where the `axis` argument of `numpy.flip` has no default value.