### PR TITLE
Update backend following colormap min/max cache

### DIFF
--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -143,12 +143,11 @@ class BackendBase(object):
         """
         return object()
 
-    def addImage(self, item, data,
+    def addImage(self, data,
                  origin, scale, z,
                  colormap, alpha):
         """Add an image to the plot.
 
-        :param ~silx.gui.plot.items.Item item: Plot item
         :param numpy.ndarray data: (nrows, ncolumns) data or
                      (nrows, ncolumns, RGBA) ubyte array
         :param origin: (origin X, origin Y) of the data.

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -584,7 +584,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
         return _PickableContainer(artists)
 
-    def addImage(self, item, data, origin, scale, z, colormap, alpha):
+    def addImage(self, data, origin, scale, z, colormap, alpha):
         # Non-uniform image
         # http://wiki.scipy.org/Cookbook/Histograms
         # Non-linear axes
@@ -626,7 +626,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
             data = data[::ystep, ::xstep]
 
         if data.ndim == 2:  # Data image, convert to RGBA image
-            data = colormap.applyToData(data, reference=item)
+            data = colormap.applyToData(data)
 
         image.set_data(data)
         self.ax.add_artist(image)

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -845,7 +845,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
         return curve
 
-    def addImage(self, item, data,
+    def addImage(self, data,
                  origin, scale, z,
                  colormap, alpha):
         for parameter in (data, origin, scale, z):
@@ -861,7 +861,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                 data = numpy.array(data, dtype=numpy.float32, order='C')
 
             colormapIsLog = colormap.getNormalization() == 'log'
-            cmapRange = colormap.getColormapRange(data=item)
+            cmapRange = colormap.getColormapRange(data=data)
             colormapLut = colormap.getNColors(nbColors=256)
 
             image = GLPlotColormap(data,

--- a/silx/gui/plot/items/complex.py
+++ b/silx/gui/plot/items/complex.py
@@ -165,12 +165,17 @@ class ImageComplexData(ImageBase, ColormapMixIn, ComplexMixIn):
             data = self.getRgbaImageData(copy=False)
         else:
             colormap = self.getColormap()
+            if colormap.isAutoscale():
+                # Avoid backend to compute autoscale: use item cache
+                colormap = colormap.copy()
+                colormap.setVRange(*colormap.getColormapRange(self))
+
             data = self.getData(copy=False)
 
         if data.size == 0:
             return None  # No data to display
 
-        return backend.addImage(self, data,
+        return backend.addImage(data,
                                 origin=self.getOrigin(),
                                 scale=self.getScale(),
                                 z=self.getZValue(),

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -301,11 +301,17 @@ class ImageData(ImageBase, ColormapMixIn):
         if dataToUse.size == 0:
             return None  # No data to display
 
-        return backend.addImage(self, dataToUse,
+        colormap = self.getColormap()
+        if colormap.isAutoscale():
+            # Avoid backend to compute autoscale: use item cache
+            colormap = colormap.copy()
+            colormap.setVRange(*colormap.getColormapRange(self))
+
+        return backend.addImage(dataToUse,
                                 origin=self.getOrigin(),
                                 scale=self.getScale(),
                                 z=self.getZValue(),
-                                colormap=self.getColormap(),
+                                colormap=colormap,
                                 alpha=self.getAlpha())
 
     def __getitem__(self, item):
@@ -432,7 +438,7 @@ class ImageRgba(ImageBase):
         if data.size == 0:
             return None  # No data to display
 
-        return backend.addImage(None, data,
+        return backend.addImage(data,
                                 origin=self.getOrigin(),
                                 scale=self.getScale(),
                                 z=self.getZValue(),

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -457,7 +457,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
                 if gridInfo.order == 'column':
                     image = numpy.transpose(image, axes=(1, 0, 2))
 
-                return backend.addImage(self,
+                return backend.addImage(
                     data=image,
                     origin=gridInfo.origin,
                     scale=gridInfo.scale,


### PR DESCRIPTION
! Merge PR #2876 first !

This PR provides some rework of PR #2876 in order to avoid passing the item to the backend.
Instead, for autoscale colormaps, provides a copy of the item colormap with the range set to what the autoscale has computed.
This leverages the item's range cache without changing the backend.