### PR TITLE
[roi/profile] Improve internal ROI objects

### DIFF
--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -828,7 +828,7 @@ class ColormapDialog(qt.QDialog):
         self._item = None
         """Weak ref to an external item"""
 
-        self._colormapChange = _ColormapChanged()
+        self._colormapChange = utils.LockReentrant()
         """Used as a semaphore to avoid editing the colormap object when we are
         only attempt to display it.
         Used instead of n connect and disconnect of the sigChanged. The
@@ -1576,19 +1576,3 @@ class ColormapDialog(qt.QDialog):
                 nextFocus.setFocus(qt.Qt.OtherFocusReason)
         else:
             super(ColormapDialog, self).keyPressEvent(event)
-
-
-class _ColormapChanged():
-    """Simple context manager to know if we should ignore or not colormap
-    modifications"""
-    def __init__(self):
-        self._ignoreColormapChange = False
-
-    def __enter__(self):
-        self._ignoreColormapChange = True
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self._ignoreColormapChange = False
-
-    def locked(self):
-        return self._ignoreColormapChange

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -431,11 +431,17 @@ class RegionOfInterest(_RegionOfInterestBase):
         self.sigEditingFinished.emit()
 
 
-class _HandleBasedROI(RegionOfInterest):
+class _Foo:
+    """This inheritance is needed to avoid wrong __init__ order in Qt"""
+    pass
+
+
+class _HandleBasedROI(RegionOfInterest, _Foo):
     """Manage a ROI based on a set of handles"""
 
     def __init__(self, parent=None):
         RegionOfInterest.__init__(self, parent=parent)
+        _Foo.__init__(self)
         self._handles = []
         self._posOrigin = None
         self._posPrevious = None

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -607,8 +607,8 @@ class _HandleBasedROI(RegionOfInterest, _Foo):
         self._posOrigin = None
         super(_HandleBasedROI, self)._editingFinished()
 
-    def isHandleBeenDragged(self):
-        """Returns True of one of the handles is dragging.
+    def isHandleBeingDragged(self):
+        """Returns True if one of the handles is currently being dragged.
 
         :rtype: bool
         """
@@ -1256,7 +1256,7 @@ class PolygonROI(_HandleBasedROI, items.LineMixIn):
                 handle.setPosition(position[0], position[1])
 
         if len(points) > 0:
-            if not self.isHandleBeenDragged():
+            if not self.isHandleBeingDragged():
                 vmin = numpy.min(points, axis=0)
                 vmax = numpy.max(points, axis=0)
                 center = (vmax + vmin) * 0.5

--- a/silx/gui/plot/tools/profile/rois.py
+++ b/silx/gui/plot/tools/profile/rois.py
@@ -48,13 +48,13 @@ class _DefaultImageProfileRoiMixIn(core.ProfileRoiMixIn):
         self.__width = 1
 
         area = items.Shape("polygon")
-        self._setItemName(area)
         color = colors.rgba(self.getColor())
         area.setColor(color)
         area.setFill(True)
         area.setOverlay(True)
         area.setPoints([[0, 0], [0, 0]])  # Else it segfault
         self.__area = area
+        self.addItem(area)
 
         self.sigRegionChanged.connect(self.__regionChanged)
 
@@ -224,16 +224,6 @@ class _DefaultImageProfileRoiMixIn(core.ProfileRoiMixIn):
         self._inheritedRoi._updated(self, event=event, checkVisibility=checkVisibility)
         self._updateAreaProperty(event, checkVisibility)
 
-    def _connectToPlot(self, plot):
-        """Glue with the ROI object"""
-        self._inheritedRoi._connectToPlot(self, plot)
-        plot.addItem(self.__area)
-
-    def _disconnectFromPlot(self, plot):
-        """Glue with the ROI object"""
-        self._inheritedRoi._disconnectFromPlot(self, plot)
-        plot.removeItem(self.__area)
-
 
 class ProfileImageHorizontalLineROI(roi_items.HorizontalLineROI,
                                     _DefaultImageProfileRoiMixIn):
