### PR TITLE
Fix histogram when item changes

### DIFF
--- a/silx/gui/plot/actions/histogram.py
+++ b/silx/gui/plot/actions/histogram.py
@@ -52,7 +52,7 @@ _logger = logging.getLogger(__name__)
 
 class _LastActiveItem(qt.QObject):
 
-    sigActiveItemChanged = qt.Signal(object)
+    sigActiveItemChanged = qt.Signal(object, object)
     """Emitted when the active plot item have changed"""
 
     def __init__(self, parent, plot):
@@ -93,7 +93,7 @@ class _LastActiveItem(qt.QObject):
             self.__item = None
         else:
             self.__item = weakref.ref(item)
-        self.sigActiveItemChanged.emit(item)
+        self.sigActiveItemChanged.emit(previous, item)
 
     def _activeImageChanged(self, previous, current):
         """Handle active image change"""

--- a/silx/gui/plot/actions/histogram.py
+++ b/silx/gui/plot/actions/histogram.py
@@ -113,6 +113,7 @@ class _LastActiveItem(qt.QObject):
         item = plot.getScatter(current)
         self.setActiveItem(item)
 
+
 class PixelIntensitiesHistoAction(PlotToolAction):
     """QAction to plot the pixels intensities diagram
 

--- a/silx/gui/plot/test/testPixelIntensityHistoAction.py
+++ b/silx/gui/plot/test/testPixelIntensityHistoAction.py
@@ -43,7 +43,7 @@ class TestPixelIntensitiesHisto(TestCaseQt, ParametricTestCase):
 
     def setUp(self):
         super(TestPixelIntensitiesHisto, self).setUp()
-        self.image = numpy.random.rand(100, 100)
+        self.image = numpy.random.rand(10, 10)
         self.plotImage = Plot2D()
         self.plotImage.getIntensityHistogramAction().setVisible(True)
 

--- a/silx/gui/plot/test/testPixelIntensityHistoAction.py
+++ b/silx/gui/plot/test/testPixelIntensityHistoAction.py
@@ -91,6 +91,59 @@ class TestPixelIntensitiesHisto(TestCaseQt, ParametricTestCase):
                 self.plotImage.addImage(self.image.astype(typeToTest),
                                         origin=(0, 0), legend='sino')
 
+    def testScatter(self):
+        """Test that an histogram from a scatter is displayed"""
+        xx = numpy.arange(10)
+        yy = numpy.arange(10)
+        value = numpy.sin(xx)
+        self.plotImage.addScatter(xx, yy, value)
+        self.plotImage.show()
+
+        histoAction = self.plotImage.getIntensityHistogramAction()
+
+        # test the pixel intensity diagram is showing
+        button = getQToolButtonFromAction(histoAction)
+        self.assertIsNot(button, None)
+        self.mouseMove(button)
+        self.mouseClick(button, qt.Qt.LeftButton)
+        self.qapp.processEvents()
+
+        plot = histoAction.getHistogramPlotWidget()
+        self.assertTrue(plot.isVisible())
+        items = plot.getItems()
+        self.assertEqual(len(items), 1)
+
+    def testChangeItem(self):
+        """Test that histogram changes it the item changes"""
+        xx = numpy.arange(10)
+        yy = numpy.arange(10)
+        value = numpy.sin(xx)
+        self.plotImage.addScatter(xx, yy, value)
+        self.plotImage.show()
+
+        histoAction = self.plotImage.getIntensityHistogramAction()
+
+        # test the pixel intensity diagram is showing
+        button = getQToolButtonFromAction(histoAction)
+        self.assertIsNot(button, None)
+        self.mouseMove(button)
+        self.mouseClick(button, qt.Qt.LeftButton)
+        self.qapp.processEvents()
+
+        # Reach histogram from the first item
+        plot = histoAction.getHistogramPlotWidget()
+        self.assertTrue(plot.isVisible())
+        items = plot.getItems()
+        data1 = items[0].getValueData(copy=False)
+
+        # Set another item to the plot
+        self.plotImage.addImage(self.image, origin=(0, 0), legend='sino')
+        self.qapp.processEvents()
+        data2 = items[0].getValueData(copy=False)
+
+        # Histogram is not the same
+        self.assertFalse(numpy.array_equal(data1, data2))
+
 
 def suite():
     test_suite = unittest.TestSuite()


### PR DESCRIPTION
This PR fixes issue on the new scatter histogram.

There was a typo on item change.

This PR fix the issue and add test to check that the histogram is updated when the active plot item changes.