### PR TITLE
[roi] Allow to select a ROI

### DIFF
--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -1069,7 +1069,8 @@ class ROI(_RegionOfInterestBase):
     """Signal emitted when the ROI is edited"""
 
     def __init__(self, name, fromdata=None, todata=None, type_=None):
-        _RegionOfInterestBase.__init__(self, name=name)
+        _RegionOfInterestBase.__init__(self)
+        self.setName(name)
         global _indexNextROI
         self._id = _indexNextROI
         _indexNextROI += 1

--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -1071,10 +1071,25 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
             scaleF = 1.1 if angle > 0 else 1. / 1.1
             applyZoomToPlot(self.machine.plot, scaleF, (x, y))
 
-        def onMove(self, x, y):
-            result = self.machine.plot._pickTopMost(
-                    x, y, lambda item: isinstance(item, items.MarkerBase))
+        def _getMarkerAt(self, x, y):
+            """Sort markers by priority"""
+            def checkDraggable(item):
+                return isinstance(item, items.MarkerBase) and item.isDraggable()
+            def checkSelectable(item):
+                return isinstance(item, items.MarkerBase) and item.isSelectable()
+            def check(item):
+                return isinstance(item, items.MarkerBase)
+
+            result = self.machine.plot._pickTopMost(x, y, checkDraggable)
+            if not result:
+                result = self.machine.plot._pickTopMost(x, y, checkSelectable)
+            if not result:
+                result = self.machine.plot._pickTopMost(x, y, check)
             marker = result.getItem() if result is not None else None
+            return marker
+
+        def onMove(self, x, y):
+            marker = self._getMarkerAt(x, y)
 
             if marker is not None:
                 dataPos = self.machine.plot.pixelToData(x, y)

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -374,7 +374,7 @@ class Item(qt.QObject):
 
 # Mix-in classes ##############################################################
 
-class ItemMixInBase(qt.QObject):
+class ItemMixInBase(object):
     """Base class for Item mix-in"""
 
     def _updated(self, event=None, checkVisibility=True):

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -144,6 +144,9 @@ class ItemChangedType(enum.Enum):
     EDITABLE = 'editableChanged'
     """Item's editable state changed flags."""
 
+    SELECTABLE = 'selectableChanged'
+    """Item's selectable state changed flags."""
+
 
 class Item(qt.QObject):
     """Description of an item of the plot"""

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -65,7 +65,7 @@ class _RegionOfInterestBase(qt.QObject):
     """
 
     def __init__(self, parent=None, name=''):
-        qt.QObject.__init__(self)
+        qt.QObject.__init__(self, parent=parent)
         self.__name = str(name)
 
     def getName(self):

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -554,6 +554,7 @@ class PointROI(RegionOfInterest, items.SymbolMixIn):
     def __init__(self, parent=None):
         items.SymbolMixIn.__init__(self)
         RegionOfInterest.__init__(self, parent=parent)
+        self._points = numpy.array([[0, 0]])
 
     def getPosition(self):
         """Returns the position of this ROI

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -323,27 +323,31 @@ class RegionOfInterest(_RegionOfInterestBase):
         nbPointsChanged = (self._points is None or
                            points.shape != self._points.shape)
 
-        if nbPointsChanged or not numpy.all(numpy.equal(points, self._points)):
-            self._points = points
+        if not nbPointsChanged and numpy.allclose(points, self._points,
+                                                  rtol=0, atol=0, equal_nan=True):
+            # There is no changes
+            return
 
-            self._updateShape()
-            if self._items and not nbPointsChanged:  # Update plot items
-                item = self._getLabelItem()
-                if item is not None:
-                    markerPos = self._getLabelPosition()
-                    item.setPosition(*markerPos)
+        self._points = points
 
-                if self._editAnchors:  # Update anchors
-                    for anchor, point in zip(self._editAnchors, points):
-                        old = anchor.blockSignals(True)
-                        anchor.setPosition(*point)
-                        anchor.blockSignals(old)
+        self._updateShape()
+        if self._items and not nbPointsChanged:  # Update plot items
+            item = self._getLabelItem()
+            if item is not None:
+                markerPos = self._getLabelPosition()
+                item.setPosition(*markerPos)
 
