### PR TITLE
Add support of not finite values in the fit

### DIFF
--- a/silx/gui/fit/FitWidget.py
+++ b/silx/gui/fit/FitWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -315,8 +315,8 @@ class FitWidget(qt.QWidget):
         configuration.update(self.configure())
 
     def setdata(self, x, y, sigmay=None, xmin=None, xmax=None):
-        warnings.warning("Method renamed to setData",
-                         DeprecationWarning)
+        warnings.warn("Method renamed to setData",
+                      DeprecationWarning)
         self.setData(x, y, sigmay, xmin, xmax)
 
     def setData(self, x, y, sigmay=None, xmin=None, xmax=None):
@@ -525,8 +525,8 @@ class FitWidget(qt.QWidget):
         self._emitSignal(ddict)
 
     def startfit(self):
-        warnings.warning("Method renamed to startFit",
-                         DeprecationWarning)
+        warnings.warn("Method renamed to startFit",
+                      DeprecationWarning)
         self.startFit()
 
     def startFit(self):

--- a/silx/gui/plot/ProfileMainWindow.py
+++ b/silx/gui/plot/ProfileMainWindow.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -85,6 +85,7 @@ class ProfileMainWindow(qt.QMainWindow):
                 self._plot2D.setParent(None)   # necessary to avoid widget destruction
             if self._plot1D is None:
                 self._plot1D = Plot1D(backend=self._backend)
+                self._plot1D.setDataMargins(yMinMargin=0.1, yMaxMargin=0.1)
                 self._plot1D.setGraphYLabel('Profile')
                 self._plot1D.setGraphXLabel('')
             self.setCentralWidget(self._plot1D)

--- a/silx/math/fit/test/test_fitmanager.py
+++ b/silx/math/fit/test/test_fitmanager.py
@@ -35,6 +35,7 @@ from silx.math.fit import bgtheories
 from silx.math.fit.fittheory import FitTheory
 from silx.math.fit.functions import sum_gauss, sum_stepdown, sum_stepup
 
+from silx.utils.testutils import ParametricTestCase
 from silx.test.utils import temp_dir
 
 custom_function_definition = """
@@ -110,7 +111,7 @@ def _order_of_magnitude(x):
     return numpy.log10(x).round()
 
 
-class TestFitmanager(unittest.TestCase):
+class TestFitmanager(ParametricTestCase):
     """
     Unit tests of multi-peak functions.
     """


### PR DESCRIPTION
This PR adds support of not finite values in fit by ignoring them.


It also fixes some calls to not existing `warnings.warning` function in `FitWidget`, and add top and bottom margins in the profile 1D plot.