### PR TITLE
Test dicttoh5 flat dict

### DIFF
--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -163,9 +163,9 @@ def dicttoh5(treedict, h5file, h5path='/',
         This function requires `h5py <http://www.h5py.org/>`_ to be installed.
 
     :param treedict: Nested dictionary/tree structure with strings or tuples as
-         keys and array-like objects as leafs. The ``"/"`` character is not
-         allowed in keys. If tuples are used as keys they should have the format
-        (dataset_name,attr_name) and will add a 5h attribute with the
+        keys and array-like objects as leafs. The ``"/"`` character can be used
+        to define sub trees. If tuples are used as keys they should have the
+        format (dataset_name,attr_name) and will add a 5h attribute with the
         corresponding value.
     :param h5file: HDF5 file name or handle. If a file name is provided, the
         function opens the file in the specified mode and closes it again
@@ -296,8 +296,8 @@ def dicttonx(
     therefor the dataset_names should not contain ``"@"``.
 
     :param treedict: Nested dictionary/tree structure with strings as keys
-         and array-like objects as leafs. The ``"/"`` character is not allowed
-         in keys. The ``"@"`` character is used to write attributes.
+         and array-like objects as leafs. The ``"/"`` character can be used
+         to define sub tree. The ``"@"`` character is used to write attributes.
 
     Detais on all other params can be found in doc of dicttoh5.
 

--- a/silx/io/test/test_dictdump.py
+++ b/silx/io/test/test_dictdump.py
@@ -183,6 +183,20 @@ class TestDictToH5(unittest.TestCase):
                 dictdump.dicttoh5(ddict, h5file)
             self.assertEqual(h5file["group"].attrs['attr'], 10)
 
+    def testFlatDict(self):
+        """Description of a tree with a single level of keys"""
+        ddict = {
+            "group/group/dataset": 10,
+            ("group/group/dataset", "attr"): 11,
+            ("group/group", "attr"): 12,
+        }
+        mem = io.BytesIO()
+        with h5py.File(mem, "w") as h5file:
+            dictdump.dicttoh5(ddict, h5file)
+            self.assertEqual(h5file["group/group/dataset"][()], 10)
+            self.assertEqual(h5file["group/group/dataset"].attrs['attr'], 11)
+            self.assertEqual(h5file["group/group"].attrs['attr'], 12)
+
 
 class TestDictToNx(unittest.TestCase):
 
@@ -243,6 +257,20 @@ class TestDictToNx(unittest.TestCase):
                         numpy.testing.assert_array_almost_equal(result, expected)
                 else:
                     self.assertEqual(result, expected)
+
+    def testFlatDict(self):
+        """Description of a tree with a single level of keys"""
+        ddict = {
+            "group/group/dataset": 10,
+            "group/group/dataset@attr": 11,
+            "group/group@attr": 12,
+        }
+        mem = io.BytesIO()
+        with h5py.File(mem, "w") as h5file:
+            dictdump.dicttonx(ddict, h5file)
+            self.assertEqual(h5file["group/group/dataset"][()], 10)
+            self.assertEqual(h5file["group/group/dataset"].attrs['attr'], 11)
+            self.assertEqual(h5file["group/group"].attrs['attr'], 12)
 
 
 class TestH5ToDict(unittest.TestCase):


### PR DESCRIPTION
Merge #3013 first

This PR add test to be sure there is no regression with subtree as key in `dicttonx` and `dicttoh5`.

As the documentation said it was forbidden, but the implementation was allowing to use it, the other solution is to add assertion in case of use of `/` in the keys. Let me know if you prefer this way.

Related to @vasole  comment on #3013