### PR TITLE
Set the mode of h5py.File to remove deprecation warnings

### DIFF
--- a/doc/source/modules/gui/hdf5/getting_started.rst
+++ b/doc/source/modules/gui/hdf5/getting_started.rst
@@ -86,7 +86,7 @@ We can use directly h5py Files, Groups and Datasets.
 .. code-block:: python
 
    import h5py
-   h5 = h5py.File("test.h5")
+   h5 = h5py.File("test.h5", mode="r")
 
    # We can use file
    model.insertH5pyObject(h5)

--- a/examples/viewer3DVolume.py
+++ b/examples/viewer3DVolume.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -74,7 +74,7 @@ def load(filename):
         filename, path = filename.split('::')
         path, indices = path.split('#')[0], path.split('#')[1:]
 
-        with h5py.File(filename) as f:
+        with h5py.File(filename, mode='r') as f:
             data = f[path]
 
             # Loop through indices along first dimensions

--- a/silx/app/view/test/test_view.py
+++ b/silx/app/view/test/test_view.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -164,7 +164,7 @@ class TestDataPanel(TestCaseQt):
         self.assertIs(widget.getCustomNxdataItem(), data)
 
     def testRemoveDatasetsFrom(self):
-        f = h5py.File(os.path.join(_tmpDirectory, "data.h5"))
+        f = h5py.File(os.path.join(_tmpDirectory, "data.h5"), mode='r')
         try:
             widget = DataPanel()
             widget.setData(f["arrays/scalar"])
@@ -175,8 +175,8 @@ class TestDataPanel(TestCaseQt):
             f.close()
 
     def testReplaceDatasetsFrom(self):
-        f = h5py.File(os.path.join(_tmpDirectory, "data.h5"))
-        f2 = h5py.File(os.path.join(_tmpDirectory, "data2.h5"))
+        f = h5py.File(os.path.join(_tmpDirectory, "data.h5"), mode='r')
+        f2 = h5py.File(os.path.join(_tmpDirectory, "data2.h5"), mode='r')
         try:
             widget = DataPanel()
             widget.setData(f["arrays/scalar"])
@@ -243,7 +243,7 @@ class TestCustomNxdataWidget(TestCaseQt):
         self.assertFalse(item.isValid())
 
     def testRemoveDatasetsFrom(self):
-        f = h5py.File(os.path.join(_tmpDirectory, "data.h5"))
+        f = h5py.File(os.path.join(_tmpDirectory, "data.h5"), mode='r')
         try:
             widget = CustomNxdataWidget()
             model = widget.model()
@@ -255,8 +255,8 @@ class TestCustomNxdataWidget(TestCaseQt):
             f.close()
 
     def testReplaceDatasetsFrom(self):
-        f = h5py.File(os.path.join(_tmpDirectory, "data.h5"))
-        f2 = h5py.File(os.path.join(_tmpDirectory, "data2.h5"))
+        f = h5py.File(os.path.join(_tmpDirectory, "data.h5"), mode='r')
+        f2 = h5py.File(os.path.join(_tmpDirectory, "data2.h5"), mode='r')
         try:
             widget = CustomNxdataWidget()
             model = widget.model()

--- a/silx/gui/data/test/test_arraywidget.py
+++ b/silx/gui/data/test/test_arraywidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -199,7 +199,7 @@ class TestH5pyArrayWidget(TestCaseQt):
         # create an h5py file with a dataset
         self.tempdir = tempfile.mkdtemp()
         self.h5_fname = os.path.join(self.tempdir, "array.h5")
-        h5f = h5py.File(self.h5_fname)
+        h5f = h5py.File(self.h5_fname, mode='w')
         h5f["my_array"] = self.data
         h5f["my_scalar"] = 3.14
         h5f["my_1D_array"] = numpy.array(numpy.arange(1000))

--- a/silx/gui/dialog/DataFileDialog.py
+++ b/silx/gui/dialog/DataFileDialog.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -210,7 +210,7 @@ class DataFileDialog(AbstractDataFileDialog):
     .. code-block:: python
 
         url = dialog.selectedDataUrl()
-        with h5py.File(url.file_path()) as h5:
+        with h5py.File(url.file_path(), mode="r") as h5:
             data = h5[url.data_path()]
     """
 

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -179,7 +179,7 @@ class TestHdf5TreeModel(TestCaseQt):
 
     def testSynchronizeObject(self):
         filename = _tmpDirectory + "/data.h5"
-        h5 = h5py.File(filename)
+        h5 = h5py.File(filename, mode="r")
         model = hdf5.Hdf5TreeModel()
         model.insertH5pyObject(h5)
         self.assertEqual(model.rowCount(qt.QModelIndex()), 1)
@@ -256,7 +256,7 @@ class TestHdf5TreeModel(TestCaseQt):
         internally."""
         filename = _tmpDirectory + "/data.h5"
         try:
-            h5File = h5py.File(filename)
+            h5File = h5py.File(filename, mode="r")
             model = hdf5.Hdf5TreeModel()
             self.assertEqual(model.rowCount(qt.QModelIndex()), 0)
             model.insertH5pyObject(h5File)
@@ -391,7 +391,7 @@ class TestHdf5TreeModelSignals(TestCaseQt):
         TestCaseQt.setUp(self)
         self.model = hdf5.Hdf5TreeModel()
         filename = _tmpDirectory + "/data.h5"
-        self.h5 = h5py.File(filename)
+        self.h5 = h5py.File(filename, mode='r')
         self.model.insertH5pyObject(self.h5)
 
         self.listener = SignalListener()
@@ -418,7 +418,7 @@ class TestHdf5TreeModelSignals(TestCaseQt):
 
     def testInsert(self):
         filename = _tmpDirectory + "/data.h5"
-        h5 = h5py.File(filename)
+        h5 = h5py.File(filename, mode='r')
         self.model.insertH5pyObject(h5)
         self.assertEqual(self.listener.callCount(), 0)
 

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -849,7 +849,7 @@ def rawfile_to_h5_external_dataset(bin_file, output_url, shape, dtype,
         raise Exception('h5py >= 2.9 should be installed to access the '
                         'external feature.')
 
-    with h5py.File(output_url.file_path()) as _h5_file:
+    with h5py.File(output_url.file_path(), mode="a") as _h5_file:
         if output_url.data_path() in _h5_file:
             if overwrite is False:
                 raise ValueError('data_path already exists')


### PR DESCRIPTION
This PR makessure all call to `h5py.File` within silx provides the `mode` argument.
This prepare the code for `h5py` v3.0 and remove a deprecation warning.

closes #2892