### PR TITLE
Support intensity histogram for scatter

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -147,13 +147,13 @@ class PlotWidget(qt.QMainWindow):
     - legend: The legend of the primitive changed.
     """
 
-    sigActiveItemChanged = qt.Signal(object, object)
+    sigCurrentChanged = qt.Signal(object, object)
     """Signal emitted when the active item has changed.
 
     It provides the following information:
 
-    - previous: The previous active item or None
     - current: The current active item or None
+    - previous: The previous active item or None
     """
 
     sigActiveCurveChanged = qt.Signal(object, object)
@@ -2633,8 +2633,8 @@ class PlotWidget(qt.QMainWindow):
             self.sigContentChanged.emit(
                 kwargs['action'], kwargs['kind'], kwargs['legend'])
         elif event == 'activeItemChanged':
-            self.sigActiveItemChanged.emit(
-                kwargs['previous'], kwargs['current'])
+            self.sigCurrentChanged.emit(
+                kwargs['current'], kwargs['previous'])
         elif event == 'activeCurveChanged':
             self.sigActiveCurveChanged.emit(
                 kwargs['previous'], kwargs['legend'])

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -1920,6 +1920,26 @@ class PlotWidget(qt.QMainWindow):
         else:
             return self._getItem(kind, self._activeLegend[kind])
 
+    def setActiveItem(self, item):
+        """Make this item the new active item.
+
+        :param ~silx.gui.plot.items.Item item: The item to use as active
+                                               or None to have no active item.
+        """
+        if item is self._activeItem:
+            # Already the active item
+            return
+
+        kind = None
+        if item is not None:
+            legend, kind = self._itemKey(item)
+            if kind in self._ACTIVE_ITEM_KINDS:
+                self._setActiveItem(kind, legend)
+            else:
+                self._updateActiveItem(item)
+        else:
+            self._updateActiveItem(None)
+
     def getActiveItem(self):
         """Returns the last active item of any kind
 

--- a/silx/gui/plot/ScatterView.py
+++ b/silx/gui/plot/ScatterView.py
@@ -41,6 +41,7 @@ import numpy
 from . import items
 from . import PlotWidget
 from . import tools
+from .actions import histogram as actions_histogram
 from .tools.profile import ScatterProfileToolBar
 from .ColorBar import ColorBarWidget
 from .ScatterMaskToolsWidget import ScatterMaskToolsWidget
@@ -124,6 +125,8 @@ class ScatterView(qt.QMainWindow):
         self._maskAction.setIcon(icons.getQIcon('image-mask'))
         self._maskAction.setToolTip("Display/hide mask tools")
 
+        self._intensityHistoAction = actions_histogram.PixelIntensitiesHistoAction(plot=plot, parent=self)
+
         # Create toolbars
         self._interactiveModeToolBar = tools.InteractiveModeToolBar(
             parent=self, plot=plot)
@@ -131,6 +134,7 @@ class ScatterView(qt.QMainWindow):
         self._scatterToolBar = tools.ScatterToolBar(
             parent=self, plot=plot)
         self._scatterToolBar.addAction(self._maskAction)
+        self._scatterToolBar.addAction(self._intensityHistoAction)
 
         self._profileToolBar = ScatterProfileToolBar(parent=self, plot=plot)
 

--- a/silx/gui/plot/actions/histogram.py
+++ b/silx/gui/plot/actions/histogram.py
@@ -112,17 +112,20 @@ class PixelIntensitiesHistoAction(PlotToolAction):
         if event == items.ItemChangedType.DATA:
             self.computeIntensityDistribution()
 
+    def _cleanUp(self):
+        plot = self.getHistogramPlotWidget()
+        try:
+            plot.removeItem('pixel intensity')
+        except:
+            pass
+
     def computeIntensityDistribution(self):
         """Get the active image and compute the image intensity distribution
         """
         item = self._getSelectedItem()
 
         if item is None:
-            plot = self.getHistogramPlotWidget()
-            try:
-                plot.removeItem('pixel intensity')
-            except:
-                pass
+            self._cleanUp()
             return
 
         if isinstance(item, items.ImageBase):
@@ -137,6 +140,10 @@ class PixelIntensitiesHistoAction(PlotToolAction):
             array = item.getValueData(copy=False)
         else:
             assert(False)
+
+        if array.size == 0:
+            self._cleanUp()
+            return
 
         xmin, xmax = min_max(array, min_positive=False, finite=True)
         nbins = min(1024, int(numpy.sqrt(array.size)))

--- a/silx/gui/plot/actions/histogram.py
+++ b/silx/gui/plot/actions/histogram.py
@@ -68,18 +68,18 @@ class PixelIntensitiesHistoAction(PlotToolAction):
         self._item = None
 
     def _connectPlot(self, window):
-        self.plot.sigActiveItemChanged.connect(self._activeItemChanged)
+        self.plot.sigCurrentChanged.connect(self._currentChanged)
         item = self.plot.getActiveItem()
         self._setSelectedItem(item)
         PlotToolAction._connectPlot(self, window)
 
     def _disconnectPlot(self, window):
