### PR TITLE
silx.gui.plot.PlotWidget: Improved support of high-DPI screen in OpenGL backend

### DIFF
--- a/silx/gui/_glutils/OpenGLWidget.py
+++ b/silx/gui/_glutils/OpenGLWidget.py
@@ -329,6 +329,20 @@ class OpenGLWidget(qt.QWidget):
         else:
             return self.__openGLWidget.getDevicePixelRatio()
 
+    def getDotsPerInch(self):
+        """Returns current screen resolution as device pixels per inch.
+
+        :rtype: float
+        """
+        screen = self.window().windowHandle().screen()
+        if screen is not None:
+            # TODO check if this is correct on different OS/screen
+            # OK on macOS10.12/qt5.13.2
+            dpi = screen.physicalDotsPerInch() * self.getDevicePixelRatio()
+        else:  # Fallback
+            dpi = 96. * self.getDevicePixelRatio()
+        return dpi
+
     def getOpenGLVersion(self):
         """Returns the available OpenGL version.
 

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -400,8 +400,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             gl.glClear(gl.GL_COLOR_BUFFER_BIT | gl.GL_STENCIL_BUFFER_BIT)
 
             # Check if window is large enough
-            plotWidth, plotHeight = self.getPlotBoundsInPixels()[2:]
-            if plotWidth <= 2 or plotHeight <= 2:
+            if self._plotFrame.plotSize <= (2, 2):
                 return
 
             # Sync plot frame with window
@@ -419,7 +418,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             True to render items that are overlays.
         """
         # Values that are often used
-        plotWidth, plotHeight = self.getPlotBoundsInPixels()[2:]
+        plotWidth, plotHeight = self._plotFrame.plotSize
         isXLog = self._plotFrame.xAxis.isLog
         isYLog = self._plotFrame.yAxis.isLog
         isYInverted = self._plotFrame.isYAxisInverted
@@ -610,7 +609,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
     def _renderOverlayGL(self):
         """Render overlay layer: overlay items and crosshair."""
