### PR TITLE
Update version.py

### DIFF
--- a/version.py
+++ b/version.py
@@ -66,6 +66,12 @@ RELEASE_LEVEL_VALUE = {"dev": 0,
                        "rc": 13,
                        "final": 15}
 
+PRERELEASE_NORMALIZED_NAME = {"dev": "a",
+                              "alpha": "a",
+                              "beta": "b",
+                              "gamma": "b",
+                              "rc": "rc"}
+
 MAJOR = 0
 MINOR = 13
 MICRO = 0
@@ -83,10 +89,7 @@ strictversion = version = debianversion = "%d.%d.%d" % version_info[:3]
 if version_info.releaselevel != "final":
     version += "-%s%s" % version_info[-2:]
     debianversion += "~adev%i" % version_info[-1] if RELEV == "dev" else "~%s%i" % version_info[-2:]
-    prerel = "a" if RELEASE_LEVEL_VALUE.get(version_info[3], 0) < 10 else "b"
-    if prerel not in "ab":
-        prerel = "a"
-    strictversion += prerel + str(version_info[-1])
+    strictversion += PRERELEASE_NORMALIZED_NAME[version_info[3]] + str(version_info[-1])
 
 
 def calc_hexversion(major=0, minor=0, micro=0, releaselevel="dev", serial=0):

--- a/version.py
+++ b/version.py
@@ -62,15 +62,13 @@ __all__ = ["date", "version_info", "strictversion", "hexversion", "debianversion
 RELEASE_LEVEL_VALUE = {"dev": 0,
                        "alpha": 10,
                        "beta": 11,
-                       "gamma": 12,
-                       "rc": 13,
+                       "candidate": 12,
                        "final": 15}
 
 PRERELEASE_NORMALIZED_NAME = {"dev": "a",
                               "alpha": "a",
                               "beta": "b",
-                              "gamma": "b",
-                              "rc": "rc"}
+                              "candidate": "rc"}
 
 MAJOR = 0
 MINOR = 13


### PR DESCRIPTION
Merge PR #3118 first.

This PR updates `version.py` to:

- Allow to have python source tarball or wheels with `rc` release level. Indeed the version used is the `strictversion` which was either `a` or `b` for pre-releases.
- Use same word and code for release level in `version_info` and `hexversion` as documented in Python `sys.version_info` and `sys.hexversion`.

Do NOT use it in `0.13` branch!

closes #3114
