### PR TITLE
[plot] Make mpl backend resilient in case PlotWidget already destroyed

### DIFF
--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1330,7 +1330,12 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
 
     def leaveEvent(self, event):
         """QWidget event handler"""
-        self._plot.onMouseLeaveWidget()
+        try:
+            plot = self._plot
+        except RuntimeError:
+            pass
+        else:
+            plot.onMouseLeaveWidget()
 
     # picking
 


### PR DESCRIPTION
This PR makes matplotlib backend resilient to PlotWidget being destroyed before leave event is handled in  the backend.

closes  #2983