-        plotWidth, plotHeight = self.getPlotBoundsInPixels()[2:]
+        plotWidth, plotHeight = self._plotFrame.plotSize
 
         # Scissor to plot area
         gl.glScissor(self._plotFrame.margins.left,
@@ -663,7 +662,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
         It renders the background, grid and items except overlays
         """
-        plotWidth, plotHeight = self.getPlotBoundsInPixels()[2:]
+        plotWidth, plotHeight = self._plotFrame.plotSize
 
         gl.glScissor(self._plotFrame.margins.left,
                      self._plotFrame.margins.bottom,
@@ -1209,8 +1208,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         :param str keepDim: The dimension to maintain: 'x', 'y' or None.
             If None (the default), the dimension with the largest range.
         """
-        plotWidth, plotHeight = self.getPlotBoundsInPixels()[2:]
-        if plotWidth <= 2 or plotHeight <= 2:
+        if self._plotFrame.plotSize <= (2, 2):
             return
 
         if keepDim is None:
@@ -1358,7 +1356,9 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         return self._plotFrame.pixelToData(x, y, axis)
 
     def getPlotBoundsInPixels(self):
-        return self._plotFrame.plotOrigin + self._plotFrame.plotSize
+        devicePixelRatio = self.getDevicePixelRatio()
+        return tuple(int(value / devicePixelRatio)
+            for value in self._plotFrame.plotOrigin + self._plotFrame.plotSize)
 
     def setAxesMargins(self, left: float, top: float, right: float, bottom: float):
         self._plotFrame.marginRatios = left, top, right, bottom

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -420,6 +420,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         labels = []
         pixelOffset = 3
 
+        context = glutils.RenderContext(isXLog=isXLog, isYLog=isYLog)
+
         for plotItem in self.getItemsFromBackToFront(
                 condition=lambda i: i.isVisible() and i.isOverlay() == overlay):
             if plotItem._backendRenderer is None:
@@ -431,12 +433,12 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                 gl.glViewport(self._plotFrame.margins.left,
                               self._plotFrame.margins.bottom,
                               plotWidth, plotHeight)
-
+                # Set matrix
                 if item.yaxis == 'right':
-                    matrix = self._plotFrame.transformedDataY2ProjMat
+                    context.matrix = self._plotFrame.transformedDataY2ProjMat
                 else:
-                    matrix = self._plotFrame.transformedDataProjMat
-                item.render(matrix, isXLog, isYLog)
+                    context.matrix = self._plotFrame.transformedDataProjMat
+                item.render(context)
 
             elif isinstance(item, _ShapeItem):  # Render shape items
                 gl.glViewport(0, 0, self._plotFrame.size[0], self._plotFrame.size[1])

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -420,7 +420,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         labels = []
         pixelOffset = 3
 
-        context = glutils.RenderContext(isXLog=isXLog, isYLog=isYLog)
+        context = glutils.RenderContext(
+            isXLog=isXLog, isYLog=isYLog, dpi=self.getDotsPerInch())
 
         for plotItem in self.getItemsFromBackToFront(
                 condition=lambda i: i.isVisible() and i.isOverlay() == overlay):
@@ -1038,7 +1039,10 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         """
         offset = self._PICK_OFFSET
         if item.marker is not None:
-            offset = max(item.markerSize / 2., offset)
+            # Convert markerSize from points to qt pixels
+            qtDpi = self.getDotsPerInch() / self.getDevicePixelRatio()
+            size = item.markerSize / 72. * qtDpi
+            offset = max(size / 2., offset)
         if item.lineStyle is not None:
             offset = max(item.lineWidth / 2., offset)
 

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -404,6 +404,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             if plotWidth <= 2 or plotHeight <= 2:
                 return
 
+            # Sync plot frame with window
+            self._plotFrame.devicePixelRatio = self.getDevicePixelRatio()
             # self._paintDirectGL()
             self._paintFBOGL()
 
@@ -526,7 +528,9 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                                 item['text'], x, y,
                                 color=item['color'],
                                 bgColor=(1., 1., 1., 0.5),
-                                align=glutils.RIGHT, valign=glutils.BOTTOM)
+                                align=glutils.RIGHT,
+                                valign=glutils.BOTTOM,
+                                devicePixelRatio=self.getDevicePixelRatio())
                             labels.append(label)
 
                         width = self._plotFrame.size[0]
@@ -545,7 +549,9 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                                 item['text'], x, y,
                                 color=item['color'],
                                 bgColor=(1., 1., 1., 0.5),
-                                align=glutils.LEFT, valign=glutils.TOP)
+                                align=glutils.LEFT,
+                                valign=glutils.TOP,
+                                devicePixelRatio=self.getDevicePixelRatio())
                             labels.append(label)
 
                         height = self._plotFrame.size[1]
@@ -577,7 +583,9 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                             item['text'], x, y,
                             color=item['color'],
                             bgColor=(1., 1., 1., 0.5),
-                            align=glutils.LEFT, valign=valign)
+                            align=glutils.LEFT,
+                            valign=valign,
+                            devicePixelRatio=self.getDevicePixelRatio())
                         labels.append(label)
 
                     # For now simple implementation: using a curve for each marker

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1044,7 +1044,10 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             size = item.markerSize / 72. * qtDpi
             offset = max(size / 2., offset)
         if item.lineStyle is not None:
-            offset = max(item.lineWidth / 2., offset)
+            # Convert line width from points to qt pixels
+            qtDpi = self.getDotsPerInch() / self.getDevicePixelRatio()
+            lineWidth = item.lineWidth / 72. * qtDpi
+            offset = max(lineWidth / 2., offset)
 
         inAreaPos = self._mouseInPlotArea(x - offset, y - offset)
         dataPos = self._plot.pixelToData(inAreaPos[0], inAreaPos[1],

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -1237,7 +1237,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         :param str keepDim: The dimension to maintain: 'x', 'y' or None.
             If None (the default), the dimension with the largest range.
         """
-        if self._plotFrame.plotSize <= (2, 2):
+        plotWidth, plotHeight = self._plotFrame.plotSize
+        if plotWidth <= 2 or plotHeight <= 2:
             return
 
         if keepDim is None:

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -501,7 +501,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                         color=item['color'],
                         dash2ndColor=item['linebgcolor'],
                         width=item['linewidth'])
