### PR TITLE
Fix renaming of  get|setLabel to get|setName

### DIFF
--- a/silx/gui/plot3d/tools/PositionInfoWidget.py
+++ b/silx/gui/plot3d/tools/PositionInfoWidget.py
@@ -189,7 +189,7 @@ class PositionInfoWidget(qt.QWidget):
             return  # No picked item
 
         item = picking.getItem()
-        self._itemLabel.setText(item.getName())
+        self._itemLabel.setText(item.getLabel())
         positions = picking.getPositions('scene', copy=False)
         x, y, z = positions[0]
         self._xLabel.setText("%g" % x)

--- a/silx/sx/_plot.py
+++ b/silx/sx/_plot.py
@@ -548,7 +548,7 @@ class _GInputHandler(roi.InteractiveRegionOfInterestManager):
         """
         if isinstance(roi, roi_items.PointROI):
             # Only handle points
-            roi.setLabel('%d' % len(self.__selections))
+            roi.setName('%d' % len(self.__selections))
             self.__updateSelection(roi)
             roi.sigRegionChanged.connect(self.__regionChanged)
 


### PR DESCRIPTION
This PR fixes issues with renaming ROI's `get|setLabel` to `get|setName`:

- Renaming was not done in `sx.ginput` while it is needed.
- Renaming has been done accidentally in `plot3d` where it is not done (and can wait another release).