### PR TITLE
Fix import

### DIFF
--- a/silx/io/url.py
+++ b/silx/io/url.py
@@ -30,7 +30,7 @@ __date__ = "29/01/2018"
 
 import logging
 import six
-from collections import Iterable
+from collections.abc import Iterable
 
 parse = six.moves.urllib.parse
 


### PR DESCRIPTION
This PR fixes a warning from Python 3.7:

If silx supports Python >= 3.3, it's fine.
```
/.../lib/python3.7/site-packages/silx/io/url.py:33: DeprecationWarning:
Using or importing the ABCs from 'collections' instead of from 'collections.abc'
is deprecated since Python 3.3,and in 3.9 it will stop working
  from collections import Iterable
```