### PR TITLE
Display the real value in the axis

### DIFF
--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -402,10 +402,15 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
         # disable the use of offsets
         try:
-            self.ax.get_yaxis().get_major_formatter().set_useOffset(False)
-            self.ax.get_xaxis().get_major_formatter().set_useOffset(False)
-            self.ax2.get_yaxis().get_major_formatter().set_useOffset(False)
-            self.ax2.get_xaxis().get_major_formatter().set_useOffset(False)
+            axes = [
+                self.ax.get_yaxis().get_major_formatter(),
+                self.ax.get_xaxis().get_major_formatter(),
+                self.ax2.get_yaxis().get_major_formatter(),
+                self.ax2.get_xaxis().get_major_formatter(),
+            ]
+            for axis in axes:
+                axis.set_useOffset(False)
+                axis.set_scientific(False)
         except:
             _logger.warning('Cannot disabled axes offsets in %s '
                             % matplotlib.__version__)


### PR DESCRIPTION
Closes  #2883

This patch disable the use of an offset in the axis to display the real value.

From matplotlib feedback, this way do display the axes is named `scientific` style. I don't really know what is the purpose of `useOffset`.

The following rendering is no more available:
![Screenshot from 2020-01-15 17-21-52](https://user-images.githubusercontent.com/7579321/72505945-34e9f900-3841-11ea-8d5c-5fe350365701.png)
