### PR TITLE
[roi] Create an highlighted style for ROIs

### DIFF
--- a/examples/plotInteractiveImageROI.py
+++ b/examples/plotInteractiveImageROI.py
@@ -74,10 +74,11 @@ def updateAddedRegionOfInterest(roi):
     if roi.getName() == '':
         roi.setName('ROI %d' % len(roiManager.getRois()))
     if isinstance(roi, LineMixIn):
-        roi.setLineWidth(2)
+        roi.setLineWidth(1)
         roi.setLineStyle('--')
     if isinstance(roi, SymbolMixIn):
         roi.setSymbolSize(5)
+    roi.setSelectable(True)
 
 
 roiManager.sigRoiAdded.connect(updateAddedRegionOfInterest)

--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -1080,25 +1080,8 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
             scaleF = 1.1 if angle > 0 else 1. / 1.1
             applyZoomToPlot(self.machine.plot, scaleF, (x, y))
 
-        def _getMarkerAt(self, x, y):
-            """Sort markers by priority"""
-            def checkDraggable(item):
-                return isinstance(item, items.MarkerBase) and item.isDraggable()
-            def checkSelectable(item):
-                return isinstance(item, items.MarkerBase) and item.isSelectable()
-            def check(item):
-                return isinstance(item, items.MarkerBase)
-
-            result = self.machine.plot._pickTopMost(x, y, checkDraggable)
-            if not result:
-                result = self.machine.plot._pickTopMost(x, y, checkSelectable)
-            if not result:
-                result = self.machine.plot._pickTopMost(x, y, check)
-            marker = result.getItem() if result is not None else None
-            return marker
-
         def onMove(self, x, y):
-            marker = self._getMarkerAt(x, y)
+            marker = self.machine.plot._getMarkerAt(x, y)
 
             if marker is not None:
                 dataPos = self.machine.plot.pixelToData(x, y)

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2985,6 +2985,28 @@ class PlotWidget(qt.QMainWindow):
         else:
             return markers
 
+    def _getMarkerAt(self, x, y):
+        """Return the most interactive marker at a location, else None
+
+        :param float x: X position in pixels
+        :param float y: Y position in pixels
+        :rtype: None of marker object
+        """
+        def checkDraggable(item):
+            return isinstance(item, items.MarkerBase) and item.isDraggable()
+        def checkSelectable(item):
+            return isinstance(item, items.MarkerBase) and item.isSelectable()
+        def check(item):
+            return isinstance(item, items.MarkerBase)
+
+        result = self._pickTopMost(x, y, checkDraggable)
+        if not result:
+            result = self._pickTopMost(x, y, checkSelectable)
+        if not result:
+            result = self._pickTopMost(x, y, check)
+        marker = result.getItem() if result is not None else None
+        return marker
+
     def _getMarker(self, legend=None):
         """Get the object describing a specific marker.
 

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -1510,3 +1510,54 @@ class BaselineMixIn(object):
             return numpy.array(self._baseline, copy=True)
         else:
             return self._baseline
+
+
+class _Style:
+    """Object which store styles"""
+
+
+class HilightedMixIn(ItemMixInBase):
+
+    def __init__(self):
+        self._highlightStyle = self._DEFAULT_HIGHLIGHT_STYLE
+        self._highlighted = False
+
+    def isHighlighted(self):
+        """Returns True if curve is highlighted.
+
+        :rtype: bool
+        """
+        return self._highlighted
+
+    def setHighlighted(self, highlighted):
+        """Set the highlight state of the curve
+
+        :param bool highlighted:
+        """
+        highlighted = bool(highlighted)
+        if highlighted != self._highlighted:
+            self._highlighted = highlighted
+            # TODO inefficient: better to use backend's setCurveColor
+            self._updated(ItemChangedType.HIGHLIGHTED)
+
+    def getHighlightedStyle(self):
+        """Returns the highlighted style in use
+
+        :rtype: CurveStyle
+        """
+        return self._highlightStyle
+
+    def setHighlightedStyle(self, style):
+        """Set the style to use for highlighting
+
+        :param CurveStyle style: New style to use
+        """
+        previous = self.getHighlightedStyle()
+        if style != previous:
+            assert isinstance(style, _Style)
+            self._highlightStyle = style
+            self._updated(ItemChangedType.HIGHLIGHTED_STYLE)
+
+            # Backward compatibility event
+            if previous.getColor() != style.getColor():
+                self._updated(ItemChangedType.HIGHLIGHTED_COLOR)

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -1516,7 +1516,7 @@ class _Style:
     """Object which store styles"""
 
 
-class HilightedMixIn(ItemMixInBase):
+class HighlightedMixIn(ItemMixInBase):
 
     def __init__(self):
         self._highlightStyle = self._DEFAULT_HIGHLIGHT_STYLE

--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -39,13 +39,13 @@ from ....utils.deprecation import deprecated
 from ... import colors
 from .core import (PointsBase, LabelsMixIn, ColorMixIn, YAxisMixIn,
                    FillMixIn, LineMixIn, SymbolMixIn, ItemChangedType,
-                   BaselineMixIn)
+                   BaselineMixIn, HilightedMixIn, _Style)
 
 
 _logger = logging.getLogger(__name__)
 
 
-class CurveStyle(object):
+class CurveStyle(_Style):
     """Object storing the style of a curve.
 
     Set a value to None to use the default
