### PR TITLE
[plot] Use set_frame_on to keep grid while hiding axes

### DIFF
--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1174,15 +1174,15 @@ class BackendMatplotlib(BackendBase.BackendBase):
         BackendBase.BackendBase.setAxesDisplayed(self, displayed)
         if displayed:
             # show axes and viewbox rect
-            self.ax.set_axis_on()
-            self.ax2.set_axis_on()
+            self.ax.set_frame_on(True)
+            self.ax2.set_frame_on(True)
             # set the default margins
             self.ax.set_position([.15, .15, .75, .75])
             self.ax2.set_position([.15, .15, .75, .75])
         else:
             # hide axes and viewbox rect
-            self.ax.set_axis_off()
-            self.ax2.set_axis_off()
+            self.ax.set_frame_on(False)
+            self.ax2.set_frame_on(False)
             # remove external margins
             self.ax.set_position([0, 0, 1, 1])
             self.ax2.set_position([0, 0, 1, 1])


### PR DESCRIPTION
This PR uses matplotlib `Axes.set_frame_on` rather than `set_axis_on|off` to show/hide the axes as it keeps the grid.

closes #2943