### PR TITLE
silx.gui.plot3d: Bug fix and minor improvement in scene rendering

### DIFF
--- a/silx/gui/plot3d/items/core.py
+++ b/silx/gui/plot3d/items/core.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -400,32 +400,32 @@ class DataItem3D(Item3D):
             self._updated(Item3DChangedType.TRANSFORM)
 
     def setRotationCenter(self, x=0., y=0., z=0.):
-         """Set the center of rotation of the item.
+        """Set the center of rotation of the item.
 
-         Position of the rotation center is either a float
-         for an absolute position or one of the following
-         string to define a position relative to the item's bounding box:
-         'lower', 'center', 'upper'
+        Position of the rotation center is either a float
+        for an absolute position or one of the following
+        string to define a position relative to the item's bounding box:
+        'lower', 'center', 'upper'
 
-         :param x: rotation center position on the X axis
-         :rtype: float or str
-         :param y: rotation center position on the Y axis
-         :rtype: float or str
-         :param z: rotation center position on the Z axis
-         :rtype: float or str
-         """
-         center = []
-         for position in (x, y, z):
-             if isinstance(position, six.string_types):
-                 assert position in self._ROTATION_CENTER_TAGS
-             else:
-                 position = float(position)
-             center.append(position)
-         center = tuple(center)
+        :param x: rotation center position on the X axis
+        :rtype: float or str
+        :param y: rotation center position on the Y axis
+        :rtype: float or str
+        :param z: rotation center position on the Z axis
+        :rtype: float or str
+        """
+        center = []
+        for position in (x, y, z):
+            if isinstance(position, six.string_types):
+                assert position in self._ROTATION_CENTER_TAGS
+            else:
+                position = float(position)
+            center.append(position)
+        center = tuple(center)
 
-         if center != self._rotationCenter:
-             self._rotationCenter = center
-             self._updateRotationCenter()
+        if center != self._rotationCenter:
+            self._rotationCenter = center
+            self._updateRotationCenter()
 
     def getRotationCenter(self):
         """Returns the rotation center set by :meth:`setRotationCenter`.

--- a/silx/gui/plot3d/scene/primitives.py
+++ b/silx/gui/plot3d/scene/primitives.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -2077,7 +2077,7 @@ class _Image(Geometry):
         self._update_texture = True
         # By updating the position rather than always using a unit square
         # we benefit from Geometry bounds handling
-        self.setAttribute('position', self._UNIT_SQUARE * self._data.shape[:2])
+        self.setAttribute('position', self._UNIT_SQUARE * (self._data.shape[1], self._data.shape[0]))
         self.notify()
 
     def getData(self, copy=True):
@@ -2188,7 +2188,7 @@ class _Image(Geometry):
         gl.glUniform1f(program.uniforms['alpha'], self._alpha)
 
         shape = self._data.shape
-        gl.glUniform2f(program.uniforms['dataScale'], 1./shape[0], 1./shape[1])
+        gl.glUniform2f(program.uniforms['dataScale'], 1./shape[1], 1./shape[0])
 
         gl.glUniform1i(program.uniforms['data'], self._texture.texUnit)
 


### PR DESCRIPTION
This PR:
- fixes an issue in rendering/picking of none square 2D images (due to using not reversed shape),
- allows to toggle keep aspect ratio on/off for `Orthographic` (i.e., parallel) projection.