@@ -153,7 +153,7 @@ class CurveStyle(object):
 
 
 class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn,
-            LineMixIn, BaselineMixIn):
+            LineMixIn, BaselineMixIn, HilightedMixIn):
     """Description of a curve"""
 
     _DEFAULT_Z_LAYER = 1
@@ -181,9 +181,8 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn,
         LabelsMixIn.__init__(self)
         LineMixIn.__init__(self)
         BaselineMixIn.__init__(self)
+        HilightedMixIn.__init__(self)
 
-        self._highlightStyle = self._DEFAULT_HIGHLIGHT_STYLE
-        self._highlighted = False
         self._setBaseline(Curve._DEFAULT_BASELINE)
 
         self.sigItemChanged.connect(self.__itemChanged)
@@ -266,46 +265,6 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn,
 
         super(Curve, self).setVisible(visible)
 
-    def isHighlighted(self):
-        """Returns True if curve is highlighted.
-
-        :rtype: bool
-        """
-        return self._highlighted
-
-    def setHighlighted(self, highlighted):
-        """Set the highlight state of the curve
-
-        :param bool highlighted:
-        """
-        highlighted = bool(highlighted)
-        if highlighted != self._highlighted:
-            self._highlighted = highlighted
-            # TODO inefficient: better to use backend's setCurveColor
-            self._updated(ItemChangedType.HIGHLIGHTED)
-
-    def getHighlightedStyle(self):
-        """Returns the highlighted style in use
-
-        :rtype: CurveStyle
-        """
-        return self._highlightStyle
-
-    def setHighlightedStyle(self, style):
-        """Set the style to use for highlighting
-
-        :param CurveStyle style: New style to use
-        """
-        previous = self.getHighlightedStyle()
-        if style != previous:
-            assert isinstance(style, CurveStyle)
-            self._highlightStyle = style
-            self._updated(ItemChangedType.HIGHLIGHTED_STYLE)
-
-            # Backward compatibility event
-            if previous.getColor() != style.getColor():
-                self._updated(ItemChangedType.HIGHLIGHTED_COLOR)
-
     @deprecated(replacement='Curve.getHighlightedStyle().getColor()',
                 since_version='0.9.0')
     def getHighlightedColor(self):
@@ -349,11 +308,11 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn,
                 symbolsize=self.getSymbolSize() if symbolsize is None else symbolsize)
 
         else:
-             return CurveStyle(color=self.getColor(),
-                               linestyle=self.getLineStyle(),
-                               linewidth=self.getLineWidth(),
-                               symbol=self.getSymbol(),
-                               symbolsize=self.getSymbolSize())
+            return CurveStyle(color=self.getColor(),
+                              linestyle=self.getLineStyle(),
+                              linewidth=self.getLineWidth(),
+                              symbol=self.getSymbol(),
+                              symbolsize=self.getSymbolSize())
 
     @deprecated(replacement='Curve.getCurrentStyle()',
                 since_version='0.9.0')

