### PR TITLE
Add option to select the reduction function for "histogram" of scatter plot

### DIFF
--- a/silx/gui/plot/PlotToolButtons.py
+++ b/silx/gui/plot/PlotToolButtons.py
@@ -482,6 +482,18 @@ class ScatterVisualizationToolButton(_SymbolToolButtonBase):
                         {Scatter.VisualizationParameter.BINNED_STATISTIC_FUNCTION: reduction}))
                     submenu.addAction(action)
 
+                submenu.addSeparator()
+                binsmenu = submenu.addMenu('N Bins')
+
+                slider = qt.QSlider(qt.Qt.Horizontal)
+                slider.setRange(10, 1000)
+                slider.setValue(100)
+                slider.setTracking(False)
+                slider.valueChanged.connect(self._binningChanged)
+                widgetAction = qt.QWidgetAction(binsmenu)
+                widgetAction.setDefaultWidget(slider)
+                binsmenu.addAction(widgetAction)
+
         menu.addSeparator()
 
         submenu = menu.addMenu(icons.getQIcon('plot-symbols'), "Symbol")
@@ -512,3 +524,19 @@ class ScatterVisualizationToolButton(_SymbolToolButtonBase):
                     for parameter, value in parameters.items():
                         item.setVisualizationParameter(parameter, value)
                 item.setVisualization(mode)
+
+    def _binningChanged(self, value):
+        """Handle change of binning.
+
+        :param int value: The number of bin on each dimension.
+        """
+        plot = self.plot()
+        if plot is None:
+            return
+
+        for item in plot.getItems():
+            if isinstance(item, Scatter):
+                item.setVisualizationParameter(
+                    Scatter.VisualizationParameter.BINNED_STATISTIC_SHAPE,
+                    (value, value))
+                item.setVisualization(Scatter.Visualization.BINNED_STATISTIC)

--- a/silx/gui/plot/PlotToolButtons.py
+++ b/silx/gui/plot/PlotToolButtons.py
@@ -468,16 +468,19 @@ class ScatterVisualizationToolButton(_SymbolToolButtonBase):
                 menu.addAction(action)
 
         if Scatter.Visualization.HISTOGRAM in Scatter.supportedVisualizations():
-            submenu = menu.addMenu('Histogram')
-            for reduction in ('mean', 'count', 'sum'):
-                name = reduction.capitalize()
-                action = qt.QAction(name, menu)
-                action.setCheckable(False)
-                action.triggered.connect(functools.partial(
-                    self._visualizationChanged,
-                    Scatter.Visualization.HISTOGRAM,
-                    {Scatter.VisualizationParameter.HISTOGRAM_REDUCTION: reduction}))
-                submenu.addAction(action)
+            reductions = Scatter.supportedVisualizationParameterValues(
+                Scatter.VisualizationParameter.HISTOGRAM_REDUCTION)
+            if reductions:
+                submenu = menu.addMenu('Histogram')
+                for reduction in reductions:
+                    name = reduction.capitalize()
+                    action = qt.QAction(name, menu)
+                    action.setCheckable(False)
+                    action.triggered.connect(functools.partial(
+                        self._visualizationChanged,
+                        Scatter.Visualization.HISTOGRAM,
+                        {Scatter.VisualizationParameter.HISTOGRAM_REDUCTION: reduction}))
+                    submenu.addAction(action)
 
         menu.addSeparator()
 

--- a/silx/gui/plot/PlotToolButtons.py
+++ b/silx/gui/plot/PlotToolButtons.py
@@ -459,7 +459,7 @@ class ScatterVisualizationToolButton(_SymbolToolButtonBase):
         # Add visualization modes
 
         for mode in Scatter.supportedVisualizations():
-            if mode is not Scatter.Visualization.HISTOGRAM:
+            if mode is not Scatter.Visualization.BINNED_STATISTIC:
                 name = mode.value.capitalize()
                 action = qt.QAction(name, menu)
                 action.setCheckable(False)
