### PR TITLE
Some fixes and minor improvements for FitAction

### DIFF
--- a/silx/gui/fit/FitWidget.py
+++ b/silx/gui/fit/FitWidget.py
@@ -512,10 +512,12 @@ class FitWidget(qt.QWidget):
                 msg.setWindowTitle('FitWidget Message')
                 msg.exec_()
                 return
-        except:    # noqa (we want to catch and report all errors)
+        except Exception as e:    # noqa (we want to catch and report all errors)
+            _logger.warning('Estimate error: %s', traceback.format_exc())
             msg = qt.QMessageBox(self)
             msg.setIcon(qt.QMessageBox.Critical)
-            msg.setText("Error on estimate: %s" % traceback.format_exc())
+            msg.setWindowTitle("Estimate Error")
+            msg.setText("Error on estimate: %s" % e)
             msg.exec_()
             ddict = {
                 'event': 'EstimateFailed',
@@ -554,10 +556,12 @@ class FitWidget(qt.QWidget):
                      'data': None}
             self._emitSignal(ddict)
             self.fitmanager.runfit(callback=self.fitStatus)
-        except:  # noqa (we want to catch and report all errors)
+        except Exception as e:  # noqa (we want to catch and report all errors)
+            _logger.warning('Estimate error: %s', traceback.format_exc())
             msg = qt.QMessageBox(self)
             msg.setIcon(qt.QMessageBox.Critical)
-            msg.setText("Error on Fit: %s" % traceback.format_exc())
+            msg.setWindowTitle("Fit Error")
+            msg.setText("Error on Fit: %s" % e)
             msg.exec_()
             ddict = {
                 'event': 'FitFailed',

--- a/silx/gui/plot/ItemsSelectionDialog.py
+++ b/silx/gui/plot/ItemsSelectionDialog.py
@@ -169,7 +169,9 @@ class PlotItemsSelector(qt.QTableWidget):
         for row in selected_rows:
             legend = self.item(row, 0).text()
             kind = self.item(row, 1).text()
-            items.append(self.plot._getItem(kind, legend))
+            item = self.plot._getItem(kind, legend)
+            if item is not None:
+                items.append(item)
 
         return items
 

--- a/silx/gui/plot/actions/fit.py
+++ b/silx/gui/plot/actions/fit.py
@@ -153,11 +153,11 @@ class FitAction(PlotToolAction):
             isd.setAvailableKinds(["curve", "histogram"])
             isd.selectAllKinds()
 
-            result = isd.exec_()
-            if result and len(isd.getSelectedItems()) == 1:
-                item = isd.getSelectedItems()[0]
+            if not isd.exec_():  # Cancel
+                self._getToolWindow().setVisible(False)
             else:
-                return
+                selectedItems = isd.getSelectedItems()
+                item = selectedItems[0] if len(selectedItems) == 1 else None
 
         self._setXRange(*plot.getXAxis().getLimits())
         self._setFittedItem(item)


### PR DESCRIPTION
!!! Merge PR #2960 first !!!

This PR provides:
- Simpler message in pop-up when estimate/fit fails.
- Fix issue when plot is cleared while the user is choosing the curve to fit.
- Deprecates `FitAction`'s `x`, `y`, `xlabel` and `ylabel` attributes.
- Adds `FitAction.get[X|Y]Data` methods.
- Hides the `FitWidget` when the user `Cancel` the curve selection.
- Makes `handle_signal` resilient to being called while it should not.

closes #2952