-                    lines.render(self.matScreenProj)
+                    context.matrix = self.matScreenProj
+                    lines.render(context)
 
             elif isinstance(item, _MarkerItem):
                 gl.glViewport(0, 0, self._plotFrame.size[0], self._plotFrame.size[1])
@@ -539,7 +540,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                             style=item['linestyle'],
                             color=item['color'],
                             width=item['linewidth'])
-                        lines.render(self.matScreenProj)
+                        context.matrix = self.matScreenProj
+                        lines.render(context)
 
                     else:  # yCoord is None: vertical line in data space
                         yRange = self._plotFrame.dataRanges[1 if yAxis == 'left' else 2]
@@ -564,7 +566,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                             style=item['linestyle'],
                             color=item['color'],
                             width=item['linewidth'])
-                        lines.render(self.matScreenProj)
+                        context.matrix = self.matScreenProj
+                        lines.render(context)
 
                 else:
                     xmin, xmax = self._plot.getXAxis().getLimits()

--- a/silx/gui/plot/backends/BackendOpenGL.py
+++ b/silx/gui/plot/backends/BackendOpenGL.py
@@ -606,7 +606,13 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                         marker=item['symbol'],
                         markerColor=item['color'],
                         markerSize=11)
-                    markerCurve.render(self.matScreenProj, False, False)
+
+                    context = glutils.RenderContext(
+                        matrix=self.matScreenProj,
+                        isXLog=False,
+                        isYLog=False,
+                        dpi=self.getDotsPerInch())
+                    markerCurve.render(context)
                     markerCurve.discard()
 
             else:

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -858,6 +858,12 @@ class _Points2D(object):
         else:
             size = self.size
         size = size / 72. * context.dpi
+
+        if self.marker in (PLUS, H_LINE, V_LINE,
+                           TICK_LEFT, TICK_RIGHT, TICK_UP, TICK_DOWN):
+            # Convert to nearest odd number
+            size = size // 2 * 2 + 1.
+
         gl.glUniform1f(program.uniforms['size'], size)
         # gl.glPointSize(self.size)
 

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -173,10 +173,10 @@ class _Fill2D(object):
 
             self._xFillVboData, self._yFillVboData = vertexBuffer(points.T)
 
-    def render(self, matrix):
+    def render(self, context):
         """Perform rendering
 
-        :param numpy.ndarray matrix: 4x4 transform matrix to use
+        :param RenderContext context:
         """
         self.prepare()
 
