### PR TITLE
Add support of SILX_style attribute to tune default NX plot

### DIFF
--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -1690,11 +1690,20 @@ class _NXdataXYVScatterView(DataView):
         else:
             y_errors = None
 
+        xscale, yscale = None, None
+        axisTypes = nxd.plot_style.axis_scale_types
+        if axisTypes is not None:
+            if len(axisTypes) >= 1:
+                yscale = axisTypes[-1]
+            if len(axisTypes) >= 2:
+                xscale = axisTypes[-2]
+
         self.getWidget().setScattersData(y_axis, x_axis, values=[nxd.signal] + nxd.auxiliary_signals,
                                          yerror=y_errors, xerror=x_errors,
                                          ylabel=y_label, xlabel=x_label,
                                          title=nxd.title,
-                                         scatter_titles=[nxd.signal_name] + nxd.auxiliary_signals_names)
+                                         scatter_titles=[nxd.signal_name] + nxd.auxiliary_signals_names,
+                                         xscale=xscale, yscale=yscale)
 
     def getDataPriority(self, data, info):
         data = self.normalizeData(data)

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -1667,7 +1667,7 @@ class _NXdataXYVScatterView(_NXdataBaseDataView):
     def createWidget(self, parent):
         from silx.gui.data.NXdataWidgets import XYVScatterPlot
         widget = XYVScatterPlot(parent)
-        widget.getPlot().setDefaultColormap(self.defaultColormap())
+        widget.getScatterView().setColormap(self.defaultColormap())
         widget.getScatterView().getScatterToolBar().getColormapAction().setColorDialog(
             self.defaultColorDialog())
         return widget

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -1752,6 +1752,7 @@ class _NXdataImageView(_NXdataBaseDataView):
         img_slicing = slice(-2, None) if not isRgba else slice(-3, -1)
         y_axis, x_axis = nxd.axes[img_slicing]
         y_label, x_label = nxd.axes_names[img_slicing]
+        y_scale, x_scale = nxd.plot_style.axes_scale_types[img_slicing]
 
         self.getWidget().setImageData(
             [nxd.signal] + nxd.auxiliary_signals,
@@ -1759,8 +1760,7 @@ class _NXdataImageView(_NXdataBaseDataView):
             signals_names=[nxd.signal_name] + nxd.auxiliary_signals_names,
             xlabel=x_label, ylabel=y_label,
             title=nxd.title, isRgba=isRgba,
-            xscale=nxd.plot_style.axes_scale_types[-1],
-            yscale=nxd.plot_style.axes_scale_types[-2])
+            xscale=x_scale, yscale=y_scale)
 
     def getDataPriority(self, data, info):
         data = self.normalizeData(data)

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -1758,7 +1758,9 @@ class _NXdataImageView(_NXdataBaseDataView):
             x_axis=x_axis, y_axis=y_axis,
             signals_names=[nxd.signal_name] + nxd.auxiliary_signals_names,
             xlabel=x_label, ylabel=y_label,
-            title=nxd.title, isRgba=isRgba)
+            title=nxd.title, isRgba=isRgba,
+            xscale=nxd.plot_style.axes_scale_types[-1],
+            yscale=nxd.plot_style.axes_scale_types[-2])
 
     def getDataPriority(self, data, info):
         data = self.normalizeData(data)

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -1628,10 +1628,19 @@ class _NXdataCurveView(DataView):
                                           title=nxd.title or nxd.signal_name)
             return
 
+        xscale, yscale = None, None
+        axisTypes = nxd.plot_style.axis_scale_types
+        if axisTypes is not None:
+            if len(axisTypes) >= 1:
+                yscale = axisTypes[-1]
+            if len(axisTypes) >= 2:
+                xscale = axisTypes[-2]
+
         self.getWidget().setCurvesData([nxd.signal] + nxd.auxiliary_signals, nxd.axes[-1],
                                        yerror=nxd.errors, xerror=x_errors,
                                        ylabels=signals_names, xlabel=nxd.axes_names[-1],
-                                       title=nxd.title or signals_names[0])
+                                       title=nxd.title or signals_names[0],
+                                       xscale=xscale, yscale=yscale)
 
     def getDataPriority(self, data, info):
         data = self.normalizeData(data)

