### PR TITLE
Plot ROI: Replaces iterChild|Handles with getChild|Handles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,10 +99,10 @@ before_script:
     # This installs PyQt and scipy if wheels are available
     - pip install ${PIP_OPTIONS} -r requirements.txt
     # Install PySide2 if needed
-    # Pin-pointing for now to avoid issues with versions [5.11.2 - 5.12.1]
+    # Pin-pointing for now to avoid issues with versions [5.15.0]
     - if [ "$QT_BINDING" == "PySide2" ];
       then
-          pip install ${PIP_OPTIONS} pyside2;
+          pip install ${PIP_OPTIONS} pyside2==5.14.2.1;
       fi
 
     # Install built package

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -159,7 +159,7 @@ class RegionOfInterest(_RegionOfInterestBase, core.HighlightedMixIn):
 
     def _connectToPlot(self, plot):
         """Called after connection to a plot"""
-        for item in self.iterChild():
+        for item in self.getItems():
             # This hack is needed to avoid reentrant call from _disconnectFromPlot
             # to the ROI manager. It also speed up the item tests in _itemRemoved
             item._roiGroup = True
@@ -167,7 +167,7 @@ class RegionOfInterest(_RegionOfInterestBase, core.HighlightedMixIn):
 
     def _disconnectFromPlot(self, plot):
         """Called before disconnection from a plot"""
-        for item in self.iterChild():
+        for item in self.getItems():
             # The item could be already be removed by the plot
             if item.getPlot() is not None:
                 del item._roiGroup
@@ -237,10 +237,12 @@ class RegionOfInterest(_RegionOfInterestBase, core.HighlightedMixIn):
             del item._roiGroup
             plot.removeItem(item)
 
-    def iterChild(self):
-        """Iterate through the all ROI child"""
-        for i in self._child:
-            yield i
+    def getItems(self):
+        """Returns the list of PlotWidget items of this RegionOfInterest.
+
+        :rtype: List[~silx.gui.plot.items.Item`]
+        """
+        return tuple(self._child)
 
     @classmethod
     def _getShortName(cls):

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -240,7 +240,7 @@ class RegionOfInterest(_RegionOfInterestBase, core.HighlightedMixIn):
     def getItems(self):
         """Returns the list of PlotWidget items of this RegionOfInterest.
 
-        :rtype: List[~silx.gui.plot.items.Item`]
+        :rtype: List[~silx.gui.plot.items.Item]
         """
         return tuple(self._child)
 

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -645,10 +645,12 @@ class HandleBasedROI(RegionOfInterest):
                 self.__updateEditable(handle, False)
         self.removeItem(handle)
 
-    def iterHandles(self):
-        """Iterate though all the handles"""
-        for data in self._handles:
-            yield data[0]
+    def getHandles(self):
+        """Returns the list of handles of this HandleBasedROI.
+
+        :rtype: List[~silx.gui.plot.items.Marker]
+        """
+        return tuple(data[0] for data in self._handles)
 
     def _updated(self, event=None, checkVisibility=True):
         """Implement Item mix-in update method by updating the plot items

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -298,7 +298,7 @@ class RegionOfInterestManager(qt.QObject):
         if this manager do not have knowledge of this ROI."""
         for roi in self._rois:
             if isinstance(roi, roi_items.RegionOfInterest):
-                for child in roi.iterChild():
+                for child in roi.getItems():
                     if child is item:
                         return roi
         return None

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -361,7 +361,7 @@ class RegionOfInterestManager(qt.QObject):
                     if m is marker:
                         return roi
             else:
-                for m in roi.iterChild():
+                for m in roi.getItems():
                     if m is marker:
                         return roi
         return None

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -357,7 +357,7 @@ class RegionOfInterestManager(qt.QObject):
         # This should be speed up
         for roi in self._rois:
             if isinstance(roi, roi_items.HandleBasedROI):
-                for m in roi.iterHandles():
+                for m in roi.getHandles():
                     if m is marker:
                         return roi
             else:


### PR DESCRIPTION
This PR replaces the `iterChild` and `iterHandles` methods with `getItems` and `getHandles`.
Interest of iterator here is limited and that would be more inline with the rest of the API (and with a `Group` item).