### PR TITLE
silx.gui.plot.PlotWidget: Added `get|setAxesMargins` methods to control margin ratios around plot area

### DIFF
--- a/doc/source/modules/gui/plot/plotwidget.rst
+++ b/doc/source/modules/gui/plot/plotwidget.rst
@@ -82,6 +82,7 @@ The following methods handle plot limits, aspect ratio, grid and axes display:
 .. automethod:: PlotWidget.setKeepDataAspectRatio
 .. automethod:: PlotWidget.getGraphGrid
 .. automethod:: PlotWidget.setGraphGrid
+.. automethod:: PlotWidget.isAxesDisplayed
 .. automethod:: PlotWidget.setAxesDisplayed
 .. automethod:: PlotWidget.getAxesMargins
 .. automethod:: PlotWidget.setAxesMargins

--- a/doc/source/modules/gui/plot/plotwidget.rst
+++ b/doc/source/modules/gui/plot/plotwidget.rst
@@ -83,6 +83,8 @@ The following methods handle plot limits, aspect ratio, grid and axes display:
 .. automethod:: PlotWidget.getGraphGrid
 .. automethod:: PlotWidget.setGraphGrid
 .. automethod:: PlotWidget.setAxesDisplayed
+.. automethod:: PlotWidget.getPlotMargins
+.. automethod:: PlotWidget.setPlotMargins
 
 Reset zoom
 ..........

--- a/doc/source/modules/gui/plot/plotwidget.rst
+++ b/doc/source/modules/gui/plot/plotwidget.rst
@@ -83,8 +83,8 @@ The following methods handle plot limits, aspect ratio, grid and axes display:
 .. automethod:: PlotWidget.getGraphGrid
 .. automethod:: PlotWidget.setGraphGrid
 .. automethod:: PlotWidget.setAxesDisplayed
-.. automethod:: PlotWidget.getPlotMargins
-.. automethod:: PlotWidget.setPlotMargins
+.. automethod:: PlotWidget.getAxesMargins
+.. automethod:: PlotWidget.setAxesMargins
 
 Reset zoom
 ..........

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -262,7 +262,7 @@ class PlotWidget(qt.QMainWindow):
 
         # Set plot margins
         self.__plotMargins = self._NO_AXES_PLOT_MARGINS
-        self.setPlotMargins(*self._DEFAULT_PLOT_MARGINS)
+        self.setAxesMargins(*self._DEFAULT_PLOT_MARGINS)
 
         self.setGraphTitle()
         self.setGraphXLabel()
@@ -2410,15 +2410,15 @@ class PlotWidget(qt.QMainWindow):
         return self._yAxis if axis == "left" else self._yRightAxis
 
     def setAxesDisplayed(self, displayed):
-        # TODO this can be deprecated in favor of setPlotMargins
+        # TODO this can be deprecated in favor of setAxesMargins
         if displayed:
-            self.setPlotMargins(*self._DEFAULT_PLOT_MARGINS)
+            self.setAxesMargins(*self._DEFAULT_PLOT_MARGINS)
         else:
-            self.setPlotMargins(*self._NO_AXES_PLOT_MARGINS)
+            self.setAxesMargins(*self._NO_AXES_PLOT_MARGINS)
 
-    @deprecated(replacement='getPlotMargins', since_version='0.14')
+    @deprecated(replacement='getAxesMargins', since_version='0.14')
     def _isAxesDisplayed(self):
-        return self._backend.getPlotMargins() != self._NO_AXES_PLOT_MARGINS
+        return self._backend.getAxesMargins() != self._NO_AXES_PLOT_MARGINS
 
     _DEFAULT_PLOT_MARGINS = .15, .1, .1, .15
     """Default values of plot margins ratios"""
@@ -2426,7 +2426,7 @@ class PlotWidget(qt.QMainWindow):
     _NO_AXES_PLOT_MARGINS = 0., 0., 0., 0.
     """Values of plot margins when there is no axes displayed"""
 