--- a/silx/gui/plot/items/curve.py
+++ b/silx/gui/plot/items/curve.py
@@ -39,7 +39,7 @@ from ....utils.deprecation import deprecated
 from ... import colors
 from .core import (PointsBase, LabelsMixIn, ColorMixIn, YAxisMixIn,
                    FillMixIn, LineMixIn, SymbolMixIn, ItemChangedType,
-                   BaselineMixIn, HilightedMixIn, _Style)
+                   BaselineMixIn, HighlightedMixIn, _Style)
 
 
 _logger = logging.getLogger(__name__)
@@ -153,7 +153,7 @@ class CurveStyle(_Style):
 
 
 class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn,
-            LineMixIn, BaselineMixIn, HilightedMixIn):
+            LineMixIn, BaselineMixIn, HighlightedMixIn):
     """Description of a curve"""
 
     _DEFAULT_Z_LAYER = 1
@@ -181,7 +181,7 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn,
         LabelsMixIn.__init__(self)
         LineMixIn.__init__(self)
         BaselineMixIn.__init__(self)
-        HilightedMixIn.__init__(self)
+        HighlightedMixIn.__init__(self)
 
         self._setBaseline(Curve._DEFAULT_BASELINE)
 

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -94,7 +94,7 @@ class _RegionOfInterestBase(qt.QObject):
         self.sigItemChanged.emit(event)
 
 
-class RegionOfInterest(_RegionOfInterestBase, core.HilightedMixIn):
+class RegionOfInterest(_RegionOfInterestBase, core.HighlightedMixIn):
     """Object describing a region of interest in a plot.
 
     :param QObject parent:
@@ -132,7 +132,7 @@ class RegionOfInterest(_RegionOfInterestBase, core.HilightedMixIn):
         from ..tools import roi as roi_tools
         assert parent is None or isinstance(parent, roi_tools.RegionOfInterestManager)
         _RegionOfInterestBase.__init__(self, parent)
-        core.HilightedMixIn.__init__(self)
+        core.HighlightedMixIn.__init__(self)
         self._color = rgba('red')
         self._editable = False
         self._selectable = False

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -39,6 +39,7 @@ from ....utils.weakref import WeakList
 from ... import qt
 from ... import utils
 from .. import items
+from ..items import core
 from ...colors import rgba
 import silx.utils.deprecation
 
@@ -93,12 +94,21 @@ class _RegionOfInterestBase(qt.QObject):
         self.sigItemChanged.emit(event)
 
 
-class RegionOfInterest(_RegionOfInterestBase):
+class RegionOfInterest(_RegionOfInterestBase, core.HilightedMixIn):
     """Object describing a region of interest in a plot.
 
     :param QObject parent:
         The RegionOfInterestManager that created this object
     """
+
+    _DEFAULT_LINEWIDTH = 1.
+    """Default line width of the curve"""
+
+    _DEFAULT_LINESTYLE = '-'
+    """Default line style of the curve"""
+
+    _DEFAULT_HIGHLIGHT_STYLE = items.CurveStyle(linewidth=2)
+    """Default highlight style of the item"""
 
     _kind = None
     """Label for this kind of ROI.
@@ -122,6 +132,7 @@ class RegionOfInterest(_RegionOfInterestBase):
         from ..tools import roi as roi_tools
         assert parent is None or isinstance(parent, roi_tools.RegionOfInterestManager)
         _RegionOfInterestBase.__init__(self, parent)
+        core.HilightedMixIn.__init__(self)
         self._color = rgba('red')
         self._editable = False
         self._selectable = False
@@ -423,6 +434,76 @@ class RegionOfInterest(_RegionOfInterestBase):
         else:
             assert False
 
