### PR TITLE
silx.gui.plot: Refactored PlotWidget OpenGL backend to enable extensions

### DIFF
--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -433,10 +433,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
             item = plotItem._backendRenderer
 
-            if isinstance(item, (glutils.GLPlotCurve2D,
-                                 glutils.GLPlotColormap,
-                                 glutils.GLPlotRGBAImage,
-                                 glutils.GLPlotTriangles)):  # Render data items
+            if isinstance(item, glutils.GLPlotItem):  # Render data items
                 gl.glViewport(self._plotFrame.margins.left,
                               self._plotFrame.margins.bottom,
                               plotWidth, plotHeight)
@@ -951,10 +948,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
     # Remove methods
 
     def remove(self, item):
-        if isinstance(item, (glutils.GLPlotCurve2D,
-                             glutils.GLPlotColormap,
-                             glutils.GLPlotRGBAImage,
-                             glutils.GLPlotTriangles)):
+        if isinstance(item, glutils.GLPlotItem):
             if isinstance(item, glutils.GLPlotCurve2D):
                 # Check if some curves remains on the right Y axis
                 y2AxisItems = (item for item in self._plot.getItems()
@@ -1107,17 +1101,11 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             return (0,) if isPicked else None
 
         # Pick image, curve, triangles
-        elif isinstance(item, (glutils.GLPlotCurve2D,
-                               glutils.GLPlotColormap,
-                               glutils.GLPlotRGBAImage,
-                               glutils.GLPlotTriangles)):
-            if isinstance(item, (glutils.GLPlotColormap, glutils.GLPlotRGBAImage, glutils.GLPlotTriangles)):
-                return item.pick(*dataPos)  # Might be None
-
-            elif isinstance(item, glutils.GLPlotCurve2D):
+        elif isinstance(item, glutils.GLPlotItem):
+            if isinstance(item, glutils.GLPlotCurve2D):
                 return self.__pickCurves(item, x, y)
             else:
-                return None
+                return item.pick(*dataPos)  # Might be None
 
     # Update curve
 

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -43,12 +43,7 @@ from ... import qt
 
 from ..._glutils import gl
 from ... import _glutils as glu
-from .glutils import (
-    GLLines2D, GLPlotTriangles,
-    GLPlotCurve2D, GLPlotColormap, GLPlotRGBAImage, GLPlotFrame2D,
-    mat4Ortho, mat4Identity,
-    LEFT, RIGHT, BOTTOM, TOP,
-    Text2D, FilledShape2D)
+from . import glutils
 from .glutils.PlotImageFile import saveImageToFile
 
 _logger = logging.getLogger(__name__)
@@ -216,7 +211,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         self._backgroundColor = 1., 1., 1., 1.
         self._dataBackgroundColor = 1., 1., 1., 1.
 
-        self.matScreenProj = mat4Identity()
+        self.matScreenProj = glutils.mat4Identity()
 
         self._progBase = glu.Program(
             _baseVertShd, _baseFragShd, attrib0='position')
@@ -231,7 +226,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
         self._glGarbageCollector = []
 
-        self._plotFrame = GLPlotFrame2D(
+        self._plotFrame = glutils.GLPlotFrame2D(
             foregroundColor=(0., 0., 0., 1.),
             gridColor=(.7, .7, .7, 1.),
             margins={'left': 100, 'right': 50, 'top': 50, 'bottom': 50})
@@ -371,7 +366,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
         gl.glUniform1i(self._progTex.uniforms['tex'], texUnit)
         gl.glUniformMatrix4fv(self._progTex.uniforms['matrix'], 1, gl.GL_TRUE,
-                              mat4Identity().astype(numpy.float32))
+                              glutils.mat4Identity().astype(numpy.float32))
 
         gl.glEnableVertexAttribArray(self._progTex.attributes['position'])
         gl.glVertexAttribPointer(self._progTex.attributes['position'],
@@ -438,15 +433,16 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
             item = plotItem._backendRenderer
 
-            if isinstance(item, (GLPlotCurve2D,
-                                 GLPlotColormap,
-                                 GLPlotRGBAImage,
-                                 GLPlotTriangles)):  # Render data items
+            if isinstance(item, (glutils.GLPlotCurve2D,
+                                 glutils.GLPlotColormap,
+                                 glutils.GLPlotRGBAImage,
+                                 glutils.GLPlotTriangles)):  # Render data items
                 gl.glViewport(self._plotFrame.margins.left,
                               self._plotFrame.margins.bottom,
                               plotWidth, plotHeight)
 
-                if isinstance(item, GLPlotCurve2D) and item.info.get('yAxis') == 'right':
+                if (isinstance(item, glutils.GLPlotCurve2D) and
+                        item.info.get('yAxis') == 'right'):
                     item.render(self._plotFrame.transformedDataY2ProjMat,
                                 isXLog, isYLog)
                 else:
@@ -490,7 +486,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                     gl.glUniform2i(self._progBase.uniforms['isLog'], False, False)
                     gl.glUniform1f(self._progBase.uniforms['tickLen'], 0.)
 
-                    shape2D = FilledShape2D(
+                    shape2D = glutils.FilledShape2D(
                         points, style=item['fill'], color=item['color'])
                     shape2D.render(
                         posAttrib=self._progBase.attributes['position'],
@@ -504,11 +500,12 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                         points = numpy.append(points,
                                               numpy.atleast_2d(points[0]), axis=0)
 
-                    lines = GLLines2D(points[:, 0], points[:, 1],
-                                      style=item['linestyle'],
-                                      color=item['color'],
-                                      dash2ndColor=item['linebgcolor'],
-                                      width=item['linewidth'])
+                    lines = glutils.GLLines2D(
+                        points[:, 0], points[:, 1],
+                        style=item['linestyle'],
+                        color=item['color'],
+                        dash2ndColor=item['linebgcolor'],
+                        width=item['linewidth'])
                     lines.render(self.matScreenProj)
 
             elif isinstance(item, _MarkerItem):
@@ -530,34 +527,38 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                             x = self._plotFrame.size[0] - \
                                 self._plotFrame.margins.right - pixelOffset
                             y = pixelPos[1] - pixelOffset
-                            label = Text2D(item['text'], x, y,
-                                           color=item['color'],
-                                           bgColor=(1., 1., 1., 0.5),
-                                           align=RIGHT, valign=BOTTOM)
+                            label = glutils.Text2D(
+                                item['text'], x, y,
+                                color=item['color'],
+                                bgColor=(1., 1., 1., 0.5),
+                                align=glutils.RIGHT, valign=glutils.BOTTOM)
                             labels.append(label)
 
                         width = self._plotFrame.size[0]
-                        lines = GLLines2D((0, width), (pixelPos[1], pixelPos[1]),
-                                          style=item['linestyle'],
-                                          color=item['color'],
-                                          width=item['linewidth'])
+                        lines = glutils.GLLines2D(
+                            (0, width), (pixelPos[1], pixelPos[1]),
+                            style=item['linestyle'],
+                            color=item['color'],
+                            width=item['linewidth'])
                         lines.render(self.matScreenProj)
 
                     else:  # yCoord is None: vertical line in data space
                         if item['text'] is not None:
                             x = pixelPos[0] + pixelOffset
                             y = self._plotFrame.margins.top + pixelOffset
-                            label = Text2D(item['text'], x, y,
-                                           color=item['color'],
-                                           bgColor=(1., 1., 1., 0.5),
-                                           align=LEFT, valign=TOP)
+                            label = glutils.Text2D(
+                                item['text'], x, y,
+                                color=item['color'],
+                                bgColor=(1., 1., 1., 0.5),
+                                align=glutils.LEFT, valign=glutils.TOP)
                             labels.append(label)
 
                         height = self._plotFrame.size[1]
-                        lines = GLLines2D((pixelPos[0], pixelPos[0]), (0, height),
-                                          style=item['linestyle'],
-                                          color=item['color'],
-                                          width=item['linewidth'])
+                        lines = glutils.GLLines2D(
+                            (pixelPos[0], pixelPos[0]), (0, height),
+                            style=item['linestyle'],
+                            color=item['color'],
+                            width=item['linewidth'])
                         lines.render(self.matScreenProj)
 
                 else:
@@ -568,24 +569,25 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                         continue
 
                     if isYInverted:
-                        valign = BOTTOM
+                        valign = glutils.BOTTOM
                         vPixelOffset = -pixelOffset
                     else:
-                        valign = TOP
+                        valign = glutils.TOP
                         vPixelOffset = pixelOffset
 
                     if item['text'] is not None:
                         x = pixelPos[0] + pixelOffset
                         y = pixelPos[1] + vPixelOffset
-                        label = Text2D(item['text'], x, y,
-                                       color=item['color'],
-                                       bgColor=(1., 1., 1., 0.5),
-                                       align=LEFT, valign=valign)
+                        label = glutils.Text2D(
+                            item['text'], x, y,
+                            color=item['color'],
+                            bgColor=(1., 1., 1., 0.5),
+                            align=glutils.LEFT, valign=valign)
                         labels.append(label)
 
                     # For now simple implementation: using a curve for each marker
                     # Should pack all markers to a single set of points
-                    markerCurve = GLPlotCurve2D(
+                    markerCurve = glutils.GLPlotCurve2D(
                         numpy.array((pixelPos[0],), dtype=numpy.float64),
                         numpy.array((pixelPos[1],), dtype=numpy.float64),
                         marker=item['symbol'],
@@ -687,9 +689,10 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             int(self.getDevicePixelRatio() * width),
             int(self.getDevicePixelRatio() * height))
 
-        self.matScreenProj = mat4Ortho(0, self._plotFrame.size[0],
-                                       self._plotFrame.size[1], 0,
-                                       1, -1)
+        self.matScreenProj = glutils.mat4Ortho(
+            0, self._plotFrame.size[0],
+            self._plotFrame.size[1], 0,
+            1, -1)
 
         # Store current ranges
         previousXRange = self.getGraphXLimits()
@@ -824,18 +827,19 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         fillColor = None
         if fill is True:
             fillColor = color
-        curve = GLPlotCurve2D(x, y, colorArray,
-                              xError=xerror,
-                              yError=yerror,
-                              lineStyle=linestyle,
-                              lineColor=color,
-                              lineWidth=linewidth,
-                              marker=symbol,
-                              markerColor=color,
-                              markerSize=symbolsize,
-                              fillColor=fillColor,
-                              baseline=baseline,
-                              isYLog=isYLog)
+        curve = glutils.GLPlotCurve2D(
+            x, y, colorArray,
+            xError=xerror,
+            yError=yerror,
+            lineStyle=linestyle,
+            lineColor=color,
+            lineWidth=linewidth,
+            marker=symbol,
+            markerColor=color,
+            markerSize=symbolsize,
+            fillColor=fillColor,
+            baseline=baseline,
+            isYLog=isYLog)
         curve.info = {
             'yAxis': 'left' if yaxis is None else yaxis,
         }
@@ -861,26 +865,27 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                 data = numpy.array(data, dtype=numpy.float32, order='C')
 
             normalization = colormap.getNormalization()
-            if normalization in GLPlotColormap.SUPPORTED_NORMALIZATIONS:
+            if normalization in glutils.GLPlotColormap.SUPPORTED_NORMALIZATIONS:
                 # Fast path applying colormap on the GPU
                 cmapRange = colormap.getColormapRange(data=data)
                 colormapLut = colormap.getNColors(nbColors=256)
                 gamma = colormap.getGammaNormalizationParameter()
                 nanColor = colors.rgba(colormap.getNaNColor())
 
-                image = GLPlotColormap(data,
-                                       origin,
-                                       scale,
-                                       colormapLut,
-                                       normalization,
-                                       gamma,
-                                       cmapRange,
-                                       alpha,
-                                       nanColor)
+                image = glutils.GLPlotColormap(
+                    data,
+                    origin,
+                    scale,
+                    colormapLut,
+                    normalization,
+                    gamma,
+                    cmapRange,
+                    alpha,
+                    nanColor)
 
             else:  # Fallback applying colormap on CPU
                 rgba = colormap.applyToData(data)
-                image = GLPlotRGBAImage(rgba, origin, scale, alpha)
+                image = glutils.GLPlotRGBAImage(rgba, origin, scale, alpha)
 
         elif len(data.shape) == 3:
             # For RGB, RGBA data
@@ -895,7 +900,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             else:
                 raise ValueError('Unsupported data type')
 
-            image = GLPlotRGBAImage(data, origin, scale, alpha)
+            image = glutils.GLPlotRGBAImage(data, origin, scale, alpha)
 
         else:
             raise RuntimeError("Unsupported data shape {0}".format(data.shape))
@@ -918,7 +923,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         if self._plotFrame.yAxis.isLog:
             y = numpy.log10(y)
 
-        triangles = GLPlotTriangles(x, y, color, triangles, alpha)
+        triangles = glutils.GLPlotTriangles(x, y, color, triangles, alpha)
 
         return triangles
 
@@ -946,11 +951,11 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
     # Remove methods
 
     def remove(self, item):
-        if isinstance(item, (GLPlotCurve2D,
-                             GLPlotColormap,
-                             GLPlotRGBAImage,
-                             GLPlotTriangles)):
-            if isinstance(item, GLPlotCurve2D):
+        if isinstance(item, (glutils.GLPlotCurve2D,
+                             glutils.GLPlotColormap,
+                             glutils.GLPlotRGBAImage,
+                             glutils.GLPlotTriangles)):
+            if isinstance(item, glutils.GLPlotCurve2D):
                 # Check if some curves remains on the right Y axis
                 y2AxisItems = (item for item in self._plot.getItems()
                                if isinstance(item, items.YAxisMixIn) and
@@ -1102,14 +1107,14 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             return (0,) if isPicked else None
 
         # Pick image, curve, triangles
-        elif isinstance(item, (GLPlotCurve2D,
-                               GLPlotColormap,
-                               GLPlotRGBAImage,
-                               GLPlotTriangles)):
-            if isinstance(item, (GLPlotColormap, GLPlotRGBAImage, GLPlotTriangles)):
+        elif isinstance(item, (glutils.GLPlotCurve2D,
+                               glutils.GLPlotColormap,
+                               glutils.GLPlotRGBAImage,
+                               glutils.GLPlotTriangles)):
+            if isinstance(item, (glutils.GLPlotColormap, glutils.GLPlotRGBAImage, glutils.GLPlotTriangles)):
                 return item.pick(*dataPos)  # Might be None
 
-            elif isinstance(item, GLPlotCurve2D):
+            elif isinstance(item, glutils.GLPlotCurve2D):
                 return self.__pickCurves(item, x, y)
             else:
                 return None

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -438,13 +438,11 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                               self._plotFrame.margins.bottom,
                               plotWidth, plotHeight)
 
-                if (isinstance(item, glutils.GLPlotCurve2D) and
-                        item.info.get('yAxis') == 'right'):
-                    item.render(self._plotFrame.transformedDataY2ProjMat,
-                                isXLog, isYLog)
+                if item.yaxis == 'right':
+                    matrix = self._plotFrame.transformedDataY2ProjMat
                 else:
-                    item.render(self._plotFrame.transformedDataProjMat,
-                                isXLog, isYLog)
+                    matrix = self._plotFrame.transformedDataProjMat
+                item.render(matrix, isXLog, isYLog)
 
             elif isinstance(item, _ShapeItem):  # Render shape items
                 gl.glViewport(0, 0, self._plotFrame.size[0], self._plotFrame.size[1])
@@ -837,9 +835,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             fillColor=fillColor,
             baseline=baseline,
             isYLog=isYLog)
-        curve.info = {
-            'yAxis': 'left' if yaxis is None else yaxis,
-        }
+        curve.yaxis = 'left' if yaxis is None else yaxis
 
         if yaxis == "right":
             self._plotFrame.isY2Axis = True
@@ -949,7 +945,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
     def remove(self, item):
         if isinstance(item, glutils.GLPlotItem):
-            if isinstance(item, glutils.GLPlotCurve2D):
+            if item.yaxis == 'right':
                 # Check if some curves remains on the right Y axis
                 y2AxisItems = (item for item in self._plot.getItems()
                                if isinstance(item, items.YAxisMixIn) and
@@ -1021,18 +1017,16 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         if item.lineStyle is not None:
             offset = max(item.lineWidth / 2., offset)
 
-        yAxis = item.info['yAxis']
-
         inAreaPos = self._mouseInPlotArea(x - offset, y - offset)
         dataPos = self._plot.pixelToData(inAreaPos[0], inAreaPos[1],
-                                         axis=yAxis, check=True)
+                                         axis=item.yaxis, check=True)
         if dataPos is None:
             return None
         xPick0, yPick0 = dataPos
 
         inAreaPos = self._mouseInPlotArea(x + offset, y + offset)
         dataPos = self._plot.pixelToData(inAreaPos[0], inAreaPos[1],
-                                         axis=yAxis, check=True)
+                                         axis=item.yaxis, check=True)
         if dataPos is None:
             return None
         xPick1, yPick1 = dataPos
@@ -1052,8 +1046,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             xPickMin = numpy.log10(xPickMin)
             xPickMax = numpy.log10(xPickMax)
 
-        if (yAxis == 'left' and self._plotFrame.yAxis.isLog) or (
-                yAxis == 'right' and self._plotFrame.y2Axis.isLog):
+        if (item.yaxis == 'left' and self._plotFrame.yAxis.isLog) or (
+                item.yaxis == 'right' and self._plotFrame.y2Axis.isLog):
             yPickMin = numpy.log10(yPickMin)
             yPickMax = numpy.log10(yPickMax)
 

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -43,6 +43,7 @@ from silx.math.combo import min_max
 from ...._glutils import gl
 from ...._glutils import Program, vertexBuffer, VertexBufferAttrib
 from .GLSupport import buildFillMaskIndices, mat4Identity, mat4Translate
+from .GLPlotImage import GLPlotItem
 
 
 _logger = logging.getLogger(__name__)
@@ -1067,7 +1068,7 @@ def _proxyProperty(*componentsAttributes):
     return property(getter, setter)
 
 
-class GLPlotCurve2D(object):
+class GLPlotCurve2D(GLPlotItem):
     def __init__(self, xData, yData, colorData=None,
                  xError=None, yError=None,
                  lineStyle=SOLID,
@@ -1080,7 +1081,7 @@ class GLPlotCurve2D(object):
                  fillColor=None,
                  baseline=None,
                  isYLog=False):
-
+        super().__init__()
         self.colorData = colorData
 
         # Compute x bounds

--- a/silx/gui/plot/backends/glutils/GLPlotImage.py
+++ b/silx/gui/plot/backends/glutils/GLPlotImage.py
@@ -40,10 +40,12 @@ from ...._glutils import gl, Program, Texture
 from ..._utils import FLOAT32_MINPOS
 from .GLSupport import mat4Translate, mat4Scale
 from .GLTexture import Image
+from .GLPlotItem import GLPlotItem
 
 
-class _GLPlotData2D(object):
+class _GLPlotData2D(GLPlotItem):
     def __init__(self, data, origin, scale):
+        super().__init__()
         self.data = data
         assert len(origin) == 2
         self.origin = tuple(origin)
@@ -79,15 +81,6 @@ class _GLPlotData2D(object):
     def yMax(self):
         oy, sy = self.origin[1], self.scale[1]
         return oy + sy * self.data.shape[0] if sy >= 0. else oy
-
-    def discard(self):
-        pass
-
-    def prepare(self):
-        pass
-
-    def render(self, matrix, isXLog, isYLog):
-        pass
 
 
 class GLPlotColormap(_GLPlotData2D):

--- a/silx/gui/plot/backends/glutils/GLPlotItem.py
+++ b/silx/gui/plot/backends/glutils/GLPlotItem.py
@@ -33,8 +33,10 @@ __date__ = "02/07/2020"
 
 class GLPlotItem:
     """Base class for primitives used in the PlotWidget OpenGL backend"""
+
     def __init__(self):
-        pass
+        self.yaxis = 'left'
+        "YAxis this item is attached to (either 'left' or 'right')"
 
     def pick(self, x, y):
         """Perform picking at given position.

--- a/silx/gui/plot/backends/glutils/GLPlotItem.py
+++ b/silx/gui/plot/backends/glutils/GLPlotItem.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -22,25 +22,40 @@
 # THE SOFTWARE.
 #
 # ############################################################################*/
-"""This module provides convenient classes for the OpenGL rendering backend.
+"""
+This module provides a base class for PlotWidget OpenGL backend primitives
 """
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "03/04/2017"
+__date__ = "02/07/2020"
 
 
-import logging
+class GLPlotItem:
+    """Base class for primitives used in the PlotWidget OpenGL backend"""
+    def __init__(self):
+        pass
 
+    def pick(self, x, y):
+        """Perform picking at given position.
 
-_logger = logging.getLogger(__name__)
+        :param float x: X coordinate in plot data frame of reference
+        :param float y: Y coordinate in plot data frame of reference
+        :returns:
+           Result of picking as a list of indices or None if nothing picked
+        :rtype: Union[List[int],None]
+        """
+        return None
 
+    def render(self, matrix, isXLog, isYLog):
+        """Performs OpenGL rendering of the item.
 
-from .GLPlotCurve import *  # noqa
-from .GLPlotFrame import *  # noqa
-from .GLPlotImage import *  # noqa
-from .GLPlotItem import GLPlotItem  # noqa
-from .GLPlotTriangles import GLPlotTriangles  # noqa
-from .GLSupport import *  # noqa
-from .GLText import *  # noqa
-from .GLTexture import *  # noqa
+        :param numpy.ndarray matrix: 4x4 transform matrix to use for rendering
+        :param bool isXLog: Whether X axis is log scale or not
+        :param bool isYLog: Whether Y axis is log scale or not
+        """
+        pass
+
+    def discard(self):
+        """Discards OpenGL resources this item has created."""
+        pass

--- a/silx/gui/plot/backends/glutils/GLPlotTriangles.py
+++ b/silx/gui/plot/backends/glutils/GLPlotTriangles.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2019 European Synchrotron Radiation Facility
+# Copyright (c) 2019-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -38,9 +38,10 @@ import numpy
 from .....math.combo import min_max
 from .... import _glutils as glutils
 from ...._glutils import gl
+from .GLPlotItem import GLPlotItem
 
 
-class GLPlotTriangles(object):
+class GLPlotTriangles(GLPlotItem):
     """Handle rendering of a set of colored triangles"""
 
     _PROGRAM = glutils.Program(
@@ -81,6 +82,7 @@ class GLPlotTriangles(object):
         :param numpy.ndarray triangles: (N, 3) array of indices of triangles
         :param float alpha: Opacity in [0, 1]
         """
+        super().__init__()
         # Check and convert input data
         x = numpy.ravel(numpy.array(x, dtype=numpy.float32))
         y = numpy.ravel(numpy.array(y, dtype=numpy.float32))


### PR DESCRIPTION
This PR is a small refactoring of the OpenGL backend which adds a `GLPlotItem` base class to rendering primitives.
Along with `PlotWidget.addItem`, this allows writing user's defined plot items with their own OpenGL rendering implementation.