### PR TITLE
silx.gui.plot.tools.roi: Fixed issue when changing ROI mode while a ROI is being created

### DIFF
--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -666,8 +666,9 @@ class RegionOfInterestManager(qt.QObject):
 
             if self._drawnROI is not None:
                 # Cancel ROI create
-                self.removeRoi(self._drawnROI)
+                roi = self._drawnROI
                 self._drawnROI = None
+                self.removeRoi(roi)
 
             plot = self.parent()
             if plot is not None:


### PR DESCRIPTION
This PR avoids an exception with ROI when changing mode while a ROI is currently added.


closes #3185
