### PR TITLE
[plot] A four-element array leads to a comparison error.

### DIFF
--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -1632,7 +1632,7 @@ class PlotInteraction(object):
         plot = self._plot()
         assert plot is not None
 
-        if color not in (None, 'video inverted'):
+        if isinstance(color, numpy.ndarray) or color not in (None, 'video inverted'):
             color = colors.rgba(color)
 
         if mode in ('draw', 'select-draw'):


### PR DESCRIPTION
The documentation says a tuple is expected although the colors.rgba method deals with arrays just fine.