### PR TITLE
[silx view] add title to plots

### DIFF
--- a/silx/gui/data/DataViewer.py
+++ b/silx/gui/data/DataViewer.py
@@ -27,10 +27,12 @@ view from the ones provided by silx.
 """
 from __future__ import division
 
+import logging
+import os.path
+import collections
+from silx.gui import qt
 from silx.gui.data import DataViews
 from silx.gui.data.DataViews import _normalizeData
-import logging
-from silx.gui import qt
 from silx.gui.utils import blockSignals
 from silx.gui.data.NumpyAxesSelector import NumpyAxesSelector
 
@@ -41,6 +43,11 @@ __date__ = "12/02/2019"
 
 
 _logger = logging.getLogger(__name__)
+
+
+DataSelection = collections.namedtuple("DataSelection",
+                                       ["filename", "datapath",
+                                        "slice", "permutation"])
 
 
 class DataViewer(qt.QFrame):
@@ -239,14 +246,39 @@ class DataViewer(qt.QFrame):
         """
         if self.__useAxisSelection:
             self.__displayedData = self.__numpySelection.selectedData()
+
+            permutation = self.__numpySelection.permutation()
+            normal = tuple(range(len(permutation)))
+            if permutation == normal:
+                permutation = None
+            slicing = self.__numpySelection.selection()
+            normal = tuple([slice(None)] * len(slicing))
+            if slicing == normal:
+                slicing = None
         else:
             self.__displayedData = self.__data
+            permutation = None
+            slicing = None
+
+        try:
+            filename = os.path.abspath(self.__data.file.filename)
+        except:
+            filename = None
+
+        try:
+            datapath = self.__data.name
+        except:
+            datapath = None
+
+        # FIXME: maybe use DataUrl, with added support of permutation
+        self.__displayedSelection = DataSelection(filename, datapath, slicing, permutation)
 
         # TODO: would be good to avoid that, it should be synchonous
         qt.QTimer.singleShot(10, self.__setDataInView)
 
     def __setDataInView(self):
         self.__currentView.setData(self.__displayedData)
+        self.__currentView.setDataSelection(self.__displayedSelection)
 
     def setDisplayedView(self, view):
         """Set the displayed view.
@@ -469,6 +501,7 @@ class DataViewer(qt.QFrame):
         self.__data = data
         self._invalidateInfo()
         self.__displayedData = None
+        self.__displayedSelection = None
         self.__updateView()
         self.__updateNumpySelectionAxis()
         self.__updateDataInView()

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -398,19 +398,23 @@ class DataView(object):
             return None
         else:
             directory, filename = os.path.split(selection.filename)
-            params = dict(directory=directory,
-                          filename=filename,
-                          datapath=selection.datapath,
-                          slicing=self.__formatSlices(selection.slice))
+            try:
+                slicing = self.__formatSlices(selection.slice)
+            except Exception:
+                _logger.debug("Error while formatting slices", exc_info=True)
+                slicing = '[sliced]'
+
             # FIXME: This could be an configurable field of the view
             pattern = "{filename}::{datapath}{slicing}"
             try:
-                title = pattern.format(**params)
+                title = pattern.format(
+                    directory=directory,
+                    filename=filename,
+                    datapath=selection.datapath,
+                    slicing=slicing)
             except Exception:
                 _logger.debug("Error while formatting title", exc_info=True)
-                title = selection.datapath
-                if selection.slice is not None:
-                    title = title + " [sliced]"
+                title = selection.datapath + slicing
             if selection.permutation is not None:
                 title = title + " [axis permutation]"
 

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -1267,7 +1267,6 @@ class _StackView(DataView):
         title = self.titleForSelection(selection)
         self.getWidget().setTitleCallback(
             lambda idx: "%s z=%d" % (title, idx))
-        DataView.setDataSelection(self, selection)
 
     def axesNames(self, data, info):
         return ["depth", "y", "x"]

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -364,6 +364,16 @@ class DataView(object):
         """
         return None
 
+    def setDataSelection(self, selection):
+        """Set the data selection displayed by the view
+
+        If called, it have to be called directly after `setData`.
+
+        :param selection: Data selected
+        :type selection: NamedTuple
+        """
+        pass
+
     def axesNames(self, data, info):
         """Returns names of the expected axes of the view, according to the
         input data. A none value will disable the default axes selectior.

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -1259,6 +1259,12 @@ class _StackView(DataView):
         self.getWidget().setColormap(self.defaultColormap())
         self.__resetZoomNextTime = False
 
+    def setDataSelection(self, selection):
+        title = self.titleForSelection(selection)
+        self.getWidget().setTitleCallback(
+            lambda idx: "%s z=%d" % (title, idx))
+        DataView.setDataSelection(self, selection)
+
     def axesNames(self, data, info):
         return ["depth", "y", "x"]
 

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -243,7 +243,7 @@ class DataView(object):
     TITLE_PATTERN = "{datapath}{slicing} {permuted}"
     """Pattern used to format the title of the plot.
 
