### PR TITLE
Rework PlotWidget ROI items handling of events/updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,10 +99,10 @@ before_script:
     # This installs PyQt and scipy if wheels are available
     - pip install ${PIP_OPTIONS} -r requirements.txt
     # Install PySide2 if needed
-    # Pin-pointing for now to avoid issues with versions [5.11.2 - 5.12.1]
+    # Pin-pointing for now to avoid issues with versions [5.15.0]
     - if [ "$QT_BINDING" == "PySide2" ];
       then
-          pip install ${PIP_OPTIONS} pyside2;
+          pip install ${PIP_OPTIONS} pyside2==5.14.2.1;
       fi
 
     # Install built package

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -836,13 +836,16 @@ class CrossROI(HandleBasedROI, items.LineMixIn):
         HandleBasedROI.__init__(self, parent=parent)
         items.LineMixIn.__init__(self)
         self._handle = self.addHandle()
+        self._handle.sigItemChanged.connect(self._handlePositionChanged)
         self._handleLabel = self.addLabelHandle()
         self._vmarker = self.addUserHandle(items.YMarker())
         self._vmarker._setSelectable(False)
         self._vmarker._setDraggable(False)
+        self._vmarker.setPosition(*self.getPosition())
         self._hmarker = self.addUserHandle(items.XMarker())
         self._hmarker._setSelectable(False)
         self._hmarker._setDraggable(False)
+        self._hmarker.setPosition(*self.getPosition())
 
     def _updated(self, event=None, checkVisibility=True):
         if event in [items.ItemChangedType.VISIBLE]:
@@ -876,19 +879,16 @@ class CrossROI(HandleBasedROI, items.LineMixIn):
 
         :param numpy.ndarray pos: 2d-coordinate of this point
         """
-        with utils.blockSignals(self._handle):
-            self._handle.setPosition(*pos)
-        with utils.blockSignals(self._handleLabel):
-            self._handleLabel.setPosition(*pos)
-        with utils.blockSignals(self._vmarker):
-            self._vmarker.setPosition(*pos)
-        with utils.blockSignals(self._hmarker):
-            self._hmarker.setPosition(*pos)
-        self.sigRegionChanged.emit()
+        self._handle.setPosition(*pos)
 
-    def handleDragUpdated(self, handle, origin, previous, current):
-        if handle is self._handle:
-            self.setPosition(current)
+    def _handlePositionChanged(self, event):
+        """Handle center marker position updates"""
+        if event is items.ItemChangedType.POSITION:
+            position = self.getPosition()
+            self._handleLabel.setPosition(*position)
+            self._vmarker.setPosition(*position)
+            self._hmarker.setPosition(*position)
+            self.sigRegionChanged.emit()
 
     @docstring(HandleBasedROI)
     def contains(self, position):

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -1049,6 +1049,7 @@ class HorizontalLineROI(RegionOfInterest, items.LineMixIn):
         RegionOfInterest.__init__(self, parent=parent)
         items.LineMixIn.__init__(self)
         self._marker = items.YMarker()
+        self._marker.sigItemChanged.connect(self._linePositionChanged)
         self._marker.sigDragStarted.connect(self._editingStarted)
         self._marker.sigDragFinished.connect(self._editingFinished)
         self.addItem(self._marker)
@@ -1057,14 +1058,8 @@ class HorizontalLineROI(RegionOfInterest, items.LineMixIn):
         if event == items.ItemChangedType.NAME:
             label = self.getName()
             self._marker.setText(label)
-        elif event == items.ItemChangedType.EDITABLE:
-            editable = self.isEditable()
-            if editable:
-                self._marker.sigItemChanged.connect(self._linePositionChanged)
-            else:
-                self._marker.sigItemChanged.disconnect(self._linePositionChanged)
-            self._marker._setDraggable(editable)
-        elif event in [items.ItemChangedType.VISIBLE,
+        elif event in [items.ItemChangedType.EDITABLE,
+                       items.ItemChangedType.VISIBLE,
                        items.ItemChangedType.SELECTABLE]:
             self._updateItemProperty(event, self, self._marker)
         super(HorizontalLineROI, self)._updated(event, checkVisibility)
@@ -1093,9 +1088,7 @@ class HorizontalLineROI(RegionOfInterest, items.LineMixIn):
 
         :param float pos: Horizontal position of this line
         """
