### PR TITLE
Use numpy.errstate to ignore warnings

### DIFF
--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -31,7 +31,6 @@ __license__ = "MIT"
 __date__ = "21/12/2018"
 
 import logging
-import warnings
 import weakref
 
 import numpy
@@ -767,8 +766,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                     xErrorMinus, xErrorPlus = xerror[0], xerror[1]
                 else:
                     xErrorMinus, xErrorPlus = xerror, xerror
-                with warnings.catch_warnings():
-                    warnings.simplefilter('ignore', category=RuntimeWarning)
+                with numpy.errstate(divide='ignore', invalid='ignore'):
                     # Ignore divide by zero, invalid value encountered in log10
                     xErrorMinus = logX - numpy.log10(x - xErrorMinus)
                 xErrorPlus = numpy.log10(x + xErrorPlus) - logX
@@ -790,8 +788,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                     yErrorMinus, yErrorPlus = yerror[0], yerror[1]
                 else:
                     yErrorMinus, yErrorPlus = yerror, yerror
-                with warnings.catch_warnings():
-                    warnings.simplefilter('ignore', category=RuntimeWarning)
+                with numpy.errstate(divide='ignore', invalid='ignore'):
                     # Ignore divide by zero, invalid value encountered in log10
                     yErrorMinus = logY - numpy.log10(y - yErrorMinus)
                 yErrorPlus = numpy.log10(y + yErrorPlus) - logY

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +35,6 @@ __date__ = "03/04/2017"
 
 import math
 import logging
-import warnings
 
 import numpy
 
@@ -1129,11 +1128,9 @@ class GLPlotCurve2D(object):
                     _baseline = numpy.repeat(_baseline,
                                              len(self.xData))
                 if isYLog is True:
-                    with warnings.catch_warnings():  # Ignore NaN comparison warnings
-                        warnings.simplefilter('ignore',
-                                              category=RuntimeWarning)
+                    with numpy.errstate(divide='ignore', invalid='ignore'):
                         log_val = numpy.log10(_baseline)
-                    _baseline = numpy.where(_baseline>0.0, log_val, -38)
+                        _baseline = numpy.where(_baseline>0.0, log_val, -38)
                 return _baseline
 
             _baseline = deduce_baseline(baseline)
@@ -1277,8 +1274,7 @@ class GLPlotCurve2D(object):
 
         if self.lineStyle is not None:
             # Using Cohen-Sutherland algorithm for line clipping
-            with warnings.catch_warnings():  # Ignore NaN comparison warnings
-                warnings.simplefilter('ignore', category=RuntimeWarning)
+            with numpy.errstate(invalid='ignore'):  # Ignore NaN comparison warnings
                 codes = ((self.yData > yPickMax) << 3) | \
                     ((self.yData < yPickMin) << 2) | \
                     ((self.xData > xPickMax) << 1) | \
@@ -1335,8 +1331,7 @@ class GLPlotCurve2D(object):
             indices.sort()
 
         else:
-            with warnings.catch_warnings():  # Ignore NaN comparison warnings
-                warnings.simplefilter('ignore', category=RuntimeWarning)
+            with numpy.errstate(invalid='ignore'):  # Ignore NaN comparison warnings
                 indices = numpy.nonzero((self.xData >= xPickMin) &
                                         (self.xData <= xPickMax) &
                                         (self.yData >= yPickMin) &

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -1231,14 +1231,12 @@ class PointsBase(Item, SymbolMixIn, AlphaMixIn):
 
             if xPositive:
                 x = self.getXData(copy=False)
-                with warnings.catch_warnings():  # Ignore NaN warnings
-                    warnings.simplefilter('ignore', category=RuntimeWarning)
+                with numpy.errstate(invalid='ignore'):  # Ignore NaN warnings
                     xclipped = x <= 0
 
             if yPositive:
                 y = self.getYData(copy=False)
-                with warnings.catch_warnings():  # Ignore NaN warnings
-                    warnings.simplefilter('ignore', category=RuntimeWarning)
+                with numpy.errstate(invalid='ignore'):  # Ignore NaN warnings
                     yclipped = y <= 0
 
             self._clippedCache[(xPositive, yPositive)] = \

--- a/silx/math/test/test_colormap.py
+++ b/silx/math/test/test_colormap.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -34,7 +34,6 @@ __date__ = "16/05/2018"
 import logging
 import sys
 import unittest
-import warnings
 
 import numpy
 
@@ -67,8 +66,7 @@ class TestColormap(ParametricTestCase):
                           'sqrt': numpy.sqrt}
 
         norm_function = norm_functions[normalization]
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore', category=RuntimeWarning)
+        with numpy.errstate(divide='ignore', invalid='ignore'):
             # Ignore divide by zero and invalid value encountered in log10, sqrt
             norm_data, vmin, vmax = map(norm_function, (data, vmin, vmax))
 

--- a/silx/math/test/test_combo.py
+++ b/silx/math/test/test_combo.py
@@ -87,7 +87,7 @@ class TestMinMax(ParametricTestCase):
                 argmax = numpy.where(data == maximum)[0][0]
 
             if min_positive:
-                with numpy.errstate(invalid='ignore')
+                with numpy.errstate(invalid='ignore'):
                     # Ignore invalid value encountered in greater
                     pos_data = filtered_data[filtered_data > 0]
                 if pos_data.size > 0:

--- a/silx/math/test/test_combo.py
+++ b/silx/math/test/test_combo.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +31,6 @@ __date__ = "17/01/2018"
 
 
 import unittest
-import warnings
 
 import numpy
 
@@ -88,8 +87,7 @@ class TestMinMax(ParametricTestCase):
                 argmax = numpy.where(data == maximum)[0][0]
 
             if min_positive:
-                with warnings.catch_warnings():
-                    warnings.simplefilter('ignore', category=RuntimeWarning)
+                with numpy.errstate(invalid='ignore')
                     # Ignore invalid value encountered in greater
                     pos_data = filtered_data[filtered_data > 0]
                 if pos_data.size > 0:


### PR DESCRIPTION
Whenever possible, this PR replaces the use of `warnings.catch_warning` by `numpy.errstate` which is more specific.