### PR TITLE
Typo on text margin property

### DIFF
--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -875,7 +875,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                                              color=color,
                                              horizontalalignment='left',
                                              verticalalignment='top')
-                textArtist.x_pixel_offset = 5, 3
+                textArtist.pixel_offset = 5, 3
         elif y is not None:
             line = ax.axhline(y,
                               color=color,
@@ -888,7 +888,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                                              color=color,
                                              horizontalalignment='right',
                                              verticalalignment='top')
-                textArtist.x_pixel_offset = 5, 3
+                textArtist.pixel_offset = 5, 3
         else:
             raise RuntimeError('A marker must at least have one coordinate')
 


### PR DESCRIPTION
This PR fixes the name of the property used to add margin between vline/hline and text.
 