+    def _updated(self, event=None, checkVisibility=True):
+        if event == items.ItemChangedType.HIGHLIGHTED:
+            style = self.getCurrentStyle()
+            self._updatedStyle(event, style)
+        else:
+            hilighted = self.isHighlighted()
+            if hilighted:
+                if event == items.ItemChangedType.HIGHLIGHTED_STYLE:
+                    style = self.getCurrentStyle()
+                    self._updatedStyle(event, style)
+            else:
+                if event in [items.ItemChangedType.COLOR,
+                             items.ItemChangedType.LINE_STYLE,
+                             items.ItemChangedType.LINE_WIDTH,
+                             items.ItemChangedType.SYMBOL,
+                             items.ItemChangedType.SYMBOL_SIZE]:
+                    style = self.getCurrentStyle()
+                    self._updatedStyle(event, style)
+        super(RegionOfInterest, self)._updated(event, checkVisibility)
+
+    def _updatedStyle(self, event, style):
+        """Called when the current displayed style of the ROI was changed.
+
+        :param event: The event responsible of the change of the style
+        :param items.CurveStyle style: The current style
+        """
+        pass
+
+    def getCurrentStyle(self):
+        """Returns the current curve style.
+
+        Curve style depends on curve highlighting
+
+        :rtype: CurveStyle
+        """
+        baseColor = rgba(self.getColor())
+        if isinstance(self, core.LineMixIn):
+            baseLinestyle = self.getLineStyle()
+            baseLinewidth = self.getLineWidth()
+        else:
+            baseLinestyle = self._DEFAULT_LINESTYLE
+            baseLinewidth = self._DEFAULT_LINEWIDTH
+        if isinstance(self, core.SymbolMixIn):
+            baseSymbol = self.getSymbol()
+            baseSymbolsize = self.getSymbolSize()
+        else:
+            baseSymbol = 'o'
+            baseSymbolsize = 1
+
+        if self.isHighlighted():
+            style = self.getHighlightedStyle()
+            color = style.getColor()
+            linestyle = style.getLineStyle()
+            linewidth = style.getLineWidth()
+            symbol = style.getSymbol()
+            symbolsize = style.getSymbolSize()
+
+            return items.CurveStyle(
+                color=baseColor if color is None else color,
+                linestyle=baseLinestyle if linestyle is None else linestyle,
+                linewidth=baseLinewidth if linewidth is None else linewidth,
+                symbol=baseSymbol if symbol is None else symbol,
+                symbolsize=baseSymbolsize if symbolsize is None else symbolsize)
+        else:
+            return items.CurveStyle(color=baseColor,
+                                    linestyle=baseLinestyle,
+                                    linewidth=baseLinewidth,
+                                    symbol=baseSymbol,
+                                    symbolsize=baseSymbolsize)
+
     def _editingStarted(self):
         assert self._editable is True
         self.sigEditingStarted.emit()
@@ -547,17 +628,6 @@ class _HandleBasedROI(RegionOfInterest, _Foo):
         """
         if event == items.ItemChangedType.NAME:
             self._updateText(self.getName())
-        elif event == items.ItemChangedType.COLOR:
-            # Update color of shape items in the plot
-            color = rgba(self.getColor())
-            handleColor = self._computeHandleColor(color)
-            for item, role in self._handles:
-                if role == 'user':
-                    pass
-                elif role == 'label':
-                    item.setColor(color)
-                else:
-                    item.setColor(handleColor)
         elif event == items.ItemChangedType.VISIBLE:
             for item, role in self._handles:
                 visible = self.isVisible() and self.isEditable()
@@ -568,6 +638,20 @@ class _HandleBasedROI(RegionOfInterest, _Foo):
                 if role not in ["user", "label"]:
                     self.__updateEditable(item, editable)
         super(_HandleBasedROI, self)._updated(event, checkVisibility)
+
+    def _updatedStyle(self, event, style):
+        super(_HandleBasedROI, self)._updatedStyle(event, style)
+
+        # Update color of shape items in the plot
+        color = rgba(self.getColor())
+        handleColor = self._computeHandleColor(color)
+        for item, role in self._handles:
+            if role == 'user':
+                pass
+            elif role == 'label':
+                item.setColor(color)
+            else:
+                item.setColor(handleColor)
 
     def __updateEditable(self, handle, editable, remove=True):
         # NOTE: visibility change emit a position update event
@@ -686,11 +770,13 @@ class PointROI(RegionOfInterest, items.SymbolMixIn):
             else:
                 self._marker.sigItemChanged.disconnect(self.__positionChanged)
             self._marker._setDraggable(editable)
-        elif event in [items.ItemChangedType.COLOR,
-                       items.ItemChangedType.VISIBLE,
+        elif event in [items.ItemChangedType.VISIBLE,
                        items.ItemChangedType.SELECTABLE]:
             self._updateItemProperty(event, self, self._marker)
         super(PointROI, self)._updated(event, checkVisibility)
+
+    def _updatedStyle(self, event, style):
+        self._marker.setColor(style.getColor())
 
     def getPosition(self):
         """Returns the position of this ROI
