### PR TITLE
Test remaining widgets with pyside2

### DIFF
--- a/silx/app/view/Viewer.py
+++ b/silx/app/view/Viewer.py
@@ -605,7 +605,7 @@ class Viewer(qt.QMainWindow):
         action.setStatusTip("Select plot rendering backend")
         self._plotBackendSelection = action
 
-        menu = qt.QMenu()
+        menu = qt.QMenu(self)
         action.setMenu(menu)
         group = qt.QActionGroup(self)
         group.setExclusive(True)
@@ -632,7 +632,7 @@ class Viewer(qt.QMainWindow):
         action.setStatusTip("Select the default y-axis orientation used by plot displaying images")
         self._plotImageOrientation = action
 
-        menu = qt.QMenu()
+        menu = qt.QMenu(self)
         action.setMenu(menu)
         group = qt.QActionGroup(self)
         group.setExclusive(True)

--- a/silx/gui/dialog/test/test_colormapdialog.py
+++ b/silx/gui/dialog/test/test_colormapdialog.py
@@ -54,12 +54,9 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
 
     def tearDown(self):
         self.qapp.processEvents()
-        colormapDiag = self.colormapDiag
-        self.colormapDiag = None
-        if colormapDiag is not None:
-            colormapDiag.close()
-            colormapDiag.deleteLater()
-            colormapDiag = None
+        if self.colormapDiag is not None:
+            self.colormapDiag.close()
+            del self.colormapDiag
         self.qapp.processEvents()
         ParametricTestCase.tearDown(self)
         TestCaseQt.tearDown(self)

--- a/silx/gui/dialog/test/test_datafiledialog.py
+++ b/silx/gui/dialog/test/test_datafiledialog.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -107,9 +107,8 @@ class _UtilsMixin(object):
         if not hasattr(self, "_dialog"):
             return
         if self._dialog is not None:
-            ref = weakref.ref(self._dialog)
-            self._dialog = None
-            self.qWaitForDestroy(ref)
+            self._dialog.close()
+            del self._dialog
 
     def qWaitForPendingActions(self, dialog):
         for _ in range(20):

--- a/silx/gui/dialog/test/test_imagefiledialog.py
+++ b/silx/gui/dialog/test/test_imagefiledialog.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -114,9 +114,8 @@ class _UtilsMixin(object):
         if not hasattr(self, "_dialog"):
             return
         if self._dialog is not None:
-            ref = weakref.ref(self._dialog)
-            self._dialog = None
-            self.qWaitForDestroy(ref)
+            self._dialog.close()
+            del self._dialog
 
     def qWaitForPendingActions(self, dialog):
         for _ in range(20):

--- a/silx/gui/plot/LegendSelector.py
+++ b/silx/gui/plot/LegendSelector.py
@@ -359,9 +359,12 @@ class LegendListItemWidget(qt.QItemDelegate):
         self.iconDict = {}
 
         # Keep checkbox and legend to get sizeHint
-        self.checkbox = qt.QCheckBox()
-        self.legend = qt.QLabel()
-        self.icon = LegendIcon()
+        self.checkbox = qt.QCheckBox(parent)
+        self.checkbox.setVisible(False)
+        self.legend = qt.QLabel(parent)
+        self.legend.setVisible(False)
+        self.icon = LegendIcon(parent)
+        self.icon.setVisible(False)
 
         # Context Menu and Editors
         self.contextMenu = None
@@ -502,7 +505,7 @@ class LegendListView(qt.QListView):
         self.__lastClickPos = None
         self.__lastModelIdx = None
         # Set default delegate
-        self.setItemDelegate(LegendListItemWidget())
+        self.setItemDelegate(LegendListItemWidget(self))
         # Set default editors
         # self.setSizePolicy(qt.QSizePolicy.MinimumExpanding,
         #                    qt.QSizePolicy.MinimumExpanding)

--- a/silx/gui/plot/test/testCompareImages.py
+++ b/silx/gui/plot/test/testCompareImages.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -44,9 +44,8 @@ class TestCompareImages(TestCaseQt):
         self.widget = CompareImages()
 
     def tearDown(self):
-        ref = weakref.ref(self.widget)
-        self.widget = None
-        self.qWaitForDestroy(ref)
+        self.widget.close()
+        del self.widget
         super(TestCompareImages, self).tearDown()
 
     def testIntensityImage(self):

--- a/silx/gui/plot/tools/test/testProfile.py
+++ b/silx/gui/plot/tools/test/testProfile.py
@@ -442,7 +442,7 @@ class TestDeprecatedProfileToolBar(TestCaseQt):
             self.plot.setAttribute(qt.Qt.WA_DeleteOnClose)
             self.plot.close()
             self.plot = None
-            self.qWait()
+            self.qapp.processEvents()
 
         super(TestDeprecatedProfileToolBar, self).tearDown()
 

--- a/silx/gui/utils/testutils.py
+++ b/silx/gui/utils/testutils.py
@@ -173,7 +173,7 @@ class TestCaseQt(unittest.TestCase):
                        _inspect.createdByPython(widget))]
         del self.__previousWidgets
 
-        if qt.BINDING in ('PySide', 'PySide2'):
+        if qt.BINDING == 'PySide':
             return  # Do not test for leaking widgets with PySide
 
         allowedLeakingWidgets = self.allowedLeakingWidgets


### PR DESCRIPTION
This PR enables testing of remaining widgets after each test with PySide2 as it is already the case with PyQt5.
It avoids remaining widgets at test level by using `QWidget.close` rather than `TestCaseQt.qWaitForDestroy` where it seems to be an issue, it makes sure widgets have parents when it is needed.