### PR TITLE
Provides an ElidedLabel

### DIFF
--- a/examples/simplewidget.py
+++ b/examples/simplewidget.py
@@ -45,6 +45,7 @@ from silx.gui.widgets.WaitingPushButton import WaitingPushButton
 from silx.gui.widgets.ThreadPoolPushButton import ThreadPoolPushButton
 from silx.gui.widgets.RangeSlider import RangeSlider
 from silx.gui.widgets.LegendIconWidget import LegendIconWidget
+from silx.gui.widgets.ElidedLabel import ElidedLabel
 
 
 class SimpleWidgetExample(qt.QMainWindow):
@@ -72,6 +73,10 @@ class SimpleWidgetExample(qt.QMainWindow):
 
         panel = self.createLegendIconPanel(self)
         layout.addWidget(qt.QLabel("LegendIconWidget"))
+        layout.addWidget(panel)
+
+        panel = self.createElidedLabelPanel(self)
+        layout.addWidget(qt.QLabel("ElidedLabel"))
         layout.addWidget(panel)
 
         self.setCentralWidget(main_panel)
@@ -183,6 +188,25 @@ class SimpleWidgetExample(qt.QMainWindow):
         legend.setSymbol(".")
         legend.setSymbolColormap("red")
         layout.addWidget(legend)
+
+        return panel
+
+    def createElidedLabelPanel(self, parent):
+        panel = qt.QWidget(parent)
+        layout = qt.QVBoxLayout(panel)
+
+        label = ElidedLabel(parent)
+        label.setText("A very long text which is far too long.")
+        layout.addWidget(label)
+
+        label = ElidedLabel(parent)
+        label.setText("A very long text which is far too long.")
+        label.setElideMode(qt.Qt.ElideMiddle)
+        layout.addWidget(label)
+
+        label = ElidedLabel(parent)
+        label.setText("Basically nothing.")
+        layout.addWidget(label)
 
         return panel
 

