### PR TITLE
Added StackViewPLugin for QtDesigner

### DIFF
--- a/qtdesigner_plugins/stackviewplugin.py
+++ b/qtdesigner_plugins/stackviewplugin.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2015-2020 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""silx.gui.plot StackView Qt designer plugin."""
+
+__authors__ = ["A. Marie"]
+__license__ = "MIT"
+__date__ = "28/02/2020"
+
+from silx.gui import qt, icons
+
+if qt.BINDING == 'PyQt4':
+    from PyQt4 import QtDesigner
+elif qt.BINDING == 'PyQt5':
+    from PyQt5 import QtDesigner
+else:
+    raise RuntimeError("Unsupport Qt BINDING: %s" % qt.BINDING)
+
+from silx.gui.plot import StackView
+
+class StackViewPlugin(QtDesigner.QPyDesignerCustomWidgetPlugin):
+
+    def __init__(self, parent=None):
+        super(StackViewPlugin, self).__init__(parent)
+        self.initialized = False
+
+    def initialize(self, core):
+        if self.initialized:
+            return
+
+        self.initialized = True
+
+    def isInitialized(self):
+        return self.initialized
+
+    def createWidget(self, parent):
+        stack = StackView(parent)
+        stack.setAutoReplot(False)
+        return stack
+
+    def name(self):
+        return "StackView"
+
+    def group(self):
+        return "silx"
+
+    def icon(self):
+        return icons.getQIcon('stack-view')
+
+    def toolTip(self):
+        return ""
+
+    def whatsThis(self):
+        return ""
+
+    def isContainer(self):
+        return False
+
+    def includeFile(self):
+        return "silx.gui.plot.StackView"


### PR DESCRIPTION
Hello, 

I am currently working with Qt Designer on a project, still I use a lot of silx widgets also.

Thus I tried to create a plugin to have one of silx widget in Qt Designer.
I made up this branch (in my fork) because I may create other plugins for widgets that I need.

I think it could be nice to append this to the silx repository.

However I don't know how really it works, I just created it by using the already existing plugins.
So if anything seems wrong or not understand, I would like to have some help, or advices.

Thanks in advance

Alexandre