### PR TITLE
Change FitAction behavior in silx view and Plot1D

### DIFF
--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -813,10 +813,13 @@ class _Plot1dView(DataView):
 
     def setData(self, data):
         data = self.normalizeData(data)
-        self.getWidget().addCurve(legend="data",
-                                  x=range(len(data)),
-                                  y=data,
-                                  resetzoom=self.__resetZoomNextTime)
+        plotWidget = self.getWidget()
+        legend = "data"
+        plotWidget.addCurve(legend=legend,
+                            x=range(len(data)),
+                            y=data,
+                            resetzoom=self.__resetZoomNextTime)
+        plotWidget.setActiveCurve(legend)
         self.__resetZoomNextTime = True
 
     def axesNames(self, data, info):

--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -839,6 +839,9 @@ class Plot1D(PlotWindow):
             self.setWindowTitle('Plot1D')
         self.getXAxis().setLabel('X')
         self.getYAxis().setLabel('Y')
+        action = self.getFitAction()
+        action.setXRangeUpdatedOnZoom(True)
+        action.setFittedItemUpdatedFromActiveCurve(True)
 
 
 class Plot2D(PlotWindow):

--- a/silx/gui/plot/actions/fit.py
+++ b/silx/gui/plot/actions/fit.py
@@ -140,7 +140,7 @@ class FitAction(PlotToolAction):
         from ...fit.FitWidget import FitWidget
 
         window = FitWidget(parent=self.plot)
-        window.setWindowFlags(qt.Qt.Window)
+        window.setWindowFlags(qt.Qt.Window | qt.Qt.WindowStaysOnTopHint)
         window.sigFitWidgetSignal.connect(self.handle_signal)
         return window
 

--- a/silx/gui/plot/actions/fit.py
+++ b/silx/gui/plot/actions/fit.py
@@ -140,7 +140,7 @@ class FitAction(PlotToolAction):
         from ...fit.FitWidget import FitWidget
 
         window = FitWidget(parent=self.plot)
-        window.setWindowFlags(qt.Qt.Window | qt.Qt.WindowStaysOnTopHint)
+        window.setWindowFlags(qt.Qt.Dialog)
         window.sigFitWidgetSignal.connect(self.handle_signal)
         return window
 


### PR DESCRIPTION
This PR proposes to change the behavior of the `FitAction` in `Plot1D` and `silx view` to use the behaviour of live update introduced in PR #2960.

It also proposes to keep the `FitWidget` always on top (only when started from the `FitAction`), related to #2935.