-        with utils.blockSignals(self._marker):
-            self._marker.setPosition(0, pos)
-        self.sigRegionChanged.emit()
+        self._marker.setPosition(0, pos)
 
     @docstring(_RegionOfInterestBase)
     def contains(self, position):
@@ -1104,8 +1097,7 @@ class HorizontalLineROI(RegionOfInterest, items.LineMixIn):
     def _linePositionChanged(self, event):
         """Handle position changed events of the marker"""
         if event is items.ItemChangedType.POSITION:
-            marker = self.sender()
-            self.setPosition(marker.getYPosition())
+            self.sigRegionChanged.emit()
 
     def __str__(self):
         params = 'y: %f' % self.getPosition()

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -1852,8 +1852,12 @@ class PolygonROI(HandleBasedROI, items.LineMixIn):
 
         :param numpy.ndarray pos: 2d-coordinate of this point
         """
-        self._polygon_shape = None
         assert(len(points.shape) == 2 and points.shape[1] == 2)
+
+        if numpy.array_equal(points, self._points):
+            return  # Nothing has changed
+
+        self._polygon_shape = None
 
         # Update the needed handles
         while len(self._handlePoints) != len(points):

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -1017,14 +1017,14 @@ class LineROI(HandleBasedROI, items.LineMixIn):
             return False
 
         return (
-                segments_intersection(seg1_start_pt=line_pt1, seg1_end_pt=line_pt2,
-                                      seg2_start_pt=bottom_left, seg2_end_pt=bottom_right) or
-                segments_intersection(seg1_start_pt=line_pt1, seg1_end_pt=line_pt2,
-                                      seg2_start_pt=bottom_right, seg2_end_pt=top_right) or
-                segments_intersection(seg1_start_pt=line_pt1, seg1_end_pt=line_pt2,
-                                      seg2_start_pt=top_right, seg2_end_pt=top_left) or
-                segments_intersection(seg1_start_pt=line_pt1, seg1_end_pt=line_pt2,
-                                      seg2_start_pt=top_left, seg2_end_pt=bottom_left)
+            segments_intersection(seg1_start_pt=line_pt1, seg1_end_pt=line_pt2,
+                                  seg2_start_pt=bottom_left, seg2_end_pt=bottom_right) or
+            segments_intersection(seg1_start_pt=line_pt1, seg1_end_pt=line_pt2,
+                                  seg2_start_pt=bottom_right, seg2_end_pt=top_right) or
+            segments_intersection(seg1_start_pt=line_pt1, seg1_end_pt=line_pt2,
+                                  seg2_start_pt=top_right, seg2_end_pt=top_left) or
+            segments_intersection(seg1_start_pt=line_pt1, seg1_end_pt=line_pt2,
+                                  seg2_start_pt=top_left, seg2_end_pt=bottom_left)
         )
 
     def __str__(self):

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -1119,6 +1119,7 @@ class VerticalLineROI(RegionOfInterest, items.LineMixIn):
         RegionOfInterest.__init__(self, parent=parent)
         items.LineMixIn.__init__(self)
         self._marker = items.XMarker()
+        self._marker.sigItemChanged.connect(self._linePositionChanged)
         self._marker.sigDragStarted.connect(self._editingStarted)
         self._marker.sigDragFinished.connect(self._editingFinished)
         self.addItem(self._marker)
@@ -1127,14 +1128,8 @@ class VerticalLineROI(RegionOfInterest, items.LineMixIn):
         if event == items.ItemChangedType.NAME:
             label = self.getName()
             self._marker.setText(label)
-        elif event == items.ItemChangedType.EDITABLE:
-            editable = self.isEditable()
-            if editable:
-                self._marker.sigItemChanged.connect(self._linePositionChanged)
-            else:
-                self._marker.sigItemChanged.disconnect(self._linePositionChanged)
-            self._marker._setDraggable(editable)
-        elif event in [items.ItemChangedType.VISIBLE,
+        elif event in [items.ItemChangedType.EDITABLE,
+                       items.ItemChangedType.VISIBLE,
                        items.ItemChangedType.SELECTABLE]:
             self._updateItemProperty(event, self, self._marker)
         super(VerticalLineROI, self)._updated(event, checkVisibility)
@@ -1146,8 +1141,6 @@ class VerticalLineROI(RegionOfInterest, items.LineMixIn):
 
     def setFirstShapePoints(self, points):
         pos = points[0, 0]
-        if pos == self.getPosition():
-            return
         self.setPosition(pos)
 
     def getPosition(self):
@@ -1163,9 +1156,7 @@ class VerticalLineROI(RegionOfInterest, items.LineMixIn):
 
         :param float pos: Horizontal position of this line
         """
