### PR TITLE
Provide stddev autoscale

### DIFF
--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -635,9 +635,18 @@ class Colormap(qt.QObject):
             return None, None
 
         if self.getNormalization() == Colormap.LOGARITHM:
-            result = min_max(data, min_positive=True, finite=True)
-            vMin = result.min_positive  # >0 or None
-            vMax = result.maximum  # can be <= 0
+            if self._autoscaleMode == Colormap.MINMAX:
+                result = min_max(data, min_positive=True, finite=True)
+                vMin = result.min_positive  # >0 or None
+                vMax = result.maximum  # can be <= 0
+            elif self._autoscaleMode == Colormap.STDDEV3:
+                normdata = numpy.log10(data)
+                mean = numpy.nanmean(normdata)
+                std = numpy.nanstd(normdata)
+                vMin = 10**(mean - 3 * std)
+                vMax = 10**(mean + 3 * std)
+            else:
+                assert False
         else:
             if self._autoscaleMode == Colormap.MINMAX:
                 vMin, vMax = min_max(data, min_positive=False, finite=True)

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -634,15 +634,19 @@ class Colormap(qt.QObject):
         if data.size == 0:
             return None, None
 
-        if self._autoscaleMode is not Colormap.MINMAX:
-            raise RuntimeError("AUtoscale not supported")
-
         if self.getNormalization() == Colormap.LOGARITHM:
             result = min_max(data, min_positive=True, finite=True)
             vMin = result.min_positive  # >0 or None
             vMax = result.maximum  # can be <= 0
         else:
-            vMin, vMax = min_max(data, min_positive=False, finite=True)
+            if self._autoscaleMode == Colormap.MINMAX:
+                vMin, vMax = min_max(data, min_positive=False, finite=True)
+            elif self._autoscaleMode == Colormap.STDDEV3:
+                mean = numpy.nanmean(data)
+                std = numpy.nanstd(data)
+                vMin, vMax = mean - 3 * std, mean + 3 * std
+            else:
+                assert False
         return vMin, vMax
 
     def getColormapRange(self, data=None):

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -356,14 +356,25 @@ class Colormap(qt.QObject):
     NORMALIZATIONS = (LINEAR, LOGARITHM)
     """Tuple of managed normalizations"""
 
+    MINMAX = 'minmax'
+    """constant for autoscale using min/max data range"""
+
+    STDDEV3 = 'stddev3'
+    """constant for autoscale using mean +/- 3*std(data)"""
+
+    AUTOSCALE_MODES = (MINMAX, STDDEV3)
+    """Tuple of managed auto scale algorithms"""
+
     sigChanged = qt.Signal()
     """Signal emitted when the colormap has changed."""
 
-    def __init__(self, name=None, colors=None, normalization=LINEAR, vmin=None, vmax=None):
+    def __init__(self, name=None, colors=None, normalization=LINEAR, vmin=None, vmax=None, autoscaleMode=MINMAX):
         qt.QObject.__init__(self)
         self._editable = True
 
         assert normalization in Colormap.NORMALIZATIONS
+        assert autoscaleMode in Colormap.AUTOSCALE_MODES
+
         if normalization is Colormap.LOGARITHM:
             if (vmin is not None and vmin < 0) or (vmax is not None and vmax < 0):
                 m = "Unsuported vmin (%s) and/or vmax (%s) given for a log scale."
@@ -394,6 +405,7 @@ class Colormap(qt.QObject):
             self.setName("gray")
 
         self._normalization = str(normalization)
+        self._autoscaleMode = str(autoscaleMode)
         self._vmin = float(vmin) if vmin is not None else None
         self._vmax = float(vmax) if vmax is not None else None
 
@@ -520,6 +532,24 @@ class Colormap(qt.QObject):
         self._normalization = str(norm)
         self.sigChanged.emit()
 
