### PR TITLE
silx.gui.plot.items: Added `DATA_BOUNDS` visualization parameter for `Scatter` item histogram bounds

### DIFF
--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -1067,6 +1067,15 @@ class ScatterVisualizationMixIn(ItemMixInBase):
         Available reduction functions are: 'mean' (default), 'count', 'sum'.
         """
 
+        DATA_BOUNDS = 'data_bounds'
+        """The expected bounds of the data in data coordinates.
+
+        A 2-tuple of 2-tuple: ((ymin, ymax), (xmin, xmax)).
+        This provides the expected data ranges in both dimensions.
+
+        WARNING: dimension 0 i.e., Y first.
+        """
+
     _SUPPORTED_VISUALIZATION_PARAMETER_VALUES = {
         VisualizationParameter.GRID_MAJOR_ORDER: ('row', 'column'),
         VisualizationParameter.BINNED_STATISTIC_FUNCTION: ('mean', 'count', 'sum'),

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -1067,11 +1067,12 @@ class ScatterVisualizationMixIn(ItemMixInBase):
         Available reduction functions are: 'mean' (default), 'count', 'sum'.
         """
 
-        DATA_BOUNDS = 'data_bounds'
+        DATA_BOUNDS_HINT = 'data_bounds_hint'
         """The expected bounds of the data in data coordinates.
 
         A 2-tuple of 2-tuple: ((ymin, ymax), (xmin, xmax)).
-        This provides the expected data ranges in both dimensions.
+        This provides a hint for the data ranges in both dimensions.
+        It is eventually enlarged with actually data ranges.
 
         WARNING: dimension 0 i.e., Y first.
         """


### PR DESCRIPTION
This PR adds `VisualizationParameter.DATA_BOUNDS` to set the histogram range for binned statistics.

As it is, it is completely decoupled from `GRID_BOUNDS`, but it could be related, e.g., using `GRID_BOUNDS` if `DATA_BOUNDS` is not defined.

It would be cleaner to replace `GRID_BOUNDS` with `DATA_BOUNDS` as in this PR and a `GRID_DIRECTION` or `GRID_ORIENTATION` providing the information about whether X and Y increase or decrease from one point to the next, i.e., `(y direction, x direction)`... but that would change the API or make it redundant.

closes #3177