### PR TITLE
[plot] Fix matplotlib crosshair rendering

### DIFF
--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1266,7 +1266,7 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
     def _onMouseMove(self, event):
         if self._graphCursor:
             lineh, linev = self._graphCursor
-            if event.inaxes != self.ax and lineh.get_visible():
+            if event.inaxes not in (self.ax, self.ax2) and lineh.get_visible():
                 lineh.set_visible(False)
                 linev.set_visible(False)
                 self._plot._setDirtyPlot(overlayOnly=True)


### PR DESCRIPTION
This PR fixes the rendering of the crosshair with the matplotlib backend which was due to the refactoring of the plot rendering and the fact that the right axes are on top of the left ones.

closes #2841