### PR TITLE
Prepare v0.13.3b0: Backport selected PR, update changelog, bump version number

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Change Log
 Bug fix version:
 
 * `silx.gui.plot.PlotWidget`: Fixed time serie axis for range < 2.5 microseconds (PR #3195)
+* Documentation: Updated changelog and version number (PR #3202)
 
 0.13.2: 2020/09/15
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+0.13.3b0: 2020/09/28
+--------------------
+
+Bug fix version:
+
+* `silx.gui.plot.PlotWidget`: Fixed time serie axis for range < 2.5 microseconds (PR #3195)
+
 0.13.2: 2020/09/15
 ------------------
 

--- a/silx/gui/plot/_utils/dtime_ticklayout.py
+++ b/silx/gui/plot/_utils/dtime_ticklayout.py
@@ -330,8 +330,12 @@ def niceDateTimeElement(value, unit, isRound=False):
 def findStartDate(dMin, dMax, nTicks):
     """ Rounds a date down to the nearest nice number of ticks
     """
-    assert dMax > dMin, \
+    assert dMax >= dMin, \
         "dMin ({}) should come before dMax ({})".format(dMin, dMax)
+
+    if dMin == dMax:
+        # Fallback when range is smaller than microsecond resolution
+        return dMin, 1, DtUnit.MICRO_SECONDS
 
     delta = dMax - dMin
     lengthSec = delta.total_seconds()

--- a/silx/gui/plot/_utils/dtime_ticklayout.py
+++ b/silx/gui/plot/_utils/dtime_ticklayout.py
@@ -381,9 +381,9 @@ def dateRange(dMin, dMax, step, unit, includeFirstBeyond = False):
     """
     if (unit == DtUnit.YEARS or unit == DtUnit.MONTHS or
         unit == DtUnit.MICRO_SECONDS):
-
-        # Month and years will be converted to integers
-        assert int(step) > 0, "Integer value or tickstep is 0"
+        # No support for fractional month or year and resolution is microsecond
+        # In those cases, make sure the step is at least 1
+        step = max(1, step)
     else:
         assert step > 0, "tickstep is 0"
 

--- a/silx/gui/plot/_utils/dtime_ticklayout.py
+++ b/silx/gui/plot/_utils/dtime_ticklayout.py
@@ -166,7 +166,7 @@ def setDateElement(dateTime, value, unit):
 
 
 def roundToElement(dateTime, unit):
-    """ Returns a copy of dateTime with the
+    """ Returns a copy of dateTime rounded to given unit
 
     :param datetime.datetime: date time object
     :param DtUnit unit: unit

--- a/silx/gui/plot/_utils/dtime_ticklayout.py
+++ b/silx/gui/plot/_utils/dtime_ticklayout.py
@@ -338,7 +338,7 @@ def findStartDate(dMin, dMax, nTicks):
     _logger.debug("findStartDate: {}, {} (duration = {} sec, {} days)"
                   .format(dMin, dMax, lengthSec, lengthSec / SECONDS_PER_DAY))
 
-    length, unit = bestUnit(delta.total_seconds())
+    length, unit = bestUnit(lengthSec)
     niceLength = niceDateTimeElement(length, unit)
 
     _logger.debug("Length: {:8.3f} {} (nice = {})"

--- a/version.py
+++ b/version.py
@@ -68,8 +68,8 @@ RELEASE_LEVEL_VALUE = {"dev": 0,
 
 MAJOR = 0
 MINOR = 13
-MICRO = 2
-RELEV = "final"  # <16
+MICRO = 3
+RELEV = "beta"  # <16
 SERIAL = 0  # <16
 
 date = __date__


### PR DESCRIPTION
This PR backports PR #3195 to branch 0.13, updates the changelog and bumps version to v0.13.3b0.