--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -1554,7 +1554,7 @@ class _NXdataBaseDataView(DataView):
 
     def _updateColormap(self, nxdata):
         """Update used colormap according to nxdata's SILX_style"""
-        cmap_norm = nxdata.plot_style.colormap_normalization
+        cmap_norm = nxdata.plot_style.signal_scale_type
         if cmap_norm is not None:
             self.defaultColormap().setNormalization(
                 'log' if cmap_norm == 'log' else 'linear')
@@ -1642,19 +1642,12 @@ class _NXdataCurveView(_NXdataBaseDataView):
                                           title=nxd.title or nxd.signal_name)
             return
 
-        xscale, yscale = None, None
-        axisTypes = nxd.plot_style.axis_scale_types
-        if axisTypes is not None:
-            if len(axisTypes) >= 1:
-                yscale = axisTypes[-1]
-            if len(axisTypes) >= 2:
-                xscale = axisTypes[-2]
-
         self.getWidget().setCurvesData([nxd.signal] + nxd.auxiliary_signals, nxd.axes[-1],
                                        yerror=nxd.errors, xerror=x_errors,
                                        ylabels=signals_names, xlabel=nxd.axes_names[-1],
                                        title=nxd.title or signals_names[0],
-                                       xscale=xscale, yscale=yscale)
+                                       xscale=nxd.plot_style.axes_scale_types[-1],
+                                       yscale=nxd.plot_style.signal_scale_type)
 
     def getDataPriority(self, data, info):
         data = self.normalizeData(data)
@@ -1709,20 +1702,13 @@ class _NXdataXYVScatterView(_NXdataBaseDataView):
 
         self._updateColormap(nxd)
 
-        xscale, yscale = None, None
-        axisTypes = nxd.plot_style.axis_scale_types
-        if axisTypes is not None:
-            if len(axisTypes) >= 1:
-                yscale = axisTypes[-1]
-            if len(axisTypes) >= 2:
-                xscale = axisTypes[-2]
-
         self.getWidget().setScattersData(y_axis, x_axis, values=[nxd.signal] + nxd.auxiliary_signals,
                                          yerror=y_errors, xerror=x_errors,
                                          ylabel=y_label, xlabel=x_label,
                                          title=nxd.title,
                                          scatter_titles=[nxd.signal_name] + nxd.auxiliary_signals_names,
-                                         xscale=xscale, yscale=yscale)
+                                         xscale=nxd.plot_style.axes_scale_types[-2],
+                                         yscale=nxd.plot_style.axes_scale_types[-1])
 
     def getDataPriority(self, data, info):
         data = self.normalizeData(data)

--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -99,7 +99,8 @@ class ArrayCurvePlot(qt.QWidget):
 
     def setCurvesData(self, ys, x=None,
                       yerror=None, xerror=None,
-                      ylabels=None, xlabel=None, title=None):
+                      ylabels=None, xlabel=None, title=None,
+                      xscale=None, yscale=None):
         """
 
         :param List[ndarray] ys: List of arrays to be represented by the y (vertical) axis.
@@ -115,6 +116,8 @@ class ArrayCurvePlot(qt.QWidget):
         :param str ylabels: Labels for each curve's Y axis
         :param str xlabel: Label for X axis
         :param str title: Graph title
+        :param str xscale: Scale of X axis in (None, 'linear', 'log')
+        :param str yscale: Scale of Y axis in (None, 'linear', 'log')
         """
         self.__signals = ys
         self.__signals_names = ylabels or (["Y"] * len(ys))
@@ -135,6 +138,12 @@ class ArrayCurvePlot(qt.QWidget):
             self._selector.show()
 
         self._plot.setGraphTitle(title or "")
+        if xscale is not None:
+            self._plot.getXAxis().setScale(
+                'log' if xscale == 'log' else 'linear')
+        if yscale is not None:
+            self._plot.getYAxis().setScale(
+                'log' if yscale == 'log' else 'linear')
         self._updateCurve()
 
         if not self.__selector_is_connected:

