### PR TITLE
Fixes rectangle mask drawn outside image

### DIFF
--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -187,6 +187,8 @@ class ImageMask(BaseMask):
         :param bool mask: True to mask (default), False to unmask.
         """
         assert 0 < level < 256
+        if row + height <= 0 or col + width <= 0:
+            return  # Rectangle outside image, avoid negative indices
         selection = self._mask[max(0, row):row + height + 1,
                                max(0, col):col + width + 1]
         if mask:


### PR DESCRIPTION
This PR fixes an issue with the rectangle mask tool when drawing on the left side of the image due to negative indices in slicing.

closes #3123 