### PR TITLE
Fix silx fat binary build

### DIFF
--- a/package/windows/README.rst
+++ b/package/windows/README.rst
@@ -26,12 +26,12 @@ Pre-requisites
 Procedure
 ---------
 
-- Go to the `package/windows` folder in the source directory
-- Run `pyinstaller pyinstaller.spec`.
-  This generates a fat binary in `package/windows/dist/silx/` for the generic launcher `silx.exe`.
-- Run `pyinstaller pyinstaller-silx-view.spec`.
-  This generates a fat binary in `package/windows/dist/silx-view/` for the silx view command `silx-view.exe`.
-- Copy `silx-view.exe` and `silx-view.exe.manifest` to `package/windows/dist/silx/`.
+- Go to the ``package/windows`` folder in the source directory
+- Run ``pyinstaller pyinstaller.spec``.
+  This generates a fat binary in ``package/windows/dist/silx/`` for the generic launcher ``silx.exe``.
+- Run ``pyinstaller pyinstaller-silx-view.spec``.
+  This generates a fat binary in ``package/windows/dist/silx-view/`` for the silx view command ``silx-view.exe``.
+- Copy ``silx-view.exe`` and ``silx-view.exe.manifest`` to ``package/windows/dist/silx/``.
   This is a hack until PyInstaller supports multiple executables (see https://github.com/pyinstaller/pyinstaller/issues/1527).
-- Zip `package\windows\dist\silx` to make the application available as a single zip file.
+- Zip ``package\windows\dist\silx`` to make the application available as a single zip file.
 

--- a/package/windows/pyinstaller-silx-view.spec
+++ b/package/windows/pyinstaller-silx-view.spec
@@ -1,6 +1,6 @@
 # -*- mode: python -*-
 import os.path
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
 datas = []
 
@@ -8,9 +8,10 @@ PROJECT_PATH = os.path.abspath(os.path.join(SPECPATH, "..", ".."))
 datas.append((os.path.join(PROJECT_PATH, "README.rst"), "."))
 datas.append((os.path.join(PROJECT_PATH, "LICENSE"), "."))
 datas.append((os.path.join(PROJECT_PATH, "copyright"), "."))
-
-
 datas += collect_data_files("silx.resources")
+
+
+hiddenimports = collect_submodules('fabio')
 
 
 block_cipher = None
@@ -20,7 +21,7 @@ a = Analysis(['bootstrap-silx-view.py'],
              pathex=[],
              binaries=[],
              datas=datas,
-             hiddenimports=[],
+             hiddenimports=hiddenimports,
              hookspath=[],
              runtime_hooks=[],
              excludes=[],

--- a/package/windows/pyinstaller.spec
+++ b/package/windows/pyinstaller.spec
@@ -1,6 +1,6 @@
 # -*- mode: python -*-
 import os.path
-from PyInstaller.utils.hooks import collect_data_files
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
 
 datas = []
 
@@ -8,9 +8,10 @@ PROJECT_PATH = os.path.abspath(os.path.join(SPECPATH, "..", ".."))
 datas.append((os.path.join(PROJECT_PATH, "README.rst"), "."))
 datas.append((os.path.join(PROJECT_PATH, "LICENSE"), "."))
 datas.append((os.path.join(PROJECT_PATH, "copyright"), "."))
-
-
 datas += collect_data_files("silx.resources")
+
+
+hiddenimports = collect_submodules('fabio')
 
 
 block_cipher = None
@@ -20,7 +21,7 @@ a = Analysis(['bootstrap.py'],
              pathex=[],
              binaries=[],
              datas=datas,
-             hiddenimports=[],
+             hiddenimports=hiddenimports,
              hookspath=[],
              runtime_hooks=[],
              excludes=[],


### PR DESCRIPTION
This PR fixes the build of `silx` fat binaries with `PyInstaller` which was due to hidden imports in `fabio`.

closes #2951