### PR TITLE
[profile] Split area shape from profile ROIs

### DIFF
--- a/silx/gui/plot/tools/profile/core.py
+++ b/silx/gui/plot/tools/profile/core.py
@@ -113,8 +113,8 @@ class ProfileRoiMixIn:
         previousPlotItem = self.getPlotItem()
         if previousPlotItem is plotItem:
             return
-        self.sigPlotItemChanged.emit()
         self.__plotItem = weakref.ref(plotItem)
+        self.sigPlotItemChanged.emit()
 
     def getPlotItem(self):
         """Returns the plot item used by this profile

--- a/silx/gui/plot/tools/profile/core.py
+++ b/silx/gui/plot/tools/profile/core.py
@@ -31,6 +31,7 @@ __date__ = "17/04/2020"
 
 import collections
 import numpy
+import weakref
 
 from silx.image.bilinear import BilinearImage
 from silx.gui import qt
@@ -80,11 +81,15 @@ class ProfileRoiMixIn:
     """Define the plot item which can be used with this profile ROI"""
 
     sigProfilePropertyChanged = qt.Signal()
-    """Emitted when a property of the profile have changed"""
+    """Emitted when a property of this profile have changed"""
+
+    sigPlotItemChanged = qt.Signal()
+    """Emitted when the plot item linked to this profile have changed"""
 
     def __init__(self, parent=None):
         self.__profileWindow = None
         self.__profileManager = None
+        self.__plotItem = None
         self.setName("Profile")
         self.setEditable(True)
         self.setSelectable(True)
@@ -99,6 +104,29 @@ class ProfileRoiMixIn:
     def invalidateProperties(self):
         """Must be called when a property of the profile have changed."""
         self.sigProfilePropertyChanged.emit()
+
+    def _setPlotItem(self, plotItem):
+        """Specify the plot item to use with this profile
+
+        :param `~silx.gui.plot.items.item.Item` plotItem: A plot item
+        """
+        previousPlotItem = self.getPlotItem()
+        if previousPlotItem is plotItem:
+            return
+        self.sigPlotItemChanged.emit()
+        self.__plotItem = weakref.ref(plotItem)
+
+    def getPlotItem(self):
+        """Returns the plot item used by this profile
+
+        :rtype: `~silx.gui.plot.items.item.Item`
+        """
+        if self.__plotItem is None:
+            return None
+        plotItem = self.__plotItem()
+        if plotItem is None:
+            self.__plotItem = None
+        return plotItem
 
     def _setProfileManager(self, profileManager):
         self.__profileManager = profileManager

--- a/silx/gui/plot/tools/profile/manager.py
+++ b/silx/gui/plot/tools/profile/manager.py
@@ -819,10 +819,15 @@ class ProfileManager(qt.QObject):
                     self._pendingRunners.remove(runner)
 
         item = self.getPlotItem()
-        if item is None:
-            # FIXME: It means the result is None profile window have to be updated
+        if item is None or not isinstance(item, profileRoi.ITEM_KIND):
+            # This item is not compatible with this profile
+            profileRoi._setPlotItem(None)
+            profileWindow = profileRoi.getProfileWindow()
+            if profileWindow is not None:
+                profileWindow.setProfile(None)
             return
 
+        profileRoi._setPlotItem(item)
         runner = _RunnableComputeProfile(threadPool, item, profileRoi)
         runner.runnerFinished.connect(self.__cleanUpRunner)
         runner.resultReady.connect(self.__displayResult)

--- a/silx/gui/plot/tools/test/testProfile.py
+++ b/silx/gui/plot/tools/test/testProfile.py
@@ -442,16 +442,18 @@ class TestDeprecatedProfileToolBar(TestCaseQt):
             self.plot.setAttribute(qt.Qt.WA_DeleteOnClose)
             self.plot.close()
             self.plot = None
+            self.qWait()
 
         super(TestDeprecatedProfileToolBar, self).tearDown()
 
     @testutils.test_logging(deprecation.depreclog.name, warning=2)
     def testCustomProfileWindow(self):
         from silx.gui.plot import ProfileMainWindow
-        profileWindow = ProfileMainWindow.ProfileMainWindow()
 
         self.plot = PlotWindow()
-        toolBar = Profile.ProfileToolBar(plot=self.plot,
+        profileWindow = ProfileMainWindow.ProfileMainWindow(self.plot)
+        toolBar = Profile.ProfileToolBar(parent=self.plot,
+                                         plot=self.plot,
                                          profileWindow=profileWindow)
 
         self.plot.show()

--- a/silx/gui/plot/tools/test/testProfile.py
+++ b/silx/gui/plot/tools/test/testProfile.py
@@ -55,7 +55,8 @@ class TestRois(TestCaseQt):
         """Check that the constructor is not called twice"""
         roi = rois.ProfileImageVerticalLineROI()
         if qt.BINDING not in ["PySide", "PySide2"]:
-            self.assertEqual(roi.receivers(roi.sigRegionChanged), 1)
+            # the profile ROI + the shape
+            self.assertEqual(roi.receivers(roi.sigRegionChanged), 2)
 
 
 class TestInteractions(TestCaseQt):

--- a/silx/gui/widgets/MultiModeAction.py
+++ b/silx/gui/widgets/MultiModeAction.py
@@ -49,13 +49,14 @@ class MultiModeAction(qt.QWidgetAction):
         button = qt.QToolButton(parent)
         button.setPopupMode(qt.QToolButton.MenuButtonPopup)
         self.setDefaultWidget(button)
+        self.__button = button
 
     def getMenu(self):
         """Returns the menu.
 
         :rtype: qt.QMenu
         """
-        button = self.defaultWidget()
+        button = self.__button
         menu = button.menu()
         if menu is None:
             menu = qt.QMenu(button)
@@ -68,15 +69,15 @@ class MultiModeAction(qt.QWidgetAction):
         :param qt.QAction action: New action
         """
         menu = self.getMenu()
-        button = self.defaultWidget()
+        button = self.__button
         menu.addAction(action)
         if button.defaultAction() is None:
             button.setDefaultAction(action)
         if action.isCheckable():
-            action.toggled.connect(self.__toggled)
+            action.toggled.connect(self._toggled)
 
-    def __toggled(self, checked):
+    def _toggled(self, checked):
         if checked:
             action = self.sender()
-            button = self.defaultWidget()
+            button = self.__button
             button.setDefaultAction(action)


### PR DESCRIPTION
This PR fix small issue relative to profile area update at the update of the active item.

- It extracts areas from the profile ROIs into an independent shape
- It creates a link from the profile ROI to the item

As result it is now possible to design this profiles by composition. But i have burned more than the time i wanted to spend here.

Most of ROIs could be merged together, reducing by 3 the amount of classes; by 3 the amount of actions. Reducing by far the complexity of the profile ROIs.