### PR TITLE
Plot item objet API

### DIFF
--- a/examples/fftPlotAction.py
+++ b/examples/fftPlotAction.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -110,7 +110,7 @@ class FftAction(PlotAction):
         for curve in allCurves:
             x = curve.getXData()
             y = curve.getYData()
-            legend = curve.getLegend()
+            legend = curve.getName()
             info = curve.getInfo()
             if info is None:
                 info = {}

--- a/examples/plotCurveLegendWidget.py
+++ b/examples/plotCurveLegendWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -71,7 +71,7 @@ class MyCurveLegendsWidget(CurveLegendsWidget):
         """
         plot = curve.getPlot()
         plot.setActiveCurve(
-            curve.getLegend() if curve != plot.getActiveCurve() else None)
+            curve.getName() if curve != plot.getActiveCurve() else None)
 
     def _switchCurveVisibility(self, curve):
         """Toggle the visibility of a curve

--- a/examples/plotItemsSelector.py
+++ b/examples/plotItemsSelector.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -49,7 +49,7 @@ isd.setItemsSelectionMode(qt.QTableWidget.ExtendedSelection)
 result = isd.exec_()
 if result:
     for item in isd.getSelectedItems():
-        print(item.getLegend(), type(item))
+        print(item.getName(), type(item))
 else:
     print("Selection cancelled")
 

--- a/silx/gui/plot/ComplexImageView.py
+++ b/silx/gui/plot/ComplexImageView.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -289,7 +289,7 @@ class ComplexImageView(qt.QWidget):
         self._plotImage = ImageComplexData()
         self._plotImage._setLegend('__ComplexImageView__complex_image__')
         self._plotImage.sigItemChanged.connect(self._itemChanged)
-        self._plot2D._add(self._plotImage)
+        self._plot2D.addItem(self._plotImage)
         self._plot2D.setActiveImage(self._plotImage.getLegend())
 
         toolBar = qt.QToolBar('Complex', self)

--- a/silx/gui/plot/ComplexImageView.py
+++ b/silx/gui/plot/ComplexImageView.py
@@ -290,7 +290,7 @@ class ComplexImageView(qt.QWidget):
         self._plotImage.setName('__ComplexImageView__complex_image__')
         self._plotImage.sigItemChanged.connect(self._itemChanged)
         self._plot2D.addItem(self._plotImage)