@@ -187,7 +187,7 @@ class _Fill2D(object):
 
         gl.glUniformMatrix4fv(
             self._PROGRAM.uniforms['matrix'], 1, gl.GL_TRUE,
-            numpy.dot(matrix,
+            numpy.dot(context.matrix,
                       mat4Translate(*self.offset)).astype(numpy.float32))
 
         gl.glUniform4f(self._PROGRAM.uniforms['color'], *self.color)
@@ -405,10 +405,10 @@ class GLLines2D(object):
         """OpenGL context initialization"""
         gl.glHint(gl.GL_LINE_SMOOTH_HINT, gl.GL_NICEST)
 
-    def render(self, matrix):
+    def render(self, context):
         """Perform rendering
 
-        :param numpy.ndarray matrix: 4x4 transform matrix to use
+        :param RenderContext context:
         """
         style = self.style
         if style is None:
@@ -467,7 +467,7 @@ class GLLines2D(object):
         if self.width != 1:
             gl.glEnable(gl.GL_LINE_SMOOTH)
 
-        matrix = numpy.dot(matrix,
+        matrix = numpy.dot(context.matrix,
                            mat4Translate(*self.offset)).astype(numpy.float32)
         gl.glUniformMatrix4fv(program.uniforms['matrix'],
                               1, gl.GL_TRUE, matrix)
@@ -834,10 +834,10 @@ class _Points2D(object):
         if majorVersion >= 3:  # OpenGL 3
             gl.glEnable(gl.GL_PROGRAM_POINT_SIZE)
 
-    def render(self, matrix):
+    def render(self, context):
         """Perform rendering
 
-        :param numpy.ndarray matrix: 4x4 transform matrix to use
+        :param RenderContext context:
         """
         if self.marker is None:
             return
@@ -845,7 +845,7 @@ class _Points2D(object):
         program = self._getProgram(self.marker)
         program.use()
 
-        matrix = numpy.dot(matrix,
+        matrix = numpy.dot(context.matrix,
                            mat4Translate(*self.offset)).astype(numpy.float32)
         gl.glUniformMatrix4fv(program.uniforms['matrix'], 1, gl.GL_TRUE, matrix)
 
@@ -1022,17 +1022,17 @@ class _ErrorBars(object):
             self._yErrPoints.yVboData.offset += (yAttrib.itemsize *
                                                  yAttrib.size // 2)
 
-    def render(self, matrix):
+    def render(self, context):
         """Perform rendering
 
-        :param numpy.ndarray matrix: 4x4 transform matrix to use
+        :param RenderContext context:
         """
         self.prepare()
 
         if self._attribs is not None:
-            self._lines.render(matrix)
-            self._xErrPoints.render(matrix)
-            self._yErrPoints.render(matrix)
+            self._lines.render(context)
+            self._xErrPoints.render(context)
+            self._yErrPoints.render(context)
 
     def discard(self):
         """Release VBOs"""
@@ -1228,10 +1228,10 @@ class GLPlotCurve2D(GLPlotItem):
         """
         self.prepare()
         if self.fill is not None:
-            self.fill.render(context.matrix)
-        self._errorBars.render(context.matrix)
-        self.lines.render(context.matrix)
-        self.points.render(context.matrix)
+            self.fill.render(context)
+        self._errorBars.render(context)
+        self.lines.render(context)
+        self.points.render(context)
 
     def discard(self):
         """Release VBOs"""

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -1221,19 +1221,17 @@ class GLPlotCurve2D(GLPlotItem):
             self.colorVboData = cAttrib
             self.useColorVboData = cAttrib is not None
 
-    def render(self, matrix, isXLog, isYLog):
+    def render(self, context):
         """Perform rendering
 
-        :param numpy.ndarray matrix: 4x4 transform matrix to use
-        :param bool isXLog:
-        :param bool isYLog:
+        :param RenderContext context: Rendering information
         """
         self.prepare()
         if self.fill is not None:
-            self.fill.render(matrix)
-        self._errorBars.render(matrix)
-        self.lines.render(matrix)
-        self.points.render(matrix)
+            self.fill.render(context.matrix)
+        self._errorBars.render(context.matrix)
+        self.lines.render(context.matrix)
+        self.points.render(context.matrix)
 
     def discard(self):
         """Release VBOs"""

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -855,6 +855,7 @@ class _Points2D(object):
             size = math.ceil(0.5 * self.size) + 1  # Mimic Matplotlib point
         else:
             size = self.size
+        size = size / 72. * context.dpi
         gl.glUniform1f(program.uniforms['size'], size)
         # gl.glPointSize(self.size)
 

--- a/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -410,6 +410,8 @@ class GLLines2D(object):
 
         :param RenderContext context:
         """
+        width = self.width / 72. * context.dpi
+
         style = self.style
         if style is None:
             return
@@ -426,7 +428,7 @@ class GLLines2D(object):
             gl.glUniform2f(program.uniforms['halfViewportSize'],
                            0.5 * viewWidth, 0.5 * viewHeight)
 
-            dashPeriod = self.dashPeriod * self.width
+            dashPeriod = self.dashPeriod * width
             if self.style == DOTTED:
                 dash = (0.2 * dashPeriod,
                         0.5 * dashPeriod,
@@ -464,7 +466,7 @@ class GLLines2D(object):
                                          0,
                                          self.distVboData)
 
-        if self.width != 1:
+        if width != 1:
             gl.glEnable(gl.GL_LINE_SMOOTH)
 
         matrix = numpy.dot(context.matrix,
@@ -504,7 +506,7 @@ class GLLines2D(object):
                                      0,
                                      self.yVboData)
 
-        gl.glLineWidth(self.width)
+        gl.glLineWidth(width)
         gl.glDrawArrays(self._drawMode, 0, self.xVboData.size)
 
         gl.glDisable(gl.GL_LINE_SMOOTH)

--- a/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -157,6 +157,12 @@ class PlotAxis(object):
             self._dirtyTicks()
 
     @property
+    def devicePixelRatio(self):
+        """Returns the ratio between qt pixels and device pixels."""
+        plotFrame = self._plotFrameRef()
+        return plotFrame.devicePixelRatio if plotFrame is not None else 1.
+
+    @property
     def title(self):
         """The text label associated with this axis as a str in latin-1."""
         return self._title
@@ -208,10 +214,9 @@ class PlotAxis(object):
         labels = []
         tickLabelsSize = [0., 0.]
 
-        plotFrame = self._plotFrameRef()
-        devicePixelRatio = plotFrame.devicePixelRatio if plotFrame is not None else 1.
-
         xTickLength, yTickLength = self._tickLength
+        xTickLength *= self.devicePixelRatio
+        yTickLength *= self.devicePixelRatio
         for (xPixel, yPixel), dataPos, text in self.ticks:
             if text is None:
                 tickScale = 0.5
@@ -224,7 +229,7 @@ class PlotAxis(object):
                                y=yPixel - yTickLength,
                                align=self._labelAlign,
                                valign=self._labelVAlign,
-                               devicePixelRatio=devicePixelRatio)
+                               devicePixelRatio=self.devicePixelRatio)
 
                 width, height = label.size
                 if width > tickLabelsSize[0]:
@@ -258,7 +263,7 @@ class PlotAxis(object):
                            align=self._titleAlign,
                            valign=self._titleVAlign,
                            rotate=self._titleRotate,
-                           devicePixelRatio=devicePixelRatio)
+                           devicePixelRatio=self.devicePixelRatio)
         labels.append(axisTitle)
 
         return vertices, labels
