### PR TITLE
Create an example to custom silx view

### DIFF
--- a/examples/customSilxView.py
+++ b/examples/customSilxView.py
@@ -1,0 +1,60 @@
+import sys
+import numpy
+
+
+def createWindow(parent, settings):
+    # Local import to avoid early import (like h5py)
+    # SOme libraries have to be configured first properly
+    from silx.gui.plot.actions import PlotAction
+    from silx.app.view.Viewer import Viewer
+    from silx.app.view.ApplicationContext import ApplicationContext
+
+    class RandomColorAction(PlotAction):
+        def __init__(self, plot, parent=None):
+            super(RandomColorAction, self).__init__(
+                plot, icon="colormap", text='Color',
+                tooltip='Random plot background color',
+                triggered=self.__randomColor,
+                checkable=False, parent=parent)
+
+        def __randomColor(self):
+            color = "#%06X" % numpy.random.randint(0xFFFFFF)
+            self.plot.setBackgroundColor(color)
+
+    class MyApplicationContext(ApplicationContext):
+        """This class is shared to all the silx view application."""
+    
+        def findPrintToolBar(self, plot):
+            # FIXME: It would be better to use the Qt API
+            return plot._outputToolBar
+
+        def viewWidgetCreated(self, view, widget):
+            """Called when the widget of the view was created.
+
+            So we can custom it.
+            """
+            from silx.gui.plot import Plot1D
+            if isinstance(widget, Plot1D):
+                toolBar = self.findPrintToolBar(widget)
+                action = RandomColorAction(widget, widget)
+                toolBar.addAction(action)
+
+    class MyViewer(Viewer):
+        def createApplicationContext(self, settings):
+            return MyApplicationContext(self, settings)
+
+    window = MyViewer(parent=parent, settings=settings)
+    window.setWindowTitle(window.windowTitle() + " [custom]")
+    return window
+
+
+def main(args):
+    from silx.app.view import main as silx_view_main
+    # Monkey patch the main window creation
+    silx_view_main.createWindow = createWindow
+    # Use the default launcher
+    silx_view_main.main(args)
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/silx/app/view/Viewer.py
+++ b/silx/app/view/Viewer.py
@@ -65,7 +65,7 @@ class Viewer(qt.QMainWindow):
         silxIcon = icons.getQIcon("silx")
         self.setWindowIcon(silxIcon)
 
-        self.__context = ApplicationContext(self, settings)
+        self.__context = self.createApplicationContext(settings)
         self.__context.restoreLibrarySettings()
 
         self.__dialogState = None
@@ -146,6 +146,9 @@ class Viewer(qt.QMainWindow):
         self.createActions()
         self.createMenus()
         self.__context.restoreSettings()
+
+    def createApplicationContext(self, settings):
+        return ApplicationContext(self, settings)
 
     def __createTreeWindow(self, treeView):
         toolbar = qt.QToolBar(self)

--- a/silx/app/view/main.py
+++ b/silx/app/view/main.py
@@ -71,6 +71,12 @@ def createParser():
     return parser
 
 
+def createWindow(parent, settings):
+    from .Viewer import Viewer
+    window = Viewer(parent=None, settings=settings)
+    return window
+
+
 def mainQt(options):
     """Part of the main depending on Qt"""
     if options.debug:
@@ -124,8 +130,7 @@ def mainQt(options):
     if options.fresh_preferences:
         settings.clear()
 
-    from .Viewer import Viewer
-    window = Viewer(parent=None, settings=settings)
+    window = createWindow(parent=None, settings=settings)
     window.setAttribute(qt.Qt.WA_DeleteOnClose, True)
 
     if options.use_opengl_plot:

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -231,6 +231,9 @@ class DataViewHooks(object):
         """Returns a color dialog for this view."""
         return None
 
+    def viewWidgetCreated(self, view, plot):
+        """Called when the widget of the view was created"""
+        return
 
 class DataView(object):
     """Holder for the data view."""
@@ -342,6 +345,9 @@ class DataView(object):
         """
         if self.__widget is None:
             self.__widget = self.createWidget(self.__parent)
+            hooks = self.getHooks()
+            if hooks is not None:
+                hooks.viewWidgetCreated(self, self.__widget)
         return self.__widget
 
     def createWidget(self, parent):


### PR DESCRIPTION
This example allow to add custom behavior to silx view.

- Create a hook on the `DataViewer` to allow to custom the widgets in the application side
- Create a silx view factiory for `Viewer` (the main window) and `ApplicationContext` (a single instance object which basically share the context of the application)
- Create an example to add an action to custom the `Plot1D` background color

![Capture d’écran de 2020-03-28 12-12-49](https://user-images.githubusercontent.com/7579321/77821877-d4ebba80-70ed-11ea-9713-7b78f6ee81b2.png)

It can be tested this way:
```
./bootstrap.py examples/customSilxView.py foo.h5
```
Or this way (i guess)
```
python -m silx.examples.customSilxView foo.h5
```