### PR TITLE
[plot] Helper to set back the previous mode used

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -268,6 +268,7 @@ class PlotWidget(qt.QMainWindow):
 
         self._eventHandler = PlotInteraction.PlotInteraction(self)
         self._eventHandler.setInteractiveMode('zoom', color=(0., 0., 0., 1.))
+        self._previousDefaultMode = "zoom", True
 
         self._pressedButtons = []  # Currently pressed mouse buttons
 
@@ -3087,6 +3088,15 @@ class PlotWidget(qt.QMainWindow):
         """
         return self._eventHandler.getInteractiveMode()
 
+    def resetInteractiveMode(self):
+        """Reset the interactive mode to use the previous basic interactive
+        mode used.
+
+        It can be one of "zoom" or "pan".
+        """
+        mode, zoomOnWheel = self._previousDefaultMode
+        self.setInteractiveMode(mode=mode, zoomOnWheel=zoomOnWheel)
+
     def setInteractiveMode(self, mode, color='black',
                            shape='polygon', label=None,
                            zoomOnWheel=True, source=None, width=None):
@@ -3112,6 +3122,8 @@ class PlotWidget(qt.QMainWindow):
         """
         self._eventHandler.setInteractiveMode(mode, color, shape, label, width)
         self._eventHandler.zoomOnWheel = zoomOnWheel
+        if mode in ["pan", "zoom"]:
+            self._previousDefaultMode = mode, zoomOnWheel
 
         self.notify(
             'interactiveModeChanged', source=source)


### PR DESCRIPTION
Here is a proposal to allow to easily set back the previously used default interactive mode.

It is useful to know what to do if we want to abort or deselect a custom interactive mode.

Now profile uses ROI, i would like to desactive the tool at the end of the interaction (in order to only deal with existing markers). And this method simplifies it.

I also did it twice on pyFAI, so i think it can be useful to share a common API for that.

You can check #3006, it can be implemented outside of the plot, but when it is used few times, i think it's better to provide it as part of the plot. 

What do you think?