-            else:  # No items or new point added
-                # re-create plot items
-                self._createPlotItems()
+            if self._editAnchors:  # Update anchors
+                for anchor, point in zip(self._editAnchors, points):
+                    old = anchor.blockSignals(True)
+                    anchor.setPosition(*point)
+                    anchor.blockSignals(old)
 
-            self.sigRegionChanged.emit()
+        else:  # No items or new point added
+            # re-create plot items
+            self._createPlotItems()
+
+        self.sigRegionChanged.emit()
 
     def _updateShape(self):
         """Called when shape must be updated.

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -41,7 +41,7 @@ from ... import qt
 from .. import items
 from ...colors import rgba
 import silx.utils.deprecation
-from silx.utils.proxy import docstring
+from silx.gui.qt import inspect
 
 
 logger = logging.getLogger(__name__)
@@ -489,10 +489,10 @@ class RegionOfInterest(_RegionOfInterestBase):
         """Remove items from their plot."""
         for item in itertools.chain(list(self._items),
                                     list(self._editAnchors)):
-
             plot = item.getPlot()
             if plot is not None:
-                plot.removeItem(item)
+                if inspect.isValid(plot):
+                    plot.removeItem(item)
         self._items = WeakList()
         self._editAnchors = WeakList()
 
@@ -500,7 +500,8 @@ class RegionOfInterest(_RegionOfInterestBase):
             item = self._labelItem
             plot = item.getPlot()
             if plot is not None:
-                plot.removeItem(item)
+                if inspect.isValid(plot):
+                    plot.removeItem(item)
         self._labelItem = None
 
     def _updated(self, event=None, checkVisibility=True):

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -54,6 +54,9 @@ class _RegionOfInterestBase(qt.QObject):
     :param str name: The name of the ROI
     """
 
+    sigAboutToBeRemoved = qt.Signal()
+    """Signal emitted just before this ROI is removed from its manager."""
+
     sigItemChanged = qt.Signal(object)
     """Signal emitted when item has changed.
 

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -35,6 +35,7 @@ import itertools
 import logging
 import collections
 import numpy
+import weakref
 
 from ....utils.weakref import WeakList
 from ... import qt
@@ -122,6 +123,7 @@ class RegionOfInterest(_RegionOfInterestBase):
         self._labelItem = None
         self._editable = False
         self._selectable = False
+        self._selectionProxy = None
         self._visible = True
         self.sigItemChanged.connect(self.__itemChanged)
 
@@ -258,6 +260,31 @@ class RegionOfInterest(_RegionOfInterestBase):
             # This should be avoided (better to edit the items, than recreate them)
             self._createPlotItems()
             self.sigItemChanged.emit(items.ItemChangedType.SELECTABLE)
+
+    def getSelectionProxy(self):
+        """Returns the ROI which have to be selected when this ROI is selected,
+        else None if no proxy specified.
+
+        :rtype: RegionOfInterest
+        """
+        proxy = self._selectionProxy
+        if proxy is None:
+            return None
+        proxy = proxy()
+        if proxy is None:
+            self._selectionProxy = None
+        return proxy
+
+    def setSelectionProxy(self, roi):
+        """Set the real ROI which will be selected when this ROI is selected,
+        else None to remove the proxy already specified.
+
+        :param RegionOfInterest roi: A ROI
+        """
+        if roi is not None:
+            self._selectionProxy = weakref.ref(roi)
+        else:
+            self._selectionProxy = None
 
     def isVisible(self):
         """Returns whether the ROI is visible in the plot.

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -1707,7 +1707,11 @@ class HorizontalRangeROI(RegionOfInterest, items.LineMixIn):
     def _updateLabelItem(self, label):
         if self._items is None or len(self._items) < 3:
             return
-        self._items[2].setText(label)
+        if self.isEditable():
+            item = self._items[2]
+        else:
+            item = self._items[0]
+        item.setText(label)
 
     def _updateShape(self):
         if len(self._items) >= 3:
@@ -1732,14 +1736,22 @@ class HorizontalRangeROI(RegionOfInterest, items.LineMixIn):
             shapes.append(marker)
 
         markerMin, markerMax, markerCen = shapes
-        markerCen.setLineStyle(":")
-        markerCen.setText(self.getName())
         markerMin._setConstraint(self.__positionMinConstraint)
         markerMax._setConstraint(self.__positionMaxConstraint)
         if self.isEditable():
             markerMin.sigItemChanged.connect(self.__positionMinChanged)
             markerMax.sigItemChanged.connect(self.__positionMaxChanged)
             markerCen.sigItemChanged.connect(self.__positionCenChanged)