-        self.plot.sigActiveItemChanged.disconnect(self._activeItemChanged)
+        self.plot.sigCurrentChanged.disconnect(self._currentChanged)
         PlotToolAction._disconnectPlot(self, window)
         self._setSelectedItem(None)
 
-    def _activeItemChanged(self, previous, current):
-        """Handle active image change: toggle enabled toolbar, update curve"""
+    def _currentChanged(self, current, previous):
+        """Handle active item change"""
         if self._isWindowInUse():
             self._setSelectedItem(current)
 

--- a/silx/gui/plot/actions/histogram.py
+++ b/silx/gui/plot/actions/histogram.py
@@ -81,13 +81,7 @@ class PixelIntensitiesHistoAction(PlotToolAction):
     def _activeItemChanged(self, previous, current):
         """Handle active image change: toggle enabled toolbar, update curve"""
         if self._isWindowInUse():
-            if current is None:
-                self._setSelectedItem(None)
-            elif isinstance(current, items.ImageBase):
-                self._setSelectedItem(current)
-            else:
-                # Do not touch anything, which is a compatible behavior with v0.12
-                pass
+            self._setSelectedItem(current)
 
     def _getSelectedItem(self):
         item = self._item
@@ -97,6 +91,11 @@ class PixelIntensitiesHistoAction(PlotToolAction):
             return item()
 
     def _setSelectedItem(self, item):
+        if item is not None:
+            if not isinstance(item, (items.ImageBase, items.Scatter)):
+                # Filter out other things
+                return
+
         old = self._getSelectedItem()
         if item is old:
             return
@@ -127,37 +126,41 @@ class PixelIntensitiesHistoAction(PlotToolAction):
             return
 
         if isinstance(item, items.ImageBase):
-            image = item.getData(copy=False)
-            if image.ndim == 3:  # RGB(A) images
+            array = item.getData(copy=False)
+            if array.ndim == 3:  # RGB(A) images
                 _logger.info('Converting current image from RGB(A) to grayscale\
                     in order to compute the intensity distribution')
-                image = (image[:, :, 0] * 0.299 +
-                         image[:, :, 1] * 0.587 +
-                         image[:, :, 2] * 0.114)
+                array = (array[:, :, 0] * 0.299 +
+                         array[:, :, 1] * 0.587 +
+                         array[:, :, 2] * 0.114)
+        elif isinstance(item, items.Scatter):
+            array = item.getValueData(copy=False)
+        else:
+            assert(False)
 
-            xmin, xmax = min_max(image, min_positive=False, finite=True)
-            nbins = min(1024, int(numpy.sqrt(image.size)))
-            data_range = xmin, xmax
+        xmin, xmax = min_max(array, min_positive=False, finite=True)
+        nbins = min(1024, int(numpy.sqrt(array.size)))
+        data_range = xmin, xmax
 
-            # bad hack: get 256 bins in the case we have a B&W
-            if numpy.issubdtype(image.dtype, numpy.integer):
-                if nbins > xmax - xmin:
-                    nbins = xmax - xmin
+        # bad hack: get 256 bins in the case we have a B&W
+        if numpy.issubdtype(array.dtype, numpy.integer):
+            if nbins > xmax - xmin:
+                nbins = xmax - xmin
 
-            nbins = max(2, nbins)
+        nbins = max(2, nbins)
 
-            data = image.ravel().astype(numpy.float32)
-            histogram = Histogramnd(data, n_bins=nbins, histo_range=data_range)
-            assert len(histogram.edges) == 1
-            self._histo = histogram.histo
-            edges = histogram.edges[0]
-            plot = self.getHistogramPlotWidget()
-            plot.addHistogram(histogram=self._histo,
-                              edges=edges,
-                              legend='pixel intensity',
-                              fill=True,
-                              color='#66aad7')
-            plot.resetZoom()
+        data = array.ravel().astype(numpy.float32)
+        histogram = Histogramnd(data, n_bins=nbins, histo_range=data_range)
+        assert len(histogram.edges) == 1
+        self._histo = histogram.histo
+        edges = histogram.edges[0]
+        plot = self.getHistogramPlotWidget()
+        plot.addHistogram(histogram=self._histo,
+                          edges=edges,
+                          legend='pixel intensity',
+                          fill=True,
+                          color='#66aad7')
+        plot.resetZoom()
 
     def getHistogramPlotWidget(self):
         """Create the plot histogram if needed, otherwise create it


### PR DESCRIPTION
Closes #2840 
Relative to #2830 

This PR update the intnesity histogram action to support scatters

- Add an `activeItem` and a `sigActiveItemChanged`  to the plot
    - Basically the last active item (not legend) from any kind
- Add a `setActiveItem` using an item (could be useful)
- Rework `PixelIntensitiesHistoAction`
   - Uses `sigActiveItemChanged`
   - Uses item, not legend
   - Uses Data update
   - Supports scatter (basic histogram from `getValueData`)
- Add the histogram action to the `ScatterView`

This also fixes glitsh on `silx view` when opening the histo, closing it, changing the dataset, opening again the histo window