### PR TITLE
silx.gui.plot.PlotWidget: Added support of float16 texture in OpenGL backend

### DIFF
--- a/silx/gui/_glutils/utils.py
+++ b/silx/gui/_glutils/utils.py
@@ -35,6 +35,7 @@ import numpy
 
 _GL_TYPE_SIZES = {
     gl.GL_FLOAT: 4,
+    gl.GL_HALF_FLOAT: 2,
     gl.GL_BYTE: 1,
     gl.GL_SHORT: 2,
     gl.GL_INT: 4,
@@ -51,6 +52,7 @@ def sizeofGLType(type_):
 
 _TYPE_CONVERTER = {
     numpy.dtype(numpy.float32): gl.GL_FLOAT,
+    numpy.dtype(numpy.float16): gl.GL_HALF_FLOAT,
     numpy.dtype(numpy.int8): gl.GL_BYTE,
     numpy.dtype(numpy.int16): gl.GL_SHORT,
     numpy.dtype(numpy.int32): gl.GL_INT,

--- a/silx/gui/_glutils/utils.py
+++ b/silx/gui/_glutils/utils.py
@@ -29,47 +29,25 @@ __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "10/01/2017"
 
-from . import gl
 import numpy
 
-
-_GL_TYPE_SIZES = {
-    gl.GL_FLOAT: 4,
-    gl.GL_HALF_FLOAT: 2,
-    gl.GL_BYTE: 1,
-    gl.GL_SHORT: 2,
-    gl.GL_INT: 4,
-    gl.GL_UNSIGNED_BYTE: 1,
-    gl.GL_UNSIGNED_SHORT: 2,
-    gl.GL_UNSIGNED_INT: 4,
-}
+from OpenGL.constants import BYTE_SIZES as _BYTE_SIZES
+from OpenGL.constants import ARRAY_TO_GL_TYPE_MAPPING as _ARRAY_TO_GL_TYPE_MAPPING
 
 
 def sizeofGLType(type_):
     """Returns the size in bytes of an element of type `type_`"""
-    return _GL_TYPE_SIZES[type_]
-
-
-_TYPE_CONVERTER = {
-    numpy.dtype(numpy.float32): gl.GL_FLOAT,
-    numpy.dtype(numpy.float16): gl.GL_HALF_FLOAT,
-    numpy.dtype(numpy.int8): gl.GL_BYTE,
-    numpy.dtype(numpy.int16): gl.GL_SHORT,
-    numpy.dtype(numpy.int32): gl.GL_INT,
-    numpy.dtype(numpy.uint8): gl.GL_UNSIGNED_BYTE,
-    numpy.dtype(numpy.uint16): gl.GL_UNSIGNED_SHORT,
-    numpy.dtype(numpy.uint32): gl.GL_UNSIGNED_INT,
-}
+    return _BYTE_SIZES[type_]
 
 
 def isSupportedGLType(type_):
     """Test if a numpy type or dtype can be converted to a GL type."""
-    return numpy.dtype(type_) in _TYPE_CONVERTER
+    return numpy.dtype(type_).char in _ARRAY_TO_GL_TYPE_MAPPING
 
 
 def numpyToGLType(type_):
     """Returns the GL type corresponding the provided numpy type or dtype."""
-    return _TYPE_CONVERTER[numpy.dtype(type_)]
+    return _ARRAY_TO_GL_TYPE_MAPPING[numpy.dtype(type_).char]
 
 
 def segmentTrianglesIntersection(segment, triangles):

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -850,7 +850,10 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
         if data.ndim == 2:
             # Ensure array is contiguous and eventually convert its type
-            if data.dtype in (numpy.float32, numpy.uint8, numpy.uint16):
+            dtypes = [dtype for dtype in (
+                numpy.float32, numpy.float16, numpy.uint8, numpy.uint16)
+                if glu.isSupportedGLType(dtype)]
+            if data.dtype in dtypes:
                 data = numpy.array(data, copy=False, order='C')
             else:
                 _logger.info(

--- a/silx/gui/plot/backends/glutils/GLPlotImage.py
+++ b/silx/gui/plot/backends/glutils/GLPlotImage.py
@@ -217,6 +217,7 @@ class GLPlotColormap(_GLPlotData2D):
 
     _INTERNAL_FORMATS = {
         numpy.dtype(numpy.float32): gl.GL_R32F,
+        numpy.dtype(numpy.float16): gl.GL_R16F,
         # Use normalized integer for unsigned int formats
         numpy.dtype(numpy.uint16): gl.GL_R16,
         numpy.dtype(numpy.uint8): gl.GL_R8,


### PR DESCRIPTION
This PR adds support for passing float16 data to the texture if supported by pyopengl.
This is not yet the case, see https://github.com/mcfletch/pyopengl/issues/51

It also avoids duplicating some conversion/information dicts from pyopengl.