### PR TITLE
Rework the StackView with a stack image plot item

### DIFF
--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -1798,7 +1798,7 @@ class _NXdataStackView(DataView):
         from silx.gui.data.NXdataWidgets import ArrayStackPlot
         widget = ArrayStackPlot(parent)
         widget.getStackView().setColormap(self.defaultColormap())
-        widget.getStackView().getPlot().getColormapAction().setColorDialog(self.defaultColorDialog())
+        widget.getStackView().getPlotWidget().getColormapAction().setColorDialog(self.defaultColorDialog())
         return widget
 
     def axesNames(self, data, info):
@@ -1899,7 +1899,7 @@ class _NXdataVolumeAsStackView(DataView):
         from silx.gui.data.NXdataWidgets import ArrayStackPlot
         widget = ArrayStackPlot(parent)
         widget.getStackView().setColormap(self.defaultColormap())
-        widget.getStackView().getPlot().getColormapAction().setColorDialog(self.defaultColorDialog())
+        widget.getStackView().getPlotWidget().getColormapAction().setColorDialog(self.defaultColorDialog())
         return widget
 
     def axesNames(self, data, info):

--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -785,8 +785,8 @@ class ArrayStackPlot(qt.QWidget):
 
         self._stack_view.setGraphTitle(title or "")
         # by default, the z axis is the image position (dimension not plotted)
-        self._stack_view.getPlot().getXAxis().setLabel(self.__x_axis_name or "X")
-        self._stack_view.getPlot().getYAxis().setLabel(self.__y_axis_name or "Y")
+        self._stack_view.getPlotWidget().getXAxis().setLabel(self.__x_axis_name or "X")
+        self._stack_view.getPlotWidget().getYAxis().setLabel(self.__y_axis_name or "Y")
 
         self._updateStack()
 

--- a/silx/gui/plot/Profile.py
+++ b/silx/gui/plot/Profile.py
@@ -775,7 +775,7 @@ class Profile3DToolBar(ProfileToolBar):
         """
         # TODO: add param profileWindow (specify the plot used for profiles)
         super(Profile3DToolBar, self).__init__(parent=parent,
-                                               plot=stackview.getPlot(),
+                                               plot=stackview.getPlotWidget(),
                                                title=title)
         self._method3D = 'sum'
         self._profileType = None

--- a/silx/gui/plot/Profile.py
+++ b/silx/gui/plot/Profile.py
@@ -777,6 +777,9 @@ class Profile3DToolBar(ProfileToolBar):
         super(Profile3DToolBar, self).__init__(parent=parent,
                                                plot=stackview.getPlot(),
                                                title=title)
+        self._method3D = 'sum'
+        self._profileType = None
+
         self.stackView = stackview
         """:class:`StackView` instance"""
 
@@ -788,9 +791,7 @@ class Profile3DToolBar(ProfileToolBar):
         self.profile3dAction.sigDimensionChanged.connect(self._setProfileType)
 
         # create the 3D toolbar
-        self._profileType = None
         self._setProfileType(2)
-        self._method3D = 'sum'
 
     def _setProfileType(self, dimensions):
         """Set the profile type: "1D" for a curve (profile on a single image)

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -898,7 +898,11 @@ class StackView(qt.QMainWindow):
         if isinstance(activeImage, items.ColormapMixIn):
             activeImage.setColormap(self.getColormap())
 
+    @deprecated(replacement="getPlotWidget", since_version="0.13")
     def getPlot(self):
+        return self.getPlotWidget()
+
+    def getPlotWidget(self):
         """Return the :class:`PlotWidget`.
 
         This gives access to advanced plot configuration options.

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -300,7 +300,7 @@ class StackView(qt.QMainWindow):
         Emit :attr:`valueChanged` signal, with (x, y, value) tuple of the
         cursor location in the plot."""
         if eventDict['event'] == 'mouseMoved':
-            activeImage = self._plot.getActiveImage()
+            activeImage = self.getActiveImage()
             if activeImage is not None:
                 data = activeImage.getData()
                 height, width = data.shape
@@ -649,7 +649,7 @@ class StackView(qt.QMainWindow):
         :return: 3D stack and parameters.
         :rtype: (numpy.ndarray, dict)
         """
-        image = self._plot.getActiveImage()
+        image = self.getActiveImage()
         if image is None:
             return None
 
@@ -894,7 +894,7 @@ class StackView(qt.QMainWindow):
         self._plot.setDefaultColormap(_colormap)
 
         # Update active image colormap
-        activeImage = self._plot.getActiveImage()
+        activeImage = self.getActiveImage()
         if isinstance(activeImage, items.ColormapMixIn):
             activeImage.setColormap(self.getColormap())
 
@@ -1058,23 +1058,11 @@ class StackView(qt.QMainWindow):
 
     # kind of private methods, but needed by Profile
     def getActiveImage(self, just_legend=False):
-        """Returns the currently active image object.
-
-        It returns None in case of not having an active image.
-
-        This method is a simple proxy to the legacy :class:`PlotWidget` method
-        of the same name. Using the object oriented approach is now
-        preferred::
-
-            stackview.getPlot().getActiveImage()
-
-        :param bool just_legend: True to get the legend of the image,
-            False (the default) to get the image data and info.
-            Note: :class:`StackView` uses the same legend for all frames.
-        :return: legend or image object
-        :rtype: str or list or None
+        """Returns the stack image object.
         """
