### PR TITLE
[plot] Fix plot add invisible item

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -624,8 +624,7 @@ class PlotWidget(qt.QMainWindow):
         # Add item to plot
         self._content[key] = item
         item._setPlot(self)
-        if item.isVisible():
-            self._itemRequiresUpdate(item)
+        self._itemRequiresUpdate(item)
         if isinstance(item, items.DATA_ITEMS):
             self._invalidateDataRange()  # TODO handle this automatically
 


### PR DESCRIPTION
This PR fixes the addition of items with `PlotWidget._add` that are not visible.
There was an issue with the update of the dirty flag in this case. 

closes #2844