### PR TITLE
Fix ColormapDialog when deleted while waiting for exec result

### DIFF
--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -805,6 +805,7 @@ class ColormapDialog(qt.QDialog):
         qt.QDialog.__init__(self, parent)
         self.setWindowTitle(title)
 
+        self.__aboutToDelete = False
         self._colormap = None
 
         self._data = None
@@ -997,11 +998,17 @@ class ColormapDialog(qt.QDialog):
         self._buttonsModal.setVisible(modal)
         qt.QDialog.setModal(self, modal)
 
+    def event(self, event):
+        if event.type() == qt.QEvent.DeferredDelete:
+            self.__aboutToDelete = True
+        return super(ColormapDialog, self).event(event)
+
     def exec_(self):
         wasModal = self.isModal()
         self.setModal(True)
         result = super(ColormapDialog, self).exec_()
-        self.setModal(wasModal)
+        if not self.__aboutToDelete:
+            self.setModal(wasModal)
         return result
 
     def _getFiniteColormapRange(self):

--- a/silx/gui/dialog/test/test_colormapdialog.py
+++ b/silx/gui/dialog/test/test_colormapdialog.py
@@ -54,10 +54,13 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
 
     def tearDown(self):
         self.qapp.processEvents()
-        self.colormapDiag.close()
-        self.colormapDiag.deleteLater()
+        colormapDiag = self.colormapDiag
+        self.colormapDiag = None
+        if colormapDiag is not None:
+            colormapDiag.close()
+            colormapDiag.deleteLater()
+            colormapDiag = None
         self.qapp.processEvents()
-        del self.colormapDiag
         ParametricTestCase.tearDown(self)
         TestCaseQt.tearDown(self)
 

--- a/silx/gui/dialog/test/test_colormapdialog.py
+++ b/silx/gui/dialog/test/test_colormapdialog.py
@@ -368,6 +368,13 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         vrange = dialog._getFiniteColormapRange()
         self.assertNotEqual(vrange, previousRange)
 
+    def testDeleteWhileExec(self):
+        colormapDiag = self.colormapDiag
+        self.colormapDiag = None
+        qt.QTimer.singleShot(1000, colormapDiag.deleteLater)
+        result = colormapDiag.exec_()
+        self.assertEqual(result, 0)
+
 
 class TestColormapAction(TestCaseQt):
     def setUp(self):


### PR DESCRIPTION
This PR catch the `DeferredDelete` to avoid to edit sub widget after the execution of the `exec`.

Without this patch, C++ exception is raised, cause the widget children do not exist any more.

Note that the use of `exec` is not recommanded by Qt, especially cause of this kind of problems.