-        self._plot2D.setActiveImage(self._plotImage.getLegend())
+        self._plot2D.setActiveImage(self._plotImage.getName())
 
         toolBar = qt.QToolBar('Complex', self)
         toolBar.addWidget(

--- a/silx/gui/plot/ComplexImageView.py
+++ b/silx/gui/plot/ComplexImageView.py
@@ -287,7 +287,7 @@ class ComplexImageView(qt.QWidget):
 
         # Create and add image to the plot
         self._plotImage = ImageComplexData()
-        self._plotImage._setLegend('__ComplexImageView__complex_image__')
+        self._plotImage.setName('__ComplexImageView__complex_image__')
         self._plotImage.sigItemChanged.connect(self._itemChanged)
         self._plot2D.addItem(self._plotImage)
         self._plot2D.setActiveImage(self._plotImage.getLegend())

--- a/silx/gui/plot/ItemsSelectionDialog.py
+++ b/silx/gui/plot/ItemsSelectionDialog.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -149,7 +149,7 @@ class PlotItemsSelector(qt.QTableWidget):
         i = 0
         for kind in self.plot_item_kinds:
             for plot_item in self.plot._getItems(kind=kind):
-                legend_twitem = qt.QTableWidgetItem(plot_item.getLegend())
+                legend_twitem = qt.QTableWidgetItem(plot_item.getName())
                 self.setItem(i, 0, legend_twitem)
 
                 kind_twitem = qt.QTableWidgetItem(kind)
@@ -192,7 +192,7 @@ class ItemsSelectionDialog(qt.QDialog):
         result = isd.exec_()
         if result:
             for item in isd.getSelectedItems():
-                print(item.getLegend(), type(item))
+                print(item.getName(), type(item))
         else:
             print("Selection cancelled")
     """

--- a/silx/gui/plot/LegendSelector.py
+++ b/silx/gui/plot/LegendSelector.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -925,7 +925,7 @@ class LegendsDockWidget(qt.QDockWidget):
             yaxis = 'right' if ddict['event'] == 'mapToRight' else 'left'
             self.plot.addCurve(x=curve.getXData(copy=False),
                                y=curve.getYData(copy=False),
-                               legend=curve.getLegend(),
+                               legend=curve.getName(),
                                info=curve.getInfo(),
                                yaxis=yaxis)
 
@@ -935,7 +935,7 @@ class LegendsDockWidget(qt.QDockWidget):
             symbol = ddict['symbol'] if ddict['points'] else ''
             self.plot.addCurve(x=curve.getXData(copy=False),
                                y=curve.getYData(copy=False),
-                               legend=curve.getLegend(),
+                               legend=curve.getName(),
                                info=curve.getInfo(),
                                symbol=symbol)
 
@@ -945,7 +945,7 @@ class LegendsDockWidget(qt.QDockWidget):
             linestyle = ddict['linestyle'] if ddict['line'] else ''
             self.plot.addCurve(x=curve.getXData(copy=False),
                                y=curve.getYData(copy=False),
-                               legend=curve.getLegend(),
+                               legend=curve.getName(),
                                info=curve.getInfo(),
                                linestyle=linestyle)
 
@@ -957,7 +957,7 @@ class LegendsDockWidget(qt.QDockWidget):
         """
         legendList = []
         for curve in self.plot.getAllCurves(withhidden=True):
-            legend = curve.getLegend()
+            legend = curve.getName()
             # Use active color if curve is active
             isActive = legend == self.plot.getActiveCurve(just_legend=True)
             style = curve.getCurrentStyle()

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -351,7 +351,7 @@ class MaskToolsWidget(BaseMaskToolsWidget):
             mustBeAdded = maskItem is None
             if mustBeAdded:
                 maskItem = items.MaskImageData()
-                maskItem._setLegend(self._maskName)
+                maskItem.setName(self._maskName)
             # update the items
             maskItem.setData(mask, copy=False)
             maskItem.setColormap(self._colormap)

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -319,7 +319,7 @@ class MaskToolsWidget(BaseMaskToolsWidget):
         # ensure all mask attributes are synchronized with the active image
         # and connect listener
         activeImage = self.plot.getActiveImage()
-        if activeImage is not None and activeImage.getLegend() != self._maskName:
+        if activeImage is not None and activeImage.getName() != self._maskName:
             self._activeImageChanged()
             self.plot.sigActiveImageChanged.connect(self._activeImageChanged)
 
@@ -407,7 +407,7 @@ class MaskToolsWidget(BaseMaskToolsWidget):
         removed, otherwise it is adjusted to origin, scale and z.
         """
         activeImage = self.plot.getActiveImage()
-        if activeImage is None or activeImage.getLegend() == self._maskName:
+        if activeImage is None or activeImage.getName() == self._maskName:
             # No active image or active image is the mask...
             self._data = numpy.zeros((0, 0), dtype=numpy.uint8)
             self._mask.setDataItem(None)
@@ -443,7 +443,7 @@ class MaskToolsWidget(BaseMaskToolsWidget):
     def _activeImageChanged(self, *args):
         """Update widget and mask according to active image changes"""
         activeImage = self.plot.getActiveImage()
-        if (activeImage is None or activeImage.getLegend() == self._maskName or
+        if (activeImage is None or activeImage.getName() == self._maskName or
                 activeImage.getData(copy=False).size == 0):
             # No active image or active image is the mask or image has no data...
             self.setEnabled(False)
@@ -770,7 +770,7 @@ class MaskToolsWidget(BaseMaskToolsWidget):
         """Set range from active image colormap range"""
         activeImage = self.plot.getActiveImage()
         if (isinstance(activeImage, items.ColormapMixIn) and
-                activeImage.getLegend() != self._maskName):
+                activeImage.getName() != self._maskName):
             # Update thresholds according to colormap
             colormap = activeImage.getColormap()
             if colormap['autoscale']:

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -360,7 +360,7 @@ class MaskToolsWidget(BaseMaskToolsWidget):
             maskItem.setZValue(self._z)
 
             if mustBeAdded:
-                self.plot._add(maskItem)
+                self.plot.addItem(maskItem)
 
         elif self.plot.getImage(self._maskName):
             self.plot.remove(self._maskName, kind='image')

--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -1,7 +1,7 @@
 #  coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1087,7 +1087,7 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
                 dataPos = self.machine.plot.pixelToData(x, y)
                 assert dataPos is not None
                 eventDict = prepareHoverSignal(
-                    marker.getLegend(), 'marker',
+                    marker.getName(), 'marker',
                     dataPos, (x, y),
                     marker.isDraggable(),
                     marker.isSelectable())
@@ -1169,7 +1169,7 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
 
                 eventDict = prepareMarkerSignal('markerClicked',
                                                 'left',
-                                                item.getLegend(),
+                                                item.getName(),
                                                 'marker',
                                                 item.isDraggable(),
                                                 item.isSelectable(),
@@ -1186,7 +1186,7 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
 
                 indices = result.getIndices(copy=False)
                 eventDict = prepareCurveSignal('left',
-                                               item.getLegend(),
+                                               item.getName(),
                                                'curve',
                                                xData[indices],
                                                yData[indices],
@@ -1201,7 +1201,7 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
                 indices = result.getIndices(copy=False)
                 row, column = indices[0][0], indices[1][0]
                 eventDict = prepareImageSignal('left',
-                                               item.getLegend(),
+                                               item.getName(),
                                                'image',
                                                column, row,
                                                dataPos[0], dataPos[1],
@@ -1224,7 +1224,7 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
 
         eventDict = prepareMarkerSignal(eventType,
                                         'left',
-                                        marker.getLegend(),
+                                        marker.getName(),
                                         'marker',
                                         marker.isDraggable(),
                                         marker.isSelectable(),
@@ -1292,7 +1292,7 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
             eventDict = prepareMarkerSignal(
                 'markerMoved',
                 'left',
-                item.getLegend(),
+                item.getName(),
                 'marker',
                 item.isDraggable(),
                 item.isSelectable(),

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -939,7 +939,7 @@ class PlotWidget(qt.QMainWindow):
                     self.removeItem(c)
 
         if mustBeAdded:
-            self._add(curve)
+            self.addItem(curve)
         else:
             self._notifyContentChanged(curve)
 
@@ -1031,7 +1031,7 @@ class PlotWidget(qt.QMainWindow):
                       align=align, copy=copy)
 
         if mustBeAdded:
-            self._add(histo)
+            self.addItem(histo)
         else:
             self._notifyContentChanged(histo)
 
@@ -1168,7 +1168,7 @@ class PlotWidget(qt.QMainWindow):
                     self.removeItem(img)
 
         if mustBeAdded:
-            self._add(image)
+            self.addItem(image)
         else:
             self._notifyContentChanged(image)
 
@@ -1275,7 +1275,7 @@ class PlotWidget(qt.QMainWindow):
             scatter.setData(x, y, value, xerror, yerror, copy=copy)
 
         if mustBeAdded:
-            self._add(scatter)
+            self.addItem(scatter)
         else:
             self._notifyContentChanged(scatter)
 
@@ -1350,7 +1350,7 @@ class PlotWidget(qt.QMainWindow):
         item.setLineWidth(linewidth)
         item.setLineBgColor(linebgcolor)
 
-        self._add(item)
+        self.addItem(item)
 
         return legend
 
@@ -1558,7 +1558,7 @@ class PlotWidget(qt.QMainWindow):
         marker.setPosition(x, y)
 
         if mustBeAdded:
-            self._add(marker)
+            self.addItem(marker)
         else:
             self._notifyContentChanged(marker)
 

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -940,7 +940,7 @@ class PlotWidget(qt.QMainWindow):
         if replace:  # Then remove all other curves
             for c in self.getAllCurves(withhidden=True):
                 if c is not curve:
-                    self._remove(c)
+                    self.removeItem(c)
 
         if mustBeAdded:
             self._add(curve)
@@ -1119,7 +1119,7 @@ class PlotWidget(qt.QMainWindow):
             # Update a data image with RGBA image or the other way around:
             # Remove previous image
             # In this case, we don't retrieve defaults from the previous image
-            self._remove(image)
+            self.removeItem(image)
             image = None
 
         mustBeAdded = image is None
@@ -1169,7 +1169,7 @@ class PlotWidget(qt.QMainWindow):
         if replace:
             for img in self.getAllImages():
                 if img is not image:
-                    self._remove(img)
+                    self.removeItem(img)
 
         if mustBeAdded:
             self._add(image)
@@ -1534,7 +1534,7 @@ class PlotWidget(qt.QMainWindow):
         if marker is not None and not isinstance(marker, markerClass):
             _logger.warning('Adding marker with same legend'
                             ' but different type replaces it')
-            self._remove(marker)
+            self.removeItem(marker)
             marker = None
 
         mustBeAdded = marker is None
@@ -1646,7 +1646,7 @@ class PlotWidget(qt.QMainWindow):
             for aKind in kind:
                 item = self._getItem(aKind, legend)
                 if item is not None:
-                    self._remove(item)
+                    self.removeItem(item)
 
     def removeCurve(self, legend):
         """Remove the curve associated to legend from the graph.

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -610,7 +610,7 @@ class PlotWidget(qt.QMainWindow):
         else:
             raise ValueError('Unsupported item type %s' % type(item))
 
-        return item.getLegend(), kind
+        return item.getName(), kind
 
     def _notifyContentChanged(self, item):
         legend, kind = self._itemKey(item)
@@ -938,13 +938,13 @@ class PlotWidget(qt.QMainWindow):
             self._notifyContentChanged(curve)
 
         if wasActive:
-            self.setActiveCurve(curve.getLegend())
+            self.setActiveCurve(curve.getName())
         elif self.getActiveCurveSelectionMode() == "legacy":
             if self.getActiveCurve(just_legend=True) is None:
                 if len(self.getAllCurves(just_legend=True,
                                      withhidden=False)) == 1:
                     if curve.isVisible():
-                        self.setActiveCurve(curve.getLegend())
+                        self.setActiveCurve(curve.getName())
 
         if resetzoom:
             # We ask for a zoom reset in order to handle the plot scaling
@@ -1274,7 +1274,7 @@ class PlotWidget(qt.QMainWindow):
             self._notifyContentChanged(scatter)
 
         if len(self._getItems(kind="scatter")) == 1 or wasActive:
-            self._setActiveItem('scatter', scatter.getLegend())
+            self._setActiveItem('scatter', scatter.getName())
 
         return legend
 
@@ -1884,7 +1884,7 @@ class PlotWidget(qt.QMainWindow):
                                            withhidden=False)
                 if len(curves) == 1:
                     if curves[0].isVisible():
