### PR TITLE
[CI] Update OS to ubuntu18.04 + update python 3.5 to 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ before_script:
     # Pin-pointing for now to avoid issues with versions [5.15.0]
     - if [ "$QT_BINDING" == "PySide2" ];
       then
-          pip install ${PIP_OPTIONS} pyside2==5.14.2.1;
+          pip install ${PIP_OPTIONS} pyside2;
       fi
 
     # Install built package

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 
-dist: xenial
+dist: bionic
 sudo: required
 
 language: python
@@ -17,7 +17,7 @@ matrix:
               - SILX_OPENCL=1
               - PIP_OPTIONS="-q --pre"
 
-        - python: 3.5
+        - python: 3.6
           os: linux
           env:
               - BUILD_COMMAND=sdist


### PR DESCRIPTION
This PR updates the OS to ubuntu18.04 and it drops testing of python3.5 since it is not available on the test image.