@@ -249,8 +239,6 @@ class ProfileImageHorizontalLineROI(roi_items.HorizontalLineROI,
 
     # Make sure to use the right inheritance
     _updated = _DefaultImageProfileRoiMixIn._updated
-    _connectToPlot = _DefaultImageProfileRoiMixIn._connectToPlot
-    _disconnectFromPlot = _DefaultImageProfileRoiMixIn._disconnectFromPlot
 
 
 class ProfileImageVerticalLineROI(roi_items.VerticalLineROI,
@@ -267,8 +255,6 @@ class ProfileImageVerticalLineROI(roi_items.VerticalLineROI,
 
     # Make sure to use the right inheritance
     _updated = _DefaultImageProfileRoiMixIn._updated
-    _connectToPlot = _DefaultImageProfileRoiMixIn._connectToPlot
-    _disconnectFromPlot = _DefaultImageProfileRoiMixIn._disconnectFromPlot
 
 
 class ProfileImageLineROI(roi_items.LineROI,
@@ -285,8 +271,6 @@ class ProfileImageLineROI(roi_items.LineROI,
 
     # Make sure to use the right inheritance
     _updated = _DefaultImageProfileRoiMixIn._updated
-    _connectToPlot = _DefaultImageProfileRoiMixIn._connectToPlot
-    _disconnectFromPlot = _DefaultImageProfileRoiMixIn._disconnectFromPlot
 
 
 class _ProfileCrossROI(roi_items.PointROI, core.ProfileRoiMixIn):
@@ -641,13 +625,13 @@ class _DefaulScatterProfileSliceRoiMixIn(core.ProfileRoiMixIn):
         core.ProfileRoiMixIn.__init__(self, parent=parent)
 
         area = items.Shape("polylines")
-        self._setItemName(area)
         color = colors.rgba(self.getColor())
         area.setColor(color)
         area.setFill(True)
         area.setOverlay(True)
         area.setPoints([[0, 0], [0, 0]])  # Else it segfault
         self.__area = area
+        self.addItem(area)
 
         self.sigRegionChanged.connect(self.__regionChanged)
 
@@ -785,16 +769,6 @@ class _DefaulScatterProfileSliceRoiMixIn(core.ProfileRoiMixIn):
         self._inheritedRoi._updated(self, event=event, checkVisibility=checkVisibility)
         self._updateAreaProperty(event, checkVisibility)
 
-    def _connectToPlot(self, plot):
-        """Glue with the ROI object"""
-        self._inheritedRoi._connectToPlot(self, plot)
-        plot.addItem(self.__area)
-
-    def _disconnectFromPlot(self, plot):
-        """Glue with the ROI object"""
-        self._inheritedRoi._disconnectFromPlot(self, plot)
-        plot.removeItem(self.__area)
-
 
 class ProfileScatterHorizontalSliceROI(roi_items.HorizontalLineROI,
                                        _DefaulScatterProfileSliceRoiMixIn):
@@ -812,8 +786,6 @@ class ProfileScatterHorizontalSliceROI(roi_items.HorizontalLineROI,
 
     # Make sure to use the right inheritance
     _updated = _DefaulScatterProfileSliceRoiMixIn._updated
-    _connectToPlot = _DefaulScatterProfileSliceRoiMixIn._connectToPlot
-    _disconnectFromPlot = _DefaulScatterProfileSliceRoiMixIn._disconnectFromPlot
 
 
 class ProfileScatterVerticalSliceROI(roi_items.VerticalLineROI,
@@ -832,8 +804,6 @@ class ProfileScatterVerticalSliceROI(roi_items.VerticalLineROI,
 
     # Make sure to use the right inheritance
     _updated = _DefaulScatterProfileSliceRoiMixIn._updated
-    _connectToPlot = _DefaulScatterProfileSliceRoiMixIn._connectToPlot
-    _disconnectFromPlot = _DefaulScatterProfileSliceRoiMixIn._disconnectFromPlot
 
 
 class ProfileScatterCrossSliceROI(_ProfileCrossROI):
@@ -921,8 +891,6 @@ class ProfileImageStackHorizontalLineROI(roi_items.HorizontalLineROI,
 
     # Make sure to use the right inheritance
     _updated = _DefaultImageStackProfileRoiMixIn._updated
-    _connectToPlot = _DefaultImageStackProfileRoiMixIn._connectToPlot
-    _disconnectFromPlot = _DefaultImageStackProfileRoiMixIn._disconnectFromPlot
 
 
 class ProfileImageStackVerticalLineROI(roi_items.VerticalLineROI,
@@ -939,8 +907,6 @@ class ProfileImageStackVerticalLineROI(roi_items.VerticalLineROI,
 
     # Make sure to use the right inheritance
     _updated = _DefaultImageStackProfileRoiMixIn._updated
-    _connectToPlot = _DefaultImageStackProfileRoiMixIn._connectToPlot
-    _disconnectFromPlot = _DefaultImageStackProfileRoiMixIn._disconnectFromPlot
 
 
 class ProfileImageStackLineROI(roi_items.LineROI,
@@ -957,8 +923,6 @@ class ProfileImageStackLineROI(roi_items.LineROI,
 
     # Make sure to use the right inheritance
     _updated = _DefaultImageStackProfileRoiMixIn._updated
-    _connectToPlot = _DefaultImageStackProfileRoiMixIn._connectToPlot
-    _disconnectFromPlot = _DefaultImageStackProfileRoiMixIn._disconnectFromPlot
 
 
 class ProfileImageStackCrossROI(ProfileImageCrossROI):

--- a/silx/gui/plot/tools/profile/rois.py
+++ b/silx/gui/plot/tools/profile/rois.py
@@ -57,6 +57,7 @@ class _DefaultImageProfileRoiMixIn(core.ProfileRoiMixIn):
         self.addItem(area)
 
         self.sigRegionChanged.connect(self.__regionChanged)
+        self.sigItemChanged.connect(self._updateAreaProperty)
 
     def _updateAreaProperty(self, event=None, checkVisibility=True):
         if event == items.ItemChangedType.COLOR:
@@ -219,11 +220,6 @@ class _DefaultImageProfileRoiMixIn(core.ProfileRoiMixIn):
             )
         return data
 
-    def _updated(self, event=None, checkVisibility=True):
-        """Glue with the ROI object"""
-        self._inheritedRoi._updated(self, event=event, checkVisibility=checkVisibility)
-        self._updateAreaProperty(event, checkVisibility)
-
 
 class ProfileImageHorizontalLineROI(roi_items.HorizontalLineROI,
                                     _DefaultImageProfileRoiMixIn):
@@ -233,12 +229,8 @@ class ProfileImageHorizontalLineROI(roi_items.HorizontalLineROI,
     NAME = 'horizontal line profile'
 
     def __init__(self, parent=None):
-        self._inheritedRoi = roi_items.HorizontalLineROI
-        self._inheritedRoi.__init__(self, parent=parent)
+        roi_items.HorizontalLineROI.__init__(self, parent=parent)
         _DefaultImageProfileRoiMixIn.__init__(self, parent=parent)
-
-    # Make sure to use the right inheritance
-    _updated = _DefaultImageProfileRoiMixIn._updated
 
 
 class ProfileImageVerticalLineROI(roi_items.VerticalLineROI,
@@ -249,12 +241,8 @@ class ProfileImageVerticalLineROI(roi_items.VerticalLineROI,
     NAME = 'vertical line profile'
 
     def __init__(self, parent=None):
-        self._inheritedRoi = roi_items.VerticalLineROI
-        self._inheritedRoi.__init__(self, parent=parent)
+        roi_items.VerticalLineROI.__init__(self, parent=parent)
         _DefaultImageProfileRoiMixIn.__init__(self, parent=parent)
-
-    # Make sure to use the right inheritance
-    _updated = _DefaultImageProfileRoiMixIn._updated
 
 
 class ProfileImageLineROI(roi_items.LineROI,
@@ -265,12 +253,8 @@ class ProfileImageLineROI(roi_items.LineROI,
     NAME = 'line profile'
 
     def __init__(self, parent=None):
-        self._inheritedRoi = roi_items.LineROI
-        self._inheritedRoi.__init__(self, parent=parent)
+        roi_items.LineROI.__init__(self, parent=parent)
         _DefaultImageProfileRoiMixIn.__init__(self, parent=parent)
-
-    # Make sure to use the right inheritance
-    _updated = _DefaultImageProfileRoiMixIn._updated
 
 
 class _ProfileCrossROI(roi_items.PointROI, core.ProfileRoiMixIn):
@@ -634,6 +618,7 @@ class _DefaulScatterProfileSliceRoiMixIn(core.ProfileRoiMixIn):
         self.addItem(area)
 
         self.sigRegionChanged.connect(self.__regionChanged)
+        self.sigItemChanged.connect(self._updateAreaProperty)
 
     def _updateAreaProperty(self, event=None, checkVisibility=True):
         if event == items.ItemChangedType.COLOR:
@@ -764,11 +749,6 @@ class _DefaulScatterProfileSliceRoiMixIn(core.ProfileRoiMixIn):
         )
         return data
 
-    def _updated(self, event=None, checkVisibility=True):
-        """Glue with the ROI object"""
-        self._inheritedRoi._updated(self, event=event, checkVisibility=checkVisibility)
-        self._updateAreaProperty(event, checkVisibility)
-
 
 class ProfileScatterHorizontalSliceROI(roi_items.HorizontalLineROI,
                                        _DefaulScatterProfileSliceRoiMixIn):
@@ -780,12 +760,8 @@ class ProfileScatterHorizontalSliceROI(roi_items.HorizontalLineROI,
     NAME = 'horizontal data slice profile'
 
     def __init__(self, parent=None):
-        self._inheritedRoi = roi_items.HorizontalLineROI
-        self._inheritedRoi.__init__(self, parent=parent)
+        roi_items.HorizontalLineROI.__init__(self, parent=parent)
         _DefaulScatterProfileSliceRoiMixIn.__init__(self, parent=parent)
-
-    # Make sure to use the right inheritance
-    _updated = _DefaulScatterProfileSliceRoiMixIn._updated
 
 
 class ProfileScatterVerticalSliceROI(roi_items.VerticalLineROI,
@@ -798,12 +774,8 @@ class ProfileScatterVerticalSliceROI(roi_items.VerticalLineROI,
     NAME = 'vertical data slice profile'
 
     def __init__(self, parent=None):
-        self._inheritedRoi = roi_items.VerticalLineROI
-        self._inheritedRoi.__init__(self, parent=parent)
+        roi_items.VerticalLineROI.__init__(self, parent=parent)
         _DefaulScatterProfileSliceRoiMixIn.__init__(self, parent=parent)
-
-    # Make sure to use the right inheritance
-    _updated = _DefaulScatterProfileSliceRoiMixIn._updated
 
 
 class ProfileScatterCrossSliceROI(_ProfileCrossROI):
@@ -885,12 +857,8 @@ class ProfileImageStackHorizontalLineROI(roi_items.HorizontalLineROI,
     NAME = 'horizontal line profile'
 
     def __init__(self, parent=None):
-        self._inheritedRoi = roi_items.HorizontalLineROI
-        self._inheritedRoi.__init__(self, parent=parent)
+        roi_items.HorizontalLineROI.__init__(self, parent=parent)
         _DefaultImageStackProfileRoiMixIn.__init__(self, parent=parent)
-
-    # Make sure to use the right inheritance
-    _updated = _DefaultImageStackProfileRoiMixIn._updated
 
 
 class ProfileImageStackVerticalLineROI(roi_items.VerticalLineROI,
@@ -901,12 +869,8 @@ class ProfileImageStackVerticalLineROI(roi_items.VerticalLineROI,
     NAME = 'vertical line profile'
 
     def __init__(self, parent=None):
-        self._inheritedRoi = roi_items.VerticalLineROI
-        self._inheritedRoi.__init__(self, parent=parent)
+        roi_items.VerticalLineROI.__init__(self, parent=parent)
         _DefaultImageStackProfileRoiMixIn.__init__(self, parent=parent)
-
-    # Make sure to use the right inheritance
-    _updated = _DefaultImageStackProfileRoiMixIn._updated
 
 
 class ProfileImageStackLineROI(roi_items.LineROI,
@@ -917,12 +881,8 @@ class ProfileImageStackLineROI(roi_items.LineROI,
     NAME = 'line profile'
 
     def __init__(self, parent=None):
-        self._inheritedRoi = roi_items.LineROI
-        self._inheritedRoi.__init__(self, parent=parent)
+        roi_items.LineROI.__init__(self, parent=parent)
         _DefaultImageStackProfileRoiMixIn.__init__(self, parent=parent)
-
-    # Make sure to use the right inheritance
-    _updated = _DefaultImageStackProfileRoiMixIn._updated
 
 
 class ProfileImageStackCrossROI(ProfileImageCrossROI):

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -323,10 +323,11 @@ class RegionOfInterestManager(qt.QObject):
         """Returns a ROI from a marker, else None"""
         # This should be speed up
         for roi in self._rois:
-            if marker in roi._editAnchors:
-                return roi
-            if marker in roi._items:
-                return roi
+            if isinstance(roi, roi_items._AnchorBasedROI):
+                if marker in roi._editAnchors:
+                    return roi
+                if marker in roi._items:
+                    return roi
         return None
 
     def setCurrentRoi(self, roi):

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -307,6 +307,7 @@ class RegionOfInterestManager(qt.QObject):
 
                 if self._drawnROI is None:  # Create new ROI
                     self._drawnROI = self.createRoi(roiClass, points=points)
+                    self._drawnROI.creationStarted()
                 else:
                     self._drawnROI.setFirstShapePoints(points)
 
@@ -315,6 +316,7 @@ class RegionOfInterestManager(qt.QObject):
                         self._drawnROI.setFirstShapePoints(points[:-1])
                     roi = self._drawnROI
                     self._drawnROI = None  # Stop drawing
+                    roi.creationFinalized()
                     self.sigInteractiveRoiFinalized.emit(roi)
 
     # RegionOfInterest selection

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -124,7 +124,7 @@ class CreateRoiModeAction(qt.QAction):
         else:
             source = roiManager.getInteractionSource()
             if source is self:
-                roiManager.abort()
+                roiManager.stop()
 
     def __interactiveModeStarted(self, roiManager):
         roiManager.sigInteractiveRoiCreated.connect(self.initRoi)

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -323,11 +323,14 @@ class RegionOfInterestManager(qt.QObject):
         """Returns a ROI from a marker, else None"""
         # This should be speed up
         for roi in self._rois:
-            if isinstance(roi, roi_items._AnchorBasedROI):
-                if marker in roi._editAnchors:
-                    return roi
-                if marker in roi._items:
-                    return roi
+            if isinstance(roi, roi_items._HandleBasedROI):
+                for m in roi.iterHandles():
+                    if m is marker:
+                        return roi
+            else:
+                for m in roi.iterChild():
+                    if m is marker:
+                        return roi
         return None
 
     def setCurrentRoi(self, roi):

--- a/silx/gui/plot/tools/test/testROI.py
+++ b/silx/gui/plot/tools/test/testROI.py
@@ -147,7 +147,7 @@ class TestRoiItems(TestCaseQt):
         self.assertAlmostEqual(item.getInnerRadius(), innerRadius)
         self.assertAlmostEqual(item.getOuterRadius(), outerRadius)
         self.assertAlmostEqual(item.getStartAngle(), item.getEndAngle() - numpy.pi * 2.0)
-        self.assertAlmostEqual(item.isClosed(), True)
+        self.assertTrue(item.isClosed())
 
     def testArc_special_donut(self):
         item = roi_items.ArcROI()
@@ -158,7 +158,7 @@ class TestRoiItems(TestCaseQt):
         self.assertAlmostEqual(item.getInnerRadius(), innerRadius)
         self.assertAlmostEqual(item.getOuterRadius(), outerRadius)
         self.assertAlmostEqual(item.getStartAngle(), item.getEndAngle() - numpy.pi * 2.0)
-        self.assertAlmostEqual(item.isClosed(), True)
+        self.assertTrue(item.isClosed())
 
     def testArc_clockwiseGeometry(self):
         """Test that we can use getGeometry as input to setGeometry"""

--- a/silx/gui/plot/tools/test/testROI.py
+++ b/silx/gui/plot/tools/test/testROI.py
@@ -60,7 +60,7 @@ class TestRoiItems(TestCaseQt):
 
     def testPoint_geometry(self):
         point = numpy.array([1, 2])
-        item = roi_items.VerticalLineROI()
+        item = roi_items.PointROI()
         item.setPosition(point)
         numpy.testing.assert_allclose(item.getPosition(), point)
 

--- a/silx/gui/plot/tools/test/testROI.py
+++ b/silx/gui/plot/tools/test/testROI.py
@@ -191,9 +191,9 @@ class TestRoiItems(TestCaseQt):
         vmin = 1
         vmax = 3
         item.setRange(vmin, vmax)
-        numpy.testing.assert_allclose(item.getMin(), vmin)
-        numpy.testing.assert_allclose(item.getMax(), vmax)
-        numpy.testing.assert_allclose(item.getCenter(), 2)
+        self.assertAlmostEqual(item.getMin(), vmin)
+        self.assertAlmostEqual(item.getMax(), vmax)
+        self.assertAlmostEqual(item.getCenter(), 2)
 
 
 class TestRegionOfInterestManager(TestCaseQt, ParametricTestCase):

--- a/silx/gui/utils/__init__.py
+++ b/silx/gui/utils/__init__.py
@@ -48,6 +48,23 @@ def blockSignals(*objs):
             obj.blockSignals(previous)
 
 
+class LockReentrant():
+    """Context manager to lock a code block and check the state.
+    """
+    def __init__(self):
+        self.__locked = False
+
+    def __enter__(self):
+        self.__locked = True
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.__locked = False
+
+    def locked(self):
+        """Returns True if the code block is locked"""
+        return self.__locked
+
+
 def getQEventName(eventType):
     """
     Returns the name of a QEvent.


### PR DESCRIPTION
This PR aim to rework the ROIs object in order to help working with composition.

This should reduce the complexity of the code, by allowing split and of the code, and by removing complex design needed to provide magic helpers.

- `RegionOfInterest` is now abstract
- Add `_connectToPlot`/`_disconnectFromPlot` to help to manage composition
- ROIs based on simple markers became really simple classes (point, hrange, vline, hline)
- Create `_HandleBasedROI` for complex anchor management (rect, polygon...)
- The `ArcROI` was cleaned up