### PR TITLE
Fix typo in depth of collapse/expand

### DIFF
--- a/silx/app/view/Viewer.py
+++ b/silx/app/view/Viewer.py
@@ -379,12 +379,12 @@ class Viewer(qt.QMainWindow):
         model = self.__treeview.model()
         while len(indexes) > 0:
             index = indexes.pop(0)
-            if index.column() != 0:
-                continue
             if isinstance(index, tuple):
                 index, depth = index
             else:
                 depth = 0
+            if index.column() != 0:
+                continue
 
             if depth > 10:
                 # Avoid infinite loop with recursive links
@@ -407,12 +407,12 @@ class Viewer(qt.QMainWindow):
         model = self.__treeview.model()
         while len(indexes) > 0:
             index = indexes.pop(0)
-            if index.column() != 0:
-                continue
             if isinstance(index, tuple):
                 index, depth = index
             else:
                 depth = 0
+            if index.column() != 0:
+                continue
 
             if depth > 10:
                 # Avoid infinite loop with recursive links


### PR DESCRIPTION
Closes  #2879

Without this fix the action to `expand all/collapse all` is not working.

This could be part of fix for 0.12