### PR TITLE
silx.gui.colors: Added `Colormap.get|setNaNColor` to change color used for NaN

### DIFF
--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -868,7 +868,6 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                 gamma = colormap.getGammaNormalizationParameter()
                 nanColor = colors.rgba(colormap.getNaNColor())
 
-
                 image = GLPlotColormap(data,
                                        origin,
                                        scale,

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -866,6 +866,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                 cmapRange = colormap.getColormapRange(data=data)
                 colormapLut = colormap.getNColors(nbColors=256)
                 gamma = colormap.getGammaNormalizationParameter()
+                nanColor = colors.rgba(colormap.getNaNColor())
+
 
                 image = GLPlotColormap(data,
                                        origin,
@@ -874,7 +876,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                                        normalization,
                                        gamma,
                                        cmapRange,
-                                       alpha)
+                                       alpha,
+                                       nanColor)
 
             else:  # Fallback applying colormap on CPU
                 rgba = colormap.applyToData(data)

--- a/silx/gui/plot/backends/glutils/GLPlotImage.py
+++ b/silx/gui/plot/backends/glutils/GLPlotImage.py
@@ -160,7 +160,7 @@ class GLPlotColormap(_GLPlotData2D):
         'fragment': """
     #version 120
 
-    /* isnan declaration for compatibily with GLSL 1.20 */
+    /* isnan declaration for compatibility with GLSL 1.20 */
     bool isnan(float value) {
         return (value != value);
     }

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -326,6 +326,23 @@ class TestPlotImage(PlotWidgetTestCase, ParametricTestCase):
                            resetzoom=False)
         self.plot.resetZoom()
 
+    def testPlotColormapNaNColor(self):
+        self.plot.setKeepDataAspectRatio(False)
+        self.plot.setGraphTitle('Colormap with NaN color')
+
+        colormap = Colormap()
+        colormap.setNaNColor('red')
+        self.assertEqual(colormap.getNaNColor(), qt.QColor(255, 0, 0))
+        data = DATA_2D.astype(numpy.float32)
+        data[len(data)//2:] = numpy.nan
+        self.plot.addImage(data, legend="image 1", colormap=colormap,
+                           resetzoom=False)
+        self.plot.resetZoom()
+
+        colormap.setNaNColor((0., 1., 0., 1.))
+        self.assertEqual(colormap.getNaNColor(), qt.QColor(0, 255, 0))
+        self.qapp.processEvents()
+
     def testImageOriginScale(self):
         """Test of image with different origin and scale"""
         self.plot.setGraphTitle('origin and scale')

--- a/silx/gui/plot3d/items/mixins.py
+++ b/silx/gui/plot3d/items/mixins.py
@@ -141,6 +141,7 @@ class ColormapMixIn(_ColormapMixIn):
             self.__sceneColormap.norm = colormap.getNormalization()
             self.__sceneColormap.gamma = colormap.getGammaNormalizationParameter()
             self.__sceneColormap.range_ = colormap.getColormapRange(self)
+            self.__sceneColormap.nancolor = rgba(colormap.getNaNColor())
 
 
 class ComplexMixIn(_ComplexMixIn):

--- a/silx/gui/test/test_colors.py
+++ b/silx/gui/test/test_colors.py
@@ -450,9 +450,10 @@ class TestObjectAPI(ParametricTestCase):
             Colormap(name="viridis"),
             Colormap(normalization=Colormap.SQRT)
         ]
-        gamma = Colormap(normalization=Colormap.GAMMA)
-        gamma.setGammaNormalizationParameter(1.2)
-        colormaps.append(gamma)
+        cmap = Colormap(normalization=Colormap.GAMMA)
+        cmap.setGammaNormalizationParameter(1.2)
+        cmap.setNaNColor('red')
+        colormaps.append(cmap)
         for expected in colormaps:
             with self.subTest(colormap=expected):
                 state = expected.saveState()
@@ -472,6 +473,21 @@ class TestObjectAPI(ParametricTestCase):
 
         expected = Colormap(name="viridis", vmin=1, vmax=2, normalization=Colormap.LOGARITHM)
         self.assertEqual(colormap, expected)
+
+    def testStorageV2(self):
+        state = b'\x00\x00\x00\x10\x00C\x00o\x00l\x00o\x00r\x00m\x00a\x00p\x00'\
+                b'\x00\x00\x02\x00\x00\x00\x0e\x00v\x00i\x00r\x00i\x00d\x00i\x00'\
+                b's\x00\x00\x00\x00\x06\x00?\xf0\x00\x00\x00\x00\x00\x00\x00\x00'\
+                b'\x00\x00\x06\x00@\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x06'\
+                b'\x00l\x00o\x00g\x00\x00\x00\x0c\x00m\x00i\x00n\x00m\x00a\x00x'
+        state = qt.QByteArray(state)
+        colormap = Colormap()
+        colormap.restoreState(state)
+
+        expected = Colormap(name="viridis", vmin=1, vmax=2, normalization=Colormap.LOGARITHM)
+        expected.setGammaNormalizationParameter(1.5)
+        self.assertEqual(colormap, expected)
+
 
 class TestPreferredColormaps(unittest.TestCase):
     """Test get|setPreferredColormaps functions"""

--- a/silx/gui/test/test_colors.py
+++ b/silx/gui/test/test_colors.py
@@ -113,6 +113,20 @@ class TestApplyColormapToData(ParametricTestCase):
         self.assertEqual(len(value), 1)
         self.assertEqual(value[0, 0], 128)
 
+    def testNaNColor(self):
+        """Test Colormap.applyToData with NaN values"""
+        colormap = Colormap(name='gray', normalization='linear')
+        colormap.setNaNColor('red')
+        self.assertEqual(colormap.getNaNColor(), qt.QColor(255, 0, 0))
+
+        data = numpy.array([50., numpy.nan])
+        image = items.ImageData()
+        image.setData(numpy.array([[0, 100]]))
+        value = colormap.applyToData(data, reference=image)
+        self.assertEqual(len(value), 2)
+        self.assertTrue(numpy.array_equal(value[0], (128, 128, 128, 255)))
+        self.assertTrue(numpy.array_equal(value[1], (255, 0, 0, 255)))
+
 
 class TestDictAPI(unittest.TestCase):
     """Make sure the old dictionary API is working


### PR DESCRIPTION
NaN values in images were displayed differentely with the matplotlib backend (transparent) and the opengl one (as lowest bound of the colormap). 
This PR fixes this difference by making the OpenGL backend behave as the matplotlib one.
Furthermore, it adds `Colormap.get|setNaNColor` methods to allow to change the color used for NaN and it supports it in both `PlotWidget` and `plot3d`.