### PR TITLE
Fix custom levels colormap dialog

### DIFF
--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -155,6 +155,9 @@ class _BoundaryWidget(qt.QWidget):
         if self.__textWasEdited:
             value = self._numVal.value()
             self.__realValue = value
+            with utils.blockSignals(self._numVal):
+                # Fix the formatting
+                self._numVal.setValue(self.__realValue)
             self.sigValueChanged.emit(value)
             self.__textWasEdited = False
 

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -174,16 +174,6 @@ class _BoundaryWidget(qt.QWidget):
             return self.__realValue
         return self._numVal.value()
 
-    def getFiniteValue(self):
-        if not self._autoCB.isChecked():
-            if self.__realValue is not None:
-                return self.__realValue
-            return self._numVal.value()
-        else:
-            if self.__realValue is not None:
-                return self.__realValue
-            return self._numVal.value()
-
     def _autoToggled(self, enabled):
         self._numVal.setEnabled(not enabled)
         self._updateDisplayedText()

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -1581,14 +1581,12 @@ class ColormapDialog(qt.QDialog):
         """
         colormap = self.getColormap()
         if vmin is not None:
-            if colormap.getVMin() is None:
-                with self._colormapChange:
-                    colormap.setVMin(vmin)
+            with self._colormapChange:
+                colormap.setVMin(vmin)
             self._minValue.setValue(vmin)
         if vmax is not None:
-            if colormap.getVMax() is None:
-                with self._colormapChange:
-                    colormap.setVMax(vmax)
+            with self._colormapChange:
+                colormap.setVMax(vmax)
             self._maxValue.setValue(vmax)
 
     def _histogramRangeMoved(self, vmin, vmax):

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -194,10 +194,12 @@ class _BoundaryWidget(qt.QWidget):
 
     def setValue(self, value, isAuto=False):
         self._autoCB.setChecked(isAuto or value is None)
-        if value is not None:
-            self._numVal.setValue(value)
+        with utils.blockSignals(self._numVal):
+            if isAuto or self.__realValue != value:
+                if not self.__textWasEdited:
+                    self._numVal.setValue(value)
             self.__realValue = value
-        self._updateDisplayedText()
+            self._numVal.setEnabled(not isAuto)
 
 
 class _AutoscaleModeComboBox(qt.QComboBox):

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -1588,7 +1588,11 @@ class ColormapDialog(qt.QDialog):
         """
         xmin = self._minValue.getValue()
         xmax = self._maxValue.getValue()
-        self._setColormapRange(xmin, xmax)
+        if vmin is None:
+            vmin = xmin
+        if vmax is None:
+            vmax = xmax
+        self._setColormapRange(vmin, vmax)
 
     def keyPressEvent(self, event):
         """Override key handling.

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -196,7 +196,14 @@ class _BoundaryWidget(qt.QWidget):
                 self._numVal.setValue(self.__realValue)
 
     def setValue(self, value, isAuto=False):
-        self._autoCB.setChecked(isAuto or value is None)
+        """Set the value of the boundary.
+
+        :param float value: A finite value for the boundary
+        :param bool isAuto: If true, the finite value was automatically computed
+            from the data, else it is a fixed custom value.
+        """
+        assert value is not None
+        self._autoCB.setChecked(isAuto)
         with utils.blockSignals(self._numVal):
             if isAuto or self.__realValue != value:
                 if not self.__textWasEdited:

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -140,14 +140,12 @@ class _BoundaryWidget(qt.QWidget):
         self._numVal.editingFinished.connect(self.__editingFinished)
         self.setFocusProxy(self._numVal)
 
-        self._dataValue = None
-
         self.__textWasEdited = False
         """True if the text was edited, in order to send an event
         at the end of the user interaction"""
 
         self.__realValue = None
-        """Store the real value set by setValue/setFiniteValue, to avoid
+        """Store the real value set by setValue, to avoid
         rounding of the widget"""
 
     def __textEdited(self):
@@ -178,12 +176,10 @@ class _BoundaryWidget(qt.QWidget):
             if self.__realValue is not None:
                 return self.__realValue
             return self._numVal.value()
-        elif self._dataValue is None:
+        else:
             if self.__realValue is not None:
                 return self.__realValue
             return self._numVal.value()
