### PR TITLE
Consistent plot backend image picking

### DIFF
--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -916,37 +916,21 @@ class Plot2D(PlotWindow):
         :param float y: Y position in plot coordinates
         :return: The value at that point or '-'
         """
-        value = '-'
-        valueZ = -float('inf')
-        mask = 0
-        maskZ = -float('inf')
+        for picked in self.pickItems(
+                *self.dataToPixel(x, y, check=False),
+                lambda item: isinstance(item, items.ImageBase)):
+            image = picked.getItem()
 
-        for image in self.getAllImages():
-            data = image.getData(copy=False)
-            isMask = isinstance(image, items.MaskImageData)
-            if isMask:
-                zIndex = maskZ
-            else:
-                zIndex = valueZ
-            if image.getZValue() >= zIndex:
-                # This image is over the previous one
-                ox, oy = image.getOrigin()
-                sx, sy = image.getScale()
-                row, col = (y - oy) / sy, (x - ox) / sx
-                if row >= 0 and col >= 0:
-                    # Test positive before cast otherwise issue with int(-0.5) = 0
-                    row, col = int(row), int(col)
-                    if (row < data.shape[0] and col < data.shape[1]):
-                        v, z = data[row, col], image.getZValue()
-                        if not isMask:
-                            value = v
-                            valueZ = z
-                        else:
-                            mask = v
-                            maskZ = z
-        if maskZ > valueZ and mask > 0:
-            return value, "Masked"
-        return value
+            indices = picked.getIndices(copy=False)
+            if indices is not None:
+                row, col = indices[0][0], indices[1][0]
+                value = image.getData(copy=False)[row, col]
+                if isinstance(image, items.MaskImageData):
+                    return value, "Masked"
+                else:
+                    return value
+
+        return '-'  # No image picked
 
     def _getImageDims(self, *args):
         activeImage = self.getActiveImage()

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1337,7 +1337,10 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
     def pickItem(self, x, y, item):
         mouseEvent = MouseEvent(
             'button_press_event', self, x, self._mplQtYAxisCoordConversion(y))
+        # Override axes and data position with the axes
         mouseEvent.inaxes = item.axes
+        mouseEvent.xdata, mouseEvent.ydata = self.pixelToData(
+            x, y, axis='left' if item.axes is self.ax else 'right')
         picked, info = item.contains(mouseEvent)
 
         if not picked:

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -354,7 +354,31 @@ class _DoubleColoredLinePatch(matplotlib.patches.Patch):
 
 
 class Image(AxesImage):
-    """An AxesImage with a fast path for uint8 RGBA images"""
+    """An AxesImage with a fast path for uint8 RGBA images.
+
+    :param List[float] silx_origin: (ox, oy) Offset of the image.
+    :param List[float] silx_scale: (sx, sy) Scale of the image.
+    """
+
+    def __init__(self, *args,
+                 silx_origin=(0., 0.),
+                 silx_scale=(1., 1.),
+                 **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__silx_origin = silx_origin
+        self.__silx_scale = silx_scale
+
+    def contains(self, mouseevent):
+        """Overridden to fill 'ind' with row and column"""
+        inside, info = super().contains(mouseevent)
+        if inside:
+            x, y = mouseevent.xdata, mouseevent.ydata
+            ox, oy = self.__silx_origin
+            sx, sy = self.__silx_scale
+            column = int((x - ox) / sx)
+            row = int((y - oy) / sy)
+            info['ind'] = (row,), (column,)
+        return inside, info
 
     def set_data(self, A):
         A = numpy.array(A, copy=False)
@@ -605,7 +629,9 @@ class BackendMatplotlib(BackendBase.BackendBase):
         image = Image(self.ax,
                       interpolation='nearest',
                       picker=True,
-                      origin='lower')
+                      origin='lower',
+                      silx_origin=origin,
+                      silx_scale=scale)
 
         if alpha < 1:
             image.set_alpha(alpha)

--- a/silx/gui/plot/backends/glutils/GLPlotImage.py
+++ b/silx/gui/plot/backends/glutils/GLPlotImage.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -56,7 +56,7 @@ class _GLPlotData2D(object):
             sx, sy = self.scale
             col = int((x - ox) / sx)
             row = int((y - oy) / sy)
-            return ((row, col),)
+            return (row,), (col,)
         else:
             return None
 

--- a/silx/gui/plot/items/_pick.py
+++ b/silx/gui/plot/items/_pick.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2019 European Synchrotron Radiation Facility
+# Copyright (c) 2019-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -47,7 +47,9 @@ class PickingResult(object):
         if indices is None or len(indices) == 0:
             self._indices = None
         else:
-            self._indices = numpy.array(indices, copy=False, dtype=numpy.int)
+            # Indices is set to None if indices array is empty
+            indices = numpy.array(indices, copy=False, dtype=numpy.int)
+            self._indices = None if indices.size == 0 else indices
 
     def getItem(self):
         """Returns the item this results corresponds to."""

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -355,7 +355,7 @@ class Item(qt.QObject):
         if indices is None:
             return None
         else:
-            return PickingResult(self, indices if len(indices) != 0 else None)
+            return PickingResult(self, indices)
 
 
 # Mix-in classes ##############################################################

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -143,25 +143,6 @@ class ImageBase(Item, LabelsMixIn, DraggableMixIn, AlphaMixIn):
                 plot._invalidateDataRange()
         super(ImageBase, self).setVisible(visible)
 
-    @docstring(Item)
-    def pick(self, x, y):
-        if super(ImageBase, self).pick(x, y) is not None:
-            plot = self.getPlot()
-            if plot is None:
-                return None
-
-            dataPos = plot.pixelToData(x, y)
-            if dataPos is None:
-                return None
-
-            origin = self.getOrigin()
-            scale = self.getScale()
-            column = int((dataPos[0] - origin[0]) / float(scale[0]))
-            row = int((dataPos[1] - origin[1]) / float(scale[1]))
-            return PickingResult(self, ([row], [column]))
-
-        return None
-
     def _isPlotLinear(self, plot):
         """Return True if plot only uses linear scale for both of x and y
         axes."""

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -524,22 +524,14 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
 
             elif visualization is self.Visualization.REGULAR_GRID:
                 # Specific handling of picking for the regular grid mode
-                plot = self.getPlot()
-                if plot is None:
+                picked = result.getIndices(copy=False)
+                if picked is None:
                     return None
-
-                dataPos = plot.pixelToData(x, y)
-                if dataPos is None:
-                    return None
+                row, column = picked[0][0], picked[1][0]
 
                 gridInfo = self.__getRegularGridInfo()
                 if gridInfo is None:
                     return None
-
-                origin = gridInfo.origin
-                scale = gridInfo.scale
-                column = int((dataPos[0] - origin[0]) / scale[0])
-                row = int((dataPos[1] - origin[1]) / scale[1])
 
                 if gridInfo.order == 'row':
                     index = row * gridInfo.shape[1] + column

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -628,7 +628,7 @@ class TestPlotScatter(PlotWidgetTestCase, ParametricTestCase):
                         else:
                             self.assertIsNotNone(result)
                             self.assertIs(result.getItem(), scatter)
-                            self.assertEqual(result.getIndices()[0], (index,))
+                            self.assertEqual(result.getIndices(), (index,))
 
 
 class TestPlotMarker(PlotWidgetTestCase):


### PR DESCRIPTION
This PR improves the implementation of image picking in the `PlotWidget`.
Beforehand, getting the picked array indices was done in the `Image` item itself, and the backends had different behaviours: the OpenGL was also doing it, but not the matplotilb one.

This PR makes both backends returning the picked indices in the array and removes the implementation in the `Image` and `Scatter` items. This avoids duplicating the image picking in each item that needs it.