@@ -331,7 +336,7 @@ class PlotAxis(object):
                 xScale = (x1 - x0) / (dataMax - dataMin)
                 yScale = (y1 - y0) / (dataMax - dataMin)
 
-                nbPixels = math.sqrt(pow(x1 - x0, 2) + pow(y1 - y0, 2))
+                nbPixels = math.sqrt(pow(x1 - x0, 2) + pow(y1 - y0, 2)) / self.devicePixelRatio
 
                 # Density of 1.3 label per 92 pixels
                 # i.e., 1.3 label per inch on a 92 dpi screen

--- a/silx/gui/plot/backends/glutils/GLPlotImage.py
+++ b/silx/gui/plot/backends/glutils/GLPlotImage.py
@@ -388,7 +388,11 @@ class GLPlotColormap(_GLPlotData2D):
 
         self._cmap_texture.bind()
 
-    def _renderLinear(self, matrix):
+    def _renderLinear(self, context):
+        """Perform rendering when both axes have linear scales
+
+        :param RenderContext context: Rendering information
+        """
         self.prepare()
 
         prog = self._linearProgram
@@ -396,7 +400,7 @@ class GLPlotColormap(_GLPlotData2D):
 
         gl.glUniform1i(prog.uniforms['data'], self._DATA_TEX_UNIT)
 
