### PR TITLE
Create addShape, deprecate addItem

### DIFF
--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -102,11 +102,11 @@ class _PlotInteraction(object):
         else:
             color2 = "black"
 
-        self.plot.addItem(points[:, 0], points[:, 1], legend=legend,
-                          replace=False,
-                          shape=shape, fill=fill,
-                          color=color, linebgcolor=color2, linestyle="--",
-                          overlay=True)
+        self.plot.addShape(points[:, 0], points[:, 1], legend=legend,
+                           replace=False,
+                           shape=shape, fill=fill,
+                           color=color, linebgcolor=color2, linestyle="--",
+                           overlay=True)
 
         self._selectionAreas.add(legend)
 

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -1240,7 +1240,18 @@ class PlotWidget(qt.QMainWindow):
 
         return legend
 
+    @deprecated(replacement="addShape", since_version="0.13")
     def addItem(self, xdata, ydata, legend=None, info=None,
+                replace=False,
+                shape="polygon", color='black', fill=True,
+                overlay=False, z=None, linestyle="-", linewidth=1.0,
+                linebgcolor=None):
+        return self.addShape(xdata, ydata, legend=legend, info=info,
+                             replace=replace, shape=shape, color=color, fill=fill,
+                             overlay=overlay, z=z, linestyle=linestyle,
+                             linewidth=linewidth, linebgcolor=linebgcolor)
+
+    def addShape(self, xdata, ydata, legend=None, info=None,
                 replace=False,
                 shape="polygon", color='black', fill=True,
                 overlay=False, z=None, linestyle="-", linewidth=1.0,

--- a/silx/gui/plot/Profile.py
+++ b/silx/gui/plot/Profile.py
@@ -702,11 +702,11 @@ class ProfileToolBar(qt.QToolBar):
                                  legend=profileName,
                                  color=self.overlayColor)
 
-        self.plot.addItem(area[0], area[1],
-                          legend=self._POLYGON_LEGEND,
-                          color=self.overlayColor,
-                          shape='polygon', fill=True,
-                          replace=False, z=z + 1)
+        self.plot.addShape(area[0], area[1],
+                           legend=self._POLYGON_LEGEND,
+                           color=self.overlayColor,
+                           shape='polygon', fill=True,
+                           replace=False, z=z + 1)
 
         self._showProfileMainWindow()
 

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -90,6 +90,7 @@ from silx.io.nxdata import save_NXdata
 from silx.utils.array_like import DatasetView, ListOfImages
 from silx.math import calibration
 from silx.utils.deprecation import deprecated_warning
+from silx.utils.deprecation import deprecated
 
 import h5py
 from silx.io.utils import is_dataset
@@ -1085,11 +1086,15 @@ class StackView(qt.QMainWindow):
         """
         self._plot.setInteractiveMode(*args, **kwargs)
 
+    @deprecated(replacement="addShape", since_version="0.13")
     def addItem(self, *args, **kwargs):
+        self.addShape(*args, **kwargs)
+
+    def addShape(self, *args, **kwargs):
         """
-        See :meth:`Plot.Plot.addItem`
+        See :meth:`Plot.Plot.addShape`
         """
-        self._plot.addItem(*args, **kwargs)
+        self._plot.addShape(*args, **kwargs)
 
 
 class PlanesWidget(qt.QWidget):

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -179,8 +179,8 @@ class BackendBase(object):
         """
         return object()
 