@@ -757,12 +843,14 @@ class LineROI(_HandleBasedROI, items.LineMixIn):
         return False
 
     def _updated(self, event=None, checkVisibility=True):
-        if event in [items.ItemChangedType.COLOR,
-                     items.ItemChangedType.VISIBLE,
-                     items.ItemChangedType.LINE_STYLE,
-                     items.ItemChangedType.LINE_WIDTH]:
+        if event == items.ItemChangedType.VISIBLE:
             self._updateItemProperty(event, self, self.__shape)
         super(LineROI, self)._updated(event, checkVisibility)
+
+    def _updatedStyle(self, event, style):
+        self.__shape.setColor(style.getColor())
+        self.__shape.setLineStyle(style.getLineStyle())
+        self.__shape.setLineWidth(style.getLineWidth())
 
     def setFirstShapePoints(self, points):
         assert len(points) == 2
@@ -857,13 +945,15 @@ class HorizontalLineROI(RegionOfInterest, items.LineMixIn):
             else:
                 self._marker.sigItemChanged.disconnect(self.__positionChanged)
             self._marker._setDraggable(editable)
-        elif event in [items.ItemChangedType.COLOR,
-                       items.ItemChangedType.LINE_STYLE,
-                       items.ItemChangedType.LINE_WIDTH,
-                       items.ItemChangedType.VISIBLE,
+        elif event in [items.ItemChangedType.VISIBLE,
                        items.ItemChangedType.SELECTABLE]:
             self._updateItemProperty(event, self, self._marker)
         super(HorizontalLineROI, self)._updated(event, checkVisibility)
+
+    def _updatedStyle(self, event, style):
+        self._marker.setColor(style.getColor())
+        self._marker.setLineStyle(style.getLineStyle())
+        self._marker.setLineWidth(style.getLineWidth())
 
     def setFirstShapePoints(self, points):
         pos = points[0, 1]
@@ -934,13 +1024,15 @@ class VerticalLineROI(RegionOfInterest, items.LineMixIn):
             else:
                 self._marker.sigItemChanged.disconnect(self.__positionChanged)
             self._marker._setDraggable(editable)
-        elif event in [items.ItemChangedType.COLOR,
-                       items.ItemChangedType.LINE_STYLE,
-                       items.ItemChangedType.LINE_WIDTH,
-                       items.ItemChangedType.VISIBLE,
+        elif event in [items.ItemChangedType.VISIBLE,
                        items.ItemChangedType.SELECTABLE]:
             self._updateItemProperty(event, self, self._marker)
         super(VerticalLineROI, self)._updated(event, checkVisibility)
+
+    def _updatedStyle(self, event, style):
+        self._marker.setColor(style.getColor())
+        self._marker.setLineStyle(style.getLineStyle())
+        self._marker.setLineWidth(style.getLineWidth())
 
     def setFirstShapePoints(self, points):
         pos = points[0, 0]
@@ -1017,12 +1109,15 @@ class RectangleROI(_HandleBasedROI, items.LineMixIn):
         return False
 
     def _updated(self, event=None, checkVisibility=True):
-        if event in [items.ItemChangedType.COLOR,
-                     items.ItemChangedType.VISIBLE,
-                     items.ItemChangedType.LINE_STYLE,
-                     items.ItemChangedType.LINE_WIDTH]:
+        if event in [items.ItemChangedType.VISIBLE]:
             self._updateItemProperty(event, self, self.__shape)
         super(RectangleROI, self)._updated(event, checkVisibility)
+
+    def _updatedStyle(self, event, style):
+        super(RectangleROI, self)._updatedStyle(event, style)
+        self.__shape.setColor(style.getColor())
+        self.__shape.setLineStyle(style.getLineStyle())
+        self.__shape.setLineWidth(style.getLineWidth())
 
     def setFirstShapePoints(self, points):
         assert len(points) == 2
@@ -1176,12 +1271,15 @@ class PolygonROI(_HandleBasedROI, items.LineMixIn):
         return False
 
     def _updated(self, event=None, checkVisibility=True):
-        if event in [items.ItemChangedType.COLOR,
-                     items.ItemChangedType.VISIBLE,
-                     items.ItemChangedType.LINE_STYLE,
-                     items.ItemChangedType.LINE_WIDTH]:
+        if event in [items.ItemChangedType.VISIBLE]:
             self._updateItemProperty(event, self, self.__shape)
         super(PolygonROI, self)._updated(event, checkVisibility)
+
+    def _updatedStyle(self, event, style):
+        super(PolygonROI, self)._updatedStyle(event, style)
+        self.__shape.setColor(style.getColor())
+        self.__shape.setLineStyle(style.getLineStyle())
+        self.__shape.setLineWidth(style.getLineWidth())
 
     def __createShape(self, interaction=False):
         kind = "polygon" if not interaction else "polylines"
@@ -1456,12 +1554,15 @@ class ArcROI(_HandleBasedROI, items.LineMixIn):
         return False
 
     def _updated(self, event=None, checkVisibility=True):
-        if event in [items.ItemChangedType.COLOR,
-                     items.ItemChangedType.VISIBLE,
-                     items.ItemChangedType.LINE_STYLE,
-                     items.ItemChangedType.LINE_WIDTH]:
+        if event == items.ItemChangedType.VISIBLE:
             self._updateItemProperty(event, self, self.__shape)
         super(ArcROI, self)._updated(event, checkVisibility)
+
+    def _updatedStyle(self, event, style):
+        super(ArcROI, self)._updatedStyle(event, style)
+        self.__shape.setColor(style.getColor())
+        self.__shape.setLineStyle(style.getLineStyle())
+        self.__shape.setLineWidth(style.getLineWidth())
 
     def setFirstShapePoints(self, points):
         """"Initialize the ROI using the points from the first interaction.
@@ -2007,13 +2108,17 @@ class HorizontalRangeROI(RegionOfInterest, items.LineMixIn):
         elif event == items.ItemChangedType.LINE_STYLE:
             markers = [self._markerMin, self._markerMax]
             self._updateItemProperty(event, self, markers)
-        elif event in [items.ItemChangedType.COLOR,
-                       items.ItemChangedType.LINE_WIDTH,
-                       items.ItemChangedType.VISIBLE,
+        elif event in [items.ItemChangedType.VISIBLE,
                        items.ItemChangedType.SELECTABLE]:
             markers = [self._markerMin, self._markerMax, self._markerCen]
             self._updateItemProperty(event, self, markers)
         super(HorizontalRangeROI, self)._updated(event, checkVisibility)
+
+    def _updatedStyle(self, event, style):
+        markers = [self._markerMin, self._markerMax, self._markerCen]
+        for m in markers:
+            m.setColor(style.getColor())
+            m.setLineWidth(style.getLineWidth())
 
     def _updateText(self):
         text = self.getName()

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -742,8 +742,8 @@ class PointROI(RegionOfInterest, items.SymbolMixIn):
     """
 
     def __init__(self, parent=None):
-        items.SymbolMixIn.__init__(self)
         RegionOfInterest.__init__(self, parent=parent)
+        items.SymbolMixIn.__init__(self)
         self._marker = items.Marker()
         self._marker.setSymbol(self._DEFAULT_SYMBOL)
         self._marker.sigDragStarted.connect(self._editingStarted)
@@ -821,8 +821,8 @@ class LineROI(_HandleBasedROI, items.LineMixIn):
     """Plot shape which is used for the first interaction"""
 
     def __init__(self, parent=None):
-        items.LineMixIn.__init__(self)
         _HandleBasedROI.__init__(self, parent=parent)
+        items.LineMixIn.__init__(self)
         self._handleStart = self.addHandle()
         self._handleEnd = self.addHandle()
         self._handleCenter = self.addTranslateHandle()
@@ -922,8 +922,8 @@ class HorizontalLineROI(RegionOfInterest, items.LineMixIn):
     """Plot shape which is used for the first interaction"""
 
     def __init__(self, parent=None):
-        items.LineMixIn.__init__(self)
         RegionOfInterest.__init__(self, parent=parent)
+        items.LineMixIn.__init__(self)
         self._marker = items.YMarker()
         self._marker.sigDragStarted.connect(self._editingStarted)
         self._marker.sigDragFinished.connect(self._editingFinished)
@@ -1001,8 +1001,8 @@ class VerticalLineROI(RegionOfInterest, items.LineMixIn):
     """Plot shape which is used for the first interaction"""
 
     def __init__(self, parent=None):
-        items.LineMixIn.__init__(self)
         RegionOfInterest.__init__(self, parent=parent)
+        items.LineMixIn.__init__(self)
         self._marker = items.XMarker()
         self._marker.sigDragStarted.connect(self._editingStarted)
         self._marker.sigDragFinished.connect(self._editingFinished)
@@ -1084,8 +1084,8 @@ class RectangleROI(_HandleBasedROI, items.LineMixIn):
     """Plot shape which is used for the first interaction"""
 
     def __init__(self, parent=None):
-        items.LineMixIn.__init__(self)
         _HandleBasedROI.__init__(self, parent=parent)
+        items.LineMixIn.__init__(self)
         self._handleTopLeft = self.addHandle()
         self._handleTopRight = self.addHandle()
         self._handleBottomLeft = self.addHandle()
@@ -1254,8 +1254,8 @@ class PolygonROI(_HandleBasedROI, items.LineMixIn):
     """Plot shape which is used for the first interaction"""
 
     def __init__(self, parent=None):
-        items.LineMixIn.__init__(self)
         _HandleBasedROI.__init__(self, parent=parent)
+        items.LineMixIn.__init__(self)
         self._handleLabel = self.addLabelHandle()
         self._handleCenter = self.addTranslateHandle()
         self._handlePoints = []
@@ -1524,8 +1524,8 @@ class ArcROI(_HandleBasedROI, items.LineMixIn):
                         self._closed))
 
     def __init__(self, parent=None):
