### PR TITLE
silx.gui.plot.PlotWidget: Fixes support of curves with infinite data

### DIFF
--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -45,6 +45,7 @@ import six
 
 from ....utils.deprecation import deprecated
 from ....utils.enum import Enum as _Enum
+from ....math.combo import min_max
 from ... import qt
 from ... import colors
 from ...colors import Colormap
@@ -1347,15 +1348,11 @@ class PointsBase(Item, SymbolMixIn, AlphaMixIn):
             else:
                 x, y, _xerror, _yerror = data
 
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', category=RuntimeWarning)
-                # Ignore All-NaN slice encountered
-                self._boundsCache[(xPositive, yPositive)] = (
-                    numpy.nanmin(x),
-                    numpy.nanmax(x),
-                    numpy.nanmin(y),
-                    numpy.nanmax(y)
-                )
+            xmin, xmax = min_max(x, finite=True)
+            ymin, ymax = min_max(y, finite=True)
+            self._boundsCache[(xPositive, yPositive)] = tuple([
+                (bound if bound is not None else numpy.nan)
+                for bound in (xmin, xmax, ymin, ymax)])
         return self._boundsCache[(xPositive, yPositive)]
 
     def _getCachedData(self):

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -455,6 +455,21 @@ class TestPlotCurve(PlotWidgetTestCase):
 
         self.plot.setActiveCurveHandling(False)
 
+    def testPlotCurveInfinite(self):
+        """Test plot curves with not finite data"""
+        tests = {
+            'y all not finite': ([0, 1, 2], [numpy.inf, numpy.nan, -numpy.inf]),
+            'x all not finite': ([numpy.inf, numpy.nan, -numpy.inf], [0, 1, 2]),
+            'x some inf': ([0, numpy.inf, 2], [0, 1, 2]),
+            'y some inf': ([0, 1, 2], [0, numpy.inf, 2])
+        }
+        for name, args in tests.items():
+            with self.subTest(name):
+                self.plot.addCurve(*args)
+                self.plot.resetZoom()
+                self.qapp.processEvents()
+                self.plot.clear()
+
     def testPlotCurveColorFloat(self):
         color = numpy.array(numpy.random.random(3 * 1000),
                             dtype=numpy.float32).reshape(1000, 3)


### PR DESCRIPTION
This PR ignores infinite values when computing the bounds of curves thus avoiding to compute infinite plot limits.
It adds a few tests for this particular case.

closes #3174