-    def addItem(self, x, y, shape, color, fill, overlay, z,
-                linestyle, linewidth, linebgcolor):
+    def addShape(self, x, y, shape, color, fill, overlay, z,
+                 linestyle, linewidth, linebgcolor):
         """Add an item (i.e. a shape) to the plot.
 
         :param numpy.ndarray x: The X coords of the points of the shape

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -651,8 +651,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
         return collection
 
-    def addItem(self, x, y, shape, color, fill, overlay, z,
-                linestyle, linewidth, linebgcolor):
+    def addShape(self, x, y, shape, color, fill, overlay, z,
+                 linestyle, linewidth, linebgcolor):
         if (linebgcolor is not None and
                 shape not in ('rectangle', 'polygon', 'polylines')):
             _logger.warning(

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -910,8 +910,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
         return triangles
 
-    def addItem(self, x, y, shape, color, fill, overlay, z,
-                linestyle, linewidth, linebgcolor):
+    def addShape(self, x, y, shape, color, fill, overlay, z,
+                 linestyle, linewidth, linebgcolor):
         x = numpy.array(x, copy=False)
         y = numpy.array(y, copy=False)
 

--- a/silx/gui/plot/items/shape.py
+++ b/silx/gui/plot/items/shape.py
@@ -68,16 +68,16 @@ class Shape(Item, ColorMixIn, FillMixIn, LineMixIn):
         """Update backend renderer"""
         points = self.getPoints(copy=False)
         x, y = points.T[0], points.T[1]
-        return backend.addItem(x,
-                               y,
-                               shape=self.getType(),
-                               color=self.getColor(),
-                               fill=self.isFill(),
-                               overlay=self.isOverlay(),
-                               z=self.getZValue(),
-                               linestyle=self.getLineStyle(),
-                               linewidth=self.getLineWidth(),
-                               linebgcolor=self.getLineBgColor())
+        return backend.addShape(x,
+                                y,
+                                shape=self.getType(),
+                                color=self.getColor(),
+                                fill=self.isFill(),
+                                overlay=self.isOverlay(),
+                                z=self.getZValue(),
+                                linestyle=self.getLineStyle(),
+                                linewidth=self.getLineWidth(),
+                                linebgcolor=self.getLineBgColor())
 
     def isOverlay(self):
         """Return true if shape is drawn as an overlay

--- a/silx/gui/plot/test/testItem.py
+++ b/silx/gui/plot/test/testItem.py
@@ -209,7 +209,7 @@ class TestSigItemChangedSignal(PlotWidgetTestCase):
     def testShapeChanged(self):
         """Test sigItemChanged for shape"""
         data = numpy.array((1., 10.))
-        self.plot.addItem(data, data, legend='test', shape='rectangle')
+        self.plot.addShape(data, data, legend='test', shape='rectangle')
         shape = self.plot._getItem(kind='item', legend='test')
 
         listener = SignalListener()

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -186,7 +186,7 @@ class TestPlotWidget(PlotWidgetTestCase, ParametricTestCase):
         self.plot.addMarker(*marker_pos)
         marker_x = 6
         self.plot.addXMarker(marker_x)
-        self.plot.addItem((0, 5), (2, 10), shape='rectangle')
+        self.plot.addShape((0, 5), (2, 10), shape='rectangle')
 
         items = self.plot.getItems()
         self.assertEqual(len(items), 6)
@@ -799,36 +799,36 @@ class TestPlotItem(PlotWidgetTestCase):
         self.plot.setGraphTitle('Item Fill')
 
         for legend, xList, yList, color in self.polygons:
-            self.plot.addItem(xList, yList, legend=legend,
-                              replace=False,
-                              shape="polygon", fill=True, color=color)
+            self.plot.addShape(xList, yList, legend=legend,
+                               replace=False,
+                               shape="polygon", fill=True, color=color)
         self.plot.resetZoom()
 
     def testPlotItemPolygonNoFill(self):
         self.plot.setGraphTitle('Item No Fill')
 
         for legend, xList, yList, color in self.polygons:
-            self.plot.addItem(xList, yList, legend=legend,
-                              replace=False,
-                              shape="polygon", fill=False, color=color)
+            self.plot.addShape(xList, yList, legend=legend,
+                               replace=False,
+                               shape="polygon", fill=False, color=color)
         self.plot.resetZoom()
 
     def testPlotItemRectangleFill(self):
         self.plot.setGraphTitle('Rectangle Fill')
 
         for legend, xList, yList, color in self.rectangles:
-            self.plot.addItem(xList, yList, legend=legend,
-                              replace=False,
-                              shape="rectangle", fill=True, color=color)
+            self.plot.addShape(xList, yList, legend=legend,
+                               replace=False,
+                               shape="rectangle", fill=True, color=color)
         self.plot.resetZoom()
 
     def testPlotItemRectangleNoFill(self):
         self.plot.setGraphTitle('Rectangle No Fill')
 
         for legend, xList, yList, color in self.rectangles:
-            self.plot.addItem(xList, yList, legend=legend,
-                              replace=False,
-                              shape="rectangle", fill=False, color=color)
+            self.plot.addShape(xList, yList, legend=legend,
+                               replace=False,
+                               shape="rectangle", fill=False, color=color)
         self.plot.resetZoom()
 
 
@@ -1736,36 +1736,36 @@ class TestPlotItemLog(PlotWidgetTestCase):
         self.plot.setGraphTitle('Item Fill Log')
 
         for legend, xList, yList, color in self.polygons:
-            self.plot.addItem(xList, yList, legend=legend,
-                              replace=False,
-                              shape="polygon", fill=True, color=color)
+            self.plot.addShape(xList, yList, legend=legend,
+                               replace=False,
+                               shape="polygon", fill=True, color=color)
         self.plot.resetZoom()
 
     def testPlotItemPolygonLogNoFill(self):
         self.plot.setGraphTitle('Item No Fill Log')
 
         for legend, xList, yList, color in self.polygons:
-            self.plot.addItem(xList, yList, legend=legend,
-                              replace=False,
-                              shape="polygon", fill=False, color=color)
+            self.plot.addShape(xList, yList, legend=legend,
+                               replace=False,
+                               shape="polygon", fill=False, color=color)
         self.plot.resetZoom()
 
     def testPlotItemRectangleLogFill(self):
         self.plot.setGraphTitle('Rectangle Fill Log')
 
         for legend, xList, yList, color in self.rectangles:
-            self.plot.addItem(xList, yList, legend=legend,
-                              replace=False,
-                              shape="rectangle", fill=True, color=color)
+            self.plot.addShape(xList, yList, legend=legend,
+                               replace=False,
+                               shape="rectangle", fill=True, color=color)
         self.plot.resetZoom()
 
     def testPlotItemRectangleLogNoFill(self):
         self.plot.setGraphTitle('Rectangle No Fill Log')
 
         for legend, xList, yList, color in self.rectangles:
-            self.plot.addItem(xList, yList, legend=legend,
-                              replace=False,
-                              shape="rectangle", fill=False, color=color)
+            self.plot.addShape(xList, yList, legend=legend,
+                               replace=False,
+                               shape="rectangle", fill=False, color=color)
         self.plot.resetZoom()
 
 

--- a/silx/gui/plot/test/testPlotWidgetNoBackend.py
+++ b/silx/gui/plot/test/testPlotWidgetNoBackend.py
@@ -62,8 +62,9 @@ class TestPlot(unittest.TestCase):
         plot = PlotWidget(backend='none')
         plot.addCurve(x=(1, 2, 3), y=(3, 2, 1))
         plot.addImage(numpy.arange(100.).reshape(10, -1))
-        plot.addItem(
-            numpy.array((1., 10.)), numpy.array((10., 10.)), shape="rectangle")
+        plot.addShape(numpy.array((1., 10.)),
+                      numpy.array((10., 10.)),
+                      shape="rectangle")
         plot.addXMarker(10.)
 
 


### PR DESCRIPTION
This PR:
- Creates a method `addShape` to replace `addItem`
- Add deprecation warning to fix use of `addItem`
- Replace `addItem` with `addShape` in the base code

Related to #2830