### PR TITLE
Isolate sys path when executing test-opengl script

### DIFF
--- a/silx/gui/utils/glutils.py
+++ b/silx/gui/utils/glutils.py
@@ -70,7 +70,7 @@ def _runtimeOpenGLCheck(version):
 
     try:
         error = subprocess.check_output(
-            [sys.executable, __file__, major, minor],
+            [sys.executable, "-I", __file__, major, minor],
             env=env,
             timeout=2)
     except subprocess.TimeoutExpired:


### PR DESCRIPTION
The exception is due to the fact the root of the module (`silx.git/build/lib.linux-x86_64-3.7/silx/gui/utils`) is used as `PYTHONPATH`, as result it overwrite the `signal` module from the system, cause there is a `silx.git/build/lib.linux-x86_64-3.7/silx/gui/utils/signal.py`. Same for `concurrent`.

I have also tried to use `-m silx.gui.utils.glutils` but it is also problematic in dev env -> `Do NOT use %s from its sources`.

So here is a solution, using `-I` which could also create other problems, i guess.

```
-I     : isolate Python from the user's environment (implies -E and -s)
-E     : ignore PYTHON* environment variables (such as PYTHONPATH)
-s     : don't add user site directory to sys.path; also PYTHONNOUSERSITE
```

Closes #3182


With `-I`
```
In [1]: import silx.gui.utils.glutils              
   ...: silx.gui.utils.glutils.isOpenGLAvailable()                                                                                                                                                                                                   
['/users/valls/Software/miniconda3/envs/silxenv/bin/python', '/users/valls/workspace/silx.git/build/lib.linux-x86_64-3.7/silx/gui/utils/glutils.py', '2', '1']
Out[1]: <_isOpenGLAvailableResult: True, "">
```

Without `-I`
```
In [1]: import silx.gui.utils.glutils              
   ...: silx.gui.utils.glutils.isOpenGLAvailable()                                                                                                                                                                                                   
['/users/valls/Software/miniconda3/envs/silxenv/bin/python', '/users/valls/workspace/silx.git/build/lib.linux-x86_64-3.7/silx/gui/utils/glutils.py', '2', '1']
Traceback (most recent call last):
  File "/users/valls/workspace/silx.git/build/lib.linux-x86_64-3.7/silx/gui/utils/glutils.py", line 30, in <module>
    import subprocess
  File "/users/valls/Software/miniconda3/envs/silxenv/lib/python3.7/subprocess.py", line 50, in <module>
    import signal
  File "/users/valls/workspace/silx.git/build/lib.linux-x86_64-3.7/silx/gui/utils/signal.py", line 32, in <module>
    from silx.gui.utils import concurrent
  File "/users/valls/workspace/silx.git/build/lib.linux-x86_64-3.7/silx/gui/utils/concurrent.py", line 35, in <module>
    from concurrent.futures import Future
  File "/users/valls/workspace/silx.git/build/lib.linux-x86_64-3.7/silx/gui/utils/concurrent.py", line 35, in <module>
    from concurrent.futures import Future
ModuleNotFoundError: No module named 'concurrent.futures'; 'concurrent' is not a package
Out[1]: <_isOpenGLAvailableResult: False, "Qt OpenGL widget error: retcode=1, error=b''">
```

Changelog: 
- Fix `isOpenGLAvailable` on specific Python version