### PR TITLE
silx view: Prevent collapsing browsing panel, Added `-f` command line option

### DIFF
--- a/doc/source/applications/view.rst
+++ b/doc/source/applications/view.rst
@@ -48,7 +48,7 @@ Options
   -h, --help           Show this help message and exit
   --debug              Set logging system in debug mode
   --use-opengl-plot    Use OpenGL for plots (instead of matplotlib)
-  --fresh              Start the application using new fresh user preferences
+  -f, --fresh          Start the application using new fresh user preferences
   --hdf5-file-locking  Start the application with HDF5 file locking enabled (it is disabled by default)
 
 Examples of usage

--- a/silx/app/view/Viewer.py
+++ b/silx/app/view/Viewer.py
@@ -116,6 +116,8 @@ class Viewer(qt.QMainWindow):
         spliter.addWidget(rightPanel)
         spliter.addWidget(self.__dataPanel)
         spliter.setStretchFactor(1, 1)
+        spliter.setCollapsible(0, False)
+        spliter.setCollapsible(1, False)
         self.__splitter = spliter
 
         main_panel = qt.QWidget(self)

--- a/silx/app/view/main.py
+++ b/silx/app/view/main.py
@@ -57,7 +57,7 @@ def createParser():
         default=False,
         help='Use OpenGL for plots (instead of matplotlib)')
     parser.add_argument(
-        '--fresh',
+        '-f', '--fresh',
         dest="fresh_preferences",
         action="store_true",
         default=False,


### PR DESCRIPTION
This PR prevents from completely hiding the left panel and adds the `-f` option to silx view as a short-cut for `--fresh`.

I choose to solve issue #3169 by disabling collapsing of the spliter since it is a simple an clean way to solve it.
The alternative of making sure the browsing panel  is visible sounds more complicated for little improvement if any.

closes #3169