### PR TITLE
Add colormap autoscale mode to plot3d parameter tree

### DIFF
--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -540,15 +540,16 @@ class Colormap(qt.QObject):
         return self._autoscaleMode
 
     def setAutoscaleMode(self, mode):
-        """Set the norm ('minmax' or 'stddev3')
+        """Set the autoscale mode: either 'minmax' or 'stddev3'
 
         :param str mode: the mode to set
         """
         if self.isEditable() is False:
             raise NotEditableError('Colormap is not editable')
         assert mode in self.AUTOSCALE_MODES
-        self._autoscaleMode = mode
-        self.sigChanged.emit()
+        if mode != self._autoscaleMode:
+            self._autoscaleMode = mode
+            self.sigChanged.emit()
 
     def isAutoscale(self):
         """Return True if both min and max are in autoscale mode"""

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -644,8 +644,8 @@ class Colormap(qt.QObject):
                 normdata = numpy.log10(data)
                 mean = numpy.nanmean(normdata)
                 std = numpy.nanstd(normdata)
-                vMin = 10**(mean - 3 * std)
-                vMax = 10**(mean + 3 * std)
+                vMin = float(10**(mean - 3 * std))
+                vMax = float(10**(mean + 3 * std))
             else:
                 assert False
         else:
@@ -654,7 +654,7 @@ class Colormap(qt.QObject):
             elif self._autoscaleMode == Colormap.STDDEV3:
                 mean = numpy.nanmean(data)
                 std = numpy.nanstd(data)
-                vMin, vMax = mean - 3 * std, mean + 3 * std
+                vMin, vMax = float(mean - 3 * std), float(mean + 3 * std)
             else:
                 assert False
         return vMin, vMax

--- a/silx/gui/plot3d/_model/items.py
+++ b/silx/gui/plot3d/_model/items.py
@@ -862,6 +862,14 @@ class ColormapRow(_ColormapBaseProxyRow):
             notify=self._sigColormapChanged,
             editorHint=norms))
 
+        modes = [mode.title() for mode in self._colormap.AUTOSCALE_MODES]
+        self.addRow(ProxyRow(
+            name='Autoscale Mode',
+            fget=self._getAutoscaleMode,
+            fset=self._setAutoscaleMode,
+            notify=self._sigColormapChanged,
+            editorHint=modes))
+
         self.addRow(_ColormapBoundRow(item, name='Min.', index=0))
         self.addRow(_ColormapBoundRow(item, name='Max.', index=1))
 
@@ -907,6 +915,18 @@ class ColormapRow(_ColormapBaseProxyRow):
         """Proxy for :meth:`Colormap.setNormalization`"""
         if self._colormap is not None:
             return self._colormap.setNormalization(normalization.lower())
+
+    def _getAutoscaleMode(self):
+        """Proxy for :meth:`Colormap.getAutoscaleMode`"""
+        if self._colormap is not None:
+            return self._colormap.getAutoscaleMode().title()
+        else:
+            return ''
+
+    def _setAutoscaleMode(self, mode):
+        """Proxy for :meth:`Colormap.setAutoscaleMode`"""
+        if self._colormap is not None:
+            return self._colormap.setAutoscaleMode(mode.lower())
 
     def _updateColormapImage(self, *args, **kwargs):
         """Notify colormap update to update the image in the tree"""


### PR DESCRIPTION
This PR follows PR #2877 and integrates the autoscale mode in the `plot3d` parameter tree.

The parameter tree doesn't like `numpy.float64`, so I cast the stddev3 colormap range to `float` (as is the minmax range).