@@ -467,19 +467,19 @@ class ScatterVisualizationToolButton(_SymbolToolButtonBase):
                     functools.partial(self._visualizationChanged, mode, None))
                 menu.addAction(action)
 
-        if Scatter.Visualization.HISTOGRAM in Scatter.supportedVisualizations():
+        if Scatter.Visualization.BINNED_STATISTIC in Scatter.supportedVisualizations():
             reductions = Scatter.supportedVisualizationParameterValues(
-                Scatter.VisualizationParameter.HISTOGRAM_REDUCTION)
+                Scatter.VisualizationParameter.BINNED_STATISTIC_FUNCTION)
             if reductions:
-                submenu = menu.addMenu('Histogram')
+                submenu = menu.addMenu('Binned Statistic')
                 for reduction in reductions:
                     name = reduction.capitalize()
                     action = qt.QAction(name, menu)
                     action.setCheckable(False)
                     action.triggered.connect(functools.partial(
                         self._visualizationChanged,
-                        Scatter.Visualization.HISTOGRAM,
-                        {Scatter.VisualizationParameter.HISTOGRAM_REDUCTION: reduction}))
+                        Scatter.Visualization.BINNED_STATISTIC,
+                        {Scatter.VisualizationParameter.BINNED_STATISTIC_FUNCTION: reduction}))
                     submenu.addAction(action)
 
         menu.addSeparator()

--- a/silx/gui/plot/ScatterView.py
+++ b/silx/gui/plot/ScatterView.py
@@ -182,7 +182,7 @@ class ScatterView(qt.QMainWindow):
                         lambda item: isinstance(item, items.Scatter))
                     if result is not None:
                         item = result.getItem()