-        return self._plot.getActiveImage(just_legend=just_legend)
+        if just_legend:
+            return self._stackItem.getName()
+        return self._stackItem
 
     def getColorBarAction(self):
         """Returns the action managing the visibility of the colorbar.

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -232,9 +232,9 @@ class StackView(qt.QMainWindow):
 
         self._addColorBarAction()
 
-        self._plot.profile = Profile3DToolBar(parent=self._plot,
-                                              stackview=self)
-        self._plot.addToolBar(self._plot.profile)
+        self._profileToolBar = Profile3DToolBar(parent=self._plot,
+                                                stackview=self)
+        self._plot.addToolBar(self._profileToolBar)
         self._plot.getXAxis().setLabel('Columns')
         self._plot.getYAxis().setLabel('Rows')
         self._plot.sigPlotSignal.connect(self._plotCallback)
@@ -262,9 +262,9 @@ class StackView(qt.QMainWindow):
 
         # clear profile lines when the perspective changes (plane browsed changed)
         self.__planeSelection.sigPlaneSelectionChanged.connect(
-            self._plot.profile.getProfilePlot().clear)
+            self._profileToolBar.getProfilePlot().clear)
         self.__planeSelection.sigPlaneSelectionChanged.connect(
-            self._plot.profile.clearProfile)
+            self._profileToolBar.clearProfile)
 
     def _saveImageStack(self, plot, filename, nameFilter):
         """Save all images from the stack into a volume.
@@ -922,10 +922,8 @@ class StackView(qt.QMainWindow):
     # proxies to PlotWidget or PlotWindow methods
     def getProfileToolbar(self):
         """Profile tools attached to this plot
-
-        See :class:`silx.gui.plot.Profile.Profile3DToolBar`
         """
-        return self._plot.profile
+        return self._profileToolBar
 
     def getGraphTitle(self):
         """Return the plot main title as a str.
@@ -1200,13 +1198,14 @@ class StackViewMainWindow(StackView):
         menu.addAction(actions.control.YAxisInvertedAction(self._plot, self))
 
         menu = self.menuBar().addMenu('Profile')
-        menu.addAction(self._plot.profile.hLineAction)
-        menu.addAction(self._plot.profile.vLineAction)
-        menu.addAction(self._plot.profile.lineAction)
+        profileToolBar = self._profileToolBar
+        menu.addAction(profileToolBar.hLineAction)
+        menu.addAction(profileToolBar.vLineAction)
+        menu.addAction(profileToolBar.lineAction)
         menu.addSeparator()
-        menu.addAction(self._plot.profile.clearAction)
-        self._plot.profile.profile3dAction.computeProfileIn2D()
-        menu.addMenu(self._plot.profile.profile3dAction.menu())
+        menu.addAction(profileToolBar.clearAction)
+        profileToolBar.profile3dAction.computeProfileIn2D()
+        menu.addMenu(profileToolBar.profile3dAction.menu())
 
         # Connect to StackView's signal
         self.valueChanged.connect(self._statusBarSlot)

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -507,7 +507,7 @@ class StackView(qt.QMainWindow):
         :param calibrations: Sequence of 3 calibration objects for each axis.
             These objects can be a subclass of :class:`AbstractCalibration`,
             or 2-tuples *(a, b)* where *a* is the y-intercept and *b* is the
-            slope of a linear calibration (:math:`x \mapsto a + b x`)
+            slope of a linear calibration (:math:`x \\mapsto a + b x`)
         """
         if stack is None:
             self.clear()

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -910,20 +910,6 @@ class StackView(qt.QMainWindow):
         """
         return self._plot
 
-    def getProfileWindow1D(self):
-        """Plot window used to display 1D profile curve.
-
-        :return: :class:`Plot1D`
-        """
-        return self._plot.profile.getProfileWindow1D()
-
-    def getProfileWindow2D(self):
-        """Plot window used to display 2D profile image.
-
-        :return: :class:`Plot2D`
-        """
-        return self._plot.profile.getProfileWindow2D()
-
     def setOptionVisible(self, isVisible):
         """
         Set the visibility of the browsing options.

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -42,7 +42,6 @@ import numpy
 from ....utils.proxy import docstring
 from .core import (Item, LabelsMixIn, DraggableMixIn, ColormapMixIn,
                    AlphaMixIn, ItemChangedType)