-        mat = numpy.dot(numpy.dot(matrix,
+        mat = numpy.dot(numpy.dot(context.matrix,
                                   mat4Translate(*self.origin)),
                         mat4Scale(*self.scale))
         gl.glUniformMatrix4fv(prog.uniforms['matrix'], 1, gl.GL_TRUE,
@@ -410,10 +414,14 @@ class GLPlotColormap(_GLPlotData2D):
                              prog.attributes['texCoords'],
                              self._DATA_TEX_UNIT)
 
-    def _renderLog10(self, matrix, isXLog, isYLog):
+    def _renderLog10(self, context):
+        """Perform rendering when one axis has log scale
+
+        :param RenderContext context: Rendering information
+        """
         xMin, yMin = self.xMin, self.yMin
-        if ((isXLog and xMin < FLOAT32_MINPOS) or
-                (isYLog and yMin < FLOAT32_MINPOS)):
+        if ((context.isXLog and xMin < FLOAT32_MINPOS) or
+                (context.isYLog and yMin < FLOAT32_MINPOS)):
             # Do not render images that are partly or totally <= 0
             return
 
@@ -427,12 +435,12 @@ class GLPlotColormap(_GLPlotData2D):
         gl.glUniform1i(prog.uniforms['data'], self._DATA_TEX_UNIT)
 
         gl.glUniformMatrix4fv(prog.uniforms['matrix'], 1, gl.GL_TRUE,
-                              matrix.astype(numpy.float32))
+                              context.matrix.astype(numpy.float32))
         mat = numpy.dot(mat4Translate(ox, oy), mat4Scale(*self.scale))
         gl.glUniformMatrix4fv(prog.uniforms['matOffset'], 1, gl.GL_TRUE,
                               mat.astype(numpy.float32))
 
-        gl.glUniform2i(prog.uniforms['isLog'], isXLog, isYLog)
+        gl.glUniform2i(prog.uniforms['isLog'], context.isXLog, context.isYLog)
 
         ex = ox + self.scale[0] * self.data.shape[1]
         ey = oy + self.scale[1] * self.data.shape[0]
@@ -471,11 +479,15 @@ class GLPlotColormap(_GLPlotData2D):
 
         gl.glDrawArrays(gl.GL_TRIANGLE_STRIP, 0, len(vertices))
 
-    def render(self, matrix, isXLog, isYLog):
-        if any((isXLog, isYLog)):
-            self._renderLog10(matrix, isXLog, isYLog)
+    def render(self, context):
+        """Perform rendering
+
+        :param RenderContext context: Rendering information
+        """
+        if any((context.isXLog, context.isYLog)):
+            self._renderLog10(context)
         else:
-            self._renderLinear(matrix)
+            self._renderLinear(context)
 
         # Unbind colormap texture
         gl.glActiveTexture(gl.GL_TEXTURE0 + self._cmap_texture.texUnit)
@@ -645,7 +657,11 @@ class GLPlotRGBAImage(_GLPlotData2D):
             format_ = gl.GL_RGBA if self.data.shape[2] == 4 else gl.GL_RGB
             self._texture.updateAll(format_=format_, data=self.data)
 
-    def _renderLinear(self, matrix):
+    def _renderLinear(self, context):
+        """Perform rendering with both axes having linear scales
+
+        :param RenderContext context: Rendering information
+        """
         self.prepare()
 
         prog = self._linearProgram
@@ -653,7 +669,7 @@ class GLPlotRGBAImage(_GLPlotData2D):
 
         gl.glUniform1i(prog.uniforms['tex'], self._DATA_TEX_UNIT)
 
-        mat = numpy.dot(numpy.dot(matrix, mat4Translate(*self.origin)),
+        mat = numpy.dot(numpy.dot(context.matrix, mat4Translate(*self.origin)),
                         mat4Scale(*self.scale))
         gl.glUniformMatrix4fv(prog.uniforms['matrix'], 1, gl.GL_TRUE,
                               mat.astype(numpy.float32))
@@ -664,7 +680,11 @@ class GLPlotRGBAImage(_GLPlotData2D):
                              prog.attributes['texCoords'],
                              self._DATA_TEX_UNIT)
 
-    def _renderLog(self, matrix, isXLog, isYLog):
+    def _renderLog(self, context):
+        """Perform rendering with axes having log scale
+
+        :param RenderContext context: Rendering information
+        """
         self.prepare()
 
         prog = self._logProgram
@@ -675,12 +695,12 @@ class GLPlotRGBAImage(_GLPlotData2D):
         gl.glUniform1i(prog.uniforms['tex'], self._DATA_TEX_UNIT)
 
         gl.glUniformMatrix4fv(prog.uniforms['matrix'], 1, gl.GL_TRUE,
-                              matrix.astype(numpy.float32))
+                              context.matrix.astype(numpy.float32))
         mat = numpy.dot(mat4Translate(ox, oy), mat4Scale(*self.scale))
         gl.glUniformMatrix4fv(prog.uniforms['matOffset'], 1, gl.GL_TRUE,
                               mat.astype(numpy.float32))
 
