### PR TITLE
[roi] Provide an action to create new ROIs

### DIFF
--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -590,7 +590,7 @@ class RegionOfInterestManager(qt.QObject):
         if plot is not None:
             # This leads to call __roiInteractiveModeEnded through
             # interactive mode changed signal
-            plot.setInteractiveMode(mode='zoom', source=None)
+            plot.resetInteractiveMode()
         else:  # Fallback
             self.__roiInteractiveModeEnded()
 

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -234,7 +234,7 @@ class RegionOfInterestManager(qt.QObject):
 
     # Associated QActions
 
-    def getInteractionModeAction(self, roiClass, parent=None):
+    def getInteractionModeAction(self, roiClass):
         """Returns the QAction corresponding to a kind of ROI
 
         The QAction allows to enable the corresponding drawing
@@ -249,7 +249,7 @@ class RegionOfInterestManager(qt.QObject):
 
         action = self._modeActions.get(roiClass, None)
         if action is None:  # Lazy-loading
-            action = CreateRoiModeAction(parent, self, roiClass)
+            action = CreateRoiModeAction(self, self, roiClass)
             self._modeActions[roiClass] = action
         return action
 

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 class CreateRoiModeAction(qt.QAction):
     """
-    This action is a plot mode which allow to create new ROIs using a ROI
+    This action is a plot mode which allows to create new ROIs using a ROI
     manager.
 
     A ROI is created using a specific `roiClass`. `initRoi` and `finalizeRoi`
@@ -264,7 +264,7 @@ class RegionOfInterestManager(qt.QObject):
         The QAction allows to enable the corresponding drawing
         interactive mode.
 
-        :param class roiClass: The ROI class which will be crated by this action.
+        :param class roiClass: The ROI class which will be created by this action.
         :rtype: QAction
         :raise ValueError: If kind is not supported
         """


### PR DESCRIPTION
This PR rework the QAction of the ROI manager in order to have independent actions.

As result:
- 2 actions using the same ROI class will not be triggered simultaneously
- It is possible custom the way each actions behave
- Resolve the issue with parent and `getInteractionModeAction`