### PR TITLE
Support intensity histogram for scatter (2)

### DIFF
--- a/silx/gui/plot/ScatterView.py
+++ b/silx/gui/plot/ScatterView.py
@@ -41,6 +41,7 @@ import numpy
 from . import items
 from . import PlotWidget
 from . import tools
+from .actions import histogram as actions_histogram
 from .tools.profile import ScatterProfileToolBar
 from .ColorBar import ColorBarWidget
 from .ScatterMaskToolsWidget import ScatterMaskToolsWidget
@@ -124,6 +125,8 @@ class ScatterView(qt.QMainWindow):
         self._maskAction.setIcon(icons.getQIcon('image-mask'))
         self._maskAction.setToolTip("Display/hide mask tools")
 
+        self._intensityHistoAction = actions_histogram.PixelIntensitiesHistoAction(plot=plot, parent=self)
+
         # Create toolbars
         self._interactiveModeToolBar = tools.InteractiveModeToolBar(
             parent=self, plot=plot)
@@ -131,6 +134,7 @@ class ScatterView(qt.QMainWindow):
         self._scatterToolBar = tools.ScatterToolBar(
             parent=self, plot=plot)
         self._scatterToolBar.addAction(self._maskAction)
+        self._scatterToolBar.addAction(self._intensityHistoAction)
 
         self._profileToolBar = ScatterProfileToolBar(parent=self, plot=plot)
 

--- a/silx/gui/plot/actions/histogram.py
+++ b/silx/gui/plot/actions/histogram.py
@@ -175,17 +175,20 @@ class PixelIntensitiesHistoAction(PlotToolAction):
         if event == items.ItemChangedType.DATA:
             self.computeIntensityDistribution()
 
+    def _cleanUp(self):
+        plot = self.getHistogramPlotWidget()
+        try:
+            plot.removeItem('pixel intensity')
+        except:
+            pass
+
     def computeIntensityDistribution(self):
         """Get the active image and compute the image intensity distribution
         """
         item = self._getSelectedItem()
 
         if item is None:
-            plot = self.getHistogramPlotWidget()
-            try:
-                plot.removeItem('pixel intensity')
-            except:
-                pass
+            self._cleanUp()
             return
 
         if isinstance(item, items.ImageBase):
@@ -200,6 +203,10 @@ class PixelIntensitiesHistoAction(PlotToolAction):
             array = item.getValueData(copy=False)
         else:
             assert(False)
+
+        if array.size == 0:
+            self._cleanUp()
+            return
 
         xmin, xmax = min_max(array, min_positive=False, finite=True)
         nbins = min(1024, int(numpy.sqrt(array.size)))


### PR DESCRIPTION
Closes #2840 

This PR update the intnesity histogram action to support scatters

- Instead of creating `sigActiveItemChanged`, it is managed out side of the plot.
- Rework `PixelIntensitiesHistoAction`
   - Uses `sigActiveItemChanged`
   - Uses item, not legend
   - Uses Data update
   - Supports scatter (basic histogram from `getValueData`)
- Add the histogram action to the `ScatterView`

This also fixes glitsh on `silx view` when opening the histo, closing it, changing the dataset, opening again the histo window.