### PR TITLE
Disable hdf5 file locking by default, add option to enable it

### DIFF
--- a/silx/app/view/main.py
+++ b/silx/app/view/main.py
@@ -80,10 +80,10 @@ def mainQt(options):
     # Import most of the things here to be sure to use the right logging level
     #
 
-    if not options.hdf5_file_locking:
-        # This needs to be done prior to load HDF5
-        _logger.info('Set HDF5_USE_FILE_LOCKING=FALSE')
-        os.environ['HDF5_USE_FILE_LOCKING'] = 'FALSE'
+    # This needs to be done prior to load HDF5
+    hdf5_file_locking = 'TRUE' if options.hdf5_file_locking else 'FALSE'
+    _logger.info('Set HDF5_USE_FILE_LOCKING=%s', hdf5_file_locking)
+    os.environ['HDF5_USE_FILE_LOCKING'] = hdf5_file_locking
 
     try:
         # it should be loaded before h5py

--- a/silx/app/view/main.py
+++ b/silx/app/view/main.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,10 +27,11 @@ __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "17/01/2019"
 
-import sys
 import argparse
 import logging
+import os
 import signal
+import sys
 
 
 _logger = logging.getLogger(__name__)
@@ -61,6 +62,12 @@ def createParser():
         action="store_true",
         default=False,
         help='Start the application using new fresh user preferences')
+    parser.add_argument(
+        '--hdf5-file-locking',
+        dest="hdf5_file_locking",
+        action="store_true",
+        default=False,
+        help='Start the application with HDF5 file locking enabled (it is disabled by default)')
     return parser
 
 
@@ -72,6 +79,11 @@ def mainQt(options):
     #
     # Import most of the things here to be sure to use the right logging level
     #
+
+    if not options.hdf5_file_locking:
+        # This needs to be done prior to load HDF5
+        _logger.info('Set HDF5_USE_FILE_LOCKING=FALSE')
+        os.environ['HDF5_USE_FILE_LOCKING'] = 'FALSE'
 
     try:
         # it should be loaded before h5py


### PR DESCRIPTION
This PR makes `silx view` no longer locking opened HDF5 files.

It also adds a  `--hdf5-file-locking` option to re-enable the file locking (which is the current behaviour).

What happens when someone removes stuff from the HDF5 file from another process is undefined, though quick tests shows that it does not crash.

See discussion and details here: https://gitlab.esrf.fr/bliss/bliss/issues/1241

closes #2859