### PR TITLE
[mpl backend] Fix mouse-y location to integer

### DIFF
--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1097,10 +1097,10 @@ class BackendMatplotlib(BackendBase.BackendBase):
     def _mplQtYAxisCoordConversion(self, y):
         """Qt origin (top) to/from matplotlib origin (bottom) conversion.
 
-        :rtype: float
+        :rtype: int
         """
         height = self.fig.get_window_extent().height
-        return height - y
+        return int(height - y)
 
     def dataToPixel(self, x, y, axis):
         ax = self.ax2 if axis == "right" else self.ax


### PR DESCRIPTION
I notice that the `ypixel` of moue event is not an integer.
```
{'x': 81.35577372604021, 'y': 93.55140186915887, 'xpixel': 542, 'ypixel': 127.0, 'button': None, 'event': 'mouseMoved'}
```

Here is a fix.

Please take a look at the consequences, cause this method is not only called by mouse event call back.

