### PR TITLE
Check Opengl availability

### DIFF
--- a/silx/gui/_glutils/OpenGLWidget.py
+++ b/silx/gui/_glutils/OpenGLWidget.py
@@ -44,14 +44,8 @@ from .._glutils import gl
 _logger = logging.getLogger(__name__)
 
 
-# Probe OpenGL availability and widget
-ERROR = ''  # Error message from probing Qt OpenGL support
-
-_check = isOpenGLAvailable(version=(2, 1), runtimeCheck=False)
-if not _check:
-    ERROR = _check.error
-    _logger.error('OpenGL-based widget disabled: %s', ERROR)
-    _OpenGLWidget = None
+if not hasattr(qt, 'QOpenGLWidget') and not hasattr(qt, 'QGLWidget'):
+    OpenGLWidget = None
 
 else:
     if hasattr(qt, 'QOpenGLWidget'):  # PyQt>=5.4
@@ -110,7 +104,6 @@ else:
 
             # Enable receiving mouse move events when no buttons are pressed
             self.setMouseTracking(True)
-
 
         def getDevicePixelRatio(self):
             """Returns the ratio device-independent / device pixel size
@@ -277,9 +270,11 @@ class OpenGLWidget(qt.QWidget):
         layout.setContentsMargins(0, 0, 0, 0)
         self.setLayout(layout)
 
-        if _OpenGLWidget is None:
+        _check = isOpenGLAvailable(version=version, runtimeCheck=False)
+        if _OpenGLWidget is None or not _check:
+            _logger.error('OpenGL-based widget disabled: %s', _check.error)
             self.__openGLWidget = None
-            label = self._createErrorQLabel(ERROR)
+            label = self._createErrorQLabel(_check.error)
             self.layout().addWidget(label)
 
         else:

--- a/silx/gui/_glutils/OpenGLWidget.py
+++ b/silx/gui/_glutils/OpenGLWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -37,6 +37,7 @@ import logging
 import sys
 
 from .. import qt
+from ..utils.glutils import isOpenGLAvailable
 from .._glutils import gl
 
 
@@ -45,31 +46,22 @@ _logger = logging.getLogger(__name__)
 
 # Probe OpenGL availability and widget
 ERROR = ''  # Error message from probing Qt OpenGL support
-_BaseOpenGLWidget = None  # Qt OpenGL widget to use
 
-if hasattr(qt, 'QOpenGLWidget'):  # PyQt>=5.4
-    _logger.info('Using QOpenGLWidget')
-    _BaseOpenGLWidget = qt.QOpenGLWidget
-
-elif not qt.HAS_OPENGL:  # QtOpenGL not installed
-    ERROR = '%s.QtOpenGL not available' % qt.BINDING
-
-elif qt.QApplication.instance() and not qt.QGLFormat.hasOpenGL():
-    # qt.QGLFormat.hasOpenGL MUST be called with a QApplication created
-    # so this is only checked if the QApplication is already created
-    ERROR = 'Qt reports OpenGL not available'
-
-else:
-    _logger.info('Using QGLWidget')
-    _BaseOpenGLWidget = qt.QGLWidget
-
-
-# Internal class wrapping Qt OpenGL widget
-if _BaseOpenGLWidget is None:
+_check = isOpenGLAvailable(version=(2, 1), runtimeCheck=False)
+if not _check:
+    ERROR = _check.error
     _logger.error('OpenGL-based widget disabled: %s', ERROR)
     _OpenGLWidget = None
 
 else:
+    if hasattr(qt, 'QOpenGLWidget'):  # PyQt>=5.4
+        _logger.info('Using QOpenGLWidget')
+        _BaseOpenGLWidget = qt.QOpenGLWidget
+
+    else:
+        _logger.info('Using QGLWidget')
+        _BaseOpenGLWidget = qt.QGLWidget
+
     class _OpenGLWidget(_BaseOpenGLWidget):
         """Wrapper over QOpenGLWidget and QGLWidget"""
 

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -215,8 +215,10 @@ class PlotWidget(qt.QMainWindow):
         else:
             self.setWindowTitle('PlotWidget')
 
-        self._backend = None
-        self._setBackend(backend)
+        # Init the backend
+        if backend is None:
+            backend = silx.config.DEFAULT_PLOT_BACKEND
+        self._backend = self.__getBackendClass(backend)(self, self)
 
         self.setCallback()  # set _callback
 
@@ -299,7 +301,7 @@ class PlotWidget(qt.QMainWindow):
 
         If multiple backends are provided, the first available one is used.
 
-        :param Union[str,BackendBase,Iterable] backend:
+        :param Union[str,BackendBase,List[Union[str,BackendBase]]] backend:
             The name of the backend or its class or an iterable of those.
         :rtype: BackendBase
         :raise ValueError: In case the backend is not supported
@@ -316,15 +318,22 @@ class PlotWidget(qt.QMainWindow):
                         BackendMatplotlibQt as backendClass
                 except ImportError:
                     _logger.debug("Backtrace", exc_info=True)
-                    raise ImportError("matplotlib backend is not available")
+                    raise RuntimeError("matplotlib backend is not available")
 
             elif backend in ('gl', 'opengl'):
+                from ..utils.glutils import isOpenGLAvailable
+                checkOpenGL = isOpenGLAvailable(version=(2, 1), runtimeCheck=False)
+                if not checkOpenGL:
+                    _logger.debug("OpenGL check failed")
+                    raise RuntimeError(
+                        "OpenGL backend is not available: %s" % checkOpenGL.error)
+
                 try:
                     from .backends.BackendOpenGL import \
                         BackendOpenGL as backendClass
                 except ImportError:
                     _logger.debug("Backtrace", exc_info=True)
-                    raise ImportError("OpenGL backend is not available")
+                    raise RuntimeError("OpenGL backend is not available")
 
             elif backend == 'none':
                 from .backends.BackendBase import BackendBase as backendClass
@@ -338,24 +347,12 @@ class PlotWidget(qt.QMainWindow):
             for b in backend:
                 try:
                     return self.__getBackendClass(b)
-                except ImportError:
+                except RuntimeError:
                     pass
             else:  # No backend was found
-                raise ValueError("No supported backend was found")
+                raise RuntimeError("None of the request backends are available")
 
         raise ValueError("Backend not supported %s" % str(backend))
-
-    def _setBackend(self, backend):
-        """Setup a new backend
-
-        :param backend: Either a str defining the backend to use
-        """
-        assert(self._backend is None)
-
-        if backend is None:
-            backend = silx.config.DEFAULT_PLOT_BACKEND
-
-        self._backend = self.__getBackendClass(backend)(self, self)
 
     # TODO: Can be removed for silx 0.10
     @staticmethod

--- a/silx/gui/test/__init__.py
+++ b/silx/gui/test/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -106,7 +106,8 @@ def suite():
     test_suite.addTest(test_icons.suite())
     test_suite.addTest(test_colors.suite())
     test_suite.addTest(test_data.suite())
-    test_suite.addTest(test_utils.suite())
     test_suite.addTest(test_plot3d_suite())
     test_suite.addTest(test_dialog.suite())
+    # Run test_utils last: it interferes with OpenGLWidget through isOpenGLAvailable
+    test_suite.addTest(test_utils.suite())
     return test_suite

--- a/silx/gui/utils/glutils.py
+++ b/silx/gui/utils/glutils.py
@@ -76,6 +76,8 @@ def _runtimeOpenGLCheck(version):
     except subprocess.TimeoutExpired:
         status = False
         error = "Qt OpenGL widget hang"
+        if sys.platform.startswith('linux'):
+            error += ':\nIf connected remotely, GLX forwarding might be disabled.'
     except subprocess.CalledProcessError as e:
         status = False
         error = "Qt OpenGL widget error: retcode=%d, error=%s" % (e.returncode, e.output)

--- a/silx/gui/utils/glutils.py
+++ b/silx/gui/utils/glutils.py
@@ -142,6 +142,7 @@ if __name__ == "__main__":
     app = qt.QApplication([])
     window = qt.QMainWindow(
         flags=qt.Qt.Window | qt.Qt.FramelessWindowHint | qt.Qt.NoDropShadowWindowHint)
+    window.move(0, 0)
     window.resize(3, 3)
     widget = _TestOpenGLWidget(version=(sys.argv[1], sys.argv[2]))
     window.setCentralWidget(widget)

--- a/silx/gui/utils/glutils.py
+++ b/silx/gui/utils/glutils.py
@@ -142,8 +142,12 @@ if __name__ == "__main__":
             gl.glClear(gl.GL_COLOR_BUFFER_BIT)
 
     app = qt.QApplication([])
-    window = qt.QMainWindow(
-        flags=qt.Qt.Window | qt.Qt.FramelessWindowHint | qt.Qt.NoDropShadowWindowHint)
+    window = qt.QMainWindow(flags=
+        qt.Qt.Window |
+        qt.Qt.FramelessWindowHint |
+        qt.Qt.NoDropShadowWindowHint |
+        qt.Qt.WindowStaysOnTopHint)
+    window.setAttribute(qt.Qt.WA_ShowWithoutActivating)
     window.move(0, 0)
     window.resize(3, 3)
     widget = _TestOpenGLWidget(version=(sys.argv[1], sys.argv[2]))

--- a/silx/gui/utils/glutils.py
+++ b/silx/gui/utils/glutils.py
@@ -1,0 +1,145 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2020 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This module provides the :func:`isOpenGLAvailable` utility function.
+"""
+
+import functools
+import os
+import sys
+import subprocess
+from silx.gui import qt
+
+
+class _isOpenGLAvailableResult:
+    """Store result of checking OpenGL availability.
+
+    It provides a `status` boolean attribute storing the result of the check and
+    an `error` string attribute storting the possible error message.
+    """
+
+    def __init__(self, error):
+        self.__error = str(error)
+
+    status = property(lambda self: not self.__error, doc="True if OpenGL is working")
+    error = property(lambda self: self.__error, doc="Error message")
+
+    def __bool__(self):
+        return self.status
+
+    def __repr__(self):
+        return '<_isOpenGLAvailableResult: %s, "%s">' % (self.status, self.error)
+
+
+@functools.lru_cache()
+def isOpenGLAvailable(version=(2, 1)):
+    """Check if OpenGL is available through Qt and actually working.
+
+    After some basic tests, this is done by starting a subprocess that
+    displays a Qt OpenGL widget.
+
+    :param List[int] version:
+        The minimal required OpenGL version as a 2-tuple (major, minor).
+        Default: (2, 1)
+    :return: A result object that evaluates to True if successful and
+        which has a `status` boolean attribute (True if successful) and
+        an `error` string attribute that is not empty if `status` is False.
+    """
+    error = ''
+
+    if not hasattr(qt, 'QOpenGLWidget') and not qt.HAS_OPENGL:
+        error = '%s.QtOpenGL not available' % qt.BINDING
+
+    elif qt.QApplication.instance() and not qt.QGLFormat.hasOpenGL():
+        # qt.QGLFormat.hasOpenGL MUST be called with a QApplication created
+        # so this is only checked if the QApplication is already created
+        error = 'Qt reports OpenGL not available'
+
+    else:
+        try:
+            import silx.gui._glutils.gl  # noqa
+        except ImportError:
+            error = "Cannot import OpenGL wrapper: pyopengl is not installed"
+        else:
+            major, minor = str(version[0]), str(version[1])
+            env = os.environ.copy()
+            env['PYTHONPATH'] = os.pathsep.join(
+                [os.path.abspath(p) for p in sys.path])
+
+            try:
+                error = subprocess.check_output(
+                    [sys.executable, __file__, major, minor], env=env)
+            except subprocess.TimeoutExpired:
+                error = "Qt OpenGL widget hang"
+            except subprocess.CalledProcessError as e:
+                error = "Qt OpenGL widget error: retcode=%d, error=%s" % (e.returncode, e.output)
+            else:
+                error = error.decode()
+
+    return _isOpenGLAvailableResult(error)
+
+
+if __name__ == "__main__":
+    from silx.gui._glutils import OpenGLWidget
+    from silx.gui._glutils import gl
+
+    class _TestOpenGLWidget(OpenGLWidget):
+        """Widget checking that OpenGL is indeed available
+
+        :param List[int] version: (major, minor) minimum OpenGL version
+        """
+
+        def __init__(self, version):
+            super(_TestOpenGLWidget, self).__init__(
+                alphaBufferSize=0,
+                depthBufferSize=0,
+                stencilBufferSize=0,
+                version=version)
+
+        def paintEvent(self, event):
+            super(_TestOpenGLWidget, self).paintEvent(event)
+
+            # Check once paint has been done
+            app = qt.QApplication.instance()
+            if not self.isValid():
+                print("OpenGL widget is not valid")
+                app.exit(1)
+            else:
+                qt.QTimer.singleShot(100, app.quit)
+
+        def paintGL(self):
+            gl.glClearColor(1., 0., 0., 0.)
+            gl.glClear(gl.GL_COLOR_BUFFER_BIT)
+
+    app = qt.QApplication([])
+    window = qt.QMainWindow(
+        flags=qt.Qt.Window | qt.Qt.FramelessWindowHint | qt.Qt.NoDropShadowWindowHint)
+    window.resize(3, 3)
+    widget = _TestOpenGLWidget(version=(sys.argv[1], sys.argv[2]))
+    window.setCentralWidget(widget)
+    window.setWindowOpacity(0.04)
+    window.show()
+
+    qt.QTimer.singleShot(1000, app.quit)
+    sys.exit(app.exec_())

