### PR TITLE
Create BoundingRect item

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -603,7 +603,7 @@ class PlotWidget(qt.QMainWindow):
         elif isinstance(item, (items.Marker,
                                items.XMarker, items.YMarker)):
             kind = 'marker'
-        elif isinstance(item, items.Shape):
+        elif isinstance(item, (items.Shape, items.BoundingRect)):
             kind = 'item'
         elif isinstance(item, items.Histogram):
             kind = 'histogram'

--- a/silx/gui/plot/items/__init__.py
+++ b/silx/gui/plot/items/__init__.py
@@ -40,7 +40,7 @@ from .complex import ImageComplexData  # noqa
 from .curve import Curve, CurveStyle  # noqa
 from .histogram import Histogram  # noqa
 from .image import ImageBase, ImageData, ImageRgba, MaskImageData  # noqa
-from .shape import Shape  # noqa
+from .shape import Shape, BoundingRect  # noqa
 from .scatter import Scatter  # noqa
 from .marker import MarkerBase, Marker, XMarker, YMarker  # noqa
 from .axis import Axis, XAxis, YAxis, YRightAxis

--- a/silx/gui/plot/items/shape.py
+++ b/silx/gui/plot/items/shape.py
@@ -36,7 +36,7 @@ import numpy
 import six
 
 from ... import colors
-from .core import Item, ColorMixIn, FillMixIn, ItemChangedType, LineMixIn
+from .core import Item, ColorMixIn, FillMixIn, ItemChangedType, LineMixIn, YAxisMixIn
 
 
 _logger = logging.getLogger(__name__)
@@ -153,3 +153,30 @@ class Shape(Item, ColorMixIn, FillMixIn, LineMixIn):
 
         self._lineBgColor = color
         self._updated(ItemChangedType.LINE_BG_COLOR)
+
+
+class BoundingRect(Item, YAxisMixIn):
+    """An invisible shape which enforce the plot view to display the defined
+    space on autoscale.
+
+    This item do not display anything. But if the visible property is true,
+    this bounding box is used by the plot, if not, the bounding box is
+    ignored. That's the default behaviour for plot items.
+
+    It can be applied on the "left" or "right" axes. Not both at the same time.
+    """
+
+    def __init__(self):
+        Item.__init__(self)
+        YAxisMixIn.__init__(self)
+        self._bound = None
+
+    def setBounds(self, rect):
+        """Set the bounding box of this item in data coordinates
+
+        :param rect: (xmin, xmax, ymin, ymax) or None
+        """
+        self._bound = rect
+
+    def _getBounds(self):
+        return self._bound

--- a/silx/gui/plot/items/shape.py
+++ b/silx/gui/plot/items/shape.py
@@ -189,6 +189,8 @@ class BoundingRect(Item, YAxisMixIn):
         """
         if rect is not None:
             rect = float(rect[0]), float(rect[1]), float(rect[2]), float(rect[3])
+            assert rect[0] <= rect[1]
+            assert rect[2] <= rect[3]
 
         if rect != self.__bounds:
             self.__bounds = rect

--- a/silx/gui/plot/items/shape.py
+++ b/silx/gui/plot/items/shape.py
@@ -197,4 +197,20 @@ class BoundingRect(Item, YAxisMixIn):
             self._updated(ItemChangedType.DATA)
 
     def _getBounds(self):
+        plot = self.getPlot()
+        if plot is not None:
+            xPositive = plot.getXAxis()._isLogarithmic()
+            yPositive = plot.getYAxis()._isLogarithmic()
+            if xPositive or yPositive:
+                bounds = list(self.__bounds)
+                if xPositive and bounds[1] <= 0:
+                    return None
+                if xPositive and bounds[0] <= 0:
+                    bounds[0] = bounds[1]
+                if yPositive and bounds[3] <= 0:
+                    return None
+                if yPositive and bounds[2] <= 0:
+                    bounds[2] = bounds[3]
+                return tuple(bounds)
+
         return self.__bounds

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -43,6 +43,7 @@ from silx.test.utils import test_options
 from silx.gui import qt
 from silx.gui.plot import PlotWidget
 from silx.gui.plot.items.curve import CurveStyle
+from silx.gui.plot.items.shape import BoundingRect
 from silx.gui.colors import Colormap
 
 from .utils import PlotWidgetTestCase
@@ -1281,6 +1282,28 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
     def testAxesDisplayedTrue(self):
         """Test coverage on setAxesDisplayed(True)"""
         self.plot.setAxesDisplayed(True)
+
+    def testBoundingRectItem(self):
+        item = BoundingRect()
+        item.setBounds((-1000, 1000, -2000, 2000))
+        self.plot._add(item)
+        self.plot.resetZoom()
+        limits = numpy.array(self.plot.getXAxis().getLimits())
+        numpy.testing.assert_almost_equal(limits, numpy.array([-1000, 1000]))
+        limits = numpy.array(self.plot.getYAxis().getLimits())
+        numpy.testing.assert_almost_equal(limits, numpy.array([-2000, 2000]))
+
+    def testBoundingRectRightItem(self):
+        item = BoundingRect()
+        item.setYAxis("right")
+        item.setBounds((-1000, 1000, -2000, 2000))
+        self.plot._add(item)
+        self.plot.resetZoom()
+        limits = numpy.array(self.plot.getXAxis().getLimits())
+        numpy.testing.assert_almost_equal(limits, numpy.array([-1000, 1000]))
+        limits = numpy.array(self.plot.getYAxis("right").getLimits())
+        numpy.testing.assert_almost_equal(limits, numpy.array([-2000, 2000]))
+
 
 
 class TestPlotCurveLog(PlotWidgetTestCase, ParametricTestCase):

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -1304,6 +1304,12 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         limits = numpy.array(self.plot.getYAxis("right").getLimits())
         numpy.testing.assert_almost_equal(limits, numpy.array([-2000, 2000]))
 
+    def testBoundingRectArguments(self):
+        item = BoundingRect()
+        with self.assertRaises(Exception):
+            item.setBounds((1000, -1000, -2000, 2000))
+        with self.assertRaises(Exception):
+            item.setBounds((-1000, 1000, 2000, -2000))
 
 
 class TestPlotCurveLog(PlotWidgetTestCase, ParametricTestCase):

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -1311,6 +1311,25 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         with self.assertRaises(Exception):
             item.setBounds((-1000, 1000, 2000, -2000))
 
+    def testBoundingRectWithLog(self):
+        item = BoundingRect()
+        self.plot._add(item)
+
+        item.setBounds((-1000, 1000, -2000, 2000))
+        self.plot.getXAxis()._setLogarithmic(True)
+        self.plot.getYAxis()._setLogarithmic(False)
+        self.assertEqual(item.getBounds(), (1000, 1000, -2000, 2000))
+
+        item.setBounds((-1000, 1000, -2000, 2000))
+        self.plot.getXAxis()._setLogarithmic(False)
+        self.plot.getYAxis()._setLogarithmic(True)
+        self.assertEqual(item.getBounds(), (-1000, 1000, 2000, 2000))
+
+        item.setBounds((-1000, 0, -2000, 2000))
+        self.plot.getXAxis()._setLogarithmic(True)
+        self.plot.getYAxis()._setLogarithmic(False)
+        self.assertIsNone(item.getBounds())
+
 
 class TestPlotCurveLog(PlotWidgetTestCase, ParametricTestCase):
     """Basic tests for addCurve with log scale axes"""


### PR DESCRIPTION
This PR introduce a `BoundingRect` item.

It is a kind of shape, which is not displayed but considered as part of the data.

This can be used to custom the expected visible region of the plot.