### PR TITLE
[plot] Fix crosshair offset issue with right axis

### DIFF
--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1270,17 +1270,22 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
 
     def _onMouseMove(self, event):
         if self._graphCursor:
+            position = self._plot.pixelToData(
+                event.x,
+                self._mplQtYAxisCoordConversion(event.y),
+                axis='left',
+                check=True)
             lineh, linev = self._graphCursor
-            if event.inaxes not in (self.ax, self.ax2) and lineh.get_visible():
-                lineh.set_visible(False)
-                linev.set_visible(False)
-                self._plot._setDirtyPlot(overlayOnly=True)
-            else:
+            if position is not None:
                 linev.set_visible(True)
-                linev.set_xdata((event.xdata, event.xdata))
+                linev.set_xdata((position[0], position[0]))
                 lineh.set_visible(True)
-                lineh.set_ydata((event.ydata, event.ydata))
+                lineh.set_ydata((position[1], position[1]))
                 self._plot._setDirtyPlot(overlayOnly=True)
+            elif lineh.get_visible():
+                    lineh.set_visible(False)
+                    linev.set_visible(False)
+                    self._plot._setDirtyPlot(overlayOnly=True)
             # onMouseMove must trigger replot if dirty flag is raised
 
         self._plot.onMouseMove(


### PR DESCRIPTION
This PR fixes an issue with the crosshair being displayed with an offset when the right y axis is on.
The issue was due to matplotlib events being received in right Y axes, while crosshair lines are displayed in the left Y axes.

closes #2899

If we make a 0.12.1, this should be included in it.