--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -403,7 +403,8 @@ class ArrayImagePlot(qt.QWidget):
                      x_axis=None, y_axis=None,
                      signals_names=None,
                      xlabel=None, ylabel=None,
-                     title=None, isRgba=False):
+                     title=None, isRgba=False,
+                     xscale=None, yscale=None):
         """
 
         :param signals: list of n-D datasets, whose last 2 dimensions are used as the
@@ -419,6 +420,8 @@ class ArrayImagePlot(qt.QWidget):
         :param ylabel: Label for Y axis
         :param title: Graph title
         :param isRgba: True if data is a 3D RGBA image
+        :param str xscale: Scale of X axis in (None, 'linear', 'log')
+        :param str yscale: Scale of Y axis in (None, 'linear', 'log')
         """
         self._selector.selectionChanged.disconnect(self._updateImage)
         self._auxSigSlider.valueChanged.disconnect(self._sliderIdxChanged)
@@ -452,6 +455,7 @@ class ArrayImagePlot(qt.QWidget):
             self._auxSigSlider.hide()
         self._auxSigSlider.setValue(0)
 
+        self._axis_scales = xscale, yscale
         self._updateImage()
         self._plot.resetZoom()
 
@@ -502,10 +506,21 @@ class ArrayImagePlot(qt.QWidget):
             origin = (xorigin, yorigin)
             scale = (xscale, yscale)
 
+            self._plot.getXAxis().setScale('linear')
+            self._plot.getYAxis().setScale('linear')
             self._plot.addImage(image, legend=legend,
                                 origin=origin, scale=scale,
                                 replace=True)
         else:
+            xaxisscale, yaxisscale = self._axis_scales
+
+            if xaxisscale is not None:
+                self._plot.getXAxis().setScale(
+                    'log' if xaxisscale == 'log' else 'linear')
+            if yaxisscale is not None:
+                self._plot.getYAxis().setScale(
+                    'log' if yaxisscale == 'log' else 'linear')
+
             scatterx, scattery = numpy.meshgrid(x_axis, y_axis)
             # fixme: i don't think this can handle "irregular" RGBA images
             self._plot.addScatter(numpy.ravel(scatterx),

--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -254,7 +254,8 @@ class XYVScatterPlot(qt.QWidget):
     def setScattersData(self, y, x, values,
                         yerror=None, xerror=None,
                         ylabel=None, xlabel=None,
-                        title="", scatter_titles=None):
+                        title="", scatter_titles=None,
+                        xscale=None, yscale=None):
         """
 
         :param ndarray y: 1D array  for y (vertical) coordinates.
@@ -269,6 +270,8 @@ class XYVScatterPlot(qt.QWidget):
         :param str xlabel: Label for X axis
         :param str title: Main graph title
         :param List[str] scatter_titles:  Subtitles (one per scatter)
+        :param str xscale: Scale of X axis in (None, 'linear', 'log')
+        :param str yscale: Scale of Y axis in (None, 'linear', 'log')
         """
         self.__y_axis = y
         self.__x_axis = x
@@ -289,6 +292,13 @@ class XYVScatterPlot(qt.QWidget):
             self._slider.hide()
         self._slider.setValue(0)
         self._slider.valueChanged[int].connect(self._sliderIdxChanged)
+
+        if xscale is not None:
+            self._plot.getXAxis().setScale(
+                'log' if xscale == 'log' else 'linear')
+        if yscale is not None:
+            self._plot.getYAxis().setScale(
+                'log' if yscale == 'log' else 'linear')
 
         self._updateScatter()
 

--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -244,6 +244,13 @@ class XYVScatterPlot(qt.QWidget):
     def _sliderIdxChanged(self, value):
         self._updateScatter()
 