-                        self.setActiveCurve(curves[0].getLegend())
+                        self.setActiveCurve(curves[0].getName())
 
     def getActiveCurveSelectionMode(self):
         """Returns the current selection mode.
@@ -2003,7 +2003,7 @@ class PlotWidget(qt.QMainWindow):
             if oldActiveItem is None:
                 oldActiveLegend = None
             else:
-                oldActiveLegend = oldActiveItem.getLegend()
+                oldActiveLegend = oldActiveItem.getName()
             self.notify(
                 'active' + kind[0].upper() + kind[1:] + 'Changed',
                 updated=oldActiveLegend != activeLegend,

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -706,6 +706,9 @@ class PlotWidget(qt.QMainWindow):
         self.notify('contentChanged', action='remove',
                     kind=kind, legend=legend)
 
+    @deprecated(replacement='addItem', since_version='0.13')
+    def _add(self, item):
+        return self.addItem(item)
 
     @deprecated(replacement='removeItem', since_version='0.13')
     def _remove(self, item):

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -876,7 +876,7 @@ class PlotWidget(qt.QMainWindow):
         if curve is None:
             # No previous curve, create a default one and add it to the plot
             curve = items.Curve() if histogram is None else items.Histogram()
-            curve._setLegend(legend)
+            curve.setName(legend)
             # Set default color, linestyle and symbol
             default_color, default_linestyle = self._getColorAndStyle()
             curve.setColor(default_color)
@@ -1009,7 +1009,7 @@ class PlotWidget(qt.QMainWindow):
             # No previous histogram, create a default one and
             # add it to the plot
             histo = items.Histogram()
-            histo._setLegend(legend)
+            histo.setName(legend)
             histo.setColor(self._getColorAndStyle()[0])
 
         # Override previous/default values with provided ones
@@ -1120,7 +1120,7 @@ class PlotWidget(qt.QMainWindow):
                 image.setColormap(self.getDefaultColormap())
             else:
                 image = items.ImageRgba()
-            image._setLegend(legend)
+            image.setName(legend)
 
         # Do not emit sigActiveImageChanged,
         # it will be sent once with _setActiveItem
@@ -1236,7 +1236,7 @@ class PlotWidget(qt.QMainWindow):
         if scatter is None:
             # No previous scatter, create a default one and add it to the plot
             scatter = items.Scatter()
-            scatter._setLegend(legend)
+            scatter.setName(legend)
             scatter.setColormap(self.getDefaultColormap())
 
         # Do not emit sigActiveScatterChanged,
@@ -1333,7 +1333,7 @@ class PlotWidget(qt.QMainWindow):
             self.remove(legend, kind='item')
 
         item = items.Shape(shape)
-        item._setLegend(legend)
+        item.setName(legend)
         item.setInfo(info)
         item.setColor(color)
         item.setFill(fill)
@@ -1531,7 +1531,7 @@ class PlotWidget(qt.QMainWindow):
         if marker is None:
             # No previous marker, create one
             marker = markerClass()
-            marker._setLegend(legend)
+            marker.setName(legend)
 
         if text is not None:
             marker.setText(text)

--- a/silx/gui/plot/ScatterMaskToolsWidget.py
+++ b/silx/gui/plot/ScatterMaskToolsWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -318,7 +318,7 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
         # check that content changed was the active scatter
         activeScatter = self.plot._getActiveItem(kind="scatter")
 
-        if activeScatter is None or activeScatter.getLegend() == self._maskName:
+        if activeScatter is None or activeScatter.getName() == self._maskName:
             # No active scatter or active scatter is the mask...
             self.plot.sigActiveScatterChanged.disconnect(
                 self._activeScatterChangedAfterCare)
@@ -347,7 +347,7 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
         """Update widget and mask according to active scatter changes"""
         activeScatter = self.plot._getActiveItem(kind="scatter")
 
-        if activeScatter is None or activeScatter.getLegend() == self._maskName:
+        if activeScatter is None or activeScatter.getName() == self._maskName:
             # No active scatter or active scatter is the mask...
             self.setEnabled(False)
 

--- a/silx/gui/plot/StatsWidget.py
+++ b/silx/gui/plot/StatsWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -198,10 +198,10 @@ class _PlotWidgetWrapper(_Wrapper):
             kind = self.getKind(item)
             if kind in plot._ACTIVE_ITEM_KINDS:
                 if plot._getActiveItem(kind) != item:
-                    plot._setActiveItem(kind, item.getLegend())
+                    plot._setActiveItem(kind, item.getName())
 
     def getLabel(self, item):
-        return item.getLegend()
+        return item.getName()
 
     def getKind(self, item):
         if isinstance(item, plotitems.Curve):

--- a/silx/gui/plot/actions/fit.py
+++ b/silx/gui/plot/actions/fit.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -143,7 +143,7 @@ class FitAction(PlotToolAction):
             # presence of a unique or active curve
             item = curve
 
-        self.legend = item.getLegend()
+        self.legend = item.getName()
 
         if isinstance(item, Histogram):
             bin_edges = item.getBinEdgesData(copy=False)

--- a/silx/gui/plot/actions/medfilt.py
+++ b/silx/gui/plot/actions/medfilt.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -89,7 +89,7 @@ class MedianFilterAction(PlotToolAction):
             self._legend = None
         else:
             self._originalImage = self.plot.getImage(self._activeImageLegend).getData(copy=False)
-            self._legend = self.plot.getImage(self._activeImageLegend).getLegend()
+            self._legend = self.plot.getImage(self._activeImageLegend).getName()
 
     def _updateFilter(self, kernelWidth, conditional=False):
         if self._originalImage is None:

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -171,7 +171,7 @@ class Item(qt.QObject):
         self._info = None
         self._xlabel = None
         self._ylabel = None
-        self.__name = None
+        self.__name = ''
 
         self._backendRenderer = None
 

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -233,14 +233,14 @@ class Item(qt.QObject):
         return False
 
     def getName(self):
-        """Returns the name of the item.
+        """Returns the name of the item which is used as legend.
 
         :rtype: str
         """
         return self.__name
 
     def setName(self, name):
