### PR TITLE
[plot] Fix PlotWidget.getInteractiveMode

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -3081,7 +3081,7 @@ class PlotWidget(qt.QMainWindow):
         """Returns the current interactive mode as a dict.
 
         The returned dict contains at least the key 'mode'.
-        Mode can be: 'draw', 'pan', 'select', 'zoom'.
+        Mode can be: 'draw', 'pan', 'select', 'select-draw', 'zoom'.
         It can also contains extra keys (e.g., 'color') specific to a mode
         as provided to :meth:`setInteractiveMode`.
         """


### PR DESCRIPTION
This PR fixes `PlotWidget.getInteractiveMode` that was not returning the correct mode when in "select-draw" mode.

This does not changes the API, it just fixes that... even though it would be worth using objects rather than dicts to describe the interactive modes.