-    def setPlotMargins(
+    def setAxesMargins(
             self, left: float, top: float, right: float, bottom: float):
         """Set ratios of margins surrounding data plot area.
 
@@ -2448,12 +2448,12 @@ class PlotWidget(qt.QMainWindow):
 
         if margins != self.__plotMargins:
             self.__plotMargins = margins
-            self._backend.setPlotMargins(*margins)
+            self._backend.setAxesMargins(*margins)
             self._setDirtyPlot()
             self._sigAxesVisibilityChanged.emit(
-                self.getPlotMargins() != self._NO_AXES_PLOT_MARGINS)
+                self.getAxesMargins() != self._NO_AXES_PLOT_MARGINS)
 
-    def getPlotMargins(self):
+    def getAxesMargins(self):
         """Returns ratio of margins surrounding data plot area.
 
         :return: (left, top, right, bottom)

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -260,9 +260,9 @@ class PlotWidget(qt.QMainWindow):
         self._grid = None
         self._graphTitle = ''
 
-        # Set plot margins
-        self.__plotMargins = self._NO_AXES_PLOT_MARGINS
-        self.setAxesMargins(*self._DEFAULT_PLOT_MARGINS)
+        # Set axes margins
+        self.__axesMargins = self._NO_AXES_MARGINS
+        self.setAxesMargins(*self._DEFAULT_AXES_MARGINS)
 
         self.setGraphTitle()
         self.setGraphXLabel()
@@ -2416,17 +2416,17 @@ class PlotWidget(qt.QMainWindow):
             are not anymore visible and the margin used for them is removed.
         """
         if displayed:
-            self.setAxesMargins(*self._DEFAULT_PLOT_MARGINS)
+            self.setAxesMargins(*self._DEFAULT_AXES_MARGINS)
         else:
-            self.setAxesMargins(*self._NO_AXES_PLOT_MARGINS)
+            self.setAxesMargins(*self._NO_AXES_MARGINS)
 
     def _isAxesDisplayed(self):
-        return self._backend.getAxesMargins() != self._NO_AXES_PLOT_MARGINS
+        return self._backend.getAxesMargins() != self._NO_AXES_MARGINS
 
-    _DEFAULT_PLOT_MARGINS = .15, .1, .1, .15
+    _DEFAULT_AXES_MARGINS = .15, .1, .1, .15
     """Default values of plot margins ratios"""
 
-    _NO_AXES_PLOT_MARGINS = 0., 0., 0., 0.
+    _NO_AXES_MARGINS = 0., 0., 0., 0.
     """Values of plot margins when there is no axes displayed"""
 
     def setAxesMargins(
@@ -2449,12 +2449,12 @@ class PlotWidget(qt.QMainWindow):
             raise ValueError("Sum of ratios of opposed sides >= 1")
         margins = left, top, right, bottom
 
-        if margins != self.__plotMargins:
-            self.__plotMargins = margins
+        if margins != self.__axesMargins:
+            self.__axesMargins = margins
             self._backend.setAxesMargins(*margins)
             self._setDirtyPlot()
             self._sigAxesVisibilityChanged.emit(
-                self.getAxesMargins() != self._NO_AXES_PLOT_MARGINS)
+                self.getAxesMargins() != self._NO_AXES_MARGINS)
 
     def getAxesMargins(self):
         """Returns ratio of margins surrounding data plot area.
@@ -2462,7 +2462,7 @@ class PlotWidget(qt.QMainWindow):
         :return: (left, top, right, bottom)
         :rtype: List[float]
         """
-        return self.__plotMargins
+        return self.__axesMargins
 
     def setYAxisInverted(self, flag=True):
         """Set the Y axis orientation.

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2410,7 +2410,7 @@ class PlotWidget(qt.QMainWindow):
         assert(axis in ["left", "right"])
         return self._yAxis if axis == "left" else self._yRightAxis
 
-    def setAxesDisplayed(self, displayed):
+    def setAxesDisplayed(self, displayed: bool):
         """Display or not the axes.
 
         :param bool displayed: If `True` axes are displayed. If `False` axes
@@ -2425,7 +2425,11 @@ class PlotWidget(qt.QMainWindow):
             self._setDirtyPlot()
             self._sigAxesVisibilityChanged.emit(displayed)
 
-    def _isAxesDisplayed(self):
+    def isAxesDisplayed(self) -> bool:
+        """Returns whether or not axes are currently displayed
+
+        :rtype: bool
+        """
         return self.__axesDisplayed
 
     def setAxesMargins(
@@ -2450,7 +2454,7 @@ class PlotWidget(qt.QMainWindow):
 
         if margins != self.__axesMargins:
             self.__axesMargins = margins
-            if self._isAxesDisplayed():  # Only apply if axes are displayed
+            if self.isAxesDisplayed():  # Only apply if axes are displayed
                 self._backend.setAxesMargins(*margins)
                 self._setDirtyPlot()
 

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -2410,13 +2410,16 @@ class PlotWidget(qt.QMainWindow):
         return self._yAxis if axis == "left" else self._yRightAxis
 
     def setAxesDisplayed(self, displayed):
-        # TODO this can be deprecated in favor of setAxesMargins
+        """Display or not the axes.
+
+        :param bool displayed: If `True` axes are displayed. If `False` axes
+            are not anymore visible and the margin used for them is removed.
+        """
         if displayed:
             self.setAxesMargins(*self._DEFAULT_PLOT_MARGINS)
         else:
             self.setAxesMargins(*self._NO_AXES_PLOT_MARGINS)
 
-    @deprecated(replacement='getAxesMargins', since_version='0.14')
     def _isAxesDisplayed(self):
         return self._backend.getAxesMargins() != self._NO_AXES_PLOT_MARGINS
 

--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -313,7 +313,7 @@ class PlotWindow(PlotWidget):
 
     def _updateColorBarBackground(self):
         """Update the colorbar background according to the state of the plot"""
-        if self._isAxesDisplayed():
+        if self.isAxesDisplayed():
             color = self.getBackgroundColor()
         else:
             color = self.getDataBackgroundColor()

--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -597,7 +597,7 @@ class ShowAxisAction(PlotAction):
                             triggered=self._actionTriggered,
                             checkable=True,
                             parent=parent)
-        self.setChecked(self.plot._isAxesDisplayed())
+        self.setChecked(self.plot.isAxesDisplayed())
         plot._sigAxesVisibilityChanged.connect(self.setChecked)
 
     def _actionTriggered(self, checked=False):

--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -597,7 +597,7 @@ class ShowAxisAction(PlotAction):
                             triggered=self._actionTriggered,
                             checkable=True,
                             parent=parent)
-        self.setChecked(self.plot._backend.isAxesDisplayed())
+        self.setChecked(self.plot._isAxesDisplayed())
         plot._sigAxesVisibilityChanged.connect(self.setChecked)
 
     def _actionTriggered(self, checked=False):

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -547,7 +547,7 @@ class BackendBase(object):
         """
         raise NotImplementedError()
 
-    def setPlotMargins(self, left: float, top: float, right: float, bottom: float):
+    def setAxesMargins(self, left: float, top: float, right: float, bottom: float):
         """Set the size of plot margins as ratios.
 
         Values are expected in [0., 1.]

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -59,7 +59,6 @@ class BackendBase(object):
         self.__yAxisInverted = False
         self.__keepDataAspectRatio = False
         self._xAxisTimeZone = None
-        self._axesDisplayed = True
         # Store a weakref to get access to the plot state.
         self._setPlot(plot)
 
@@ -548,20 +547,17 @@ class BackendBase(object):
         """
         raise NotImplementedError()
 
-    def setAxesDisplayed(self, displayed):
-        """Display or not the axes.
+    def setPlotMargins(self, left: float, top: float, right: float, bottom: float):
+        """Set the size of plot margins as ratios.
 
-        :param bool displayed: If `True` axes are displayed. If `False` axes
-            are not anymore visible and the margin used for them is removed.
-        """
-        self._axesDisplayed = displayed
+        Values are expected in [0., 1.]
 
-    def isAxesDisplayed(self):
-        """private because in some case it is possible that one of the two axes
-        are displayed and not the other.
-        This only check status set to axes from the public API
+        :param float left:
+        :param float top:
+        :param float right:
+        :param float bottom:
         """
-        return self._axesDisplayed
+        pass
 
     def setForegroundColors(self, foregroundColor, gridColor):
         """Set foreground and grid colors used to display this widget.

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1240,7 +1240,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                 int(bbox.width),
                 int(bbox.height))
 