-        """Set the name of the item
+        """Set the name of the item which is used as legend.
 
         :param str name: New name of the item
         :raises RuntimeError: If item belongs to a PlotWidget.

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -178,9 +178,9 @@ class Item(qt.QObject):
         self._backendRenderer = None
 
     def getPlot(self):
-        """Returns Plot this item belongs to.
+        """Returns the ~silx.gui.plot.PlotWidget this item belongs to.
 
-        :rtype: Plot or None
+        :rtype: Union[~silx.gui.plot.PlotWidget,None]
         """
         return None if self._plotRef is None else self._plotRef()
 
@@ -189,7 +189,7 @@ class Item(qt.QObject):
 
         WARNING: This should only be called from the Plot.
 
-        :param Plot plot: The Plot instance.
+        :param Union[~silx.gui.plot.PlotWidget,None] plot: The Plot instance.
         """
         if plot is not None and self._plotRef is not None:
             raise RuntimeError('Trying to add a node at two places.')

--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -228,7 +228,7 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn,
         elif item == 1:
             return self.getYData(copy=False)
         elif item == 2:
-            return self.getLegend()
+            return self.getName()
         elif item == 3:
             info = self.getInfo(copy=False)
             return {} if info is None else info

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -108,7 +108,7 @@ class ImageBase(Item, LabelsMixIn, DraggableMixIn, AlphaMixIn):
         elif item == 0:
             return self.getData(copy=False)
         elif item == 1:
-            return self.getLegend()
+            return self.getName()
         elif item == 2:
             info = self.getInfo(copy=False)
             return {} if info is None else info

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -376,14 +376,14 @@ class RegionOfInterest(_RegionOfInterestBase):
         if self._labelItem is None:
             self._labelItem = self._createLabelItem()
             if self._labelItem is not None:
-                self._labelItem._setLegend(legendPrefix + "label")
+                self._labelItem.setName(legendPrefix + "label")
                 plot.addItem(self._labelItem)
                 self._labelItem.setVisible(self.isVisible())
 
         self._items = WeakList()
         plotItems = self._createShapeItems(controlPoints)
         for item in plotItems:
-            item._setLegend(legendPrefix + str(itemIndex))
+            item.setName(legendPrefix + str(itemIndex))
             plot.addItem(item)
             item.setVisible(self.isVisible())
             self._items.append(item)
@@ -395,7 +395,7 @@ class RegionOfInterest(_RegionOfInterestBase):
             color = rgba(self.getColor())
             color = self._getAnchorColor(color)
             for index, item in enumerate(plotItems):
-                item._setLegend(legendPrefix + str(itemIndex))
+                item.setName(legendPrefix + str(itemIndex))
                 item.setColor(color)
                 item.setVisible(self.isVisible())
                 plot.addItem(item)

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -377,14 +377,14 @@ class RegionOfInterest(_RegionOfInterestBase):
             self._labelItem = self._createLabelItem()
             if self._labelItem is not None:
                 self._labelItem._setLegend(legendPrefix + "label")