+    def getScatterView(self):
+        """Returns the :class:`ScatterView` used for the display
+
+        :rtype: ScatterView
+        """
+        return self._plot
+
     def getPlot(self):
         """Returns the plot used for the display
 

--- a/silx/io/nxdata/parse.py
+++ b/silx/io/nxdata/parse.py
@@ -70,6 +70,7 @@ class _SilxStyle(object):
 
     def __init__(self, nxdata):
         self._axis_scale_types = None
+        self._colormap_normalization = None
 
         stylestr = get_attr_as_unicode(nxdata.group, "SILX_style")
         if stylestr is None:
@@ -101,9 +102,21 @@ class _SilxStyle(object):
                 else:  # All values are valid
                     self._axis_scale_types = tuple(axis_scale_types)
 
+        if 'colormap_normalization' in style:
+            normalization = style['colormap_normalization']
+            if normalization not in ('linear', 'log'):
+                nxdata_logger.error(
+                    "Ignoring SILX_style:colormap_normalization, invalid value: %s", str(normalization))
+            else:
+                self._colormap_normalization = normalization
+
     axis_scale_types = property(
         lambda self: self._axis_scale_types,
         doc="Tuple of plot axis scale types (either 'linear' or 'log').")
+
+    colormap_normalization = property(
+        lambda self: self._colormap_normalization,
+        doc="Normalization to use to apply the colormap (either 'linear' or 'log').")
 
 
 class NXdata(object):

--- a/silx/io/nxdata/parse.py
+++ b/silx/io/nxdata/parse.py
@@ -120,14 +120,14 @@ class _SilxStyle(object):
                 nxdata_logger.error(
                     "Ignoring SILX_style:signal_scale_type, invalid value: %s", str(scale_type))
             else:
-                self._signal_scale_types = scale_type
+                self._signal_scale_type = scale_type
 
     axes_scale_types = property(
         lambda self: self._axes_scale_types,
         doc="Tuple of NXdata axes scale types (None, 'linear' or 'log'). List[str]")
 
     signal_scale_type = property(
-        lambda self: self._signal_scale_types,
+        lambda self: self._signal_scale_type,
         doc="NXdata signal scale type (None, 'linear' or 'log'). str")
 
 

--- a/silx/io/nxdata/parse.py
+++ b/silx/io/nxdata/parse.py
@@ -90,6 +90,10 @@ class _SilxStyle(object):
         if 'axis_scale_types' in style:
             axis_scale_types = style['axis_scale_types']
 
+            if isinstance(axis_scale_types, str):
+                # Convert single argument to list
+                axis_scale_types = [axis_scale_types]
+
             if not isinstance(axis_scale_types, list):
                 nxdata_logger.error(
                     "Ignoring SILX_style:axis_scale_types, not a list")

--- a/silx/io/nxdata/parse.py
+++ b/silx/io/nxdata/parse.py
@@ -69,7 +69,7 @@ class _SilxStyle(object):
     """
 
     def __init__(self, nxdata):
-        naxes = len(nxdata.axes_dataset_names)
+        naxes = len(nxdata.axes)
         self._axes_scale_types = [None] * naxes
         self._signal_scale_type = None
 
@@ -111,7 +111,7 @@ class _SilxStyle(object):
                         axes_scale_types = axes_scale_types[:naxes]
                     elif len(axes_scale_types) < naxes:
                         # Extend axes_scale_types with None to match number of axes
-                        axes_scale_types.extend([None] * (naxes - len(axes_scale_types)))
+                        axes_scale_types = [None] * (naxes - len(axes_scale_types)) + axes_scale_types
                     self._axes_scale_types = tuple(axes_scale_types)
 
         if 'signal_scale_type' in style:

--- a/silx/io/nxdata/parse.py
+++ b/silx/io/nxdata/parse.py
@@ -139,6 +139,7 @@ class NXdata(object):
     """
     def __init__(self, group, validate=True):
         super(NXdata, self).__init__()
+        self._plot_style = None
 
         self.group = group
         """h5py-like group object with @NX_class=NXdata.
@@ -210,7 +211,7 @@ class NXdata(object):
             # excludes scatters
             self.signal_is_1d = self.signal_is_1d and len(self.axes) <= 1  # excludes n-D scatters
 
