### PR TITLE
Fix dicttoh5 warn

### DIFF
--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -214,6 +214,10 @@ def dicttoh5(treedict, h5file, h5path='/',
         h5path += "/"
 
     with _SafeH5FileWrite(h5file, mode=mode) as h5f:
+        if isinstance(treedict, dict) and h5path != "/":
+            if h5path not in h5f:
+                h5f.create_group(h5path)
+
         for key in filter(lambda k: not isinstance(k, tuple), treedict):
             if isinstance(treedict[key], dict) and len(treedict[key]):
                 # non-empty group: recurse

--- a/silx/io/test/test_dictdump.py
+++ b/silx/io/test/test_dictdump.py
@@ -173,7 +173,7 @@ class TestDictToH5(unittest.TestCase):
             "group": {"dataset": "hmmm", ("", "attr"): 10},
             ("group", "attr"): 10,
         }
-        with h5py.File(self.h5_fname) as h5file:
+        with h5py.File(self.h5_fname, "w") as h5file:
             with TestLogging(dictdump_logger, warning=1):
                 dictdump.dicttoh5(ddict, h5file)
             self.assertEqual(h5file["group"].attrs['attr'], 10)

--- a/silx/io/test/test_dictdump.py
+++ b/silx/io/test/test_dictdump.py
@@ -128,6 +128,16 @@ class TestDictToH5(unittest.TestCase):
             self.assertEqual(h5file["dataset"].attrs['dataset_attr'], 12)
             self.assertEqual(h5file["group"].attrs['group_attr2'], 13)
 
+    def testPathAttributes(self):
+        """A group is requested at a path"""
+        ddict = {
+            ("", "NX_class"): 'NXcollection',
+        }
+        with h5py.File(self.h5_fname, "w") as h5file:
+            # This should not warn
+            with TestLogging(dictdump_logger, warning=0):
+                dictdump.dicttoh5(ddict, h5file, h5path="foo/bar")
+
     def testKeyOrder(self):
         ddict1 = {
             "d": "plow",


### PR DESCRIPTION
This PR fixes a warning on dicttoh5 when a path is set and the data is a dict.

In this case we expect to create a group.

```
        ddict = {
            ("", "NX_class"): 'NXcollection',
        }
        with h5py.File(self.h5_fname, "w") as h5file:
            dictdump.dicttoh5(ddict, h5file, h5path="foo/bar")
```

The warning was complaining that a group will be implicitly created. But as it is requested, that's an explicit action.

```
WARNING:silx.io.dictdump:key (foo/bar/) does not exist. attr NX_class will be written to .
```