-                plot._add(self._labelItem)
+                plot.addItem(self._labelItem)
                 self._labelItem.setVisible(self.isVisible())
 
         self._items = WeakList()
         plotItems = self._createShapeItems(controlPoints)
         for item in plotItems:
             item._setLegend(legendPrefix + str(itemIndex))
-            plot._add(item)
+            plot.addItem(item)
             item.setVisible(self.isVisible())
             self._items.append(item)
             itemIndex += 1
@@ -398,7 +398,7 @@ class RegionOfInterest(_RegionOfInterestBase):
                 item._setLegend(legendPrefix + str(itemIndex))
                 item.setColor(color)
                 item.setVisible(self.isVisible())
-                plot._add(item)
+                plot.addItem(item)
                 # connect item changed
                 item.sigItemChanged.connect(functools.partial(
                     self._controlPointAnchorChanged, index))

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -492,7 +492,7 @@ class RegionOfInterest(_RegionOfInterestBase):
 
             plot = item.getPlot()
             if plot is not None:
-                plot._remove(item)
+                plot.removeItem(item)
         self._items = WeakList()
         self._editAnchors = WeakList()
 
@@ -500,7 +500,7 @@ class RegionOfInterest(_RegionOfInterestBase):
             item = self._labelItem
             plot = item.getPlot()
             if plot is not None:
