### PR TITLE
Speed up image.tomography.get_next_power()

### DIFF
--- a/silx/image/tomography.py
+++ b/silx/image/tomography.py
@@ -32,6 +32,7 @@ __date__ = "12/09/2017"
 
 import numpy as np
 from math import pi
+from functools import lru_cache
 from itertools import product
 from bisect import bisect
 from silx.math.fit import leastsq
@@ -128,6 +129,7 @@ def compute_fourier_filter(dwidth_padded, filter_name, cutoff=1.):
     return filt_f
 
 
+@lru_cache(maxsize=1)
 def generate_powers():
     """
     Generate a list of powers of [2, 3, 5, 7],


### PR DESCRIPTION
The module `silx.image.tomography` uses a function `get_next_power()` which, given an integer `n`, finds the next "friendly" power of `(2, 3, 5 ,7)`. This is used for padding data before performing FFT.

The current implementation builds a sorted list of numbers in the form `(2**a)*(3**b)*(5**c)*(7**d)`, and finds the "next friendly power" by bisection. 

Building this list takes some time, which can be noticeable if `get_next_power()` is needed many times. In this PR, the list of powers is cached in a LRU structure.
