### PR TITLE
silx.gui.utils: Fix `glutils.isOpenGLAvailable` issue

### DIFF
--- a/silx/gui/utils/glutils.py
+++ b/silx/gui/utils/glutils.py
@@ -27,6 +27,13 @@
 
 import os
 import sys
+
+if __name__ == "__main__":
+    # When run as a script, remove directory from sys.path
+    # This avoids other script in same directory to override Python modules
+    if os.path.abspath(sys.path[0]) == os.path.abspath(os.path.dirname(__file__)):
+        sys.path.pop(0)
+
 import subprocess
 from silx.gui import qt
 


### PR DESCRIPTION
This PR fixes the runtime check of OpenGL by removing `sys.path[0]` when running the subprocess since it contains the directory of the "script", here it is `silx/gui/utils/` which also contains `signal` and `concurrent` which conflicts with python modules....
There is a check in case something is already messing around with `sys.path` (e.g., through `PYTHONSTARTUP`).

closes #3182

Some alternatives for the record:
- Copying (or creating) the script in a temporary folder
- Creating a `silx.gui.glutils` package with only `__init__` and the check script.