-        items.LineMixIn.__init__(self)
         _HandleBasedROI.__init__(self, parent=parent)
+        items.LineMixIn.__init__(self)
         self._geometry  = self._Geometry.createEmpty()
         self._handleLabel = self.addLabelHandle()
 
@@ -2071,8 +2071,8 @@ class HorizontalRangeROI(RegionOfInterest, items.LineMixIn):
     """Plot shape which is used for the first interaction"""
 
     def __init__(self, parent=None):
-        items.LineMixIn.__init__(self)
         RegionOfInterest.__init__(self, parent=parent)
+        items.LineMixIn.__init__(self)
         self._markerMin = items.XMarker()
         self._markerMax = items.XMarker()
         self._markerCen = items.XMarker()

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -380,7 +380,15 @@ class RegionOfInterestManager(qt.QObject):
             else:
                 self.setCurrentRoi(None)
         elif event['event'] == 'mouseClicked' and event['button'] == 'left':
-            self.setCurrentRoi(None)
+            # Marker click is only for dnd
+            # This also can click on a marker
+            plot = self.parent()
+            marker = plot._getMarkerAt(event['xpixel'], event['ypixel'])
+            roi = self.__getRoiFromMarker(marker)
+            if roi is not None and roi.isSelectable():
+                self.setCurrentRoi(roi)
+            else:
+                self.setCurrentRoi(None)
 
     # RegionOfInterest API
 

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -354,7 +354,11 @@ class RegionOfInterestManager(qt.QObject):
             else:
                 raise RuntimeError("Max selection proxy depth (10) reached.")
 
+        if self._currentRoi is not None:
+            self._currentRoi.setHighlighted(False)
         self._currentRoi = roi
+        if self._currentRoi is not None:
+            self._currentRoi.setHighlighted(True)
         self.sigCurrentRoiChanged.emit(roi)
 
     def getCurrentRoi(self):


### PR DESCRIPTION
This PR reuse concept from `Curve` and the `CurveStyle` object to custom the highlighted state of ROIs.

I wanted to make obvious which ROI was selected. So now it's the case.

If it's fine, i still have to update the profile with it.

Possible improvements:
- Make the shapes selectable
- Make the shapes draggable

![Capture d’écran de 2020-04-29 15-08-12](https://user-images.githubusercontent.com/7579321/80600115-37591300-8a2c-11ea-8099-aa4bde76f930.png)