-    def setPlotMargins(self, left: float, top: float, right: float, bottom: float):
+    def setAxesMargins(self, left: float, top: float, right: float, bottom: float):
         width, height = 1. - left - right, 1. - top - bottom
         position = left, bottom, width, height
 

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1240,27 +1240,18 @@ class BackendMatplotlib(BackendBase.BackendBase):
                 int(bbox.width),
                 int(bbox.height))
 
-    def setAxesDisplayed(self, displayed):
-        """Display or not the axes.
+    def setPlotMargins(self, left: float, top: float, right: float, bottom: float):
+        width, height = 1. - left - right, 1. - top - bottom
+        position = left, bottom, width, height
 
-        :param bool displayed: If `True` axes are displayed. If `False` axes
-            are not anymore visible and the margin used for them is removed.
-        """
-        BackendBase.BackendBase.setAxesDisplayed(self, displayed)
-        if displayed:
-            # show axes and viewbox rect
-            self.ax.set_frame_on(True)
-            self.ax2.set_frame_on(True)
-            # set the default margins
-            self.ax.set_position([.15, .15, .75, .75])
-            self.ax2.set_position([.15, .15, .75, .75])
-        else:
-            # hide axes and viewbox rect
-            self.ax.set_frame_on(False)
-            self.ax2.set_frame_on(False)
-            # remove external margins
-            self.ax.set_position([0, 0, 1, 1])
-            self.ax2.set_position([0, 0, 1, 1])
+        # Toggle display of axes and viewbox rect
+        isFrameOn = position != (0., 0., 1., 1.)
+        self.ax.set_frame_on(isFrameOn)
+        self.ax2.set_frame_on(isFrameOn)
+
+        self.ax.set_position(position)
+        self.ax2.set_position(position)
+
         self._synchronizeBackgroundColors()
         self._synchronizeForegroundColors()
         self._plot._setDirtyPlot()

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1349,7 +1349,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
     def getPlotBoundsInPixels(self):
         return self._plotFrame.plotOrigin + self._plotFrame.plotSize
 
