### PR TITLE
Improves scatter irregular grid visualization

### DIFF
--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -616,30 +616,29 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
                         shape = shape[0], int(numpy.ceil(nbpoints / shape[0]))
 
                 if shape[0] < 2 or shape[1] < 2:  # Single line, at least 2 points
-                    points = numpy.empty((numpy.prod(shape) * 2, 2), dtype=xFiltered.dtype)
+                    points = numpy.ones((2, nbpoints, 2), dtype=numpy.float64)
                     # Use row/column major depending on shape, not on info value
                     gridOrder = 'row' if shape[0] == 1 else 'column'
 
                     if gridOrder == 'row':
-                        points[:nbpoints, 0] = xFiltered
-                        points[:nbpoints, 1] = yFiltered
+                        points[0, :, 0] = xFiltered
+                        points[0, :, 1] = yFiltered
                     else:  # column-major order
-                        points[:nbpoints, 0] = yFiltered
-                        points[:nbpoints, 1] = xFiltered
-                        shape = shape[1], shape[0]  # Invert shape
+                        points[0, :, 0] = yFiltered
+                        points[0, :, 1] = xFiltered
 
                     # Add a second line that will be clipped in the end
-                    points[nbpoints:-1] = points[:nbpoints-1] + numpy.cross(
-                        points[1:nbpoints] - points[:nbpoints-1], (0., 0., 1.))[:, :2]
-                    points[-1] = points[nbpoints-1] + numpy.cross(
-                        points[nbpoints-1] - points[nbpoints-2], (0., 0., 1.))[:2]
+                    points[1, :-1] = points[0, :-1] + numpy.cross(
+                        points[0, 1:] - points[0, :-1], (0., 0., 1.))[:, :2]
+                    points[1, -1] = points[0, -1] + numpy.cross(
+                        points[0, -1] - points[0, -2], (0., 0., 1.))[:2]
 
-                    points.shape = max(2, shape[0]), max(2, shape[1]), 2
+                    points.shape = 2, nbpoints, 2  # Use same shape for both orders
                     coords, indices = _quadrilateral_grid_as_triangles(points)
 
                 elif gridOrder == 'row':  # row-major order
                     if nbpoints != numpy.prod(shape):
-                        points = numpy.empty((numpy.prod(shape), 2), dtype=xFiltered.dtype)
+                        points = numpy.empty((numpy.prod(shape), 2), dtype=numpy.float64)
                         points[:nbpoints, 0] = xFiltered
                         points[:nbpoints, 1] = yFiltered
                         # Index of last element of last fully filled row
@@ -652,7 +651,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
 
                 else:   # column-major order
                     if nbpoints != numpy.prod(shape):
-                        points = numpy.empty((numpy.prod(shape), 2), dtype=xFiltered.dtype)
+                        points = numpy.empty((numpy.prod(shape), 2), dtype=numpy.float64)
                         points[:nbpoints, 0] = yFiltered
                         points[:nbpoints, 1] = xFiltered
                         # Index of last element of last fully filled column

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -591,8 +591,23 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
                 if shape is None:  # No shape, no display
                     return None
 
-                # Make shape include all points
                 nbpoints = len(xFiltered)
+                if nbpoints == 1:
+                    # single point, render as a square points
+                    return backend.addCurve(xFiltered, yFiltered,
+                                            color=rgbacolors[mask],
+                                            symbol='s',
+                                            linewidth=0,
+                                            linestyle="",
+                                            yaxis='left',
+                                            xerror=None,
+                                            yerror=None,
+                                            fill=False,
+                                            alpha=self.getAlpha(),
+                                            symbolsize=7,
+                                            baseline=None)
+
+                # Make shape include all points
                 if nbpoints != numpy.prod(shape):
                     if gridInfo.order == 'row':
                         shape = int(numpy.ceil(nbpoints / shape[1])), shape[1]

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -635,13 +635,9 @@ class TestPlotScatter(PlotWidgetTestCase, ParametricTestCase):
                     for index, position in enumerate(zip(x, y)):
                         xpixel, ypixel = self.plot.dataToPixel(*position)
                         result = scatter.pick(xpixel, ypixel)
-                        if (visualization is scatter.Visualization.IRREGULAR_GRID and
-                                (shape[0] < 2 or shape[1] < 2)):
-                            self.assertIsNone(result)
-                        else:
-                            self.assertIsNotNone(result)
-                            self.assertIs(result.getItem(), scatter)
-                            self.assertEqual(result.getIndices(), (index,))
+                        self.assertIsNotNone(result)
+                        self.assertIs(result.getItem(), scatter)
+                        self.assertEqual(result.getIndices(), (index,))
 
     def testBinnedStatisticVisualization(self):
         """Test binned display"""


### PR DESCRIPTION
This PR improves the rendering of the scatter plot irregular grid visualization by no longer clipping the data to a grid, falling back to points for a single data point, and handling data as a single row/column.

closes  #2828