-                plot._remove(item)
+                plot.removeItem(item)
         self._labelItem = None
 
     def _updated(self, event=None, checkVisibility=True):

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1350,7 +1350,7 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
     def testBoundingRectItem(self):
         item = BoundingRect()
         item.setBounds((-1000, 1000, -2000, 2000))
-        self.plot._add(item)
+        self.plot.addItem(item)
         self.plot.resetZoom()
         limits = numpy.array(self.plot.getXAxis().getLimits())
         numpy.testing.assert_almost_equal(limits, numpy.array([-1000, 1000]))
@@ -1361,7 +1361,7 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         item = BoundingRect()
         item.setYAxis("right")
         item.setBounds((-1000, 1000, -2000, 2000))
-        self.plot._add(item)
+        self.plot.addItem(item)
         self.plot.resetZoom()
         limits = numpy.array(self.plot.getXAxis().getLimits())
         numpy.testing.assert_almost_equal(limits, numpy.array([-1000, 1000]))
@@ -1377,7 +1377,7 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
 
     def testBoundingRectWithLog(self):
         item = BoundingRect()
-        self.plot._add(item)
+        self.plot.addItem(item)
 
         item.setBounds((-1000, 1000, -2000, 2000))
         self.plot.getXAxis()._setLogarithmic(True)

--- a/silx/gui/plot/test/testPlotWidgetNoBackend.py
+++ b/silx/gui/plot/test/testPlotWidgetNoBackend.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -401,21 +401,21 @@ class TestPlotGetCurveImage(unittest.TestCase):
 
         # Active curve
         active = plot.getActiveCurve()
-        self.assertEqual(active.getLegend(), 'curve 0')
+        self.assertEqual(active.getName(), 'curve 0')
         curve = plot.getCurve()
-        self.assertEqual(curve.getLegend(), 'curve 0')
+        self.assertEqual(curve.getName(), 'curve 0')
 
         # No active curve and curves
         plot.setActiveCurveHandling(False)
         active = plot.getActiveCurve()
         self.assertIsNone(active)  # No active curve
         curve = plot.getCurve()
-        self.assertEqual(curve.getLegend(), 'curve 2')  # Last added curve
+        self.assertEqual(curve.getName(), 'curve 2')  # Last added curve
 
         # Last curve hidden
         plot.hideCurve('curve 2', True)
         curve = plot.getCurve()
-        self.assertEqual(curve.getLegend(), 'curve 1')  # Last added curve
+        self.assertEqual(curve.getName(), 'curve 1')  # Last added curve
 
         # All curves hidden
         plot.hideCurve('curve 1', True)
@@ -466,9 +466,9 @@ class TestPlotGetCurveImage(unittest.TestCase):
 
         # Active image
         active = plot.getActiveImage()
-        self.assertEqual(active.getLegend(), 'image 0')
+        self.assertEqual(active.getName(), 'image 0')
         image = plot.getImage()
-        self.assertEqual(image.getLegend(), 'image 0')
+        self.assertEqual(image.getName(), 'image 0')
 
         # No active image
         plot.addImage(((0, 1), (2, 3)), legend='image 2')
@@ -476,14 +476,14 @@ class TestPlotGetCurveImage(unittest.TestCase):
         active = plot.getActiveImage()
         self.assertIsNone(active)
         image = plot.getImage()
-        self.assertEqual(image.getLegend(), 'image 2')
+        self.assertEqual(image.getName(), 'image 2')
 
         # Active image
         plot.setActiveImage('image 1')
         active = plot.getActiveImage()
-        self.assertEqual(active.getLegend(), 'image 1')
+        self.assertEqual(active.getName(), 'image 1')
         image = plot.getImage()