-from ._pick import PickingResult
 
 
 _logger = logging.getLogger(__name__)

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -458,3 +458,82 @@ class MaskImageData(ImageData):
     internal silx widgets.
     """
     pass
+
+
+class ImageStack(ImageData):
+    """Item to store a stack of images and to show it in the plot as one
+    of the images of the stack.
+
+    The stack is a 3D array ordered this way: `frame id, y, x`.
+    So the first image of the stack can be reached this way: `stack[0, :, :]`
+    """
+
+    def __init__(self):
+        ImageData.__init__(self)
+        self.__stack = None
+        """A 3D numpy array (or a mimic one, see ListOfImages)"""
+        self.__stackPosition = None
+        """Displayed position in the cube"""
+
+    def setStackData(self, stack, position=None, copy=True):
+        """Set the stack data
+
+        :param stack: A 3D numpy array like
+        :param int position: The position of the displayed image in the stack
+        :param bool copy: True (Default) to get a copy,
+                          False to use internal representation (do not modify!)
+        """
+        if self.__stack is stack:
+            return
+        if copy:
+            stack = numpy.array(stack)
+        assert stack.ndim == 3
+        self.__stack = stack
+        if position is not None:
+            self.__stackPosition = position
+        if self.__stackPosition is None:
+            self.__stackPosition = 0
+        self.__updateDisplayedData()
+
+    def getStackData(self, copy=True):
+        """Get the stored stack array.
+
+        :param bool copy: True (Default) to get a copy,
+                          False to use internal representation (do not modify!)
+        :rtype: A 3D numpy array, or numpy array like
+        """
+        if copy:
+            return numpy.array(self.__stack)
+        else:
+            return self.__stack
+
+    def setStackPosition(self, pos):
+        """Set the displayed position on the stack.
+
+        This function will clamp the stack position according to
+        the real size of the first axis of the stack.
+
+        :param int pos: A position on the first axis of the stack.
+        """
+        if self.__stackPosition == pos:
+            return
+        self.__stackPosition = pos
+        self.__updateDisplayedData()
+
+    def getStackPosition(self):
+        """Get the displayed position of the stack.
+
+        :rtype: int
+        """
+        return self.__stackPosition
+
+    def __updateDisplayedData(self):
+        """Update the displayed frame whenever the stack or the stack
+        position are updated."""
+        if self.__stack is None or self.__stackPosition is None:
+            empty = numpy.array([]).reshape(0, 0)
+            self.setData(empty, copy=False)
+            return
+        size = len(self.__stack)
+        self.__stackPosition = numpy.clip(self.__stackPosition, 0, size)
+        self.setData(self.__stack[self.__stackPosition], copy=False)

--- a/silx/gui/plot/test/testProfile.py
+++ b/silx/gui/plot/test/testProfile.py
@@ -179,7 +179,7 @@ class TestProfile3DToolBar(TestCaseQt):
         self.assertIsNot(toolButton, None)
         self.mouseMove(toolButton)
         self.mouseClick(toolButton, qt.Qt.LeftButton)
-        plot2D = self.plot.getPlot().getWidgetHandle()
+        plot2D = self.plot.getPlotWidget().getWidgetHandle()
         pos1 = plot2D.width() * 0.5, plot2D.height() * 0.5
         self.mouseClick(plot2D, qt.Qt.LeftButton, pos=pos1)
         self.assertTrue(numpy.array_equal(
@@ -221,7 +221,7 @@ class TestProfile3DToolBar(TestCaseQt):
         self.assertIsNot(toolButton, None)
         self.mouseMove(toolButton)
         self.mouseClick(toolButton, qt.Qt.LeftButton)
-        plot2D = self.plot.getPlot().getWidgetHandle()
+        plot2D = self.plot.getPlotWidget().getWidgetHandle()
         pos1 = plot2D.width() * 0.5, plot2D.height() * 0.2
         pos2 = plot2D.width() * 0.5, plot2D.height() * 0.8
 

--- a/silx/utils/array_like.py
+++ b/silx/utils/array_like.py
@@ -53,6 +53,7 @@ import sys
 
 import numpy
 import six
+import numbers
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
@@ -363,7 +364,7 @@ class ListOfImages(object):
         frozen_dimensions = []
         for i, idx in enumerate(item):
             # slices and sequences
-            if not isinstance(idx, int):
+            if not isinstance(idx, numbers.Integral):
                 output_dimensions.append(self.transposition[i])
             # regular integer index
             else:


### PR DESCRIPTION
This is a small refactoring to allow to clean up other part of Silx, basically the profiles (#2988).

This PR creates an `ImageStack` in order to store in the plot a model of the stack.

An `ImageStack` is only an extends of `ImageData`. That's a 3D stack, in which only a single frame is displayed.

Storing the stack in the plot allows to rework other part of the GUI with this extra information. The profile do not need anymore a dependency to this `StackView` view in order to display a profile in the 3D depth. Other tools can also benefit to it, like a generic statusbar, for example.