-        with utils.blockSignals(self._marker):
-            self._marker.setPosition(pos, 0)
-        self.sigRegionChanged.emit()
+        self._marker.setPosition(pos, 0)
 
     @docstring(RegionOfInterest)
     def contains(self, position):
@@ -1174,8 +1165,7 @@ class VerticalLineROI(RegionOfInterest, items.LineMixIn):
     def _linePositionChanged(self, event):
         """Handle position changed events of the marker"""
         if event is items.ItemChangedType.POSITION:
-            marker = self.sender()
-            self.setPosition(marker.getXPosition())
+            self.sigRegionChanged.emit()
 
     def __str__(self):
         params = 'x: %f' % self.getPosition()

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -953,6 +953,15 @@ class LineROI(HandleBasedROI, items.LineMixIn):
         :param numpy.ndarray startPoint: Staring bounding point of the line
         :param numpy.ndarray endPoint: Ending bounding point of the line
         """
+        if not numpy.array_equal((startPoint, endPoint), self.getEndPoints()):
+            self.__updateEndPoints(startPoint, endPoint)
+
+    def __updateEndPoints(self, startPoint, endPoint):
+        """Update marker and shape to match given end points
+
+        :param numpy.ndarray startPoint: Staring bounding point of the line
+        :param numpy.ndarray endPoint: Ending bounding point of the line
+        """
         startPoint = numpy.array(startPoint)
         endPoint = numpy.array(endPoint)
         center = (startPoint + endPoint) * 0.5
@@ -982,10 +991,10 @@ class LineROI(HandleBasedROI, items.LineMixIn):
     def handleDragUpdated(self, handle, origin, previous, current):
         if handle is self._handleStart:
             _start, end = self.getEndPoints()
-            self.setEndPoints(current, end)
+            self.__updateEndPoints(current, end)
         elif handle is self._handleEnd:
             start, _end = self.getEndPoints()
-            self.setEndPoints(start, current)
+            self.__updateEndPoints(start, current)
         elif handle is self._handleCenter:
             start, end = self.getEndPoints()
             delta = current - previous

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -2701,7 +2701,17 @@ class HorizontalRangeROI(RegionOfInterest, items.LineMixIn):
             self._markerCen.sigItemChanged.disconnect(self._cenPositionChanged)
             self._markerCen.setLineStyle(" ")
 
-    def _updatePos(self, vmin, vmax):
+    def _updatePos(self, vmin, vmax, force=False):
+        """Update marker position and emit signal.
+
+        :param float vmin:
+        :param float vmax:
+        :param bool force:
+            True to update even if already at the right position.
+        """
+        if not force and numpy.array_equal((vmin, vmax), self.getRange()):
+            return  # Nothing has changed
+
         center = (vmin + vmax) * 0.5
         with self.__filterReentrant:
             with utils.blockSignals(self._markerMin):
@@ -2808,13 +2818,13 @@ class HorizontalRangeROI(RegionOfInterest, items.LineMixIn):
         """Handle position changed events of the marker"""
         if event is items.ItemChangedType.POSITION:
             marker = self.sender()
-            self.setMin(marker.getXPosition())
+            self._updatePos(marker.getXPosition(), self.getMax(), force=True)
 
     def _maxPositionChanged(self, event):
         """Handle position changed events of the marker"""
         if event is items.ItemChangedType.POSITION:
             marker = self.sender()
-            self.setMax(marker.getXPosition())
+            self._updatePos(self.getMin(), marker.getXPosition(), force=True)
 
     def _cenPositionChanged(self, event):
         """Handle position changed events of the marker"""

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -783,8 +783,9 @@ class PointROI(RegionOfInterest, items.SymbolMixIn):
         if event == items.ItemChangedType.NAME:
             label = self.getName()
             self._marker.setText(label)
-        elif event in [items.ItemChangedType.EDITABLE,
-                       items.ItemChangedType.VISIBLE,
+        elif event == items.ItemChangedType.EDITABLE:
+            self._marker._setDraggable(self.isEditable())
+        elif event in [items.ItemChangedType.VISIBLE,
                        items.ItemChangedType.SELECTABLE]:
             self._updateItemProperty(event, self, self._marker)
         super(PointROI, self)._updated(event, checkVisibility)
@@ -1058,8 +1059,9 @@ class HorizontalLineROI(RegionOfInterest, items.LineMixIn):
         if event == items.ItemChangedType.NAME:
             label = self.getName()
             self._marker.setText(label)
-        elif event in [items.ItemChangedType.EDITABLE,
-                       items.ItemChangedType.VISIBLE,
+        elif event == items.ItemChangedType.EDITABLE:
+            self._marker._setDraggable(self.isEditable())
+        elif event in [items.ItemChangedType.VISIBLE,
                        items.ItemChangedType.SELECTABLE]:
             self._updateItemProperty(event, self, self._marker)
         super(HorizontalLineROI, self)._updated(event, checkVisibility)
@@ -1128,8 +1130,9 @@ class VerticalLineROI(RegionOfInterest, items.LineMixIn):
         if event == items.ItemChangedType.NAME:
             label = self.getName()
             self._marker.setText(label)
-        elif event in [items.ItemChangedType.EDITABLE,
-                       items.ItemChangedType.VISIBLE,
+        elif event == items.ItemChangedType.EDITABLE:
+            self._marker._setDraggable(self.isEditable())
+        elif event in [items.ItemChangedType.VISIBLE,
                        items.ItemChangedType.SELECTABLE]:
             self._updateItemProperty(event, self, self._marker)
         super(VerticalLineROI, self)._updated(event, checkVisibility)

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -1229,7 +1229,7 @@ class RectangleROI(HandleBasedROI, items.LineMixIn):
         left = min(points[:, 0])
         right = max(points[:, 0])
         size = right - left, top - bottom
-        self.setGeometry(origin=(left, bottom), size=size)
+        self._updateGeometry(origin=(left, bottom), size=size)
 
     def _updateText(self, text):
         self._handleLabel.setText(text)
@@ -1287,6 +1287,15 @@ class RectangleROI(HandleBasedROI, items.LineMixIn):
     def setGeometry(self, origin=None, size=None, center=None):
         """Set the geometry of the ROI
         """
+        if ((origin is None or numpy.array_equal(origin, self.getOrigin())) and
+                (center is None or numpy.array_equal(center, self.getCenter())) and
+                numpy.array_equal(size, self.getSize())):
+            return  # Nothing has changed
+
+        self._updateGeometry(origin, size, center)
+
+    def _updateGeometry(self, origin=None, size=None, center=None):
+        """Forced update of the geometry of the ROI"""
         if origin is not None:
             origin = numpy.array(origin)
             size = numpy.array(size)
@@ -1326,7 +1335,7 @@ class RectangleROI(HandleBasedROI, items.LineMixIn):
         if handle is self._handleCenter:
             # It is the center anchor
             size = self.getSize()
-            self.setGeometry(center=current, size=size)
+            self._updateGeometry(center=current, size=size)
         else:
             opposed = {
                 self._handleBottomLeft: self._handleTopRight,

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -2645,9 +2645,9 @@ class HorizontalRangeROI(RegionOfInterest, items.LineMixIn):
         self._markerMax.sigDragFinished.connect(self._editingFinished)
         self._markerCen.sigDragStarted.connect(self._editingStarted)
         self._markerCen.sigDragFinished.connect(self._editingFinished)
+        self.addItem(self._markerCen)
         self.addItem(self._markerMin)
         self.addItem(self._markerMax)
-        self.addItem(self._markerCen)
         self.__filterReentrant = utils.LockReentrant()
 
     def setFirstShapePoints(self, points):


### PR DESCRIPTION
This PR reworks the `PlotWidget` ROI items to avoid updating and emitting the `sigRegionChanged` signal when a setter is called with the same parameters as the current ones.
This is done for all ROIs but `ArcROI` which is far more complicated than the others.
This is useful e.g., if one wants to synchronize ROI on different plots.

For `EllipsisROI`, I changed the API of `EllipsisROI.setGeometry` has changed (@PiRK is it an issue?), but now, the anchors no longer "jumps" when released after a drag.

For `HorizontalRangeROI`, I changed the order of the marker so on can enlarge the ROI when it is colapsed (before it was only possible to move it around).

closes #3071