-        self.assertEqual(image.getLegend(), 'image 1')
+        self.assertEqual(image.getName(), 'image 1')
 
     def testGetImageOldApi(self):
         """PlotWidget.getImage and PlotWidget.getActiveImage old API tests"""
@@ -522,8 +522,8 @@ class TestPlotGetCurveImage(unittest.TestCase):
         self.assertEqual(list(images), ['1', '2'])
         images = plot.getAllImages(just_legend=False)
         self.assertEqual(len(images), 2)
-        self.assertEqual(images[0].getLegend(), '1')
-        self.assertEqual(images[1].getLegend(), '2')
+        self.assertEqual(images[0].getName(), '1')
+        self.assertEqual(images[1].getName(), '2')
 
 
 class TestPlotAddScatter(unittest.TestCase):
@@ -544,7 +544,7 @@ class TestPlotAddScatter(unittest.TestCase):
 
         # Active scatter
         active = plot._getActiveItem(kind='scatter')
-        self.assertEqual(active.getLegend(), 'scatter 0')
+        self.assertEqual(active.getName(), 'scatter 0')
 
         # check default values
         self.assertAlmostEqual(active.getSymbolSize(), active._DEFAULT_SYMBOL_SIZE)
@@ -563,7 +563,7 @@ class TestPlotAddScatter(unittest.TestCase):
         self.assertAlmostEqual(s0.getAlpha(), 0.777)
 
         scatter1 = plot._getItem(kind='scatter', legend='scatter 1')
-        self.assertEqual(scatter1.getLegend(), 'scatter 1')
+        self.assertEqual(scatter1.getName(), 'scatter 1')
 
     def testGetAllScatters(self):
         """PlotWidget.getAllImages test"""
@@ -579,8 +579,8 @@ class TestPlotAddScatter(unittest.TestCase):
 
         scatters = plot._getItems(kind='scatter')
         self.assertEqual(len(scatters), 3)
-        self.assertEqual(scatters[0].getLegend(), 'scatter 0')
-        self.assertEqual(scatters[2].getLegend(), 'scatter 2')
+        self.assertEqual(scatters[0].getName(), 'scatter 0')
+        self.assertEqual(scatters[2].getName(), 'scatter 2')
 
         scatters = plot._getItems(kind='scatter', just_legend=True)
         self.assertEqual(len(scatters), 3)

--- a/silx/gui/plot/test/testPlotWindow.py
+++ b/silx/gui/plot/test/testPlotWindow.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -125,7 +125,7 @@ class TestPlotWindow(TestCaseQt):
             # Remove and add again the same item
             image = self.plot.getImage("foo")
             self.plot.removeImage("foo")
-            self.plot._add(image)
+            self.plot.addItem(image)
             self.qWait(50)
         finally:
             Colormap._computeAutoscaleRange = old

--- a/silx/gui/plot/tools/CurveLegendsWidget.py
+++ b/silx/gui/plot/tools/CurveLegendsWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -62,7 +62,7 @@ class _LegendWidget(qt.QWidget):
         icon = _LegendIcon(curve=curve)
         layout.addWidget(icon)
 
-        label = qt.QLabel(curve.getLegend())
+        label = qt.QLabel(curve.getName())
         label.setAlignment(qt.Qt.AlignLeft | qt.Qt.AlignVCenter)
         layout.addWidget(label)
 
@@ -184,12 +184,12 @@ class CurveLegendsWidget(qt.QWidget):
     def _itemAdded(self, item):
         """Handle item added to the plot content"""
         if isinstance(item, items.Curve):
-            self._addLegend(item.getLegend())
+            self._addLegend(item.getName())
 
     def _itemRemoved(self, item):
         """Handle item removed from the plot content"""
         if isinstance(item, items.Curve):
-            self._removeLegend(item.getLegend())
+            self._removeLegend(item.getName())
 
     def _addLegend(self, legend):
         """Add a curve to the legends


### PR DESCRIPTION
This PR completes the objet orient plot item API by making `add|removeItem` the public version of `_add` and `_remove`, so one can instanciate and item and add it to the plot.

With `sigItemAdded`, `sigItemAboutToBeRemoved` and `getItems` to me, the API is completed.
Compatibility of `add|removeItem` is maintained (with a deprecation).

TODO:  handle item legends: init with a unique default legend.
