### PR TITLE
[plot] Replace usage of PlotWidget's _getAllMarkers and _getItems by getItems

### DIFF
--- a/silx/gui/plot/ItemsSelectionDialog.py
+++ b/silx/gui/plot/ItemsSelectionDialog.py
@@ -141,20 +141,22 @@ class PlotItemsSelector(qt.QTableWidget):
     def updatePlotItems(self):
         self._clear()
 
-        nrows = len(self.plot._getItems(kind=self.plot_item_kinds,
-                                        just_legend=True))
-        self.setRowCount(nrows)
-
         # respect order of kinds as set in method setKindsFilter
-        i = 0
+        itemsAndKind = []
         for kind in self.plot_item_kinds:
-            for plot_item in self.plot._getItems(kind=kind):
-                legend_twitem = qt.QTableWidgetItem(plot_item.getName())
-                self.setItem(i, 0, legend_twitem)
+            itemClasses = self.plot._KIND_TO_CLASSES[kind]
+            for item in self.plot.getItems():
+                if isinstance(item, itemClasses) and item.isVisible():
+                    itemsAndKind.append((item, kind))
 
-                kind_twitem = qt.QTableWidgetItem(kind)
-                self.setItem(i, 1, kind_twitem)
-                i += 1
+        self.setRowCount(len(itemsAndKind))
+
+        for index, (item, kind) in enumerate(itemsAndKind):
+            legend_twitem = qt.QTableWidgetItem(item.getName())
+            self.setItem(index, 0, legend_twitem)
+
+            kind_twitem = qt.QTableWidgetItem(kind)
+            self.setItem(index, 1, kind_twitem)
 
     @property
     def selectedPlotItems(self):

--- a/silx/gui/plot/PlotToolButtons.py
+++ b/silx/gui/plot/PlotToolButtons.py
@@ -399,7 +399,7 @@ class _SymbolToolButtonBase(PlotToolButton):
         if plot is None:
             return
 
-        for item in plot._getItems(withhidden=True):
+        for item in plot.getItems():
             if isinstance(item, SymbolMixIn):
                 item.setSymbolSize(value)
 
@@ -412,7 +412,7 @@ class _SymbolToolButtonBase(PlotToolButton):
         if plot is None:
             return
 
-        for item in plot._getItems(withhidden=True):
+        for item in plot.getItems():
             if isinstance(item, SymbolMixIn):
                 item.setSymbol(marker)
 
@@ -487,6 +487,6 @@ class ScatterVisualizationToolButton(_SymbolToolButtonBase):
         if plot is None:
             return
 
-        for item in plot._getItems(withhidden=True):
+        for item in plot.getItems():
             if isinstance(item, Scatter):
                 item.setVisualization(mode)

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2124,7 +2124,7 @@ class PlotWidget(qt.QMainWindow):
         """
         return self._getItem(kind='histogram', legend=legend)
 
-    @deprecated(replacement='getItems', since_version='0.13.0')
+    @deprecated(replacement='getItems', since_version='0.13')
     def _getItems(self, kind=ITEM_KINDS, just_legend=False, withhidden=False):
         """Retrieve all items of a kind in the plot
 
@@ -2196,7 +2196,7 @@ class PlotWidget(qt.QMainWindow):
             id(self.getWidgetHandle()), xRange, yRange, y2Range)
         self.notify(**event)
 
-    @deprecated(replacement='getItems', since_version='0.13.0')
+    @deprecated(replacement='getItems', since_version='0.13')
     def _getAllMarkers(self, just_legend=False):
         markers = [item for item in self.getItems() if isinstance(item, items.MarkerBase)]
         if just_legend:

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2196,14 +2196,6 @@ class PlotWidget(qt.QMainWindow):
             id(self.getWidgetHandle()), xRange, yRange, y2Range)
         self.notify(**event)
 
-    @deprecated(replacement='getItems', since_version='0.13')
-    def _getAllMarkers(self, just_legend=False):
-        markers = [item for item in self.getItems() if isinstance(item, items.MarkerBase)]
-        if just_legend:
-            return [marker.getName() for marker in markers]
-        else:
-            return markers
-
     def getLimitsHistory(self):
         """Returns the object handling the history of limits of the plot"""
         return self._limitsHistory
