### PR TITLE
[ROI] Allow to move anchors to the other side of the rect

### DIFF
--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -1352,6 +1352,19 @@ class RectangleROI(HandleBasedROI, items.LineMixIn):
             size = self.getSize()
             self._updateGeometry(center=current, size=size)
         else:
+            # Switch handles if they were crossed
+            cx, cy = self.getCenter()
+            if ((handle in (self._handleBottomLeft, self._handleTopLeft) and current[0] > cx) or
+                    (handle in (self._handleBottomRight, self._handleTopRight) and current[0] < cx)):
+                # Switch handles vertically
+                self._handleBottomLeft, self._handleBottomRight = self._handleBottomRight, self._handleBottomLeft
+                self._handleTopLeft, self._handleTopRight = self._handleTopRight, self._handleTopLeft
+            if ((handle in (self._handleBottomLeft, self._handleBottomRight) and current[1] > cy) or
+                    (handle in (self._handleTopLeft, self._handleTopRight) and current[1] < cy)):
+                # Switch handles horizontally
+                self._handleBottomLeft, self._handleTopLeft = self._handleTopLeft, self._handleBottomLeft
+                self._handleBottomRight, self._handleTopRight = self._handleTopRight, self._handleBottomRight
+
             opposed = {
                 self._handleBottomLeft: self._handleTopRight,
                 self._handleTopRight: self._handleBottomLeft,

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -1352,19 +1352,6 @@ class RectangleROI(HandleBasedROI, items.LineMixIn):
             size = self.getSize()
             self._updateGeometry(center=current, size=size)
         else:
-            # Switch handles if they were crossed
-            cx, cy = self.getCenter()
-            if ((handle in (self._handleBottomLeft, self._handleTopLeft) and current[0] > cx) or
-                    (handle in (self._handleBottomRight, self._handleTopRight) and current[0] < cx)):
-                # Switch handles vertically
-                self._handleBottomLeft, self._handleBottomRight = self._handleBottomRight, self._handleBottomLeft
-                self._handleTopLeft, self._handleTopRight = self._handleTopRight, self._handleTopLeft
-            if ((handle in (self._handleBottomLeft, self._handleBottomRight) and current[1] > cy) or
-                    (handle in (self._handleTopLeft, self._handleTopRight) and current[1] < cy)):
-                # Switch handles horizontally
-                self._handleBottomLeft, self._handleTopLeft = self._handleTopLeft, self._handleBottomLeft
-                self._handleBottomRight, self._handleTopRight = self._handleTopRight, self._handleBottomRight
-
             opposed = {
                 self._handleBottomLeft: self._handleTopRight,
                 self._handleTopRight: self._handleBottomLeft,
@@ -1374,6 +1361,20 @@ class RectangleROI(HandleBasedROI, items.LineMixIn):
             handle2 = opposed[handle]
             current2 = handle2.getPosition()
             points = numpy.array([current, current2])
+
+            # Switch handles if they were crossed by interaction
+            if self._handleBottomLeft.getXPosition() > self._handleBottomRight.getXPosition():
+                self._handleBottomLeft, self._handleBottomRight = self._handleBottomRight, self._handleBottomLeft
+
+            if self._handleTopLeft.getXPosition() > self._handleTopRight.getXPosition():
+                self._handleTopLeft, self._handleTopRight = self._handleTopRight, self._handleTopLeft
+
+            if self._handleBottomLeft.getYPosition() > self._handleTopLeft.getYPosition():
+                self._handleBottomLeft, self._handleTopLeft = self._handleTopLeft, self._handleBottomLeft
+
+            if self._handleBottomRight.getYPosition() > self._handleTopRight.getYPosition():
+                self._handleBottomRight, self._handleTopRight = self._handleTopRight, self._handleBottomRight
+
             self._setBound(points)
 
     def __str__(self):


### PR DESCRIPTION
This PR allows to edit rectangular ROI an move the anchors freely without moving the other anchors even when "reverting" the rectangle (i.e., moving top-left anchor to be either the bottom-left or top-right one).