### PR TITLE
Clean up roi manager

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -192,6 +192,12 @@ class PlotWidget(qt.QMainWindow):
     It provides the item that will be removed.
     """
 
+    sigItemRemoved = qt.Signal(items.Item)
+    """Signal emitted right after an item was removed from the plot.
+
+    It provides the item that was removed.
+    """
+
     sigVisibilityChanged = qt.Signal(bool)
     """Signal emitted when the widget becomes visible (or invisible).
     This happens when the widget is hidden or shown.
@@ -718,6 +724,8 @@ class PlotWidget(qt.QMainWindow):
         if (kind == 'curve' and not self.getAllCurves(just_legend=True,
                                                       withhidden=True)):
             self._resetColorAndStyle()
+
+        self.sigItemRemoved.emit(item)
 
         self.notify('contentChanged', action='remove',
                     kind=kind, legend=item.getName())

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -30,9 +30,7 @@ __license__ = "MIT"
 __date__ = "28/06/2018"
 
 
-import collections
 import enum
-import functools
 import logging
 import time
 import weakref

--- a/silx/gui/plot/tools/test/testROI.py
+++ b/silx/gui/plot/tools/test/testROI.py
@@ -563,6 +563,49 @@ class TestRegionOfInterestManager(TestCaseQt, ParametricTestCase):
         manager.clear()
         self.qapp.processEvents()
 
+    def testPlotWhenCleared(self):
+        """PlotWidget.clear should clean up the available ROIs"""
+        manager = roi.RegionOfInterestManager(self.plot)
+        item = roi_items.LineROI()
+        item.setEndPoints((0, 0), (1, 1))
+        item.setEditable(True)
+        manager.addRoi(item)
+        self.qWait()
+        try:
+            # Make sure the test setup is fine
+            self.assertNotEqual(len(manager.getRois()), 0)
+            self.assertNotEqual(len(self.plot.getItems()), 0)
+
+            # Call clear and test the expected state
+            self.plot.clear()
+            self.assertEqual(len(manager.getRois()), 0)
+            self.assertEqual(len(self.plot.getItems()), 0)
+        finally:
+            # Clean up
+            manager.clear()
+
+    def testPlotWhenRoiRemoved(self):
+        """Make sure there is no remaining items in the plot when a ROI is removed"""
+        manager = roi.RegionOfInterestManager(self.plot)
+        item = roi_items.LineROI()
+        item.setEndPoints((0, 0), (1, 1))
+        item.setEditable(True)
+        manager.addRoi(item)
+        self.qWait()
+        try:
+            # Make sure the test setup is fine
+            self.assertNotEqual(len(manager.getRois()), 0)
+            self.assertNotEqual(len(self.plot.getItems()), 0)
+
+            # Call clear and test the expected state
+            manager.removeRoi(item)
+            self.assertEqual(len(manager.getRois()), 0)
+            self.assertEqual(len(self.plot.getItems()), 0)
+        finally:
+            # Clean up
+            manager.clear()
+
+
 
 def suite():
     test_suite = unittest.TestSuite()


### PR DESCRIPTION
This PR clean up ROI when one of its item was removed from the plot.

This allows to use `plot.clear()` to also remove the ROIs, and not only the shape of the ROIs.

Closes #3065 