@@ -2943,6 +2935,14 @@ class PlotWidget(qt.QMainWindow):
         :param str cursor: Name of the cursor shape
         """
         self._backend.setGraphCursorShape(cursor)
+
+    @deprecated(replacement='getItems', since_version='0.13')
+    def _getAllMarkers(self, just_legend=False):
+        markers = [item for item in self.getItems() if isinstance(item, items.MarkerBase)]
+        if just_legend:
+            return [marker.getName() for marker in markers]
+        else:
+            return markers
 
     def _getMarker(self, legend=None):
         """Get the object describing a specific marker.

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -1502,7 +1502,8 @@ class PlotWidget(qt.QMainWindow):
         assert (x, y) != (None, None)
 
         if legend is None:  # Find an unused legend
-            markerLegends = self._getAllMarkers(just_legend=True)
+            markerLegends = [item.getName() for item in self.getItems()
+                             if isinstance(item, items.MarkerBase)]
             for index in itertools.count():
                 legend = "Unnamed Marker %d" % index
                 if legend not in markerLegends:
@@ -2189,6 +2190,14 @@ class PlotWidget(qt.QMainWindow):
         event = PlotEvents.prepareLimitsChangedSignal(
             id(self.getWidgetHandle()), xRange, yRange, y2Range)
         self.notify(**event)
+
+    @deprecated(replacement='getItems', since_version='0.13.0')
+    def _getAllMarkers(self, just_legend=False):
+        markers = [item for item in self.getItems() if isinstance(item, items.MarkerBase)]
+        if just_legend:
+            return [marker.getName() for marker in markers]
+        else:
+            return markers
 
     def getLimitsHistory(self):
         """Returns the object handling the history of limits of the plot"""
@@ -2929,17 +2938,6 @@ class PlotWidget(qt.QMainWindow):
         :param str cursor: Name of the cursor shape
         """
         self._backend.setGraphCursorShape(cursor)
-
-    def _getAllMarkers(self, just_legend=False):
-        """Returns all markers' legend or objects
-
-        :param bool just_legend: True to get the legend of the markers,
-                                 False (the default) to get marker objects.
-        :return: list of legend of list of marker objects
-        :rtype: list of str or list of marker objects
-        """
-        return self._getItems(
-            kind='marker', just_legend=just_legend, withhidden=True)
 
     def _getMarker(self, legend=None):
         """Get the object describing a specific marker.

--- a/silx/gui/plot/StatsWidget.py
+++ b/silx/gui/plot/StatsWidget.py
@@ -180,7 +180,10 @@ class _PlotWidgetWrapper(_Wrapper):
 
     def getItems(self):
         plot = self.getPlot()
-        return () if plot is None else plot._getItems()
+        if plot is None:
+            return ()
+        else:
+            return [item for item in plot.getItems() if item.isVisible()]
 
     def getSelectedItems(self):
         plot = self.getPlot()

--- a/silx/gui/plot/items/axis.py
+++ b/silx/gui/plot/items/axis.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -239,7 +239,7 @@ class Axis(qt.QObject):
 
         # TODO hackish way of forcing update of curves and images
         plot = self._getPlot()
-        for item in plot._getItems(withhidden=True):
+        for item in plot.getItems():
             item._updated()
         plot._invalidateDataRange()
 

--- a/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/silx/gui/plot/test/testCurvesROIWidget.py
@@ -36,7 +36,7 @@ from collections import OrderedDict
 import numpy
 
 from silx.gui import qt
-from silx.gui.plot import import items
+from silx.gui.plot import items
 from silx.gui.plot import Plot1D
 from silx.test.utils import temp_dir
 from silx.gui.utils.testutils import TestCaseQt, SignalListener

--- a/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/silx/gui/plot/test/testCurvesROIWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -36,6 +36,7 @@ from collections import OrderedDict
 import numpy
 
 from silx.gui import qt