-        gl.glUniform2i(prog.uniforms['isLog'], isXLog, isYLog)
+        gl.glUniform2i(prog.uniforms['isLog'], context.isXLog, context.isYLog)
 
         gl.glUniform1f(prog.uniforms['alpha'], self.alpha)
 
@@ -717,8 +737,12 @@ class GLPlotRGBAImage(_GLPlotData2D):
 
         gl.glDrawArrays(gl.GL_TRIANGLE_STRIP, 0, len(vertices))
 
-    def render(self, matrix, isXLog, isYLog):
-        if any((isXLog, isYLog)):
-            self._renderLog(matrix, isXLog, isYLog)
+    def render(self, context):
+        """Perform rendering
+
+        :param RenderContext context: Rendering information
+        """
+        if any((context.isXLog, context.isYLog)):
+            self._renderLog(context)
         else:
-            self._renderLinear(matrix)
+            self._renderLinear(context)

--- a/silx/gui/plot/backends/glutils/GLPlotItem.py
+++ b/silx/gui/plot/backends/glutils/GLPlotItem.py
@@ -40,7 +40,7 @@ class RenderContext:
     :param float dpi: Number of device pixels per inch
     """
 
-    def __init__(self, matrix=None, isXLog=False, isYLog=False, dpi=90.):
+    def __init__(self, matrix=None, isXLog=False, isYLog=False, dpi=96.):
         self.matrix = matrix
         """Current transformation matrix"""
 

--- a/silx/gui/plot/backends/glutils/GLPlotItem.py
+++ b/silx/gui/plot/backends/glutils/GLPlotItem.py
@@ -37,14 +37,16 @@ class RenderContext:
     :param numpy.ndarray matrix: 4x4 transform matrix to use for rendering
     :param bool isXLog: Whether X axis is log scale or not
     :param bool isYLog: Whether Y axis is log scale or not
+    :param float dpi: Number of device pixels per inch
     """
 
-    def __init__(self, matrix=None, isXLog=False, isYLog=False):
+    def __init__(self, matrix=None, isXLog=False, isYLog=False, dpi=90.):
         self.matrix = matrix
         """Current transformation matrix"""
 
         self.__isXLog = isXLog
         self.__isYLog = isYLog
+        self.__dpi = dpi
 
     @property
     def isXLog(self):
@@ -55,6 +57,11 @@ class RenderContext:
     def isYLog(self):
         """True if Y axis is using log scale"""
         return self.__isYLog
+
+    @property
+    def dpi(self):
+        """Number of device pixels per inch"""
+        return self.__dpi
 
 
 class GLPlotItem:

--- a/silx/gui/plot/backends/glutils/GLPlotItem.py
+++ b/silx/gui/plot/backends/glutils/GLPlotItem.py
@@ -31,6 +31,32 @@ __license__ = "MIT"
 __date__ = "02/07/2020"
 
 