-        self._plot_style = _SilxStyle(self)
+            self._plot_style = _SilxStyle(self)
 
     def _validate(self):
         """Fill :attr:`issues` with error messages for each error found."""
@@ -716,7 +717,13 @@ class NXdata(object):
 
     @property
     def plot_style(self):
-        """Information extracted from the optional SILX_style attribute"""
+        """Information extracted from the optional SILX_style attribute
+
+        :raises: InvalidNXdataError
+        """
+        if not self.is_valid:
+            raise InvalidNXdataError("Unable to parse invalid NXdata")
+
         return self._plot_style
 
     @property

--- a/tools/create_h5_sample.py
+++ b/tools/create_h5_sample.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -31,6 +31,7 @@ __license__ = "MIT"
 __date__ = "26/03/2019"
 
 
+import json
 import logging
 import sys
 
@@ -263,6 +264,24 @@ def create_hdf5_types(group):
     group.create_dataset("unicode_1d", data=numpy.array([text], dtype=unicode_vlen_dt))
 
 
+def set_silx_style(group, axes_scales=None, signal_scale=None):
+    """Set SILX_style attribute
+
+    :param group: NXdata group to set SILX_style for.
+    :param axes_scales: Scale to use for the axes.
+        Used for plot axis scales.
+    :param signal_scale: Scale to use for the signal.
+        Used either for plot axis scale or colormap normalization.
+    """
+    style = {}
+    if axes_scales is not None:
+        style['axes_scale_types'] = axes_scales
+    if signal_scale is not None:
+        style['signal_scale_type'] = signal_scale
+    if style:
+        group.attrs["SILX_style"] = json.dumps(style)
+
+
 def create_nxdata_group(group):
     print("- Creating NXdata types...")
 
@@ -299,12 +318,14 @@ def create_nxdata_group(group):
     g1d0.create_dataset("count", data=numpy.arange(10))
     g1d0.create_dataset("energy_calib", data=(10, 5))     # 10 * idx + 5
     g1d0.create_dataset("energy_errors", data=3.14 * numpy.random.rand(10))
+    set_silx_style(g1d0, axes_scales=['linear'], signal_scale='log')
 
     g1d1 = g1d.create_group("2D_spectra")
     g1d1.attrs["NX_class"] = "NXdata"
     g1d1.attrs["signal"] = "counts"
     ds = g1d1.create_dataset("counts", data=numpy.arange(3 * 10).reshape((3, 10)))
     ds.attrs["interpretation"] = "spectrum"
+    set_silx_style(g1d1, axes_scales=['linear'], signal_scale='log')
 
     g1d2 = g1d.create_group("4D_spectra")
     g1d2.attrs["NX_class"] = "NXdata"
@@ -319,6 +340,7 @@ def create_nxdata_group(group):
     ds.attrs["first_good"] = 3
     ds.attrs["last_good"] = 12
     g1d2.create_dataset("energy_errors", data=10 * numpy.random.rand(15))
+    set_silx_style(g1d2, axes_scales=['linear'], signal_scale='log')
 
     # IMAGES
     g2d = main_group.create_group("images")
@@ -331,6 +353,7 @@ def create_nxdata_group(group):
     ds = g2d0.create_dataset("rows_calib", data=(10, 5))
     ds.attrs["long_name"] = "Calibrated Y"
     g2d0.create_dataset("columns_coordinates", data=0.5 + 0.02 * numpy.arange(6))
+    set_silx_style(g1d2, axes_scales=['linear'], signal_scale='log')
 
     g2d1 = g2d.create_group("2D_irregular_data")
     g2d1.attrs["NX_class"] = "NXdata"
@@ -339,12 +362,14 @@ def create_nxdata_group(group):
     g2d1.create_dataset("data", data=numpy.arange(64 * 128).reshape((64, 128)))
     g2d1.create_dataset("rows_coordinates", data=numpy.arange(64) + numpy.random.rand(64))
     g2d1.create_dataset("columns_coordinates", data=numpy.arange(128) + 2.5 * numpy.random.rand(128))
