### PR TITLE
Improve polygon closure

### DIFF
--- a/silx/gui/plot/Interaction.py
+++ b/silx/gui/plot/Interaction.py
@@ -137,6 +137,11 @@ class State(object):
         """
         pass
 
+    def validate(self):
+        """Called externally to validate the current interaction in case of a
+        creation.
+        """
+        pass
 
 class StateMachine(object):
     """State machine controller.
@@ -190,6 +195,12 @@ class StateMachine(object):
                 handler = None
         if handler is not None:
             return handler(*args, **kwargs)
+
+    def validate(self):
+        """Called externally to validate the current interaction in case of a
+        creation.
+        """
+        self.state.validate()
 
 
 # clickOrDrag #################################################################

--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -472,6 +472,8 @@ class SelectPolygon(Select):
             if len(self.points) > 2:
                 self.closePolygon()
             else:
+                # It would be nice to have a cancel event.
+                # The plot is not aware that the interaction was cancelled
                 self.machine.cancel()
 
         def closePolygon(self):

--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -1363,11 +1363,12 @@ class FocusManager(StateMachine):
     """
     class Idle(State):
         def onPress(self, x, y, btn):
-            for eventHandler in self.machine.eventHandlers:
-                requestFocus = eventHandler.handleEvent('press', x, y, btn)
-                if requestFocus:
-                    self.goto('focus', eventHandler, btn)
-                    break
+            if btn == LEFT_BTN:
+                for eventHandler in self.machine.eventHandlers:
+                    requestFocus = eventHandler.handleEvent('press', x, y, btn)
+                    if requestFocus:
+                        self.goto('focus', eventHandler, btn)
+                        break
 
         def _processEvent(self, *args):
             for eventHandler in self.machine.eventHandlers:
@@ -1379,7 +1380,8 @@ class FocusManager(StateMachine):
             self._processEvent('move', x, y)
 
         def onRelease(self, x, y, btn):
-            self._processEvent('release', x, y, btn)
+            if btn == LEFT_BTN:
+                self._processEvent('release', x, y, btn)
 
         def onWheel(self, x, y, angle):
             self._processEvent('wheel', x, y, angle)
@@ -1394,17 +1396,19 @@ class FocusManager(StateMachine):
             self.goto('idle')
 
         def onPress(self, x, y, btn):
-            self.focusBtns.add(btn)
-            self.eventHandler.handleEvent('press', x, y, btn)
+            if btn == LEFT_BTN:
+                self.focusBtns.add(btn)
+                self.eventHandler.handleEvent('press', x, y, btn)
 
         def onMove(self, x, y):
             self.eventHandler.handleEvent('move', x, y)
 
         def onRelease(self, x, y, btn):
-            self.focusBtns.discard(btn)
-            requestFocus = self.eventHandler.handleEvent('release', x, y, btn)
-            if len(self.focusBtns) == 0 and not requestFocus:
-                self.goto('idle')
+            if btn == LEFT_BTN:
+                self.focusBtns.discard(btn)
+                requestFocus = self.eventHandler.handleEvent('release', x, y, btn)
+                if len(self.focusBtns) == 0 and not requestFocus:
+                    self.goto('idle')
 
         def onWheel(self, x, y, angleInDegrees):
             self.eventHandler.handleEvent('wheel', x, y, angleInDegrees)

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -382,6 +382,16 @@ class PlotWidget(qt.QMainWindow):
         """
         return self._dirty
 
+    # Default Qt context menu
+
+    def contextMenuEvent(self, event):
+        """Override QWidget.contextMenuEvent to implement the context menu"""
+        from .actions.control import ZoomBackAction  # Avoid cyclic import
+        zoomBackAction = ZoomBackAction(plot=self, parent=self)
+        menu = qt.QMenu(self)
+        menu.addAction(zoomBackAction)
+        menu.exec_(event.globalPos())
+
     def _setDirtyPlot(self, overlayOnly=False):
         """Mark the plot as needing redraw
 

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -386,10 +386,17 @@ class PlotWidget(qt.QMainWindow):
 
     def contextMenuEvent(self, event):
         """Override QWidget.contextMenuEvent to implement the context menu"""
-        from .actions.control import ZoomBackAction  # Avoid cyclic import
-        zoomBackAction = ZoomBackAction(plot=self, parent=self)
         menu = qt.QMenu(self)
+        from .actions.control import ZoomBackAction  # Avoid cyclic import
+        zoomBackAction = ZoomBackAction(plot=self, parent=menu)
         menu.addAction(zoomBackAction)
+
+        mode = self.getInteractiveMode()
+        if "shape" in mode and mode["shape"] == "polygon":
+            from .actions.control import ClosePolygonInteractionAction  # Avoid cyclic import
+            action = ClosePolygonInteractionAction(plot=self, parent=menu)
+            menu.addAction(action)
+
         menu.exec_(event.globalPos())
 
     def _setDirtyPlot(self, overlayOnly=False):

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -397,6 +397,10 @@ class PlotWidget(qt.QMainWindow):
             action = ClosePolygonInteractionAction(plot=self, parent=menu)
             menu.addAction(action)
 
+        # Make sure the plot is updated, especially when the plot is in
+        # draw interaction mode
+        menu.aboutToHide.connect(self.__simulateMouseMove)
+
         menu.exec_(event.globalPos())
 
     def _setDirtyPlot(self, overlayOnly=False):
@@ -3203,6 +3207,16 @@ class PlotWidget(qt.QMainWindow):
         qt.Qt.Key_Down: 'down'
     }
 
+    def __simulateMouseMove(self):
+        qapp = qt.QApplication.instance()
+        event = qt.QMouseEvent(
+            qt.QEvent.MouseMove,
+            self.getWidgetHandle().mapFromGlobal(qt.QCursor.pos()),
+            qt.Qt.NoButton,
+            qapp.mouseButtons(),
+            qapp.keyboardModifiers())
+        qapp.sendEvent(self.getWidgetHandle(), event)
+
     def keyPressEvent(self, event):
         """Key event handler handling panning on arrow keys.
 
