### PR TITLE
support uint16 RGB images with the OpenGL backend

### DIFF
--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -632,6 +632,9 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
         if data.ndim == 2:  # Data image, convert to RGBA image
             data = colormap.applyToData(data)
+        elif data.dtype == numpy.uint16:
+            # Normalize uint16 data to have a similar behavior as opengl backend
+            data = data.astype(numpy.float32) / 65535
 
         image.set_data(data)
         self.ax.add_artist(image)

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -634,8 +634,9 @@ class BackendMatplotlib(BackendBase.BackendBase):
             data = colormap.applyToData(data)
         elif data.dtype == numpy.uint16:
             # Normalize uint16 data to have a similar behavior as opengl backend
-            data = data.astype(numpy.float32) / 65535
-
+            data = data.astype(numpy.float32)
+            data /= 65535
+        
         image.set_data(data)
         self.ax.add_artist(image)
         return image

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -878,6 +878,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
             if numpy.issubdtype(data.dtype, numpy.floating):
                 data = numpy.array(data, dtype=numpy.float32, copy=False)
+            elif data.dtype in [numpy.uint8, numpy.uint16]:
+                pass
             elif numpy.issubdtype(data.dtype, numpy.integer):
                 data = numpy.array(data, dtype=numpy.uint8, copy=False)
             else:

--- a/silx/gui/plot/backends/glutils/GLPlotImage.py
+++ b/silx/gui/plot/backends/glutils/GLPlotImage.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -583,9 +583,14 @@ class GLPlotRGBAImage(_GLPlotData2D):
 
     def prepare(self):
         if self._texture is None:
-            format_ = gl.GL_RGBA if self.data.shape[2] == 4 else gl.GL_RGB
+            formatName = 'GL_RGBA' if self.data.shape[2] == 4 else 'GL_RGB'
+            format_ = getattr(gl, formatName)
 
-            self._texture = Image(format_,
+            if self.data.dtype == numpy.uint16:
+                formatName += '16'  # Use sized internal format for uint16
+            internalFormat = getattr(gl, formatName)
+
+            self._texture = Image(internalFormat,
                                   self.data,
                                   format_=format_,
                                   texUnit=self._DATA_TEX_UNIT)

--- a/silx/gui/plot/backends/glutils/GLPlotImage.py
+++ b/silx/gui/plot/backends/glutils/GLPlotImage.py
@@ -530,7 +530,8 @@ class GLPlotRGBAImage(_GLPlotData2D):
     _DATA_TEX_UNIT = 0
 
     _SUPPORTED_DTYPES = (numpy.dtype(numpy.float32),
-                         numpy.dtype(numpy.uint8))
+                         numpy.dtype(numpy.uint8),
+                         numpy.dtype(numpy.uint16))
 
     _linearProgram = Program(_SHADERS['linear']['vertex'],
                              _SHADERS['linear']['fragment'],

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -273,11 +273,20 @@ class TestPlotImage(PlotWidgetTestCase, ParametricTestCase):
 
         rgb = numpy.array(
             (((0, 0, 0), (128, 0, 0), (255, 0, 0)),
-             ((0, 128, 0), (0, 128, 128), (0, 128, 256))),
+             ((0, 128, 0), (0, 128, 128), (0, 128, 255))),
             dtype=numpy.uint8)
 
-        self.plot.addImage(rgb, legend="rgb",
-                           origin=(0, 0), scale=(10, 10),
+        self.plot.addImage(rgb, legend="rgb_uint8",
+                           origin=(0, 0), scale=(1, 1),
+                           resetzoom=False)
+
+        rgb = numpy.array(
+            (((0, 0, 0), (32768, 0, 0), (65535, 0, 0)),
+             ((0, 32768, 0), (0, 32768, 32768), (0, 32768, 65535))),
+            dtype=numpy.uint16)
+
+        self.plot.addImage(rgb, legend="rgb_uint16",
+                           origin=(3, 2), scale=(2, 2),
                            resetzoom=False)
 
         rgba = numpy.array(
@@ -285,8 +294,8 @@ class TestPlotImage(PlotWidgetTestCase, ParametricTestCase):
              ((0, .5, 0, 1), (0, .5, .5, 1), (0, 1, 1, .5))),
             dtype=numpy.float32)
 
-        self.plot.addImage(rgba, legend="rgba",
-                           origin=(5, 5), scale=(10, 10),
+        self.plot.addImage(rgba, legend="rgba_float32",
+                           origin=(9, 6), scale=(1, 1),
                            resetzoom=False)
 
         self.plot.resetZoom()


### PR DESCRIPTION
uint16 RGB seems to be already supported in the OpenGL backend, except for these 2 lines.

I have been testing it for a few days, now.

To test it: 
```
from silx.gui import qt
from silx.gui.plot import PlotWidget
import numpy

img_rgb = numpy.empty((300, 300, 3), dtype=numpy.uint16)
img_rgba = numpy.empty((300, 300, 4), dtype=numpy.uint16)

max_uint16 = numpy.iinfo(numpy.uint16).max

r, g = numpy.meshgrid(numpy.arange(0, max_uint16, max_uint16 / 300),
                      numpy.arange(max_uint16, 0, - max_uint16 / 300))

b = (r + g) / 2
a = b.T

img_rgb[..., 0] = r
img_rgb[..., 1] = g
img_rgb[..., 2] = b

img_rgba[..., 0:3] = img_rgb
img_rgba[..., 3] = a

app = qt.QApplication([])

pw = {}
for be in "gl", "mpl":
	pw[(be, "rgb")] = PlotWidget(backend=be)
	pw[(be, "rgba")] = PlotWidget(backend=be)
	
	pw[(be, "rgb")].setGraphTitle(be + "uint16 RGB")
	pw[(be, "rgba")].setGraphTitle(be + "uint16 RGBA")

	pw[(be, "rgb")].addImage(img_rgb)
	pw[(be, "rgba")].addImage(img_rgba)

	pw[(be, "rgb")].show()
	pw[(be, "rgba")].show()

app.exec_()
```
