### PR TITLE
[io][url] fix path() when data_slice is not an iterable.

### DIFF
--- a/silx/io/test/test_url.py
+++ b/silx/io/test/test_url.py
@@ -197,6 +197,15 @@ class TestDataUrl(unittest.TestCase):
         url = DataUrl(scheme="silx", file_path="/foo.h5", data_slice=(5, 1))
         self.assertFalse(url.is_valid())
 
+    def test_path_creation(self):
+        """make sure the construction of path succeed and that we can
+        recreate a DataUrl from a path"""
+        for data_slice in (1, (1,)):
+            with self.subTest(data_slice=data_slice):
+                url = DataUrl(scheme="silx", file_path="/foo.h5", data_slice=data_slice)
+                path = url.path()
+                DataUrl(path=path)
+
 
 def suite():
     test_suite = unittest.TestSuite()

--- a/silx/io/url.py
+++ b/silx/io/url.py
@@ -30,6 +30,7 @@ __date__ = "29/01/2018"
 
 import logging
 import six
+from collections import Iterable
 
 parse = six.moves.urllib.parse
 
@@ -297,7 +298,10 @@ class DataUrl(object):
             if self.__data_path is not None:
                 queries.append("path=" + self.__data_path)
             if self.__data_slice is not None:
-                data_slice = ",".join([slice_to_string(s) for s in self.__data_slice])
+                if isinstance(self.__data_slice, Iterable):
+                    data_slice = ",".join([slice_to_string(s) for s in self.__data_slice])
+                else:
+                    data_slice = slice_to_string(self.__data_slice)
                 queries.append("slice=" + data_slice)
             query = "&".join(queries)
 


### PR DESCRIPTION
if data_slice is not an iterable simply convert it to str instead of calling '",".join([slice_to_string(s) for s in self.__data_slice])' which fails if data_slice is not an iterable

closes #2972