### PR TITLE
make code compatible with matplotlib 3.3

### DIFF
--- a/silx/gui/plot/matplotlib/__init__.py
+++ b/silx/gui/plot/matplotlib/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -44,7 +44,7 @@ import matplotlib
 from ... import qt
 
 
-def _matplotlib_use(backend, warn, force):
+def _matplotlib_use(backend, force):
     """Wrapper of `matplotlib.use` to set-up backend.
 
      It adds extra initialization for PySide and PySide2 with matplotlib < 2.2.
@@ -56,15 +56,15 @@ def _matplotlib_use(backend, warn, force):
         if qt.BINDING == 'PySide2':
             matplotlib.rcParams['backend.qt5'] = 'PySide2'
 
-    matplotlib.use(backend, warn=warn, force=force)
+    matplotlib.use(backend, force=force)
 
 
 if qt.BINDING in ('PyQt4', 'PySide'):
-    _matplotlib_use('Qt4Agg', warn=True, force=False)
+    _matplotlib_use('Qt4Agg', force=False)
     from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg  # noqa
 
 elif qt.BINDING in ('PyQt5', 'PySide2'):
-    _matplotlib_use('Qt5Agg', warn=True, force=False)
+    _matplotlib_use('Qt5Agg', force=False)
     from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg  # noqa
 
 else:


### PR DESCRIPTION
This PR removes the following warning, and makes the plot compatible with `matplotlib` v3.3.

```
WARNING:py.warnings:C:\projects\silx\venv_test\lib\site-packages\silx\gui\plot\matplotlib\__init__.py:59: MatplotlibDeprecationWarning: The 'warn' parameter of use() is deprecated since Matplotlib 3.1 and will be removed in 3.3.  If any parameter follows 'warn', they should be pass as keyword, not positionally.
  matplotlib.use(backend, warn=warn, force=force)
```

If we are to make a v0.12.1, this should go into it.