### PR TITLE
Fix numpy ndarray.tostring deprecation warning

### DIFF
--- a/silx/gui/plot/backends/glutils/PlotImageFile.py
+++ b/silx/gui/plot/backends/glutils/PlotImageFile.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -59,7 +59,7 @@ def convertRGBDataToPNG(data):
                            0, 0, interlace)
 
     # Add filter 'None' before each scanline
-    preparedData = b'\x00' + b'\x00'.join(line.tostring() for line in data)
+    preparedData = b'\x00' + b'\x00'.join(line.tobytes() for line in data)
     compressedData = zlib.compress(preparedData, 8)
 
     IDATdata = struct.pack("cccc", b'I', b'D', b'A', b'T')
@@ -134,7 +134,7 @@ def saveImageToFile(data, fileNameOrObj, fileFormat):
         fileObj.write(b'P6\n')
         fileObj.write(b'%d %d\n' % (width, height))
         fileObj.write(b'255\n')
-        fileObj.write(data.tostring())
+        fileObj.write(data.tobytes())
 
     elif fileFormat == 'png':
         fileObj.write(convertRGBDataToPNG(data))

--- a/silx/gui/plot3d/utils/mng.py
+++ b/silx/gui/plot3d/utils/mng.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -108,7 +108,7 @@ def convert(images, nb_images=0, fps=25):
 
         # Add filter 'None' before each scanline
         prepared_data = b'\x00' + b'\x00'.join(
-            line.tostring() for line in image)  # TODO optimize that
+            line.tobytes() for line in image)  # TODO optimize that
         compressed_data = zlib.compress(prepared_data, 8)
 
         # IDAT chunk: Payload

--- a/silx/opencl/codec/byte_offset.py
+++ b/silx/opencl/codec/byte_offset.py
@@ -4,7 +4,7 @@
 #    Project: Sift implementation in Python + OpenCL
 #             https://github.com/silx-kit/silx
 #
-#    Copyright (C) 2013-2018  European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2013-2020  European Synchrotron Radiation Facility, Grenoble, France
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -436,4 +436,4 @@ class ByteOffset(OpenclProcessing):
         :rtype: bytes
         """
         compressed_array = self.encode(data)
-        return compressed_array.get().tostring()
+        return compressed_array.get().tobytes()

--- a/silx/opencl/codec/test/test_byte_offset.py
+++ b/silx/opencl/codec/test/test_byte_offset.py
@@ -4,7 +4,7 @@
 #    Project: Byte-offset decompression in OpenCL
 #             https://github.com/silx-kit/silx
 #
-#    Copyright (C) 2013-2018  European Synchrotron Radiation Facility,
+#    Copyright (C) 2013-2020  European Synchrotron Radiation Facility,
 #                             Grenoble, France
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -170,7 +170,7 @@ class TestByteOffset(unittest.TestCase):
         compressed_array = bo.encode(ref)
         t1 = time.time()
 
-        compressed_stream = compressed_array.get().tostring()
+        compressed_stream = compressed_array.get().tobytes()
         self.assertEqual(raw, compressed_stream)
 
         logger.debug("Global execution time: OpenCL: %.3fms.",
@@ -203,7 +203,7 @@ class TestByteOffset(unittest.TestCase):
 
         # Get data from out array, read it from bo object queue
         out_bo_queue = out.with_queue(bo.queue)
-        compressed_stream = out_bo_queue.get().tostring()[:compressed_size]
+        compressed_stream = out_bo_queue.get().tobytes()[:compressed_size]
         self.assertEqual(raw, compressed_stream)
 
     def test_encode_to_bytes(self):

--- a/silx/third_party/EdfFile.py
+++ b/silx/third_party/EdfFile.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -846,9 +846,9 @@ class EdfFile(object):
 
         # if self.Images[Index].StaticHeader["ByteOrder"] != self.SysByteOrder:
         if self.Images[Index].ByteOrder.upper() != self.SysByteOrder.upper():
-            self.File.write((Data.byteswap()).tostring())
+            self.File.write((Data.byteswap()).tobytes())
         else:
-            self.File.write(Data.tostring())
+            self.File.write(Data.tobytes())
 
     def __makeSureFileIsOpen(self):
         if DEBUG:

--- a/silx/third_party/TiffIO.py
+++ b/silx/third_party/TiffIO.py
@@ -2,7 +2,7 @@
 #
 # The PyMca X-Ray Fluorescence Toolkit
 #
-# Copyright (c) 2004-2015 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -850,9 +850,9 @@ class TiffIO(object):
 
         #write the image
         if self._swap:
-            fd.write(image.byteswap().tostring())
+            fd.write(image.byteswap().tobytes())
         else:
-            fd.write(image.tostring())
+            fd.write(image.tobytes())
 
         fd.flush()
         self.fd=fd


### PR DESCRIPTION
This PR avoids numpy 1.19.x deprecation warnings about `tostring` being renamed `tobytes` (introduced in numpy 1.9).