--- a/silx/gui/widgets/ElidedLabel.py
+++ b/silx/gui/widgets/ElidedLabel.py
@@ -1,0 +1,140 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Module contains an elidable label
+"""
+
+__license__ = "MIT"
+__date__ = "07/12/2018"
+
+from silx.gui import qt
+
+
+class ElidedLabel(qt.QLabel):
+    """QLabel with an edile property.
+
+    By default if the text is too big, it is elided on the right.
+
+    This mode can be changed with :func:`setElideMode`.
+
+    In case the text is elided, the full content is displayed as part of the
+    tool tip. This behavior can be disabled with :func:`setTextAsToolTip`.
+    """
+
+    def __init__(self, parent=None):
+        super(ElidedLabel, self).__init__(parent)
+        self.__text = ""
+        self.__toolTip = ""
+        self.__textAsToolTip = True
+        self.__textIsElided = False
+        self.__elideMode = qt.Qt.ElideRight
+        self.__updateMinimumSize()
+
+    def resizeEvent(self, event):
+        self.__updateText()
+        return qt.QLabel.resizeEvent(self, event)
+
+    def setFont(self, font):
+        qt.QLabel.setFont(self, font)
+        self.__updateMinimumSize()
+        self.__updateText()
+
+    def __updateMinimumSize(self):
+        metrics = qt.QFontMetrics(self.font())
+        width = metrics.width("...")
+        self.setMinimumWidth(width)
+
+    def __updateText(self):
+        metrics = qt.QFontMetrics(self.font())
+        elidedText = metrics.elidedText(self.__text, self.__elideMode, self.width())
+        qt.QLabel.setText(self, elidedText)
+        self.__setTextIsElided(elidedText != self.__text)
+
+    def __updateToolTip(self):
+        if self.__textIsElided and self.__textAsToolTip:
+            qt.QLabel.setToolTip(self, self.__text + "<br/>" + self.__toolTip)
+        else:
+            qt.QLabel.setToolTip(self, self.__toolTip)
+
+    def __setTextIsElided(self, enable):
+        if self.__textIsElided == enable:
+            return
+        self.__textIsElided = enable
+        self.__updateToolTip()
+
+    # Properties
+
+    def setText(self, text):
+        self.__text = text
+        self.__updateText()
+
+    def getText(self):
+        return self.__text
+
+    text = qt.Property(str, getText, setText)
+
+    def setToolTip(self, toolTip):
+        self.__toolTip = toolTip
+        self.__updateToolTip()
+
+    def getToolTip(self):
+        return self.__toolTip
+
+    toolTip = qt.Property(str, getToolTip, setToolTip)
+
+    def setElideMode(self, elideMode):
+        """Set the elide mode.
+
+        :param qt.Qt.TextElideMode elidMode: Elide mode to use
+        """
+        self.__elideMode = elideMode
+        self.__updateText()
+
+    def getElideMode(self):
+        """Returns the used elide mode.
+
+        :rtype: qt.Qt.TextElideMode
+        """
+        return self.__elideMode
+
+    elideMode = qt.Property(qt.Qt.TextElideMode, getToolTip, setToolTip)
+
+    def setTextAsToolTip(self, enabled):
+        """Enable displaying text as part of the tooltip if it is elided.
+
+        :param bool enabled: Enable the behavior
+        """
+        if self.__textAsToolTip == enabled:
+            return
+        self.__textAsToolTip = enabled
+        self.__updateToolTip()
+
+    def getTextAsToolTip(self):
+        """True if an elided text is displayed as part of the tooltip.
+
+        :rtype: bool
+        """
+        return self.__textAsToolTip
+
+    textAsToolTip = qt.Property(bool, getTextAsToolTip, setTextAsToolTip)

--- a/silx/gui/widgets/test/__init__.py
+++ b/silx/gui/widgets/test/__init__.py
@@ -33,6 +33,7 @@ from . import test_framebrowser
 from . import test_boxlayoutdockwidget
 from . import test_rangeslider
 from . import test_flowlayout
+from . import test_elidedlabel
 
 __authors__ = ["V. Valls", "P. Knobel"]
 __license__ = "MIT"
@@ -51,5 +52,6 @@ def suite():
          test_boxlayoutdockwidget.suite(),
          test_rangeslider.suite(),
          test_flowlayout.suite(),
+         test_elidedlabel.suite(),
          ])
     return test_suite

--- a/silx/gui/widgets/test/test_elidedlabel.py
+++ b/silx/gui/widgets/test/test_elidedlabel.py
@@ -1,0 +1,78 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2020 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Tests for ElidedLabel"""
+
+__license__ = "MIT"
+__date__ = "08/06/2020"
+
+import unittest
+
+from silx.gui import qt
+from silx.gui.widgets.ElidedLabel import ElidedLabel
+from silx.gui.utils import testutils
+
+
+class TestElidedLabel(testutils.TestCaseQt):
+
+    def setUp(self):
+        self.label = ElidedLabel()
+        self.label.show()
+        self.qWaitForWindowExposed(self.label)
+
+    def tearDown(self):
+        self.label.setAttribute(qt.Qt.WA_DeleteOnClose)
+        self.label.close()
+        del self.label
+        self.qapp.processEvents()
+
+    def testElidedValue(self):
+        """Test elided text"""
+        raw = "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm"
+        self.label.setText(raw)
+        self.label.setFixedWidth(30)
+        displayedText = qt.QLabel.text(self.label)
+        self.assertNotEqual(raw, displayedText)
+        self.assertIn("…", displayedText)
+        self.assertIn("m", displayedText)
+
+    def testNotElidedValue(self):
+        """Test elided text"""
+        raw = "mmmmmmm"
+        self.label.setText(raw)
+        self.label.setFixedWidth(200)
+        displayedText = qt.QLabel.text(self.label)
+        self.assertNotIn("…", displayedText)
+        self.assertEqual(raw, displayedText)
+
+
+def suite():
+    loader = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite = unittest.TestSuite()
+    test_suite.addTest(loader(TestElidedLabel))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest='suite')


### PR DESCRIPTION
This PR provides an elidable label widget.

The source code come from PyFAI, with few clean up, documentation, and test.

An example is provided as part of our "simple" widgets.