### PR TITLE
[CI] Fix travis CI with latest Qt bindings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ addons:
             - libxkbcommon-x11-0 # needed for Qt plugins
             - libxkbcommon0
             - libxkbcommon-dev
+            - libxcb-icccm4
 
 before_install:
     # On Linux: install OpenCL

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ matrix:
               - QT_BINDING=PyQt5
               - SILX_OPENCL=1
               - PIP_OPTIONS="-q --pre"
-              - QT_DEBUG_PLUGINS=1
 
         - python: 3.6
           os: linux
@@ -26,7 +25,6 @@ matrix:
               - PIP_INSTALL_EXTRA_ARGS="--global-option build --global-option --debug"
               - SILX_OPENCL=1
               - PIP_OPTIONS="-q"
-              - QT_DEBUG_PLUGINS=1
 
         - language: generic
           os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
               - QT_BINDING=PyQt5
               - SILX_OPENCL=1
               - PIP_OPTIONS="-q --pre"
+              - QT_DEBUG_PLUGINS=1
 
         - python: 3.6
           os: linux
@@ -25,6 +26,7 @@ matrix:
               - PIP_INSTALL_EXTRA_ARGS="--global-option build --global-option --debug"
               - SILX_OPENCL=1
               - PIP_OPTIONS="-q"
+              - QT_DEBUG_PLUGINS=1
 
         - language: generic
           os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,18 @@ addons:
             - libxkbcommon0
             - libxkbcommon-dev
             - libxcb-icccm4
+            - libxcb-image0
+            - libxcb-shm0
+            - libxcb-keysyms1
+            - libxcb-randr0
+            - libxcb-render-util0
+            - libxcb-render0
+            - libxcb-shape0
+            - libxcb-sync1
+            - libxcb-xfixes0
+            - libxcb-xinerama0
+            - libxcb-xkb1
+            - libxcb1
 
 before_install:
     # On Linux: install OpenCL


### PR DESCRIPTION
This PR adds missing dependencies to run Qt with "xcb" platform.

closes #3080