### PR TITLE
silx.gui.plot3d: Fixed handling of transparency of cut plane

### DIFF
--- a/silx/gui/plot3d/scene/cutplane.py
+++ b/silx/gui/plot3d/scene/cutplane.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -88,7 +88,7 @@ class ColormapMesh3D(Geometry):
 
         float value = texture3D(data, vTexCoords).r;
         vec4 color = $colormapCall(value);
-        color.a = alpha;
+        color.a *= alpha;
 
         gl_FragColor = $lightingCall(color, vPosition, vNormal);
 


### PR DESCRIPTION
This PR fixes a typo in the handling of transparency: Both alpha and transparency of the colormap should be taken into account.