+from silx.gui.plot import import items
 from silx.gui.plot import Plot1D
 from silx.test.utils import temp_dir
 from silx.gui.utils.testutils import TestCaseQt, SignalListener
@@ -254,7 +255,9 @@ class TestCurvesROIWidget(TestCaseQt):
         self.widget.roiWidget.showAllMarkers(True)
         roiWidget = self.plot.getCurvesRoiDockWidget().roiWidget
         roiWidget.setRois(roisDefsDict)
-        self.assertTrue(len(self.plot._getAllMarkers()) is 2*3)
+        markers = [item for item in self.plot.getItems()
+                   if isinstance(item, items.MarkerBase)]
+        self.assertEqual(len(markers), 2*3)
 
         markersHandler = self.widget.roiWidget.roiTable._markersHandler
         roiWidget.showAllMarkers(True)
@@ -267,7 +270,9 @@ class TestCurvesROIWidget(TestCaseQt):
 
         roiWidget.setRois(roisDefsObj)
         self.qapp.processEvents()
-        self.assertTrue(len(self.plot._getAllMarkers()) is 2*3)
+        markers = [item for item in self.plot.getItems()
+                   if isinstance(item, items.MarkerBase)]
+        self.assertTrue(len(markers), 2*3)
 
         markersHandler = self.widget.roiWidget.roiTable._markersHandler
         roiWidget.showAllMarkers(True)

--- a/silx/gui/plot/test/testPlotWidgetNoBackend.py
+++ b/silx/gui/plot/test/testPlotWidgetNoBackend.py
@@ -570,21 +570,18 @@ class TestPlotAddScatter(unittest.TestCase):
 
         plot = PlotWidget(backend='none')
 
-        scatters = plot._getItems(kind='scatter')
-        self.assertEqual(len(scatters), 0)
+        items = plot.getItems()
+        self.assertEqual(len(items), 0)
 
         plot.addScatter(x=(0, 1), y=(0, 1), value=(0, 1), legend='scatter 0')
         plot.addScatter(x=(0, 1), y=(0, 1), value=(0, 1), legend='scatter 1')
         plot.addScatter(x=(0, 1), y=(0, 1), value=(0, 1), legend='scatter 2')
 
-        scatters = plot._getItems(kind='scatter')
-        self.assertEqual(len(scatters), 3)
-        self.assertEqual(scatters[0].getName(), 'scatter 0')
-        self.assertEqual(scatters[2].getName(), 'scatter 2')
-
-        scatters = plot._getItems(kind='scatter', just_legend=True)
-        self.assertEqual(len(scatters), 3)
-        self.assertEqual(list(scatters), ['scatter 0', 'scatter 1', 'scatter 2'])
+        items = plot.getItems()
+        self.assertEqual(len(items), 3)
+        self.assertEqual(items[0].getName(), 'scatter 0')
+        self.assertEqual(items[1].getName(), 'scatter 1')
+        self.assertEqual(items[2].getName(), 'scatter 2')
 
 
 class TestPlotHistogram(unittest.TestCase):

--- a/silx/gui/plot/tools/PositionInfo.py
+++ b/silx/gui/plot/tools/PositionInfo.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -212,10 +212,11 @@ class PositionInfo(qt.QWidget):
             else:
                 kinds = []
                 if snappingMode & self.SNAPPING_CURVE:
-                    kinds.append('curve')
+                    kinds.append(items.Curve)
                 if snappingMode & self.SNAPPING_SCATTER:
-                    kinds.append('scatter')
-                selectedItems = plot._getItems(kind=kinds)
+                    kinds.append(items.Scatter)
+                selectedItems = [item for item in plot.getItems()
+                                 if isinstance(item, kinds) and item.isVisible()]
 
             # Compute distance threshold
             if qt.BINDING in ('PyQt5', 'PySide2'):


### PR DESCRIPTION
This PR replace the use of `PlotWidget._getAllMarkers` and `PlotWidget._getItems` by `PlotWidget.getItems` and deprecates the former private methods.

Following PR #2904, this reduces the amount of methods used and moves towards using the item-based API internally.
