### PR TITLE
Sample code: Remove auto-edit behavior when adding ROIs

### DIFF
--- a/examples/plotInteractiveImageROI.py
+++ b/examples/plotInteractiveImageROI.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -84,24 +84,6 @@ def updateAddedRegionOfInterest(roi):
 
 
 roiManager.sigRoiAdded.connect(updateAddedRegionOfInterest)
-
-
-# Enable/disable editing for all ROIs of the current selected type
-def stopEditing():
-    for roi in roiManager.getRois():
-        roi.setEditable(False)
-
-
-roiManager.sigInteractiveModeFinished.connect(stopEditing)
-
-
-def startEditingRoiType(roi_class):
-    for roi in roiManager.getRois():
-        if isinstance(roi, roi_class):
-            roi.setEditable(True)
-
-
-roiManager.sigInteractiveModeStarted.connect(startEditingRoiType)
 
 
 # Add a rectangular region of interest


### PR DESCRIPTION
This PR removes the toggle of editable ROI when selecting a mode to draw a ROI since this is hard to understand when running the sample code.