+    def getAutoscaleMode(self):
+        """Return the autoscale mode of the colormap ('minmax' or 'stddev3')
+
+        :rtype: str
+        """
+        return self._autoscaleMode
+
+    def setAutoscaleMode(self, mode):
+        """Set the norm ('minmax' or 'stddev3')
+
+        :param str mode: the mode to set
+        """
+        if self.isEditable() is False:
+            raise NotEditableError('Colormap is not editable')
+        assert mode in self.AUTOSCALE_MODES
+        self._autoscaleMode = mode
+        self.sigChanged.emit()
+
     def isAutoscale(self):
         """Return True if both min and max are in autoscale mode"""
         return self._vmin is None and self._vmax is None
@@ -603,6 +633,9 @@ class Colormap(qt.QObject):
             return None, None
         if data.size == 0:
             return None, None
+
+        if self._autoscaleMode is not Colormap.MINMAX:
+            raise RuntimeError("AUtoscale not supported")
 
         if self.getNormalization() == Colormap.LOGARITHM:
             result = min_max(data, min_positive=True, finite=True)
@@ -695,6 +728,8 @@ class Colormap(qt.QObject):
             return self.getVMax()
         elif item == 'colors':
             return self.getColormapLUT()
+        elif item == 'autoscaleMode':
+            return self.getAutoscaleMode()
         else:
             raise KeyError(item)
 
@@ -711,7 +746,8 @@ class Colormap(qt.QObject):
             'vmin': self._vmin,
             'vmax': self._vmax,
             'autoscale': self.isAutoscale(),
-            'normalization': self._normalization
+            'normalization': self._normalization,
+            'autoscaleMode': self._autoscaleMode
         }
 
     def _setFromDict(self, dic):
@@ -742,7 +778,12 @@ class Colormap(qt.QObject):
             err = 'The colormap should have a name defined or a tuple of colors'
             raise ValueError(err)
         if normalization not in Colormap.NORMALIZATIONS:
-            err = 'Given normalization is not recoginized (%s)' % normalization
+            err = 'Given normalization is not recognized (%s)' % normalization
+            raise ValueError(err)
+
+        autoscaleMode = dic.get('autoscaleMode', Colormap.MINMAX)
+        if autoscaleMode not in Colormap.AUTOSCALE_MODES:
+            err = 'Given autoscale mode is not recognized (%s)' % autoscaleMode
             raise ValueError(err)
 
         # If autoscale, then set boundaries to None
@@ -757,6 +798,7 @@ class Colormap(qt.QObject):
         self._vmax = vmax
         self._autoscale = True if (vmin is None and vmax is None) else False
         self._normalization = normalization
+        self._autoscaleMode = autoscaleMode
 
         self.sigChanged.emit()
 
@@ -775,7 +817,8 @@ class Colormap(qt.QObject):
                         colors=self.getColormapLUT(),
                         vmin=self._vmin,
                         vmax=self._vmax,
-                        normalization=self._normalization)
+                        normalization=self._normalization,
+                        autoscaleMode=self._autoscaleMode)
 
     def applyToData(self, data, reference=None):
         """Apply the colormap to the data
@@ -833,12 +876,13 @@ class Colormap(qt.QObject):
             return False
         return (self.getName() == other.getName() and
                 self.getNormalization() == other.getNormalization() and
+                self.getAutoscaleMode() == other.getAutoscaleMode() and
                 self.getVMin() == other.getVMin() and
                 self.getVMax() == other.getVMax() and
                 numpy.array_equal(self.getColormapLUT(), other.getColormapLUT())
                 )
 
-    _SERIAL_VERSION = 1
+    _SERIAL_VERSION = 2
 
     def restoreState(self, byteArray):
         """
@@ -858,7 +902,7 @@ class Colormap(qt.QObject):
             return False
 
         version = stream.readUInt32()
-        if version != self._SERIAL_VERSION:
+        if version not in (1, self._SERIAL_VERSION):
             _logger.warning("Serial version mismatch. Found %d." % version)
             return False
 
@@ -875,11 +919,17 @@ class Colormap(qt.QObject):
             vmax = None
         normalization = stream.readQString()
 
