### PR TITLE
[mpl backend] Fix mouse-y location to integer

### DIFF
--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1094,13 +1094,16 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
     # Data <-> Pixel coordinates conversion
 
-    def _mplQtYAxisCoordConversion(self, y):
+    def _mplQtYAxisCoordConversion(self, y, asint=True):
         """Qt origin (top) to/from matplotlib origin (bottom) conversion.
 
-        :rtype: int
+        :param y:
+        :param bool asint: True to cast to int, False to keep as float
+
+        :rtype: float
         """
-        height = self.fig.get_window_extent().height
-        return int(height - y)
+        value = self.fig.get_window_extent().height - y
+        return int(value) if asint else value
 
     def dataToPixel(self, x, y, axis):
         ax = self.ax2 if axis == "right" else self.ax
@@ -1109,7 +1112,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
         xPixel, yPixel = pixels.T
 
         # Convert from matplotlib origin (bottom) to Qt origin (top)
-        yPixel = self._mplQtYAxisCoordConversion(yPixel)
+        yPixel = self._mplQtYAxisCoordConversion(yPixel, asint=False)
 
         return xPixel, yPixel
 
@@ -1117,7 +1120,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
         ax = self.ax2 if axis == "right" else self.ax
 
         # Convert from Qt origin (top) to matplotlib origin (bottom)
-        y = self._mplQtYAxisCoordConversion(y)
+        y = self._mplQtYAxisCoordConversion(y, asint=False)
 
         inv = ax.transData.inverted()
         x, y = inv.transform_point((x, y))
@@ -1126,10 +1129,10 @@ class BackendMatplotlib(BackendBase.BackendBase):
     def getPlotBoundsInPixels(self):
         bbox = self.ax.get_window_extent()
         # Warning this is not returning int...
-        return (bbox.xmin,
-                self._mplQtYAxisCoordConversion(bbox.ymax),
-                bbox.width,
-                bbox.height)
+        return (int(bbox.xmin),
+                self._mplQtYAxisCoordConversion(bbox.ymax, asint=True),
+                int(bbox.width),
+                int(bbox.height))
 
     def setAxesDisplayed(self, displayed):
         """Display or not the axes.

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1097,10 +1097,10 @@ class BackendMatplotlib(BackendBase.BackendBase):
     def _mplQtYAxisCoordConversion(self, y):
         """Qt origin (top) to/from matplotlib origin (bottom) conversion.
 
-        :rtype: float
+        :rtype: int
         """
         height = self.fig.get_window_extent().height
-        return height - y
+        return int(height - y)
 
     def dataToPixel(self, x, y, axis):
         ax = self.ax2 if axis == "right" else self.ax


### PR DESCRIPTION
This PR includes and supersedes PR #2843 by taking care of casting to int or not depending on the usage.
It casts to int for mouse events, and leaves it as float for `dataToPixel` and `pixelToData`.
It also fixes types for `getPlotBoundsInPixels` as this is documented to be `int`.