### PR TITLE
Stop testing python2.7 + simplify requirements file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,38 +9,22 @@ git:
 
 matrix:
     include:
-        - python: 2.7
+        - python: 3.8
           os: linux
           env:
-              - BUILD_COMMAND=sdist
-              - QT_BINDING=
+              - BUILD_COMMAND=bdist_wheel
+              - QT_BINDING=PyQt5
               - SILX_OPENCL=1
-              - PIP_OPTIONS="-q"
-
-        - python: 3.4
-          os: linux
-          env:
-              - BUILD_COMMAND=sdist
-              - QT_BINDING=
-              - PIP_INSTALL_EXTRA_ARGS="--global-option build --global-option --debug"
-              - SILX_OPENCL=1
-              - PIP_OPTIONS="-q"
+              - PIP_OPTIONS="-q --pre"
 
         - python: 3.5
           os: linux
           env:
               - BUILD_COMMAND=sdist
-              - QT_BINDING=PyQt5
-              - SILX_OPENCL=1
-              - PIP_OPTIONS="-q --pre"
-
-        - python: 3.7
-          os: linux
-          env:
-              - BUILD_COMMAND=sdist
               - QT_BINDING=PySide2
+              - PIP_INSTALL_EXTRA_ARGS="--global-option build --global-option --debug"
               - SILX_OPENCL=1
-              - PIP_OPTIONS="-q --pre"
+              - PIP_OPTIONS="-q"
 
         - language: generic
           os: osx

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -24,16 +24,16 @@ environment:
         VENV_TEST_DIR: "venv_test"
 
     matrix:
-        # Python 3.7
-        - PYTHON_DIR: "C:\\Python37-x64"
+        # Python 3.8
+        - PYTHON_DIR: "C:\\Python38-x64"
           QT_BINDING: "PyQt5"
           WITH_GL_TEST: True
           PIP_OPTIONS: "-q --pre"
 
-        # Python 2.7
-        - PYTHON_DIR: "C:\\Python27-x64"
-          QT_BINDING: "PyQt4"
-          WITH_GL_TEST: False
+        # Python 3.6
+        - PYTHON_DIR: "C:\\Python36-x64"
+          QT_BINDING: "PySide2"
+          WITH_GL_TEST: True
           PIP_OPTIONS: "-q"
 
 install:
@@ -44,16 +44,12 @@ install:
     - "pip install %PIP_OPTIONS% --upgrade setuptools"
     - "python -m pip install %PIP_OPTIONS% --upgrade pip"
 
-    # Install virtualenv
-    - "pip install %PIP_OPTIONS% --upgrade virtualenv"
-    - "virtualenv --version"
-
     # Download Mesa OpenGL in Python directory when testing OpenGL
     - IF %WITH_GL_TEST%==True curl -fsS -o %PYTHON_DIR%\\opengl32.dll http://www.silx.org/pub/silx/continuous_integration/opengl32_mingw-mesa-x86_64.dll
 
 build_script:
     # Create build virtualenv
-    - "virtualenv --clear %VENV_BUILD_DIR%"
+    - "python -m venv --clear %VENV_BUILD_DIR%"
     - "%VENV_BUILD_DIR%\\Scripts\\activate.bat"
 
     # Install build dependencies
@@ -75,7 +71,7 @@ build_script:
 
 before_test:
     # Create test virtualenv
-    - "virtualenv --clear %VENV_TEST_DIR%"
+    - "python -m venv --clear %VENV_TEST_DIR%"
     - "%VENV_TEST_DIR%\\Scripts\\activate.bat"
 
     # First install any temporary pinned/additional requirements
@@ -85,7 +81,7 @@ before_test:
     - pip install %PIP_OPTIONS% -r requirements.txt
 
     # Install selected Qt binding
-    - "pip install %PIP_OPTIONS% --trusted-host www.silx.org --find-links http://www.silx.org/pub/wheelhouse/ %QT_BINDING%"
+    - "pip install %PIP_OPTIONS% %QT_BINDING%"
 
     # Install the generated wheel package to test it
     # Make sure silx does not come from cache or pypi

--- a/ci/requirements-pinned.txt
+++ b/ci/requirements-pinned.txt
@@ -4,7 +4,7 @@
 
 pybind11  # Required to build pyopencl
 
-# Pinpoint pyopencl on Windows to latest wheel available for python 2.7
-# on https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyopencl
+# Pinpoint pyopencl on Windows to latest wheel available in www.silx.org
+# downloaded from https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyopencl
 # Anyway, we don't test OpenCL on appveyor
-pyopencl == 2018.1.1; sys_platform == 'win32'
+pyopencl == 2019.1.2; sys_platform == 'win32'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,9 +2,7 @@
 # Those ARE NOT required for installation, at runtime or to build from source (except for the doc)
 
 -r requirements.txt
-setuptools        # Advanced packaging tools
 wheel             # To build wheels
-Cython >= 0.21.1  # To regenerate .c/.cpp files from .pyx
 Sphinx            # To build the documentation in doc/
 lxml              # For test coverage in run_test.py
 coverage          # For test coverage in run_test.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,16 +3,15 @@
 
 --trusted-host www.silx.org
 --find-links http://www.silx.org/pub/wheelhouse/
---only-binary numpy,h5py,scipy,PyQt4,PyQt5
+--only-binary numpy,h5py,scipy,PySide2,PyQt5
 
-# Required dependencies (from setup.py install_requires)
+# Required dependencies (from setup.py setup_requires and install_requires)
 numpy >= 1.12
 setuptools
+Cython >= 0.21.1
 h5py
 fabio >= 0.7
 six
-enum34; python_version == '2.7'
-futures; python_version == '2.7'
 
 # Extra dependencies (from setup.py extra_requires 'full' target)
 pyopencl; platform_machine in "i386, x86_64, AMD64"  # For silx.opencl
@@ -23,13 +22,4 @@ PyOpenGL                  # For silx.gui.plot3d
 python-dateutil           # For silx.gui.plot
 scipy                     # For silx.math.fit demo, silx.image.sift demo, silx.image.sift.test
 Pillow                    # For silx.opencl.image.test
-Cython >= 0.21.1          # For silx.math, silx.io, silx.image
-
-# PyQt5, PySide2 or PyQt4 # For silx.gui
-# Try to install a Qt binding from a wheel
-# This is no available for all configurations
-
-# Require PyQt when wheel is available
-PyQt5; python_version >= '3.5'
-PyQt4; sys_platform == 'win32' and python_version == '2.7'  # From silx.org
-PyQt4; sys_platform == 'darwin' and python_version == '2.7'  # From silx.org
+PyQt5  # or PySide2       # For silx.gui


### PR DESCRIPTION
This PR updates the continuous integration matrix and requirements file to stop testing python < 3.5.