-                        if item.getVisualization() is items.Scatter.Visualization.HISTOGRAM:
+                        if item.getVisualization() is items.Scatter.Visualization.BINNED_STATISTIC:
                             # Get highest index of closest points
                             selected = result.getIndices(copy=False)[::-1]
                             dataIndex = selected[numpy.argmin(

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -1021,8 +1021,8 @@ class ScatterVisualizationMixIn(ItemMixInBase):
         (either all lines from left to right or all from right to left).
         """
 
-        HISTOGRAM = 'histogram'
-        """Display scatter plot as a 2D histogram.
+        BINNED_STATISTIC = 'binned_statistic'
+        """Display scatter plot as 2D binned statistic (i.e., generalized histogram).
         """
 
     @enum.unique
@@ -1051,19 +1051,19 @@ class ScatterVisualizationMixIn(ItemMixInBase):
         in which case the grid is not fully filled.
         """
 
-        HISTOGRAM_SHAPE = 'histogram_shape'
-        """The number of bins of the histogram in each dimension (height, width).
+        BINNED_STATISTIC_SHAPE = 'binned_statistic_shape'
+        """The number of bins in each dimension (height, width).
         """
 
-        HISTOGRAM_REDUCTION = 'histogram_reduction'
+        BINNED_STATISTIC_FUNCTION = 'binned_statistic_function'
         """The reduction function to apply to each bin (str).
 
-        Available reductions are: 'mean' (default), 'count', 'sum'.
+        Available reduction functions are: 'mean' (default), 'count', 'sum'.
         """
 
     _SUPPORTED_VISUALIZATION_PARAMETER_VALUES = {
         VisualizationParameter.GRID_MAJOR_ORDER: ('row', 'column'),
-        VisualizationParameter.HISTOGRAM_REDUCTION: ('mean', 'count', 'sum'),
+        VisualizationParameter.BINNED_STATISTIC_FUNCTION: ('mean', 'count', 'sum'),
     }
     """Supported visualization parameter values.
 
@@ -1074,7 +1074,7 @@ class ScatterVisualizationMixIn(ItemMixInBase):
         self.__visualization = self.Visualization.POINTS
         self.__parameters = dict(  # Init parameters to None
             (parameter, None) for parameter in self.VisualizationParameter)
-        self.__parameters[self.VisualizationParameter.HISTOGRAM_REDUCTION] = 'mean'
+        self.__parameters[self.VisualizationParameter.BINNED_STATISTIC_FUNCTION] = 'mean'
 
     @classmethod
     def supportedVisualizations(cls):

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -984,9 +984,6 @@ class ScatterVisualizationMixIn(ItemMixInBase):
     _SUPPORTED_SCATTER_VISUALIZATION = None
     """Allows to override supported Visualizations"""
 
-    _SUPPORTED_HISTOGRAM_REDUCTIONS = 'mean', 'count', 'sum'
-    """Supported histogram reduction functions"""
-
     @enum.unique
     class Visualization(_Enum):
         """Different modes of scatter plot visualizations"""
@@ -1064,6 +1061,15 @@ class ScatterVisualizationMixIn(ItemMixInBase):
         Available reductions are: 'mean' (default), 'count', 'sum'.
         """
 
+    _SUPPORTED_VISUALIZATION_PARAMETER_VALUES = {
+        VisualizationParameter.GRID_MAJOR_ORDER: ('row', 'column'),
+        VisualizationParameter.HISTOGRAM_REDUCTION: ('mean', 'count', 'sum'),
+    }
+    """Supported visualization parameter values.
+
+    Defined for parameters with a set of acceptable values.
+    """
+
     def __init__(self):
         self.__visualization = self.Visualization.POINTS
         self.__parameters = dict(  # Init parameters to None
@@ -1082,6 +1088,20 @@ class ScatterVisualizationMixIn(ItemMixInBase):
             return cls.Visualization.members()
         else:
             return cls._SUPPORTED_SCATTER_VISUALIZATION
+
+    @classmethod
+    def supportedVisualizationParameterValues(cls, parameter):
+        """Returns the list of supported scatter visualization modes.
+
+        See :meth:`VisualizationParameters`
+
+        :param VisualizationParameter parameter:
+            This parameter for which to retrieve the supported values.
+        :returns: tuple of supported of values or None if not defined.
+        """
+        parameter = cls.VisualizationParameter(parameter)
+        return cls._SUPPORTED_VISUALIZATION_PARAMETER_VALUES.get(
+            parameter, None)
 
     def setVisualization(self, mode):
         """Set the scatter plot visualization mode to use.
@@ -1127,9 +1147,9 @@ class ScatterVisualizationMixIn(ItemMixInBase):
         parameter = self.VisualizationParameter.from_value(parameter)
 
         if self.__parameters[parameter] != value:
-            if (parameter == self.VisualizationParameter.HISTOGRAM_REDUCTION and
-                    value not in self._SUPPORTED_HISTOGRAM_REDUCTIONS):
-                raise ValueError("Unsupported histogram_reduction: %s" % str(value))
+            validValues = self.supportedVisualizationParameterValues(parameter)
+            if validValues is not None and value not in validValues:
+                raise ValueError("Unsupported parameter value: %s" % str(value))
 
             self.__parameters[parameter] = value
             self._updated(ItemChangedType.VISUALIZATION_MODE)

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -984,6 +984,9 @@ class ScatterVisualizationMixIn(ItemMixInBase):
     _SUPPORTED_SCATTER_VISUALIZATION = None
     """Allows to override supported Visualizations"""
 
+    _SUPPORTED_HISTOGRAM_REDUCTIONS = 'mean', 'count', 'sum'
+    """Supported histogram reduction functions"""
+
     @enum.unique
     class Visualization(_Enum):
         """Different modes of scatter plot visualizations"""
@@ -1055,10 +1058,17 @@ class ScatterVisualizationMixIn(ItemMixInBase):
         """The number of bins of the histogram in each dimension (height, width).
         """
 
+        HISTOGRAM_REDUCTION = 'histogram_reduction'
+        """The reduction function to apply to each bin (str).
+
+        Available reductions are: 'mean' (default), 'count', 'sum'.
+        """
+
     def __init__(self):
         self.__visualization = self.Visualization.POINTS
         self.__parameters = dict(  # Init parameters to None
             (parameter, None) for parameter in self.VisualizationParameter)
+        self.__parameters[self.VisualizationParameter.HISTOGRAM_REDUCTION] = 'mean'
 
     @classmethod
     def supportedVisualizations(cls):
@@ -1112,10 +1122,15 @@ class ScatterVisualizationMixIn(ItemMixInBase):
         :raises ValueError: If parameter is not supported
         :return: True if parameter was set, False if is was already set
         :rtype: bool
+        :raise ValueError: If value is not supported
         """
         parameter = self.VisualizationParameter.from_value(parameter)
 
         if self.__parameters[parameter] != value:
+            if (parameter == self.VisualizationParameter.HISTOGRAM_REDUCTION and
+                    value not in self._SUPPORTED_HISTOGRAM_REDUCTIONS):
+                raise ValueError("Unsupported histogram_reduction: %s" % str(value))
+
             self.__parameters[parameter] = value
             self._updated(ItemChangedType.VISUALIZATION_MODE)
             return True

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -307,10 +307,14 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
     def _updateColormappedData(self):
         """Update the colormapped data, to be called when changed"""
         if self.getVisualization() is self.Visualization.HISTOGRAM:
-            data = getattr(
-                self.__getHistogramInfo(),
-                self.getVisualizationParameter(
-                    self.VisualizationParameter.HISTOGRAM_REDUCTION))
+            histoInfo = self.__getHistogramInfo()
+            if histoInfo is None:
+                data = None
+            else:
+                data = getattr(
+                    histoInfo,
+                    self.getVisualizationParameter(
+                        self.VisualizationParameter.HISTOGRAM_REDUCTION))
         else:
             data = self.getValueData(copy=False)
         self._setColormappedData(data, copy=False)
@@ -436,6 +440,9 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
                 shape = 100, 100 # TODO compute auto shape
 
             x, y, values = self.getData(copy=False)[:3]
+            if len(x) == 0:  # No histogram
+                return None
+
             if not numpy.issubdtype(x.dtype, numpy.floating):
                 x = x.astype(numpy.float64)
             if not numpy.issubdtype(y.dtype, numpy.floating):
@@ -490,6 +497,8 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
                 return None
 
             histoInfo = self.__getHistogramInfo()
+            if histoInfo is None:
+                return None
             data = getattr(histoInfo, self.getVisualizationParameter(
                 self.VisualizationParameter.HISTOGRAM_REDUCTION))
 
@@ -661,6 +670,8 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
                     return None
                 row, col = picked[0][0], picked[1][0]
                 histoInfo = self.__getHistogramInfo()
+                if histoInfo is None:
+                    return None
                 sx, sy = histoInfo.scale
                 ox, oy = histoInfo.origin
                 xdata = self.getXData(copy=False)

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -281,7 +281,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
         ScatterVisualizationMixIn.Visualization.SOLID,
         ScatterVisualizationMixIn.Visualization.REGULAR_GRID,
         ScatterVisualizationMixIn.Visualization.IRREGULAR_GRID,
-        ScatterVisualizationMixIn.Visualization.HISTOGRAM,
+        ScatterVisualizationMixIn.Visualization.BINNED_STATISTIC,
         )
     """Overrides supported Visualizations"""
 
@@ -306,7 +306,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
 
     def _updateColormappedData(self):
         """Update the colormapped data, to be called when changed"""
-        if self.getVisualization() is self.Visualization.HISTOGRAM:
+        if self.getVisualization() is self.Visualization.BINNED_STATISTIC:
             histoInfo = self.__getHistogramInfo()
             if histoInfo is None:
                 data = None
@@ -314,7 +314,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
                 data = getattr(
                     histoInfo,
                     self.getVisualizationParameter(
-                        self.VisualizationParameter.HISTOGRAM_REDUCTION))
+                        self.VisualizationParameter.BINNED_STATISTIC_FUNCTION))
         else:
             data = self.getValueData(copy=False)
         self._setColormappedData(data, copy=False)