-        else:
-            return self._dataValue
 
     def _autoToggled(self, enabled):
         self._numVal.setEnabled(not enabled)
@@ -191,22 +187,10 @@ class _BoundaryWidget(qt.QWidget):
         self.sigAutoScaleChanged.emit(enabled)
 
     def _updateDisplayedText(self):
-        # if dataValue is finite
         self.__textWasEdited = False
-        if self._autoCB.isChecked() and self._dataValue is not None:
+        if self._autoCB.isChecked() and self.__realValue is not None:
             with utils.blockSignals(self._numVal):
-                self._numVal.setValue(self._dataValue)
-
-    def setDataValue(self, dataValue):
-        self._dataValue = dataValue
-        self._updateDisplayedText()
-
-    def setFiniteValue(self, value):
-        assert(value is not None)
-        old = self._numVal.blockSignals(True)
-        self._numVal.setValue(value)
-        self.__realValue = value
-        self._numVal.blockSignals(old)
+                self._numVal.setValue(self.__realValue)
 
     def setValue(self, value, isAuto=False):
         self._autoCB.setChecked(isAuto or value is None)

--- a/silx/gui/dialog/test/test_colormapdialog.py
+++ b/silx/gui/dialog/test/test_colormapdialog.py
@@ -99,9 +99,9 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.qapp.processEvents()
         self.colormapDiag.setColormap(self.colormap)
         self.assertTrue(self.colormap.getVMin() is not None)
-        self.colormapDiag._minValue.setValue(None)
+        self.colormapDiag._minValue.sigAutoScaleChanged.emit(True)
         self.assertTrue(self.colormap.getVMin() is None)
-        self.colormapDiag._maxValue.setValue(None)
+        self.colormapDiag._maxValue.sigAutoScaleChanged.emit(True)
         self.mouseClick(
             widget=self.colormapDiag._buttonsModal.button(qt.QDialogButtonBox.Ok),
             button=qt.Qt.LeftButton
@@ -118,7 +118,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.qapp.processEvents()
         self.colormapDiag.setColormap(self.colormap)
         self.assertTrue(self.colormap.getVMin() is not None)
-        self.colormapDiag._minValue.setValue(None)
+        self.colormapDiag._minValue.sigAutoScaleChanged.emit(True)
         self.assertTrue(self.colormap.getVMin() is None)
         self.mouseClick(
             widget=self.colormapDiag._buttonsModal.button(qt.QDialogButtonBox.Cancel),
@@ -133,7 +133,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.qapp.processEvents()
         self.colormapDiag.setColormap(self.colormap)
         self.assertTrue(self.colormap.getVMin() is not None)
-        self.colormapDiag._minValue.setValue(None)
+        self.colormapDiag._minValue.sigAutoScaleChanged.emit(True)
         self.assertTrue(self.colormap.getVMin() is None)
         self.mouseClick(
             widget=self.colormapDiag._buttonsNonModal.button(qt.QDialogButtonBox.Close),
@@ -148,7 +148,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.qapp.processEvents()
         self.colormapDiag.setColormap(self.colormap)
         self.assertTrue(self.colormap.getVMin() is not None)
-        self.colormapDiag._minValue.setValue(None)
+        self.colormapDiag._minValue.sigAutoScaleChanged.emit(True)
         self.assertTrue(self.colormap.getVMin() is None)
         self.mouseClick(
             widget=self.colormapDiag._buttonsNonModal.button(qt.QDialogButtonBox.Reset),
@@ -164,7 +164,7 @@ class TestColormapDialog(TestCaseQt, ParametricTestCase):
         self.qapp.processEvents()
         self.colormapDiag.setColormap(self.colormap)
         self.assertTrue(self.colormap.getVMin() is not None)
-        self.colormapDiag._minValue.setValue(None)
+        self.colormapDiag._minValue.sigAutoScaleChanged.emit(True)
         self.assertTrue(self.colormap.getVMin() is None)
         self.colormapDiag.close()
         self.qapp.processEvents()


### PR DESCRIPTION
This PR fixes 2 issues on the `ColormapDialog` which was forbid the user to custom the levels of the colormap when the image was often refreshed.

It was still possible to custom the values during the time of a single frame.

This PR:
- Make sure the result of the histogram range edition is used (it was not the case)
- Make sure the handle moved bu the user are to reset during the interaction

Closes #3148