### PR TITLE
Show the profile window only if there is data to display

### DIFF
--- a/silx/gui/plot/tools/profile/_BaseProfileToolBar.py
+++ b/silx/gui/plot/tools/profile/_BaseProfileToolBar.py
@@ -231,7 +231,7 @@ class _BaseProfileToolBar(qt.QToolBar):
             profilePlot.addCurve(
                 xProfile, values, legend='Profile', color=self._color)
 
-        self._showDefaultProfileWindow()
+            self._showDefaultProfileWindow()
 
     def _showDefaultProfileWindow(self):
         """If profile window was created by this toolbar,


### PR DESCRIPTION
This PR avoid to show the profile when the user click on the 'clear profile' action.