### PR TITLE
Add animated axes

### DIFF
--- a/examples/testAnimatedAxis.py
+++ b/examples/testAnimatedAxis.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Example demonstrating animated axis"""
+
+import numpy
+from silx.gui import qt
+from silx.gui.plot import Plot1D
+from silx.gui.plot.actions import control as control_actions
+
+
+class TestAnimatedAxes(Plot1D):
+    def __init__(self, parent=None):
+        super(TestAnimatedAxes, self).__init__(parent=parent)
+        self._createActions()
+        self._i = 0
+        self._timer = qt.QTimer(self)
+        self._timer.timeout.connect(self._tick)
+        self._toggleSequence()
+
+        toolbar = qt.QToolBar(self)
+        toolbar.addAction(control_actions.OpenGLAction(parent=toolbar, plot=self))
+        self.addToolBar(toolbar)
+
+
+    def _createActions(self):
+        action = qt.QAction(self)
+        action.setText("Start/stop sequence")
+        action.triggered.connect(self._toggleSequence)
+        action.setShortcut(" ")
+        self.addAction(action)
+
+        action = qt.QAction(self)
+        action.setText("Create/remove curve1")
+        action.triggered.connect(self._toggleCurve1)
+        action.setShortcut("1")
+        self.addAction(action)
+
+        action = qt.QAction(self)
+        action.setText("Create/remove curve1")
+        action.triggered.connect(self._toggleCurve2)
+        action.setShortcut("2")
+        self.addAction(action)
+
+        action = qt.QAction(self)
+        action.setText("Create/remove curve1")
+        action.triggered.connect(self._toggleCurve3)
+        action.setShortcut("3")
+        self.addAction(action)
+
+        action = qt.QAction(self)
+        action.setText("Create/remove curve1")
+        action.triggered.connect(self._toggleCurve4)
+        action.setShortcut("4")
+        self.addAction(action)
+
+        action = qt.QAction(self)
+        action.setText("Create/remove curve5")
+        action.triggered.connect(self._toggleCurve5)
+        action.setShortcut("5")
+        self.addAction(action)
+
+    def _executeCommand(self, command):
+        sequence = qt.QKeySequence(command)
+        for action in self.actions():
+            if action.shortcut() == sequence:
+                action.trigger()
+
+    def _tick(self):
+        sequence = "12531415"
+        command = sequence[self._i % len(sequence)]
+        self._executeCommand(command)
+        self._i += 1
+
+    def _toggleSequence(self):
+        if self._timer.isActive():
+            self._timer.stop()
+        else:
+            self._timer.start(2000)
+
+    def _toggleCurve1(self):
+        legend = "curve1"
+        curve = self.getCurve(legend)
+        if curve is None:
+            xx = numpy.arange(0, 50)
+            yy = numpy.sin(xx) + 2
+            self.addCurve(xx, yy, legend=legend)
+        else:
+            self.removeCurve(legend)
+            self.resetZoom()
+
+    def _toggleCurve2(self):
+        legend = "curve2"
+        curve = self.getCurve(legend)
+        if curve is None:
+            xx = numpy.arange(100, 200)
+            yy = numpy.sin(xx) + 3
+            self.addCurve(xx, yy, legend=legend)
+        else:
+            self.removeCurve(legend)
+            self.resetZoom()
+
+    def _toggleCurve3(self):
+        legend = "curve3"
+        curve = self.getCurve(legend)
+        if curve is None:
+            xx = numpy.arange(10, 100)
+            yy = numpy.sin(xx) + -1
+            self.addCurve(xx, yy, legend=legend)
+        else:
+            self.removeCurve(legend)
+            self.resetZoom()
+
+    def _toggleCurve4(self):
+        legend = "curve4"
+        curve = self.getCurve(legend)
+        if curve is None:
+            xx = numpy.arange(110, 130)
+            yy = numpy.sin(xx) + 1.5
+            self.addCurve(xx, yy, legend=legend, yaxis="right")
+        else:
+            self.removeCurve(legend)
+            self.resetZoom()
+
+    def _toggleCurve5(self):
+        legend = "curve5"
+        curve = self.getCurve(legend)
+        if curve is None:
+            xx = numpy.arange(-10, 30)
+            yy = numpy.sin(xx) + 1.5
+            self.addCurve(xx, yy, legend=legend, yaxis="right")
+        else:
+            self.removeCurve(legend)
+            self.resetZoom()
+
+
+def main():
+    app = qt.QApplication([])
+    plot = TestAnimatedAxes()
+    plot.getView().setAnimated(True)
+    plot.show()
+    return app.exec_()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -890,7 +890,11 @@ class PlotWidget(qt.QMainWindow):
         """
         if self._dataRange is None:
             self._updateDataRange()
-        return self._dataRange
+
+        dataRange = self._dataRange
+        if self._view is not None:
+            dataRange = self._view.updateDataRange(dataRange)
+        return dataRange
 
     # Content management
 

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -65,6 +65,7 @@ from . import _utils
 from . import items
 from .items.curve import CurveStyle
 from .items.axis import TickMode  # noqa
+from .items.axis import View
 
 from .. import qt
 from ._utils.panzoom import ViewConstraints
@@ -370,6 +371,7 @@ class PlotWidget(qt.QMainWindow):
         self.__muteActiveItemChanged = False
 
         self._panWithArrowKeys = True
+        self._view = None
         self._viewConstrains = None
 
         super(PlotWidget, self).__init__(parent)
@@ -634,6 +636,15 @@ class PlotWidget(qt.QMainWindow):
         :rtype: ~silx.gui.plot.backend.BackendBase.BackendBase
         """
         return self._backend
+
+    def getView(self):
+        """Returns an object that represent the data view visualized by the plot.
+
+        :rtype: View
+        """
+        if self._view is None:
+            self._view = View(self)
+        return self._view
 
     def _getDirtyPlot(self):
         """Return the plot dirty flag.

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -3171,6 +3171,11 @@ class PlotWidget(qt.QMainWindow):
             if ranges.y is None:
                 ymin, ymax = ranges.yright
 
+        if ymin is None and ymax is None:
+            # FIXME: Workaround y1 can be None if y2 contains something
+            ymin = 0
+            ymax = 1
+
         self.setLimits(
             xmin,
             xmax,


### PR DESCRIPTION
This is a proposal to add animated axes to the plot. That's a way to provide a smooth transition between 2 states, when a new item is added or edited. It is really convenient with live data plot to avoid to lose the context.

This PR:
- Creates a new object `View` to deal with that
- The animation is computed based on time (in case of lag)
- The transition is slow at start and end
- An example is provided displaying and hiding automatically items in the plot.

The `View` returns the result by cheating on the `dataRange` of the plot. That's convenient but
really dirty, that is why this PR have to be reworked. To make it clean, few things could be done:
- The `View` have to be informed that the data range have changed
- It must have the responsibility of the update of the axis location

As result this should provide a better way for axis synchronization. The current way is not really convenient in case of user interaction and when the plot is in fixed aspect ratio. In this cases both axis have to be updated at the same time, but the events are not synchronized. As result the synchronization between plots is difficult without blinking or inconsistencies.

Problem to solve
- [ ] Better integration
- [x] Right axes looks to fail
- [ ] Change from log/linear scale
- [ ] User interaction have to cancel any transition