@@ -323,8 +323,8 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
     def setVisualization(self, mode):
         previous = self.getVisualization()
         if super().setVisualization(mode):
-            if (bool(mode is self.Visualization.HISTOGRAM) ^
-                    bool(previous is self.Visualization.HISTOGRAM)):
+            if (bool(mode is self.Visualization.BINNED_STATISTIC) ^
+                    bool(previous is self.Visualization.BINNED_STATISTIC)):
                 self._updateColormappedData()
             return True
         else:
@@ -338,11 +338,11 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
                              self.VisualizationParameter.GRID_SHAPE):
                 self.__cacheRegularGridInfo = None
 
-            if parameter in (self.VisualizationParameter.HISTOGRAM_SHAPE,
-                             self.VisualizationParameter.HISTOGRAM_REDUCTION):
-                if parameter == self.VisualizationParameter.HISTOGRAM_SHAPE:
+            if parameter in (self.VisualizationParameter.BINNED_STATISTIC_SHAPE,
+                             self.VisualizationParameter.BINNED_STATISTIC_FUNCTION):
+                if parameter == self.VisualizationParameter.BINNED_STATISTIC_SHAPE:
                     self.__cacheHistogramInfo = None  # Clean-up cache
-                if self.getVisualization() is self.Visualization.HISTOGRAM:
+                if self.getVisualization() is self.Visualization.BINNED_STATISTIC:
                     self._updateColormappedData()
             return True
         else:
@@ -366,7 +366,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
             grid = self.__getRegularGridInfo()
             return None if grid is None else grid.shape
 
-        elif parameter is self.VisualizationParameter.HISTOGRAM_SHAPE:
+        elif parameter is self.VisualizationParameter.BINNED_STATISTIC_SHAPE:
             info = self.__getHistogramInfo()
             return None if info is None else info.shape
 
@@ -435,7 +435,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
         """Get histogram info"""
         if self.__cacheHistogramInfo is None:
             shape = self.getVisualizationParameter(
-                self.VisualizationParameter.HISTOGRAM_SHAPE)
+                self.VisualizationParameter.BINNED_STATISTIC_SHAPE)
             if shape is None:
                 shape = 100, 100 # TODO compute auto shape
 
@@ -488,7 +488,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
 
         visualization = self.getVisualization()
 
-        if visualization is self.Visualization.HISTOGRAM:
+        if visualization is self.Visualization.BINNED_STATISTIC:
             plot = self.getPlot()
             if (plot is None or
                     plot.getXAxis().getScale() != Axis.LINEAR or
@@ -500,7 +500,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
             if histoInfo is None:
                 return None
             data = getattr(histoInfo, self.getVisualizationParameter(
-                self.VisualizationParameter.HISTOGRAM_REDUCTION))
+                self.VisualizationParameter.BINNED_STATISTIC_FUNCTION))
 
             return backend.addImage(
                 data=data,
@@ -664,7 +664,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
 
                 result = PickingResult(self, (index,))
 
-            elif visualization is self.Visualization.HISTOGRAM:
+            elif visualization is self.Visualization.BINNED_STATISTIC:
                 picked = result.getIndices(copy=False)
                 if picked is None or len(picked) == 0 or len(picked[0]) == 0:
                     return None

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -562,12 +562,12 @@ class TestPlotScatter(PlotWidgetTestCase, ParametricTestCase):
                               'points',
                               'regular_grid',
                               'irregular_grid',
-                              'histogram',
+                              'binned_statistic',
                               scatter.Visualization.SOLID,
                               scatter.Visualization.POINTS,
                               scatter.Visualization.REGULAR_GRID,
                               scatter.Visualization.IRREGULAR_GRID,
-                              scatter.Visualization.HISTOGRAM):
+                              scatter.Visualization.BINNED_STATISTIC):
             with self.subTest(visualization=visualization):
                 scatter.setVisualization(visualization)
                 self.qapp.processEvents()
@@ -634,16 +634,16 @@ class TestPlotScatter(PlotWidgetTestCase, ParametricTestCase):
                             self.assertIs(result.getItem(), scatter)
                             self.assertEqual(result.getIndices(), (index,))
 
