### PR TITLE
Reorder colormaps: mono, perseptual, garbage

### DIFF
--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -90,16 +90,16 @@ _LUT_DESCRIPTION = collections.namedtuple("_LUT_DESCRIPTION", ["source", "cursor
 _AVAILABLE_LUTS = collections.OrderedDict([
     ('gray', _LUT_DESCRIPTION('builtin', 'pink', True)),
     ('reversed gray', _LUT_DESCRIPTION('builtin', 'pink', True)),
-    ('temperature', _LUT_DESCRIPTION('builtin', 'pink', True)),
     ('red', _LUT_DESCRIPTION('builtin', 'green', True)),
     ('green', _LUT_DESCRIPTION('builtin', 'pink', True)),
     ('blue', _LUT_DESCRIPTION('builtin', 'yellow', True)),
-    ('jet', _LUT_DESCRIPTION('matplotlib', 'pink', True)),
     ('viridis', _LUT_DESCRIPTION('resource', 'pink', True)),
     ('cividis', _LUT_DESCRIPTION('resource', 'pink', True)),
     ('magma', _LUT_DESCRIPTION('resource', 'green', True)),
     ('inferno', _LUT_DESCRIPTION('resource', 'green', True)),
     ('plasma', _LUT_DESCRIPTION('resource', 'green', True)),
+    ('temperature', _LUT_DESCRIPTION('builtin', 'pink', True)),
+    ('jet', _LUT_DESCRIPTION('matplotlib', 'pink', True)),
     ('hsv', _LUT_DESCRIPTION('matplotlib', 'black', True)),
 ])
 """Description for internal porpose of all the default LUT provided by the library."""


### PR DESCRIPTION
Sorry, this triggers me for a while.

I have grouped together mono, perceptual, and other stuffs

![colormap-lut](https://user-images.githubusercontent.com/7579321/84874053-58310280-b084-11ea-94c9-52e89a60995b.png)