+        if version == 1:
+            autoscaleMode = Colormap.MINMAX
+        else:
+            autoscaleMode = stream.readQString()
+
         # emit change event only once
         old = self.blockSignals(True)
         try:
             self.setName(name)
             self.setNormalization(normalization)
+            self.setAutoscaleMode(autoscaleMode)
             self.setVRange(vmin, vmax)
         finally:
             self.blockSignals(old)
@@ -905,6 +955,7 @@ class Colormap(qt.QObject):
         if self.getVMax() is not None:
             stream.writeQVariant(self.getVMax())
         stream.writeQString(self.getNormalization())
+        stream.writeQString(self.getAutoscaleMode())
         return data
 
 

--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -391,9 +391,8 @@ class ColormapAction(PlotAction):
         elif isinstance(image, items.ColormapMixIn):
             # Set dialog from active image
             colormap = image.getColormap()
-            data = image.getData(copy=False)
             # Set histogram and range if any
-            self._dialog.setData(data)
+            self._dialog.setItem(image)
 
         else:
             # No active image or active image is RGBA,
@@ -401,8 +400,7 @@ class ColormapAction(PlotAction):
             scatter = self.plot._getActiveItem(kind='scatter')
             if scatter is not None:
                 colormap = scatter.getColormap()
-                data = scatter.getValueData(copy=False)
-                self._dialog.setData(data)
+                self._dialog.setItem(scatter)
 
             else:
                 # No active data image nor scatter,

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -502,9 +502,9 @@ class ColormapMixIn(ItemMixInBase):
         # Fill-up colormap range cache if values are provided
         if max_ is not None and numpy.isfinite(max_):
             if min_ is not None and numpy.isfinite(min_):
-                self.__cacheColormapRange[Colormap.LINEAR] = min_, max_
+                self.__cacheColormapRange[Colormap.LINEAR, Colormap.MINMAX] = min_, max_
             if minPositive is not None and numpy.isfinite(minPositive):
-                self.__cacheColormapRange[Colormap.LOGARITHM] = minPositive, max_
+                self.__cacheColormapRange[Colormap.LOGARITHM, Colormap.MINMAX] = minPositive, max_
 
         colormap = self.getColormap()
         if None in (colormap.getVMin(), colormap.getVMax()):
@@ -537,11 +537,13 @@ class ColormapMixIn(ItemMixInBase):
             return None, None
 
         normalization = colormap.getNormalization()
-        if normalization not in self.__cacheColormapRange:
-            self.__cacheColormapRange[normalization] = \
-                colormap._computeAutoscaleRange(self.__data)
-
-        return self.__cacheColormapRange[normalization]
+        autoscaleMode = colormap.getAutoscaleMode()
+        key = normalization, autoscaleMode
+        vRange = self.__cacheColormapRange.get(key, None)
+        if vRange is None:
+            vRange = colormap._computeAutoscaleRange(self.__data)
+            self.__cacheColormapRange[key] = vRange
+        return vRange
 
 
 class SymbolMixIn(ItemMixInBase):

--- a/silx/gui/test/test_colors.py
+++ b/silx/gui/test/test_colors.py
@@ -34,6 +34,7 @@ __date__ = "09/11/2018"
 import unittest
 import numpy
 from silx.utils.testutils import ParametricTestCase
+from silx.gui import qt
 from silx.gui import colors
 from silx.gui.colors import Colormap
 from silx.gui.plot import items
@@ -424,6 +425,24 @@ class TestObjectAPI(ParametricTestCase):
         self.assertIsNot(colormap, other)
         self.assertEqual(colormap, other)
 
