### PR TITLE
PlotWidget XAxisExtent and YAxisExtent items

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -598,9 +598,13 @@ class PlotWidget(qt.QMainWindow):
         elif isinstance(item, items.Scatter):
             kind = 'scatter'
         elif isinstance(item, (items.Marker,
-                               items.XMarker, items.YMarker)):
+                               items.XMarker,
+                               items.YMarker)):
             kind = 'marker'
-        elif isinstance(item, (items.Shape, items.BoundingRect)):
+        elif isinstance(item, (items.Shape,
+                               items.BoundingRect,
+                               items.XAxisExtent,
+                               items.YAxisExtent)):
             kind = 'item'
         elif isinstance(item, items.Histogram):
             kind = 'histogram'

--- a/silx/gui/plot/items/__init__.py
+++ b/silx/gui/plot/items/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -40,11 +40,12 @@ from .complex import ImageComplexData  # noqa
 from .curve import Curve, CurveStyle  # noqa
 from .histogram import Histogram  # noqa
 from .image import ImageBase, ImageData, ImageRgba, MaskImageData  # noqa
-from .shape import Shape, BoundingRect  # noqa
+from .shape import Shape, BoundingRect, XAxisExtent, YAxisExtent  # noqa
 from .scatter import Scatter  # noqa
 from .marker import MarkerBase, Marker, XMarker, YMarker  # noqa
 from .axis import Axis, XAxis, YAxis, YRightAxis
 
-DATA_ITEMS = ImageComplexData, Curve, Histogram, ImageBase, Scatter, BoundingRect
+DATA_ITEMS = (ImageComplexData, Curve, Histogram, ImageBase, Scatter,
+              BoundingRect, XAxisExtent, YAxisExtent)
 """Classes of items representing data and to consider to compute data bounds.
 """

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -43,7 +43,7 @@ from silx.test.utils import test_options
 from silx.gui import qt
 from silx.gui.plot import PlotWidget
 from silx.gui.plot.items.curve import CurveStyle
-from silx.gui.plot.items.shape import BoundingRect
+from silx.gui.plot.items import BoundingRect, XAxisExtent, YAxisExtent
 from silx.gui.colors import Colormap
 
 from .utils import PlotWidgetTestCase
@@ -1393,6 +1393,28 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         self.plot.getXAxis()._setLogarithmic(True)
         self.plot.getYAxis()._setLogarithmic(False)
         self.assertIsNone(item.getBounds())
+
+    def testAxisExtent(self):
+        """Test XAxisExtent and yAxisExtent"""
+        for cls, axis in ((XAxisExtent, self.plot.getXAxis()),
+                          (YAxisExtent, self.plot.getYAxis())):
+            for range_, logRange in (((2, 3), (2, 3)),
+                                     ((-2, -1), (1, 100)),
+                                     ((-1, 3), (3. * 0.9, 3. * 1.1))):
+                extent = cls()
+                extent.setRange(*range_)
+                self.plot.addItem(extent)
+
+                for isLog, plotRange in ((False, range_), (True, logRange)):
+                    with self.subTest(
+                            cls=cls.__name__, range=range_, isLog=isLog):
+                        axis._setLogarithmic(isLog)
+                        self.plot.resetZoom()
+                        self.qapp.processEvents()
+                        self.assertEqual(axis.getLimits(), plotRange)
+
+                axis._setLogarithmic(False)
+                self.plot.clear()
 
 
 class TestPlotCurveLog(PlotWidgetTestCase, ParametricTestCase):


### PR DESCRIPTION
This PR adds 2 items to the `PlotWidget` items: `XAxisExtent` and `YAxisExtent` which allows to define data extent along each axis to be taken into account by reset zoom. Those items do not display anything.
Those are similar to the `BoundingRect` item except that they only interfere with the data range on a single axis.

closes #2926