@@ -3215,15 +3229,7 @@ class PlotWidget(qt.QMainWindow):
             # Send a mouse move event to the plot widget to take into account
             # that even if mouse didn't move on the screen, it moved relative
             # to the plotted data.
-            qapp = qt.QApplication.instance()
-            event = qt.QMouseEvent(
-                qt.QEvent.MouseMove,
-                self.getWidgetHandle().mapFromGlobal(qt.QCursor.pos()),
-                qt.Qt.NoButton,
-                qapp.mouseButtons(),
-                qapp.keyboardModifiers())
-            qapp.sendEvent(self.getWidgetHandle(), event)
-
+            self.__simulateMouseMove()
         else:
             # Only call base class implementation when key is not handled.
             # See QWidget.keyPressEvent for details.

--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -603,3 +603,32 @@ class ShowAxisAction(PlotAction):
     def _actionTriggered(self, checked=False):
         self.plot.setAxesDisplayed(checked)
 
+
+class ClosePolygonInteractionAction(PlotAction):
+    """QAction controlling closure of a polygon in draw interaction mode
+    if the :class:`.PlotWidget`.
+
+    :param plot: :class:`.PlotWidget` instance on which to operate
+    :param parent: See :class:`QAction`
+    """
+
+    def __init__(self, plot, parent=None):
+        tooltip = 'Close the current polygon drawn'
+        PlotAction.__init__(self,
+                            plot,
+                            icon='add-shape-polygon',
+                            text='Close the polygon',
+                            tooltip=tooltip,
+                            triggered=self._actionTriggered,
+                            checkable=True,
+                            parent=parent)
+        self.plot.sigInteractiveModeChanged.connect(self._modeChanged)
+        self._modeChanged(None)
+
+    def _modeChanged(self, source):
+        mode = self.plot.getInteractiveMode()
+        enabled = "shape" in mode and mode["shape"] == "polygon"
+        self.setEnabled(enabled)
+
+    def _actionTriggered(self, checked=False):
+        self.plot._eventHandler.validate()

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -63,8 +63,6 @@ class BackendBase(object):
         # Store a weakref to get access to the plot state.
         self._setPlot(plot)
 
-        self.__zoomBackAction = None
-
     @property
     def _plot(self):
         """The plot this backend is attached to."""
@@ -82,18 +80,6 @@ class BackendBase(object):
         Use with caution, basically **immediately** after init.
         """
         self._plotRef = weakref.ref(plot)
-
-    # Default Qt context menu
-
-    def contextMenuEvent(self, event):
-        """Override QWidget.contextMenuEvent to implement the context menu"""
-        if self.__zoomBackAction is None:
-            from ..actions.control import ZoomBackAction  # Avoid cyclic import
-            self.__zoomBackAction = ZoomBackAction(plot=self._plot,
-                                                   parent=self._plot)
-        menu = qt.QMenu(self)
-        menu.addAction(self.__zoomBackAction)
-        menu.exec_(event.globalPos())
 
     # Add methods
 

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1276,11 +1276,6 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
         self.mpl_connect('motion_notify_event', self._onMouseMove)
         self.mpl_connect('scroll_event', self._onMouseWheel)
 
-    def contextMenuEvent(self, event):
-        """Override QWidget.contextMenuEvent to implement the context menu"""
-        # Makes sure it is overridden (issue with PySide)
-        BackendBase.BackendBase.contextMenuEvent(self, event)
-
     def postRedisplay(self):
         self._sigPostRedisplay.emit()
 

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -248,11 +248,6 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
     _MOUSE_BTNS = {1: 'left', 2: 'right', 4: 'middle'}
 
-    def contextMenuEvent(self, event):
-        """Override QWidget.contextMenuEvent to implement the context menu"""
-        # Makes sure it is overridden (issue with PySide)
-        BackendBase.BackendBase.contextMenuEvent(self, event)
-
     def sizeHint(self):
         return qt.QSize(8 * 80, 6 * 80)  # Mimic MatplotlibBackend
 


### PR DESCRIPTION
This PR improve the behavior of the polygon draw interaction.

- Provide another action to the context menu to close the polygon while there is the draw interaction
- The context menu is now provided by the widget, not by the backend (then it can be overwrited)

It fixes 3 issues:
- During polygon creation, using the mouse right click to open the context menu was also triggering the PlotInteraction focus class, as result it was not anymore possible to interact with the plot markers
- During polygon creation, closing the context menu was not updating the polygon while the mouse was not again moved
- Restart the plot interaction if the current drawn ROI was removed (this avoid to have a strange behavior with a recreated ROI while it was explicitly removed)

There is remained small issue:
- It is possible to create a polygon ROI with 2 points, there is no real way to cancel the polygon interaction, the plot is not aware of that.