-    Supported fields: `{filename}`, `{datapath}`, `{slicing}`, `{permuted}`.
+    Supported fields: `{directory}`, `{filename}`, `{datapath}`, `{slicing}`, `{permuted}`.
     """
 
     def __init__(self, parent, modeId=None, icon=None, label=None):

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -404,19 +404,20 @@ class DataView(object):
                 _logger.debug("Error while formatting slices", exc_info=True)
                 slicing = '[sliced]'
 
-            # FIXME: This could be an configurable field of the view
-            pattern = "{filename}::{datapath}{slicing}"
+            permuted = '[permuted]' if selection.permutation is not None else ''
+
+            # FIXME: This could be a configurable field of the view
+            pattern = "{filename}::{datapath}{slicing} {permuted}"
             try:
                 title = pattern.format(
                     directory=directory,
                     filename=filename,
                     datapath=selection.datapath,
-                    slicing=slicing)
+                    slicing=slicing,
+                    permuted=permuted)
             except Exception:
                 _logger.debug("Error while formatting title", exc_info=True)
                 title = selection.datapath + slicing
-            if selection.permutation is not None:
-                title = title + " [axis permutation]"
 
             return title
 

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -240,6 +240,12 @@ class DataView(object):
     """Priority returned when the requested data can't be displayed by the
     view."""
 
+    TITLE_PATTERN = "{datapath}{slicing} {permuted}"
+    """Pattern used to format the title of the plot.
+
+    Supported fields: `{filename}`, `{datapath}`, `{slicing}`, `{permuted}`.
+    """
+
     def __init__(self, parent, modeId=None, icon=None, label=None):
         """Constructor
 
@@ -404,12 +410,10 @@ class DataView(object):
                 _logger.debug("Error while formatting slices", exc_info=True)
                 slicing = '[sliced]'
 
-            permuted = '[permuted]' if selection.permutation is not None else ''
+            permuted = '(permuted)' if selection.permutation is not None else ''
 
-            # FIXME: This could be a configurable field of the view
-            pattern = "{filename}::{datapath}{slicing} {permuted}"
             try:
-                title = pattern.format(
+                title = self.TITLE_PATTERN.format(
                     directory=directory,
                     filename=filename,
                     datapath=selection.datapath,

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -365,6 +365,29 @@ class DataView(object):
         """
         return None
 
+    def __formatSlices(self, indices):
+        """Format an iterable of slice objects
+
+        :param indices: The slices to format
+        :type indices: Union[None,List[Union[slice,int]]]
+        :rtype: str
+        """
+        if indices is None:
+            return ''
+
+        def formatSlice(slice_):
+            start, stop, step = slice_.start, slice_.stop, slice_.step
+            string = ('' if start is None else str(start)) + ':'
+            if stop is not None:
+                string += str(stop)
+            if step not in (None, 1):
+                string += ':' + step
+            return string
+
+        return '[' + ', '.join(
+            formatSlice(index) if isinstance(index, slice) else str(index)
+            for index in indices) + ']'
+
     def titleForSelection(self, selection):
         """Build title from given selection information.
 
@@ -375,15 +398,12 @@ class DataView(object):
             return None
         else:
             directory, filename = os.path.split(selection.filename)
-            slicing = selection.slice
-            if slicing == None:
-                slicing = "()"
             params = dict(directory=directory,
                           filename=filename,
                           datapath=selection.datapath,
-                          slice=slicing)
+                          slicing=self.__formatSlices(selection.slice))
             # FIXME: This could be an configurable field of the view
-            pattern = "{filename}::{datapath}[{slice}]"
+            pattern = "{filename}::{datapath}{slicing}"
             try:
                 title = pattern.format(**params)
             except Exception:

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -29,6 +29,7 @@ from collections import OrderedDict
 import logging
 import numbers
 import numpy
+import os
 
 import silx.io
 from silx.utils import deprecation
@@ -822,6 +823,33 @@ class _Plot1dView(DataView):
                                   y=data,
                                   resetzoom=self.__resetZoomNextTime)
         self.__resetZoomNextTime = True
+
+    def setDataSelection(self, selection):
+        if selection is None:
+            title = None
+        else:
+            directory, filename = os.path.split(selection.filename)
+            slicing = selection.slice
+            if slicing == None:
+                slicing = "()"
+            params = dict(directory=directory,
+                          filename=filename,
+                          datapath=selection.datapath,
+                          slice=slicing)
+            # FIXME: This could be an configurable field of the view
+            pattern = "{filename}::{datapath}[{slice}]"
+            try:
+                title = pattern.format(**params)
+            except Exception:
+                _logger.debug("Error while formatting title", exc_info=True)
+                title = selection.datapath
+                if selection.slice is not None:
+                    title = title + " [sliced]"
+            if selection.permutation is not None:
+                title = title + " [axis permutation]"
+
+        plot = self.getWidget()
+        plot.setGraphTitle(title)
 
     def axesNames(self, data, info):
         return ["y"]


### PR DESCRIPTION
This PR adds a title to plots in silx view taking the dataset path and slicing information into account.
This paves the way to have a configurable way of deciding what the title is built from.

Initially proposed in PR #2978 by @vallsv 
related to PR #2974