### PR TITLE
[silx view] When NXdata title is defined, do not append dataset name

### DIFF
--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -289,10 +289,10 @@ class XYVScatterPlot(qt.QWidget):
 
         idx = self._slider.value()
 
-        title = ""
         if self.__graph_title:
-            title += self.__graph_title + "\n"  # main NXdata @title
-        title += self.__scatter_titles[idx]     # scatter dataset name
+            title = self.__graph_title  # main NXdata @title
+        else:
+            title = self.__scatter_titles[idx]  # scatter dataset name
 
         self._plot.setGraphTitle(title)
         self._plot.setData(x, y, self.__values[idx],
@@ -484,11 +484,10 @@ class ArrayImagePlot(qt.QWidget):
                                   numpy.ravel(image),
                                   legend=legend)
 
-        title = ""
         if self.__title:
-            title += self.__title
-        if not title.strip().endswith(self.__signals_names[auxSigIdx]):
-            title += "\n" + self.__signals_names[auxSigIdx]
+            title = self.__title
+        else:
+            title = self.__signals_names[auxSigIdx]
         self._plot.setGraphTitle(title)
         self._plot.getXAxis().setLabel(self.__x_axis_name)
         self._plot.getYAxis().setLabel(self.__y_axis_name)
@@ -672,11 +671,10 @@ class ArrayComplexImagePlot(qt.QWidget):
         self._plot.setOrigin((xorigin, yorigin))
         self._plot.setScale((xscale, yscale))
 
-        title = ""
         if self.__title:
-            title += self.__title
-        if not title.strip().endswith(self.__signals_names[auxSigIdx]):
-            title += "\n" + self.__signals_names[auxSigIdx]
+            title = self.__title
+        else:
+            title = self.__signals_names[auxSigIdx]
         self._plot.setGraphTitle(title)
         self._plot.getXAxis().setLabel(self.__x_axis_name)
         self._plot.getYAxis().setLabel(self.__y_axis_name)

--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -291,6 +291,9 @@ class XYVScatterPlot(qt.QWidget):
 
         if self.__graph_title:
             title = self.__graph_title  # main NXdata @title
+            if len(self.__scatter_titles) > 1:
+                # Append dataset name only when there is many datasets
+                title += '\n' + self.__scatter_titles[idx]
         else:
             title = self.__scatter_titles[idx]  # scatter dataset name
 
@@ -486,6 +489,9 @@ class ArrayImagePlot(qt.QWidget):
 
         if self.__title:
             title = self.__title
+            if len(self.__signals_names) > 1:
+                # Append dataset name only when there is many datasets
+                title += '\n' + self.__signals_names[auxSigIdx]
         else:
             title = self.__signals_names[auxSigIdx]
         self._plot.setGraphTitle(title)
@@ -673,6 +679,9 @@ class ArrayComplexImagePlot(qt.QWidget):
 
         if self.__title:
             title = self.__title
+            if len(self.__signals_names) > 1:
+                # Append dataset name only when there is many datasets
+                title += '\n' + self.__signals_names[auxSigIdx]
         else:
             title = self.__signals_names[auxSigIdx]
         self._plot.setGraphTitle(title)


### PR DESCRIPTION
This PR avoid appending the dataset name to the plot title when the `title` attribute is defined.

closes #2998