+    def testAutoscaleMode(self):
+        colormap = Colormap(autoscaleMode=Colormap.STDDEV3)
+        self.assertEqual(colormap.getAutoscaleMode(), Colormap.STDDEV3)
+        colormap.setAutoscaleMode(Colormap.MINMAX)
+        self.assertEqual(colormap.getAutoscaleMode(), Colormap.MINMAX)
+
+    def testStorageV1(self):
+        state = b'\x00\x00\x00\x10\x00C\x00o\x00l\x00o\x00r\x00m\x00a\x00p\x00\x00'\
+                b'\x00\x01\x00\x00\x00\x0E\x00v\x00i\x00r\x00i\x00d\x00i\x00s\x00'\
+                b'\x00\x00\x00\x06\x00?\xF0\x00\x00\x00\x00\x00\x00\x00\x00\x00'\
+                b'\x00\x06\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06\x00'\
+                b'l\x00o\x00g'
+        state = qt.QByteArray(state)
+        colormap = Colormap()
+        colormap.restoreState(state)
+
+        expected = Colormap(name="viridis", vmin=1, vmax=2, normalization=Colormap.LOGARITHM)
+        self.assertEqual(colormap, expected)
 
 class TestPreferredColormaps(unittest.TestCase):
     """Test get|setPreferredColormaps functions"""

--- a/silx/gui/test/test_colors.py
+++ b/silx/gui/test/test_colors.py
@@ -521,6 +521,37 @@ class TestRegisteredLut(unittest.TestCase):
         self.assertEqual(lut[0, 3], 128)
 
 
+class TestAutoscaleRange(ParametricTestCase):
+
+    def testAutoscaleRange(self):
+        nan = numpy.nan
+        data = [
+            # Positive values
+            (Colormap.LINEAR, Colormap.MINMAX, numpy.array([10, 20, 50]), (10, 50)),
+            (Colormap.LOGARITHM, Colormap.MINMAX, numpy.array([10, 50, 100]), (10, 100)),
+            (Colormap.LINEAR, Colormap.STDDEV3, numpy.array([10, 100]), (-80, 190)),
+            (Colormap.LOGARITHM, Colormap.STDDEV3, numpy.array([10, 100]), (1, 1000)),
+            # With nan
+            (Colormap.LINEAR, Colormap.MINMAX, numpy.array([10, 20, 50, nan]), (10, 50)),
+            (Colormap.LOGARITHM, Colormap.MINMAX, numpy.array([10, 50, 100, nan]), (10, 100)),
+            (Colormap.LINEAR, Colormap.STDDEV3, numpy.array([10, 100, nan]), (-80, 190)),
+            (Colormap.LOGARITHM, Colormap.STDDEV3, numpy.array([10, 100, nan]), (1, 1000)),
+            # With negative
+            (Colormap.LOGARITHM, Colormap.MINMAX, numpy.array([10, 50, 100, -50]), (10, 100)),
+            (Colormap.LOGARITHM, Colormap.STDDEV3, numpy.array([10, 100, -10]), (1, 1000)),
+        ]
+        for norm, mode, array, expectedRange in data:
+            with self.subTest(norm=norm, mode=mode, array=array):
+                colormap = Colormap()
+                colormap.setNormalization(norm)
+                colormap.setAutoscaleMode(mode)
+                vRange = colormap._computeAutoscaleRange(array)
+                if vRange is None:
+                    self.assertIsNone(expectedRange)
+                else:
+                    self.assertEqual(vRange[0], expectedRange[0])
+                    self.assertEqual(vRange[1], expectedRange[1])
+
 def suite():
     test_suite = unittest.TestSuite()
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
@@ -530,6 +561,7 @@ def suite():
     test_suite.addTest(loadTests(TestObjectAPI))
     test_suite.addTest(loadTests(TestPreferredColormaps))
     test_suite.addTest(loadTests(TestRegisteredLut))
+    test_suite.addTest(loadTests(TestAutoscaleRange))
     return test_suite
 
 


### PR DESCRIPTION
Closes #2739

The PR #2876 have to be merged first

This PR provides a new autoscale for image using standard deviation.
- Add `autoscaleMode` to the `Colormap`
- Add `STDDEV3` to compute range from data using: `mean ± 3 * std`
- Allow to set a plot item to the `ColormapDialog`
- Use colormap API from the dialog to compute the range

Note:
- The autoscale mode edition in the `ColormapDialog`will be part of another PR