+class RenderContext:
+    """Context with which to perform OpenGL rendering.
+
+    :param numpy.ndarray matrix: 4x4 transform matrix to use for rendering
+    :param bool isXLog: Whether X axis is log scale or not
+    :param bool isYLog: Whether Y axis is log scale or not
+    """
+
+    def __init__(self, matrix=None, isXLog=False, isYLog=False):
+        self.matrix = matrix
+        """Current transformation matrix"""
+
+        self.__isXLog = isXLog
+        self.__isYLog = isYLog
+
+    @property
+    def isXLog(self):
+        """True if X axis is using log scale"""
+        return self.__isXLog
+
+    @property
+    def isYLog(self):
+        """True if Y axis is using log scale"""
+        return self.__isYLog
+
+
 class GLPlotItem:
     """Base class for primitives used in the PlotWidget OpenGL backend"""
 
@@ -49,12 +75,10 @@ class GLPlotItem:
         """
         return None
 
-    def render(self, matrix, isXLog, isYLog):
+    def render(self, context):
         """Performs OpenGL rendering of the item.
 
-        :param numpy.ndarray matrix: 4x4 transform matrix to use for rendering
-        :param bool isXLog: Whether X axis is log scale or not
-        :param bool isYLog: Whether Y axis is log scale or not
+        :param RenderContext context: Rendering context information
         """
         pass
 

--- a/silx/gui/plot/backends/glutils/GLPlotTriangles.py
+++ b/silx/gui/plot/backends/glutils/GLPlotTriangles.py
@@ -163,12 +163,10 @@ class GLPlotTriangles(GLPlotItem):
                 usage=gl.GL_STATIC_DRAW,
                 target=gl.GL_ELEMENT_ARRAY_BUFFER)
 
-    def render(self, matrix, isXLog, isYLog):
+    def render(self, context):
         """Perform rendering
 
-        :param numpy.ndarray matrix: 4x4 transform matrix to use
-        :param bool isXLog:
-        :param bool isYLog:
+        :param RenderContext context: Rendering information
         """
         self.prepare()
 
@@ -180,7 +178,7 @@ class GLPlotTriangles(GLPlotItem):
         gl.glUniformMatrix4fv(self._PROGRAM.uniforms['matrix'],
                               1,
                               gl.GL_TRUE,
-                              matrix.astype(numpy.float32))
+                              context.matrix.astype(numpy.float32))
 
         gl.glUniform1f(self._PROGRAM.uniforms['alpha'], self.__alpha)
 

--- a/silx/gui/plot/backends/glutils/__init__.py
+++ b/silx/gui/plot/backends/glutils/__init__.py
@@ -39,7 +39,7 @@ _logger = logging.getLogger(__name__)
 from .GLPlotCurve import *  # noqa
 from .GLPlotFrame import *  # noqa
 from .GLPlotImage import *  # noqa
-from .GLPlotItem import GLPlotItem  # noqa
+from .GLPlotItem import GLPlotItem, RenderContext  # noqa
 from .GLPlotTriangles import GLPlotTriangles  # noqa
 from .GLSupport import *  # noqa
 from .GLText import *  # noqa


### PR DESCRIPTION
This PR reworks the `PlotWidget` OpenGL backend with a goal to improve high DPI screen support by taking into account the `devicePixelRatio` between Qt "logical" pixel and "device" pixel.

WIth this PR:
- Text is displayed with a similar size on high-dpi and standard dpi screens.
- Marker size and line width is defined in points rather than screen pixels.

closes #789
closes #2773
closes #2914

This required some internal restructuring, so rendering is now passing a `RenderContext` object for providing condition of the rendering to backend items.
It adds an `OpenGLWidget.getDotsPerInch` method.

Changelog: 
- silx.gui.plot.PlotWidget: Improved support of high-DPI screen in OpenGL backend
- silx.gui.plot.PlotWidget: Use points rather than pixels for marker size and line width with OpenGL backend