### PR TITLE
Fix none and log bound

### DIFF
--- a/silx/gui/plot/items/shape.py
+++ b/silx/gui/plot/items/shape.py
@@ -197,6 +197,8 @@ class BoundingRect(Item, YAxisMixIn):
             self._updated(ItemChangedType.DATA)
 
     def _getBounds(self):
+        if self.__bounds is None:
+            return None
         plot = self.getPlot()
         if plot is not None:
             xPositive = plot.getXAxis()._isLogarithmic()


### PR DESCRIPTION
Here is a fix to avoid to fail when `BoundRect` is None and the plot is in log.