--- a/silx/gui/utils/glutils.py
+++ b/silx/gui/utils/glutils.py
@@ -96,7 +96,9 @@ def isOpenGLAvailable(version=(2, 1)):
 
         try:
             error = subprocess.check_output(
-                [sys.executable, __file__, major, minor], env=env)
+                [sys.executable, __file__, major, minor],
+                env=env,
+                timeout=2)
         except subprocess.TimeoutExpired:
             error = "Qt OpenGL widget hang"
         except subprocess.CalledProcessError as e:

--- a/silx/gui/utils/qtutils.py
+++ b/silx/gui/utils/qtutils.py
@@ -1,3 +1,29 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2020 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This module provides the :func:`getQEventName` utility function."""
+
 from silx.gui import qt
 
 

--- a/silx/gui/utils/test/test_glutils.py
+++ b/silx/gui/utils/test/test_glutils.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,35 +22,40 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-"""silx.gui.utils tests"""
-
+"""Tests for the silx.gui.utils.glutils module."""
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "24/04/2018"
+__date__ = "15/01/2020"
 
 
 import unittest
+from silx.gui.utils.glutils import isOpenGLAvailable
 
-from . import test_async
-from . import test_glutils
-from . import test_image
-from . import test_qtutils
-from . import test_testutils
-from . import test
+
+class TestIsOpenGLAvailable(unittest.TestCase):
+    """Test isOpenGLAvailable"""
+
+    def test(self):
+        for version in ((2, 1), (2, 1), (1000, 1)):
+            with self.subTest(version=version):
+                result = isOpenGLAvailable(version=version)
+                if version[0] == 1000:
+                    self.assertFalse(result)
+                if not result:
+                    self.assertFalse(result.status)
+                    self.assertTrue(len(result.error) > 0)
+                else:
+                    self.assertTrue(result.status)
+                    self.assertTrue(len(result.error) == 0)
 
 
 def suite():
-    """Test suite for module silx.image.test"""
     test_suite = unittest.TestSuite()
-    test_suite.addTest(test.suite())
-    test_suite.addTest(test_async.suite())
-    test_suite.addTest(test_glutils.suite())
-    test_suite.addTest(test_image.suite())
-    test_suite.addTest(test_qtutils.suite())
-    test_suite.addTest(test_testutils.suite())
+    test_suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(
+        TestIsOpenGLAvailable))
     return test_suite
 
 
-if __name__ == "__main__":
-    unittest.main(defaultTest="suite")
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')

--- a/silx/gui/utils/test/test_glutils.py
+++ b/silx/gui/utils/test/test_glutils.py
@@ -29,8 +29,12 @@ __license__ = "MIT"
 __date__ = "15/01/2020"
 
 
+import logging
 import unittest
 from silx.gui.utils.glutils import isOpenGLAvailable
+
+
+_logger = logging.getLogger(__name__)
 
 
 class TestIsOpenGLAvailable(unittest.TestCase):
@@ -40,6 +44,7 @@ class TestIsOpenGLAvailable(unittest.TestCase):
         for version in ((2, 1), (2, 1), (1000, 1)):
             with self.subTest(version=version):
                 result = isOpenGLAvailable(version=version)
+                _logger.info("isOpenGLAvailable returned: %s", str(result))
                 if version[0] == 1000:
                     self.assertFalse(result)
                 if not result:


### PR DESCRIPTION
This PR adds a `isOpenGLAvailable` function in a `silx.gui.utils.glutils` module.
This function checks whether a specific version of OpenGL (2.1 by default as it is used by `silx`) is really available.
It does different checks and end-up running a small Qt OpenGL widget in a subprocess...

TODOs:

- [x] Tested in different conditions
- [x] Add some automated tests? Not sure it is such a good idea....

closes #2866