### PR TITLE
[CI] only run CI on master and x.y branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,11 @@ matrix:
               - QT_BINDING=PyQt5
               - PIP_OPTIONS="-q --pre"
 
+branches:
+    only:
+        - master
+        - /\d*\.\d*/
+
 cache:
     apt: true
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -36,6 +36,11 @@ environment:
           WITH_GL_TEST: True
           PIP_OPTIONS: "-q"
 
+branches:
+    only:
+        - master
+        - /\d*\.\d*/
+
 install:
     # Add Python to PATH
     - "SET PATH=%PYTHON_DIR%;%PYTHON_DIR%\\Scripts;%PATH%"


### PR DESCRIPTION
This PR avoids running CI on branches other than master and x.y.
This prevents to run CI on branches (so running twice) when pull requests are created from the github web interface.