### PR TITLE
Fix implicit int cast deprecation warning with python 3.8

### DIFF
--- a/silx/gui/_glutils/font.py
+++ b/silx/gui/_glutils/font.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -128,8 +128,8 @@ def rasterText(text, font,
     width = bounds.width() * devicePixelRatio + 2
     # align line size to 32 bits to ease conversion to numpy array
     width = 4 * ((width + 3) // 4)
-    image = qt.QImage(width,
-                      bounds.height() * devicePixelRatio + 2,
+    image = qt.QImage(int(width),
+                      int(bounds.height() * devicePixelRatio + 2),
                       qt.QImage.Format_RGB888)
     if (devicePixelRatio != 1.0 and
             hasattr(image, 'setDevicePixelRatio')):  # Qt 5

--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -583,8 +583,8 @@ class _ColorScale(qt.QWidget):
         painter.drawRect(qt.QRect(
             0,
             self.margin,
-            self.width() - 1.,
-            self.height() - 2. * self.margin - 1.))
+            self.width() - 1,
+            self.height() - 2 * self.margin - 1))
 
     def mouseMoveEvent(self, event):
         tooltip = str(self.getValueFromRelativePosition(
@@ -630,7 +630,7 @@ class _ColorScale(qt.QWidget):
 
         :param int margin: the margin to apply on the top and bottom.
         """
-        self.margin = margin
+        self.margin = int(margin)
         self.update()
 
 
@@ -820,19 +820,18 @@ class _TickBar(qt.QWidget):
         fm = qt.QFontMetrics(painter.font())
         viewportHeight = self.rect().height() - self.margin * 2 - 1
         relativePos = self._getRelativePosition(val)
-        height = viewportHeight * relativePos
-        height += self.margin
+        height = int(viewportHeight * relativePos + self.margin)
         lineWidth = _TickBar._LINE_WIDTH
         if majorTick is False:
             lineWidth /= 2
 
-        painter.drawLine(qt.QLine(self.width() - lineWidth,
+        painter.drawLine(qt.QLine(int(self.width() - lineWidth),
                                   height,
                                   self.width(),
                                   height))
 
         if self.displayValues and majorTick is True:
-            painter.drawText(qt.QPoint(0.0, height + (fm.height() / 2)),
+            painter.drawText(qt.QPoint(0, int(height + fm.height() / 2)),
                              self.form.format(val))
 
     def setDisplayType(self, disType):

--- a/silx/gui/plot/PlotToolButtons.py
+++ b/silx/gui/plot/PlotToolButtons.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -370,7 +370,7 @@ class _SymbolToolButtonBase(PlotToolButton):
         """
         slider = qt.QSlider(qt.Qt.Horizontal)
         slider.setRange(1, 20)
-        slider.setValue(config.DEFAULT_PLOT_SYMBOL_SIZE)
+        slider.setValue(int(config.DEFAULT_PLOT_SYMBOL_SIZE))
         slider.setTracking(False)
         slider.valueChanged.connect(self._sizeChanged)
         widgetAction = qt.QWidgetAction(menu)

--- a/silx/gui/plot3d/SFViewParamTree.py
+++ b/silx/gui/plot3d/SFViewParamTree.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -380,7 +380,7 @@ class _LightDirectionAngleBaseItem(SubjectItem):
         editor.setOrientation(qt.Qt.Horizontal)
         editor.setMinimum(-90)
         editor.setMaximum(90)
-        editor.setValue(self._pullData())
+        editor.setValue(int(self._pullData()))
 
         # Wrapping call in lambda is a workaround for PySide with Python 3
         editor.valueChanged.connect(
@@ -389,7 +389,7 @@ class _LightDirectionAngleBaseItem(SubjectItem):
         return editor
 
     def setEditorData(self, editor):
-        editor.setValue(self._pullData())
+        editor.setValue(int(self._pullData()))
         return True
 
     def _setModelData(self, editor):
@@ -826,7 +826,7 @@ class _IsoLevelSlider(qt.QSlider):
             if width > 0:
                 sliderWidth = self.maximum() - self.minimum()
                 sliderPosition = sliderWidth * (self.__norm(level) - min_) / width
-                self.setValue(sliderPosition)
+                self.setValue(int(sliderPosition))
 
     def __dataChanged(self):
         """Handles data update to refresh slider range if needed"""

--- a/silx/gui/utils/testutils.py
+++ b/silx/gui/utils/testutils.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -265,7 +265,7 @@ class TestCaseQt(unittest.TestCase):
         """
         if modifier is None:
             modifier = qt.Qt.KeyboardModifiers()
-        pos = qt.QPoint(pos[0], pos[1]) if pos is not None else qt.QPoint()
+        pos = qt.QPoint(int(pos[0]), int(pos[1])) if pos is not None else qt.QPoint()
         QTest.mouseClick(widget, button, modifier, pos, delay)
         self.qWait(20)
 
@@ -276,7 +276,7 @@ class TestCaseQt(unittest.TestCase):
         """
         if modifier is None:
             modifier = qt.Qt.KeyboardModifiers()
-        pos = qt.QPoint(pos[0], pos[1]) if pos is not None else qt.QPoint()
+        pos = qt.QPoint(int(pos[0]), int(pos[1])) if pos is not None else qt.QPoint()
         QTest.mouseDClick(widget, button, modifier, pos, delay)
         self.qWait(20)
 
@@ -285,7 +285,7 @@ class TestCaseQt(unittest.TestCase):
 
         See QTest.mouseMove for details.
         """
-        pos = qt.QPoint(pos[0], pos[1]) if pos is not None else qt.QPoint()
+        pos = qt.QPoint(int(pos[0]), int(pos[1])) if pos is not None else qt.QPoint()
         QTest.mouseMove(widget, pos, delay)
         self.qWait(20)
 
@@ -296,7 +296,7 @@ class TestCaseQt(unittest.TestCase):
         """
         if modifier is None:
             modifier = qt.Qt.KeyboardModifiers()
-        pos = qt.QPoint(pos[0], pos[1]) if pos is not None else qt.QPoint()
+        pos = qt.QPoint(int(pos[0]), int(pos[1])) if pos is not None else qt.QPoint()
         QTest.mousePress(widget, button, modifier, pos, delay)
         self.qWait(20)
 
@@ -307,7 +307,7 @@ class TestCaseQt(unittest.TestCase):
         """
         if modifier is None:
             modifier = qt.Qt.KeyboardModifiers()
-        pos = qt.QPoint(pos[0], pos[1]) if pos is not None else qt.QPoint()
+        pos = qt.QPoint(int(pos[0]), int(pos[1])) if pos is not None else qt.QPoint()
         QTest.mouseRelease(widget, button, modifier, pos, delay)
         self.qWait(20)
 
@@ -316,7 +316,7 @@ class TestCaseQt(unittest.TestCase):
 
         See QTest.qSleep for details.
         """
-        QTest.qSleep(ms + self.TIMEOUT_WAIT)
+        QTest.qSleep(int(ms) + self.TIMEOUT_WAIT)
 
     @classmethod
     def qWait(cls, ms=None):
@@ -337,7 +337,7 @@ class TestCaseQt(unittest.TestCase):
                                    maxtime=timeout)
                 timeout = endTimeMS - int(time.time() * 1000)
         else:
-            QTest.qWait(ms + cls.TIMEOUT_WAIT)
+            QTest.qWait(int(ms) + cls.TIMEOUT_WAIT)
 
     def qWaitForWindowExposed(self, window, timeout=None):
         """Waits until the window is shown in the screen.

--- a/silx/gui/widgets/RangeSlider.py
+++ b/silx/gui/widgets/RangeSlider.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -606,9 +606,9 @@ class RangeSlider(qt.QWidget):
                                     -self._SLIDER_WIDTH, 0)
 
     def __sliderAreaRect(self):
-        return self.__drawArea().adjusted(self._SLIDER_WIDTH / 2.,
+        return self.__drawArea().adjusted(self._SLIDER_WIDTH // 2,
                                           0,
-                                          -self._SLIDER_WIDTH / 2. + 1,
+                                          -self._SLIDER_WIDTH // 2 + 1,
                                           0)
 
     def __pixMapRect(self):
@@ -722,7 +722,7 @@ class RangeSlider(qt.QWidget):
         buttonColor = option.palette.button().color()
         val = qt.qGray(buttonColor.rgb())
         buttonColor = buttonColor.lighter(100 + max(1, (180 - val) // 6))
-        buttonColor.setHsv(buttonColor.hue(), buttonColor.saturation() * 0.75, buttonColor.value())
+        buttonColor.setHsv(buttonColor.hue(), (buttonColor.saturation() * 3) // 4, buttonColor.value())
 
         grooveColor = qt.QColor()
         grooveColor.setHsv(buttonColor.hue(),


### PR DESCRIPTION
This PR fixes the following deprecation warning with python 3.8:
```
DeprecationWarning: an integer is required (got type float).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
```

Those were found in CI logs (see https://ci.appveyor.com/project/ESRF/silx/builds/30254806/job/p3800jrftcqxa9sr?fullLog=true), this PR does not fix this can of warning of Qt related calls.