+            markerCen.setLineStyle(":")
+        else:
+            markerCen.setLineStyle(" ")
+
+        if self.isEditable():
+            label = markerCen
+        else:
+            label = markerMin
+        label.setText(self.getName())
+
         return [markerMin, markerMax, markerCen]
 
     def __positionMinConstraint(self, x, y):

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -393,6 +393,8 @@ class RegionOfInterest(_RegionOfInterestBase):
             item.setName(legendPrefix + str(itemIndex))
             plot.addItem(item)
             item.setVisible(self.isVisible())
+            if hasattr(item, "_setSelectable"):
+                item._setSelectable(True)
             self._items.append(item)
             itemIndex += 1
 
@@ -405,6 +407,7 @@ class RegionOfInterest(_RegionOfInterestBase):
                 item.setName(legendPrefix + str(itemIndex))
                 item.setColor(color)
                 item.setVisible(self.isVisible())
+                item._setSelectable(True)
                 plot.addItem(item)
                 # connect item changed
                 item.sigItemChanged.connect(functools.partial(

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -64,9 +64,9 @@ class _RegionOfInterestBase(qt.QObject):
     See :class:`ItemChangedType` for flags description.
     """
 
-    def __init__(self, parent=None, name=''):
+    def __init__(self, parent=None):
         qt.QObject.__init__(self, parent=parent)
-        self.__name = str(name)
+        self.__name = ''
 
     def getName(self):
         """Returns the name of the ROI
@@ -114,7 +114,7 @@ class RegionOfInterest(_RegionOfInterestBase):
         # Avoid circular dependency
         from ..tools import roi as roi_tools
         assert parent is None or isinstance(parent, roi_tools.RegionOfInterestManager)
-        _RegionOfInterestBase.__init__(self, parent, '')
+        _RegionOfInterestBase.__init__(self, parent)
         self._color = rgba('red')
         self._items = WeakList()
         self._editAnchors = WeakList()
@@ -384,6 +384,7 @@ class RegionOfInterest(_RegionOfInterestBase):
             self._labelItem = self._createLabelItem()
             if self._labelItem is not None:
                 self._labelItem.setName(legendPrefix + "label")
+                self._labelItem.setText(self.getName())
                 plot.addItem(self._labelItem)
                 self._labelItem.setVisible(self.isVisible())
 
@@ -573,6 +574,8 @@ class PointROI(RegionOfInterest, items.SymbolMixIn):
         return None
 
     def _updateLabelItem(self, label):
+        if self._items is None or len(self._items) == 0:
+            return
         self._items[0].setText(label)
 
     def _updateShape(self):
@@ -757,6 +760,8 @@ class HorizontalLineROI(RegionOfInterest, items.LineMixIn):
         return None
 
     def _updateLabelItem(self, label):
+        if self._items is None or len(self._items) == 0:
+            return
         self._items[0].setText(label)
 
     def _updateShape(self):
@@ -827,6 +832,8 @@ class VerticalLineROI(RegionOfInterest, items.LineMixIn):
         return None
 
     def _updateLabelItem(self, label):
+        if self._items is None or len(self._items) == 0:
+            return
         self._items[0].setText(label)
 
     def _updateShape(self):

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -121,6 +121,7 @@ class RegionOfInterest(_RegionOfInterestBase):
         self._points = None
         self._labelItem = None
         self._editable = False
+        self._selectable = False
         self._visible = True
         self.sigItemChanged.connect(self.__itemChanged)
 
@@ -236,6 +237,27 @@ class RegionOfInterest(_RegionOfInterestBase):
             # This can be avoided once marker.setDraggable is public
             self._createPlotItems()
             self.sigItemChanged.emit(items.ItemChangedType.EDITABLE)
+
+    def isSelectable(self):
+        """Returns whether the ROI is selectable by the user or not.
+
+        :rtype: bool
+        """
+        return self._selectable
+
+    def setSelectable(self, selectable):
+        """Set whether the ROI can be selected interactively.
+
+        :param bool selectable: True to allow selection by the user,
+           False to disable.
+        """
+        selectable = bool(selectable)
+        if self._selectable != selectable:
+            self._selectable = selectable
+            # Recreate plot items
+            # This should be avoided (better to edit the items, than recreate them)
+            self._createPlotItems()
+            self.sigItemChanged.emit(items.ItemChangedType.SELECTABLE)
 
     def isVisible(self):
         """Returns whether the ROI is visible in the plot.
@@ -395,7 +417,7 @@ class RegionOfInterest(_RegionOfInterestBase):
             plot.addItem(item)
             item.setVisible(self.isVisible())
             if hasattr(item, "_setSelectable"):
-                item._setSelectable(True)
+                item._setSelectable(self.isSelectable())
             self._items.append(item)
             itemIndex += 1
 
@@ -408,7 +430,7 @@ class RegionOfInterest(_RegionOfInterestBase):
                 item.setName(legendPrefix + str(itemIndex))
                 item.setColor(color)
                 item.setVisible(self.isVisible())
-                item._setSelectable(True)
+                item._setSelectable(self.isSelectable())
                 plot.addItem(item)
                 # connect item changed
                 item.sigItemChanged.connect(functools.partial(
@@ -786,6 +808,7 @@ class HorizontalLineROI(RegionOfInterest, items.LineMixIn):
         marker.setLineWidth(self.getLineWidth())
         marker.setLineStyle(self.getLineStyle())
         marker._setDraggable(self.isEditable())
+        marker._setSelectable(self.isSelectable())
         if self.isEditable():
             marker.sigItemChanged.connect(self.__positionChanged)
         return [marker]
@@ -858,6 +881,7 @@ class VerticalLineROI(RegionOfInterest, items.LineMixIn):
         marker.setLineWidth(self.getLineWidth())
         marker.setLineStyle(self.getLineStyle())
         marker._setDraggable(self.isEditable())
+        marker._setSelectable(self.isSelectable())
         if self.isEditable():
             marker.sigItemChanged.connect(self.__positionChanged)
         return [marker]
@@ -1704,6 +1728,7 @@ class HorizontalRangeROI(RegionOfInterest, items.LineMixIn):
             marker.setLineWidth(self.getLineWidth())
             marker.setLineStyle(self.getLineStyle())
             marker._setDraggable(self.isEditable())
+            marker._setSelectable(self.isSelectable())
             shapes.append(marker)
 
         markerMin, markerMax, markerCen = shapes

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -322,6 +322,7 @@ class RegionOfInterestManager(qt.QObject):
             raise ValueError(
                 'RegionOfInterest does not belong to this instance')
 
+        roi.sigAboutToBeRemoved.emit()
         self.sigRoiAboutToBeRemoved.emit(roi)
 
         self._rois.remove(roi)

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -306,7 +306,7 @@ class RegionOfInterestManager(qt.QObject):
         """Handle ROI object changed"""
         self.sigRoiChanged.emit()
 
-    def createRoi(self, roiClass, points, label='', index=None):
+    def createRoi(self, roiClass, points, label=None, index=None):
         """Create a new ROI and add it to list of ROIs.
 
         :param class roiClass: The class of the ROI to create
@@ -320,7 +320,8 @@ class RegionOfInterestManager(qt.QObject):
            number of ROIs has been reached.
         """
         roi = roiClass(parent=None)
-        roi.setName(str(label))
+        if label is not None:
+            roi.setName(str(label))
         roi.setFirstShapePoints(points)
 
         self.addRoi(roi, index)

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -87,6 +87,12 @@ class RegionOfInterestManager(qt.QObject):
     mode.
     """
 
+    sigInteractiveRoiCreationFinished = qt.Signal(object)
+    """Signal emitted when a ROI creation is complet.
+
+    It provides the ROI object which was just been created.
+    """
+
     sigInteractiveModeFinished = qt.Signal()
     """Signal emitted when leaving and interactive ROI drawing.
 
@@ -214,8 +220,8 @@ class RegionOfInterestManager(qt.QObject):
             if event['event'] == 'mouseClicked' and event['button'] == 'left':
                 points = numpy.array([(event['x'], event['y'])],
                                      dtype=numpy.float64)
-                self.createRoi(roiClass, points=points)
-
+                roi = self.createRoi(roiClass, points=points)
+                self.sigInteractiveRoiCreationFinished.emit(roi)
         else:  # other shapes
             if (event['event'] in ('drawingProgress', 'drawingFinished') and
                     event['parameters']['label'] == self._label):
@@ -230,7 +236,9 @@ class RegionOfInterestManager(qt.QObject):
                 if event['event'] == 'drawingFinished':
                     if kind == 'polygon' and len(points) > 1:
                         self._drawnROI.setFirstShapePoints(points[:-1])
+                    roi = self._drawnROI
                     self._drawnROI = None  # Stop drawing
+                    self.sigInteractiveRoiCreationFinished.emit(roi)
 
     # RegionOfInterest selection
 

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -140,7 +140,7 @@ class RegionOfInterestManager(qt.QObject):
 
     # Associated QActions
 
-    def getInteractionModeAction(self, roiClass):
+    def getInteractionModeAction(self, roiClass, parent=None):
         """Returns the QAction corresponding to a kind of ROI
 
         The QAction allows to enable the corresponding drawing
@@ -163,7 +163,7 @@ class RegionOfInterestManager(qt.QObject):
                 if name is None:
                     name = roiClass.__name__
                 text = 'Add %s' % name
-            action = qt.QAction(self)
+            action = qt.QAction(parent)
             action.setIcon(icons.getQIcon(iconName))
             action.setText(text)
             action.setCheckable(True)

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -375,6 +375,8 @@ class RegionOfInterestManager(qt.QObject):
         roi.sigAboutToBeRemoved.emit()
         self.sigRoiAboutToBeRemoved.emit(roi)
 
+        if roi is self._drawnROI:
+            self._drawnROI = None
         self._rois.remove(roi)
         roi.sigRegionChanged.disconnect(self._regionOfInterestChanged)
         roi.sigItemChanged.disconnect(self._regionOfInterestChanged)

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -77,6 +77,9 @@ class RegionOfInterestManager(qt.QObject):
     sigRoiChanged = qt.Signal()
     """Signal emitted whenever the ROIs have changed."""
 
+    sigRoiSelected = qt.Signal(object)
+    """Signal emitted whenever a ROI is selected."""
+
     sigInteractiveModeStarted = qt.Signal(object)
     """Signal emitted when switching to ROI drawing interactive mode.
 
@@ -115,9 +118,14 @@ class RegionOfInterestManager(qt.QObject):
 
         self._label = "__RegionOfInterestManager__%d" % id(self)
 
+        self._selectedRoi = None
+        """Hold selected ROI"""
+
         self._eventLoop = None
 
         self._modeActions = {}
+
+        parent.sigPlotSignal.connect(self._plotSignals)
 
         parent.sigInteractiveModeChanged.connect(
             self._plotInteractiveModeChanged)
@@ -224,6 +232,46 @@ class RegionOfInterestManager(qt.QObject):
                         self._drawnROI.setFirstShapePoints(points[:-1])
                     self._drawnROI = None  # Stop drawing
 
+    # RegionOfInterest selection
+
+    def __getRoiFromMarker(self, marker):
+        """Returns a ROI from a marker, else None"""
+        # This should be speed up
+        for roi in self._rois:
+            if marker in roi._editAnchors:
+                return roi
+            if marker in roi._items:
+                return roi
+        return None
+
+    def setSelectedRoi(self, roi):
+        """Set the selected ROI, and emit a signal.
+
+        :param Union[RegionOfInterest] roi: The ROI to select
+        """
+        if self._selectedRoi is roi:
+            return
+        self._selectedRoi = roi
+        self.sigRoiSelected.emit(roi)
+
+    def getSelectedRoi(self):
+        """Returns the selected ROI, else None.
+
+        :rtype: Union[RegionOfInterest]
+        """
+        return self._selectedRoi
+
+    def _plotSignals(self, event):
+        """Handle mouse interaction for ROI addition"""
+        if event['event'] in ('markerClicked', 'markerMoving'):
+            plot = self.parent()
+            legend = event['label']
+            marker = plot._getMarker(legend=legend)
+            roi = self.__getRoiFromMarker(marker)
+            self.setSelectedRoi(roi)
+        elif event['event'] == 'mouseClicked' and event['button'] == 'left':
+            self.setSelectedRoi(None)
+
     # RegionOfInterest API
 
     def getRois(self):
@@ -276,6 +324,7 @@ class RegionOfInterestManager(qt.QObject):
         roi.setFirstShapePoints(points)
 
         self.addRoi(roi, index)
+        self.setSelectedRoi(roi)
         return roi
 
     def addRoi(self, roi, index=None, useManagerColor=True):

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -251,6 +251,16 @@ class RegionOfInterestManager(qt.QObject):
         """
         if self._selectedRoi is roi:
             return
+        if roi is not None:
+            # Note: Fixed range to avoid infinite loops
+            for _ in range(10):
+                target = roi.getSelectionProxy()
+                if target is None:
+                    break
+                roi = target
+            else:
+                logger.error("May be a selection proxy cycle")
+
         self._selectedRoi = roi
         self.sigRoiSelected.emit(roi)
 

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -348,6 +348,14 @@ class RegionOfInterestManager(qt.QObject):
             self.setSelectedRoi(roi)
         return roi
 
+    def containsRoi(self, roi):
+        """Returns true if the this ROI is port of this manager.
+
+        :param roi_items.RegionOfInterest roi: The ROI to add
+        :rtype: bool
+        """
+        return roi in self._rois
+
     def addRoi(self, roi, index=None, useManagerColor=True):
         """Add the ROI to the list of ROIs.
 

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -268,7 +268,8 @@ class RegionOfInterestManager(qt.QObject):
             legend = event['label']
             marker = plot._getMarker(legend=legend)
             roi = self.__getRoiFromMarker(marker)
-            self.setSelectedRoi(roi)
+            if roi.isSelectable():
+                self.setSelectedRoi(roi)
         elif event['event'] == 'mouseClicked' and event['button'] == 'left':
             self.setSelectedRoi(None)
 
@@ -325,7 +326,8 @@ class RegionOfInterestManager(qt.QObject):
         roi.setFirstShapePoints(points)
 
         self.addRoi(roi, index)
-        self.setSelectedRoi(roi)
+        if roi.isSelectable():
+            self.setSelectedRoi(roi)
         return roi
 
     def addRoi(self, roi, index=None, useManagerColor=True):

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -403,6 +403,9 @@ class RegionOfInterestManager(qt.QObject):
         roi.sigAboutToBeRemoved.emit()
         self.sigRoiAboutToBeRemoved.emit(roi)
 
+        if roi is self._selectedRoi:
+            self.setSelectedRoi(None)
+
         if roi is self._drawnROI:
             self._drawnROI = None
         self._rois.remove(roi)

--- a/silx/gui/plot/tools/test/testROI.py
+++ b/silx/gui/plot/tools/test/testROI.py
@@ -396,6 +396,15 @@ class TestRegionOfInterestManager(TestCaseQt, ParametricTestCase):
         manager.setSelectedRoi(item1)
         self.assertIs(manager.getSelectedRoi(), item2)
 
+    def testRemovedSelection(self):
+        item1 = roi_items.PointROI()
+        item1.setSelectable(True)
+        manager = roi.RegionOfInterestManager(self.plot)
+        manager.addRoi(item1)
+        manager.setSelectedRoi(item1)
+        manager.removeRoi(item1)
+        self.assertIs(manager.getSelectedRoi(), None)
+
     def testMaxROI(self):
         """Test Max ROI"""
         origin1 = numpy.array([1., 10.])

--- a/silx/gui/plot/tools/test/testROI.py
+++ b/silx/gui/plot/tools/test/testROI.py
@@ -386,6 +386,16 @@ class TestRegionOfInterestManager(TestCaseQt, ParametricTestCase):
                 manager.removeRoi(item)
                 self.qapp.processEvents()
 
+    def testSelectionProxy(self):
+        item1 = roi_items.PointROI()
+        item1.setSelectable(True)
+        item2 = roi_items.PointROI()
+        item2.setSelectable(True)
+        item1.setSelectionProxy(item2)
+        manager = roi.RegionOfInterestManager(self.plot)
+        manager.setSelectedRoi(item1)
+        self.assertIs(manager.getSelectedRoi(), item2)
+
     def testMaxROI(self):
         """Test Max ROI"""
         origin1 = numpy.array([1., 10.])


### PR DESCRIPTION
This PR allows to select a ROI from the plot.

- A ROI provides `setSelectable` and `setSelectionProxy`
- When an anchor is clicked, or a ROI created, the manager update the current selected ROI
- Plus other small things relative to ROIs
- Create `sigInteractiveRoiCreationFinished` to know when the manager create a new ROI (and is not just added)
- Create `sigAboutToRemove` to allow the ROIs to clean up things