### PR TITLE
silx.gui: Deprecated `silx.gui.plot.matplotlib` module (use `silx.gui.utils.matplotlib` instead)

### DIFF
--- a/silx/app/view/main.py
+++ b/silx/app/view/main.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -104,7 +104,7 @@ def mainQt(options):
     from silx.gui import qt
     # Make sure matplotlib is configured
     # Needed for Debian 8: compatibility between Qt4/Qt5 and old matplotlib
-    from silx.gui.plot import matplotlib
+    import silx.gui.utils.matplotlib  # noqa
 
     app = qt.QApplication([])
     qt.QLocale.setDefault(qt.QLocale.c())

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -46,6 +46,7 @@ from silx.resources import resource_filename as _resource_filename
 _logger = logging.getLogger(__file__)
 
 try:
+    import silx.gui.utils.matplotlib  # noqa  Initalize matplotlib
     from matplotlib import cm as _matplotlib_cm
     from matplotlib.pyplot import colormaps as _matplotlib_colormaps
 except ImportError:

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -52,7 +52,7 @@ from silx.utils.property import classproperty
 from silx.utils.deprecation import deprecated, deprecated_warning
 try:
     # Import matplotlib now to init matplotlib our way
-    from . import matplotlib
+    import silx.gui.utils.matplotlib  # noqa
 except ImportError:
     _logger.debug("matplotlib not available")
 

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -44,7 +44,7 @@ _logger = logging.getLogger(__name__)
 from ... import qt
 
 # First of all init matplotlib and set its backend
-from ..matplotlib import FigureCanvasQTAgg
+from ...utils.matplotlib import FigureCanvasQTAgg
 import matplotlib
 from matplotlib.container import Container
 from matplotlib.figure import Figure

--- a/silx/gui/plot/matplotlib/__init__.py
+++ b/silx/gui/plot/matplotlib/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,49 +23,15 @@
 #
 # ###########################################################################*/
 
-from __future__ import absolute_import
-
-"""This module initializes matplotlib and sets-up the backend to use.
-
-It MUST be imported prior to any other import of matplotlib.
-
-It provides the matplotlib :class:`FigureCanvasQTAgg` class corresponding
-to the used backend.
-"""
-
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "02/05/2018"
+__date__ = "15/07/2020"
 
+from silx.utils.deprecation import deprecated_warning
 
-from pkg_resources import parse_version
-import matplotlib
+deprecated_warning(type_='module',
+                   name=__file__,
+                   replacement='silx.gui.utils.matplotlib',
+                   since_version='0.14.0')
 
-from ... import qt
-
-
-def _matplotlib_use(backend, force):
-    """Wrapper of `matplotlib.use` to set-up backend.
-
-     It adds extra initialization for PySide and PySide2 with matplotlib < 2.2.
-    """
-    # This is kept for compatibility with matplotlib < 2.2
-    if parse_version(matplotlib.__version__) < parse_version('2.2'):
-        if qt.BINDING == 'PySide':
-            matplotlib.rcParams['backend.qt4'] = 'PySide'
-        if qt.BINDING == 'PySide2':
-            matplotlib.rcParams['backend.qt5'] = 'PySide2'
-
-    matplotlib.use(backend, force=force)
-
-
-if qt.BINDING in ('PyQt4', 'PySide'):
-    _matplotlib_use('Qt4Agg', force=False)
-    from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg  # noqa
-
-elif qt.BINDING in ('PyQt5', 'PySide2'):
-    _matplotlib_use('Qt5Agg', force=False)
-    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg  # noqa
-
-else:
-    raise ImportError("Unsupported Qt binding: %s" % qt.BINDING)
+from silx.gui.utils.matplotlib import FigureCanvasQTAgg  # noqa

--- a/silx/gui/utils/matplotlib.py
+++ b/silx/gui/utils/matplotlib.py
@@ -1,0 +1,71 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+
+from __future__ import absolute_import
+
+"""This module initializes matplotlib and sets-up the backend to use.
+
+It MUST be imported prior to any other import of matplotlib.
+
+It provides the matplotlib :class:`FigureCanvasQTAgg` class corresponding
+to the used backend.
+"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "02/05/2018"
+
+
+from pkg_resources import parse_version
+import matplotlib
+
+from .. import qt
+
+
+def _matplotlib_use(backend, force):
+    """Wrapper of `matplotlib.use` to set-up backend.
+
+     It adds extra initialization for PySide and PySide2 with matplotlib < 2.2.
+    """
+    # This is kept for compatibility with matplotlib < 2.2
+    if parse_version(matplotlib.__version__) < parse_version('2.2'):
+        if qt.BINDING == 'PySide':
+            matplotlib.rcParams['backend.qt4'] = 'PySide'
+        if qt.BINDING == 'PySide2':
+            matplotlib.rcParams['backend.qt5'] = 'PySide2'
+
+    matplotlib.use(backend, force=force)
+
+
+if qt.BINDING in ('PyQt4', 'PySide'):
+    _matplotlib_use('Qt4Agg', force=False)
+    from matplotlib.backends.backend_qt4agg import FigureCanvasQTAgg  # noqa
+
+elif qt.BINDING in ('PyQt5', 'PySide2'):
+    _matplotlib_use('Qt5Agg', force=False)
+    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg  # noqa
+
+else:
+    raise ImportError("Unsupported Qt binding: %s" % qt.BINDING)


### PR DESCRIPTION
This PR follows PR #3145 and fixes an issue it introduced (dut to the import of `matplotlib.pyplot`).

This required to move `silx/gui/plot/matplotlib/__init__.py` outside of `silx.gui.plot`, and it was moved to `silx/gui/utils/`.

closes  #3157