### PR TITLE
Fix mismatch between widget rect and paint update rect

### DIFF
--- a/silx/gui/widgets/LegendIconWidget.py
+++ b/silx/gui/widgets/LegendIconWidget.py
@@ -336,10 +336,11 @@ class LegendIconWidget(qt.QWidget):
                 pixmapRect = qt.QRect(0, 0, _COLORMAP_PIXMAP_SIZE, 1)
                 widthMargin = 0
                 halfHeight = 4
+                widgetRect = self.rect()
                 dest = qt.QRect(
-                    rect.left() + widthMargin,
-                    rect.center().y() - halfHeight + 1,
-                    rect.width() - widthMargin * 2,
+                    widgetRect.left() + widthMargin,
+                    widgetRect.center().y() - halfHeight + 1,
+                    widgetRect.width() - widthMargin * 2,
                     halfHeight * 2,
                 )
                 painter.drawImage(dest, image, pixmapRect)


### PR DESCRIPTION
This PR fixes a glitch while displaying the colormap LUT of the legend widget.

The region used for the repaint request was used instead of the size of the widget.

As result the widget was glitching when used together with a scrollbar, for example when it was embedded in a table view.