-    def setPlotMargins(self, left: float, top: float, right: float, bottom: float):
+    def setAxesMargins(self, left: float, top: float, right: float, bottom: float):
         self._plotFrame.marginRatios = left, top, right, bottom
 
     def setForegroundColors(self, foregroundColor, gridColor):

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -229,7 +229,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         self._plotFrame = glutils.GLPlotFrame2D(
             foregroundColor=(0., 0., 0., 1.),
             gridColor=(.7, .7, .7, 1.),
-            margins={'left': 100, 'right': 50, 'top': 50, 'bottom': 50})
+            marginRatios=(.15, .1, .1, .15))
 
         # Make postRedisplay asynchronous using Qt signal
         self._sigPostRedisplay.connect(
@@ -1349,9 +1349,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
     def getPlotBoundsInPixels(self):
         return self._plotFrame.plotOrigin + self._plotFrame.plotSize
 
-    def setAxesDisplayed(self, displayed):
-        BackendBase.BackendBase.setAxesDisplayed(self, displayed)
-        self._plotFrame.displayed = displayed
+    def setPlotMargins(self, left: float, top: float, right: float, bottom: float):
+        self._plotFrame.marginRatios = left, top, right, bottom
 
     def setForegroundColors(self, foregroundColor, gridColor):
         self._plotFrame.foregroundColor = foregroundColor

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -1416,6 +1416,20 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         """Test coverage on setAxesDisplayed(True)"""
         self.plot.setAxesDisplayed(True)
 
+    def testPlotMargins(self):
+        """Test PlotWidget's getPlotMargins and setPlotMargins"""
+        self.plot.show()
+        self.qWaitForWindowExposed(self.plot)
+
+        margins = self.plot.getPlotMargins()
+        self.assertEqual(margins, (.15, .1, .1, .15))
+
+        for margins in ((0., 0., 0., 0.), (.15, .1, .1, .15)):
+            with self.subTest(margins=margins):
+                self.plot.setPlotMargins(*margins)
+                self.qapp.processEvents()
+                self.assertEqual(self.plot.getPlotMargins(), margins)
+
     def testBoundingRectItem(self):
         item = BoundingRect()
         item.setBounds((-1000, 1000, -2000, 2000))

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -1416,19 +1416,19 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         """Test coverage on setAxesDisplayed(True)"""
         self.plot.setAxesDisplayed(True)
 
-    def testPlotMargins(self):
-        """Test PlotWidget's getPlotMargins and setPlotMargins"""
+    def testAxesMargins(self):
+        """Test PlotWidget's getAxesMargins and setAxesMargins"""
         self.plot.show()
         self.qWaitForWindowExposed(self.plot)
 
-        margins = self.plot.getPlotMargins()
+        margins = self.plot.getAxesMargins()
         self.assertEqual(margins, (.15, .1, .1, .15))
 
         for margins in ((0., 0., 0., 0.), (.15, .1, .1, .15)):
             with self.subTest(margins=margins):
-                self.plot.setPlotMargins(*margins)
+                self.plot.setAxesMargins(*margins)
                 self.qapp.processEvents()
-                self.assertEqual(self.plot.getPlotMargins(), margins)
+                self.assertEqual(self.plot.getAxesMargins(), margins)
 
     def testBoundingRectItem(self):
         item = BoundingRect()


### PR DESCRIPTION
This PR adds `PlotWidget.setAxesMargins(left, top, right, bottom)` and `PlotWidget.getAxesMargins` methods for controlling the margins in which the axes and labels are displayed.
It is implemented for both matplotlib and OpenGL backends.

closes #3193 
closes #2681