+    set_silx_style(g2d1, axes_scales=['linear', 'log'], signal_scale='log')
 
     g2d2 = g2d.create_group("3D_images")
     g2d2.attrs["NX_class"] = "NXdata"
     g2d2.attrs["signal"] = "images"
     ds = g2d2.create_dataset("images", data=numpy.arange(2 * 4 * 6).reshape((2, 4, 6)))
     ds.attrs["interpretation"] = "image"
+    set_silx_style(g2d2, signal_scale='log')
 
     g2d3 = g2d.create_group("5D_images")
     g2d3.attrs["NX_class"] = "NXdata"
@@ -354,6 +379,7 @@ def create_nxdata_group(group):
     ds.attrs["interpretation"] = "image"
     g2d3.create_dataset("rows_coordinates", data=5 + 10 * numpy.arange(4))
     g2d3.create_dataset("columns_coordinates", data=0.5 + 0.02 * numpy.arange(6))
+    set_silx_style(g2d3, signal_scale='log')
 
     y = numpy.arange(-5, 10).reshape(-1, 1)
     x = numpy.arange(-5, 10).reshape(1, -1)
@@ -367,6 +393,7 @@ def create_nxdata_group(group):
     g2d3.create_dataset("image", data=data)
     g2d3.create_dataset("rows", data=0.5 + 0.02 * numpy.arange(data.shape[0]))
     g2d3.create_dataset("columns", data=0.5 + 0.02 * numpy.arange(data.shape[1]))
+    set_silx_style(g2d3, signal_scale='log')
 
     # SCATTER
     g = main_group.create_group("scatters")
@@ -379,6 +406,7 @@ def create_nxdata_group(group):
     gd0.create_dataset("x", data=2 * numpy.random.rand(128))
     gd0.create_dataset("x_errors", data=0.05 * numpy.random.rand(128))
     gd0.create_dataset("errors", data=0.05 * numpy.random.rand(128))
+    set_silx_style(gd0, axes_scales=['linear'], signal_scale='log')
 
     gd1 = g.create_group("x_y_value_scatter")
     gd1.attrs["NX_class"] = "NXdata"
@@ -389,6 +417,7 @@ def create_nxdata_group(group):
     gd1.create_dataset("y_errors", data=0.02 * numpy.random.rand(128))
     gd1.create_dataset("x", data=numpy.random.rand(128))
     gd1.create_dataset("x_errors", data=0.02 * numpy.random.rand(128))
+    set_silx_style(gd1, axes_scales=['linear', 'log'], signal_scale='log')
 
     # NDIM > 3
     g = main_group.create_group("cubes")
@@ -401,12 +430,14 @@ def create_nxdata_group(group):
     gd0.create_dataset("img_idx", data=numpy.arange(4))
     gd0.create_dataset("rows_coordinates", data=0.1 * numpy.arange(5))
     gd0.create_dataset("cols_coordinates", data=[0.2, 0.3])  # linear calibration
+    set_silx_style(gd0, axes_scales=['log', 'linear'], signal_scale='log')
 
     gd1 = g.create_group("5D")
     gd1.attrs["NX_class"] = "NXdata"
     gd1.attrs["signal"] = "hypercube"
     data = numpy.arange(2 * 3 * 4 * 5 * 6).reshape((2, 3, 4, 5, 6))
     gd1.create_dataset("hypercube", data=data)
+    set_silx_style(gd1, axes_scales=['log', 'linear'], signal_scale='log')
 
 
 FILTER_LZF = 32000


### PR DESCRIPTION
This PR adds support of `SILX_style` hdf5 attribute storing a json string describing the plot.
For now it only supports a `axis_scale_types` key with a list of 'linear' or 'log' value:

`@SILX_style = {'axis_scale_types': ['linear', 'log']}`
Are you OK with this syntax (inspired by https://github.com/nexusformat/NIAC/issues/29)?

This is supported for curves and 2D scatters.
Display of json in silx view is ugly because of escape `\` escape characters.

related to  #2100
closes #2928