-    def testHistogramVisualization(self):
+    def testBinnedStatisticVisualization(self):
         """Test binned display"""
         self.plot.addScatter((), (), ())
         scatter = self.plot.getItems()[0]
-        scatter.setVisualization(scatter.Visualization.HISTOGRAM)
+        scatter.setVisualization(scatter.Visualization.BINNED_STATISTIC)
         self.assertIs(scatter.getVisualization(),
-                      scatter.Visualization.HISTOGRAM)
+                      scatter.Visualization.BINNED_STATISTIC)
         self.assertEqual(
             scatter.getVisualizationParameter(
-                scatter.VisualizationParameter.HISTOGRAM_REDUCTION),
+                scatter.VisualizationParameter.BINNED_STATISTIC_FUNCTION),
             'mean')
 
         self.qapp.processEvents()
@@ -653,11 +653,11 @@ class TestPlotScatter(PlotWidgetTestCase, ParametricTestCase):
         for reduction in ('count', 'sum', 'mean'):
             with self.subTest(reduction=reduction):
                 scatter.setVisualizationParameter(
-                    scatter.VisualizationParameter.HISTOGRAM_REDUCTION,
+                    scatter.VisualizationParameter.BINNED_STATISTIC_FUNCTION,
                     reduction)
                 self.assertEqual(
                     scatter.getVisualizationParameter(
-                        scatter.VisualizationParameter.HISTOGRAM_REDUCTION),
+                        scatter.VisualizationParameter.BINNED_STATISTIC_FUNCTION),
                     reduction)
 
                 self.qapp.processEvents()

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -561,9 +561,13 @@ class TestPlotScatter(PlotWidgetTestCase, ParametricTestCase):
         for visualization in ('solid',
                               'points',
                               'regular_grid',
+                              'irregular_grid',
+                              'histogram',
                               scatter.Visualization.SOLID,
                               scatter.Visualization.POINTS,
-                              scatter.Visualization.REGULAR_GRID):
+                              scatter.Visualization.REGULAR_GRID,
+                              scatter.Visualization.IRREGULAR_GRID,
+                              scatter.Visualization.HISTOGRAM):
             with self.subTest(visualization=visualization):
                 scatter.setVisualization(visualization)
                 self.qapp.processEvents()
@@ -629,6 +633,34 @@ class TestPlotScatter(PlotWidgetTestCase, ParametricTestCase):
                             self.assertIsNotNone(result)
                             self.assertIs(result.getItem(), scatter)
                             self.assertEqual(result.getIndices(), (index,))
+
+    def testHistogramVisualization(self):
+        """Test binned display"""
+        self.plot.addScatter((), (), ())
+        scatter = self.plot.getItems()[0]
+        scatter.setVisualization(scatter.Visualization.HISTOGRAM)
+        self.assertIs(scatter.getVisualization(),
+                      scatter.Visualization.HISTOGRAM)
+        self.assertEqual(
+            scatter.getVisualizationParameter(
+                scatter.VisualizationParameter.HISTOGRAM_REDUCTION),
+            'mean')
+
+        self.qapp.processEvents()
+
+        scatter.setData(*numpy.random.random(3000).reshape(3, -1))
+
+        for reduction in ('count', 'sum', 'mean'):
+            with self.subTest(reduction=reduction):
+                scatter.setVisualizationParameter(
+                    scatter.VisualizationParameter.HISTOGRAM_REDUCTION,
+                    reduction)
+                self.assertEqual(
+                    scatter.getVisualizationParameter(
+                        scatter.VisualizationParameter.HISTOGRAM_REDUCTION),
+                    reduction)
+
+                self.qapp.processEvents()
 
 
 class TestPlotMarker(PlotWidgetTestCase):


### PR DESCRIPTION
Merge PR #2912 first!

This PR adds the option to select the reduction function (mean, count, sum for now) for the histogramming visualization of the scatter plot.

This PR also renames the "histogram" visualization mode to "binned_statistic" which is more generic.
