### PR TITLE
silx.gui: Added lazy update handling of OpenGL textures

### DIFF
--- a/silx/gui/_glutils/FramebufferTexture.py
+++ b/silx/gui/_glutils/FramebufferTexture.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -62,6 +62,7 @@ class FramebufferTexture(object):
                  **kwargs):
 
         self._texture = Texture(internalFormat, shape=shape, **kwargs)
+        self._texture.prepare()
 
         self._previousFramebuffer = 0  # Used by with statement
 

--- a/silx/gui/_glutils/Texture.py
+++ b/silx/gui/_glutils/Texture.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -81,20 +81,23 @@ class Texture(object):
             else:
                 shape = data.shape
 
+        self._deferredUpdates = [(format_, data, None)]
+
         assert len(shape) in (2, 3)
         self._shape = tuple(shape)
         self._ndim = len(shape)
 
         self.texUnit = texUnit
 
-        self._name = gl.glGenTextures(1)
-        self.bind(self.texUnit)
+        self._texParameterUpdates = {}  # Store texture params to update
 
-        self._minFilter = None
-        self.minFilter = minFilter if minFilter is not None else gl.GL_NEAREST
+        self._minFilter = minFilter if minFilter is not None else gl.GL_NEAREST
+        self._texParameterUpdates[gl.GL_TEXTURE_MIN_FILTER] = self._minFilter
 
-        self._magFilter = None
-        self.magFilter = magFilter if magFilter is not None else gl.GL_LINEAR
+        self._magFilter = magFilter if magFilter is not None else gl.GL_LINEAR
+        self._texParameterUpdates[gl.GL_TEXTURE_MAG_FILTER] = self._magFilter
+
+        self._name = None  # Store texture ID
 
         if wrap is not None:
             if not isinstance(wrap, abc.Iterable):
@@ -102,69 +105,10 @@ class Texture(object):
 
             assert len(wrap) == self.ndim
 
-            gl.glTexParameter(self.target,
-                              gl.GL_TEXTURE_WRAP_S,
-                              wrap[-1])
-            gl.glTexParameter(self.target,
-                              gl.GL_TEXTURE_WRAP_T,
-                              wrap[-2])
+            self._texParameterUpdates[gl.GL_TEXTURE_WRAP_S] = wrap[-1]
+            self._texParameterUpdates[gl.GL_TEXTURE_WRAP_T] = wrap[-2]
             if self.ndim == 3:
-                gl.glTexParameter(self.target,
-                                  gl.GL_TEXTURE_WRAP_R,
-                                  wrap[0])
-
-        gl.glPixelStorei(gl.GL_UNPACK_ALIGNMENT, 1)
-
-        # This are the defaults, useless to set if not modified
-        # gl.glPixelStorei(gl.GL_UNPACK_ROW_LENGTH, 0)
-        # gl.glPixelStorei(gl.GL_UNPACK_SKIP_PIXELS, 0)
-        # gl.glPixelStorei(gl.GL_UNPACK_SKIP_ROWS, 0)
-        # gl.glPixelStorei(gl.GL_UNPACK_IMAGE_HEIGHT, 0)
-        # gl.glPixelStorei(gl.GL_UNPACK_SKIP_IMAGES, 0)
-
-        if data is None:
-            data = c_void_p(0)
-            type_ = gl.GL_UNSIGNED_BYTE
-        else:
-            type_ = utils.numpyToGLType(data.dtype)
-
-        if self.ndim == 2:
-            _logger.debug(
-                'Creating 2D texture shape: (%d, %d),'
-                ' internal format: %s, format: %s, type: %s',
-                self.shape[0], self.shape[1],
-                str(self.internalFormat), str(format_), str(type_))
-
-            gl.glTexImage2D(
-                gl.GL_TEXTURE_2D,
-                0,
-                self.internalFormat,
-                self.shape[1],
-                self.shape[0],
-                0,
-                format_,
-                type_,
-                data)
-        else:
-            _logger.debug(
-                'Creating 3D texture shape: (%d, %d, %d),'
-                ' internal format: %s, format: %s, type: %s',
-                self.shape[0], self.shape[1], self.shape[2],
-                str(self.internalFormat), str(format_), str(type_))
-
-            gl.glTexImage3D(
-                gl.GL_TEXTURE_3D,
-                0,
-                self.internalFormat,
-                self.shape[2],
-                self.shape[1],
-                self.shape[0],
-                0,
-                format_,
-                type_,
-                data)
-
-        gl.glBindTexture(self.target, 0)
+                self._texParameterUpdates[gl.GL_TEXTURE_WRAP_R] = wrap[0]
 
     @property
     def target(self):
@@ -188,12 +132,11 @@ class Texture(object):
 
     @property
     def name(self):
-        """OpenGL texture name"""
-        if self._name is not None:
-            return self._name
-        else:
-            raise RuntimeError(
-                "No OpenGL texture resource, discard has already been called")
+        """OpenGL texture name.
+
+        It is None if not initialized or already discarded.
+        """
+        return self._name
 
     @property
     def minFilter(self):
@@ -204,10 +147,7 @@ class Texture(object):
     def minFilter(self, minFilter):
         if minFilter != self.minFilter:
             self._minFilter = minFilter
-            self.bind()
-            gl.glTexParameter(self.target,
-                              gl.GL_TEXTURE_MIN_FILTER,
-                              self.minFilter)
+            self._texParameterUpdates[gl.GL_TEXTURE_MIN_FILTER] = minFilter
 
     @property
     def magFilter(self):
@@ -218,20 +158,112 @@ class Texture(object):
     def magFilter(self, magFilter):
         if magFilter != self.magFilter:
             self._magFilter = magFilter
-            self.bind()
-            gl.glTexParameter(self.target,
-                              gl.GL_TEXTURE_MAG_FILTER,
-                              self.magFilter)
+            self._texParameterUpdates[gl.GL_TEXTURE_MAG_FILTER] = magFilter
 
-    def discard(self):
-        """Delete associated OpenGL texture"""
-        if self._name is not None:
-            gl.glDeleteTextures(self._name)
-            self._name = None
-        else:
-            _logger.warning("Discard as already been called")
+    def _isPrepareRequired(self) -> bool:
+        """Returns True if OpenGL texture needs to be updated.
 
-    def bind(self, texUnit=None):
+        :rtype: bool
+        """
+        return (self._name is None or
+                self._texParameterUpdates or
+                self._deferredUpdates)
+
+    def _prepareAndBind(self, texUnit=None):
+        """Synchronizes the OpenGL texture"""
+        if self._name is None:
+            self._name = gl.glGenTextures(1)
+
+        self._bind(texUnit)
+
+        # Synchronizes texture parameters
+        for pname, param in self._texParameterUpdates.items():
+            gl.glTexParameter(self.target, pname, param)
+        self._texParameterUpdates = {}
+
+        # Copy data to texture
+        for format_, data, offset in self._deferredUpdates:
+            gl.glPixelStorei(gl.GL_UNPACK_ALIGNMENT, 1)
+
+            # This are the defaults, useless to set if not modified
+            # gl.glPixelStorei(gl.GL_UNPACK_ROW_LENGTH, 0)
+            # gl.glPixelStorei(gl.GL_UNPACK_SKIP_PIXELS, 0)
+            # gl.glPixelStorei(gl.GL_UNPACK_SKIP_ROWS, 0)
+            # gl.glPixelStorei(gl.GL_UNPACK_IMAGE_HEIGHT, 0)
+            # gl.glPixelStorei(gl.GL_UNPACK_SKIP_IMAGES, 0)
+
+            if data is None:
+                data = c_void_p(0)
+                type_ = gl.GL_UNSIGNED_BYTE
+            else:
+                type_ = utils.numpyToGLType(data.dtype)
+
+            if offset is None:  # Initialize texture
+                if self.ndim == 2:
+                    _logger.debug(
+                        'Creating 2D texture shape: (%d, %d),'
+                        ' internal format: %s, format: %s, type: %s',
+                        self.shape[0], self.shape[1],
+                        str(self.internalFormat), str(format_), str(type_))
+
+                    gl.glTexImage2D(
+                        gl.GL_TEXTURE_2D,
+                        0,
+                        self.internalFormat,
+                        self.shape[1],
+                        self.shape[0],
+                        0,
+                        format_,
+                        type_,
+                        data)
+
+                else:
+                    _logger.debug(
+                        'Creating 3D texture shape: (%d, %d, %d),'
+                        ' internal format: %s, format: %s, type: %s',
+                        self.shape[0], self.shape[1], self.shape[2],
+                        str(self.internalFormat), str(format_), str(type_))
+
+                    gl.glTexImage3D(
+                        gl.GL_TEXTURE_3D,
+                        0,
+                        self.internalFormat,
+                        self.shape[2],
+                        self.shape[1],
+                        self.shape[0],
+                        0,
+                        format_,
+                        type_,
+                        data)
+
+            else:  # Update already existing texture
+                if self.ndim == 2:
+                    gl.glTexSubImage2D(gl.GL_TEXTURE_2D,
+                                       0,
+                                       offset[1],
+                                       offset[0],
+                                       data.shape[1],
+                                       data.shape[0],
+                                       format_,
+                                       type_,
+                                       data)
+
+                else:
+                    gl.glTexSubImage3D(gl.GL_TEXTURE_3D,
+                                       0,
+                                       offset[2],
+                                       offset[1],
+                                       offset[0],
+                                       data.shape[2],
+                                       data.shape[1],
+                                       data.shape[0],
+                                       format_,
+                                       type_,
+                                       data)
+
+        self._deferredUpdates = []
+
+    def _bind(self, texUnit=None):
         """Bind the texture to a texture unit.
 
         :param int texUnit: The texture unit to use
@@ -241,73 +273,80 @@ class Texture(object):
         gl.glActiveTexture(gl.GL_TEXTURE0 + texUnit)
         gl.glBindTexture(self.target, self.name)
 
+    def _unbind(self, texUnit=None):
+        """Reset texture binding to a texture unit.
+
+        :param int texUnit: The texture unit to use
+        """
+        if texUnit is None:
+            texUnit = self.texUnit
+        gl.glActiveTexture(gl.GL_TEXTURE0 + texUnit)
+        gl.glBindTexture(self.target, 0)
+
+    def prepare(self):
+        """Synchronizes the OpenGL texture.
+
+        This method must be called with a current OpenGL context.
+        """
+        if self._isPrepareRequired():
+            self._prepareAndBind()
+            self._unbind()
+
+    def bind(self, texUnit=None):
+        """Bind the texture to a texture unit.
+
+        The OpenGL texture is updated if needed.
+
+        This method must be called with a current OpenGL context.
+
+        :param int texUnit: The texture unit to use
+        """
+        if self._isPrepareRequired():
+            self._prepareAndBind(texUnit)
+        else:
+            self._bind(texUnit)
+
+    def discard(self):
+        """Delete associated OpenGL texture.
+
+        This method must be called with a current OpenGL context.
+        """
+        if self._name is not None:
+            gl.glDeleteTextures(self._name)
+            self._name = None
+        else:
+            _logger.warning("Texture not initialized or already discarded")
+
     # with statement
 
     def __enter__(self):
         self.bind()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        gl.glActiveTexture(gl.GL_TEXTURE0 + self.texUnit)
-        gl.glBindTexture(self.target, 0)
+        self._unbind()
 
-    def update(self,
-               format_,
-               data,
-               offset=(0, 0, 0),
-               texUnit=None):
+    def update(self, format_, data, offset=(0, 0, 0), copy=True):
         """Update the content of the texture.
 
         Texture is not resized, so data must fit into texture with the
         given offset.
 
+        This update is performed lazily during next call to
+        :meth:`prepare` or :meth:`bind`.
+        Data MUST not be changed until then.
+
         :param format_: The OpenGL format of the data
         :param data: The data to use to update the texture
-        :param offset: The offset in the texture where to copy the data
-        :type offset: List[int]
-        :param int texUnit:
-            The texture unit to use (default: the one provided at init)
+        :param List[int] offset: Offset in the texture where to copy the data
+        :param bool copy:
+            True (default) to copy data, False to use as is (do not modify)
         """
-        data = numpy.array(data, copy=False, order='C')
+        data = numpy.array(data, copy=copy, order='C')
+        offset = tuple(offset)
 
         assert data.ndim == self.ndim
         assert len(offset) >= self.ndim
         for i in range(self.ndim):
             assert offset[i] + data.shape[i] <= self.shape[i]
 
-        gl.glPixelStorei(gl.GL_UNPACK_ALIGNMENT, 1)
-
-        # This are the defaults, useless to set if not modified
-        # gl.glPixelStorei(gl.GL_UNPACK_ROW_LENGTH, 0)
-        # gl.glPixelStorei(gl.GL_UNPACK_SKIP_PIXELS, 0)
-        # gl.glPixelStorei(gl.GL_UNPACK_SKIP_ROWS, 0)
-        # gl.glPixelStorei(gl.GL_UNPACK_IMAGE_HEIGHT, 0)
-        # gl.glPixelStorei(gl.GL_UNPACK_SKIP_IMAGES, 0)
-
-        self.bind(texUnit)
-
-        type_ = utils.numpyToGLType(data.dtype)
-
-        if self.ndim == 2:
-            gl.glTexSubImage2D(gl.GL_TEXTURE_2D,
-                               0,
-                               offset[1],
-                               offset[0],
-                               data.shape[1],
-                               data.shape[0],
-                               format_,
-                               type_,
-                               data)
-            gl.glBindTexture(gl.GL_TEXTURE_2D, 0)
-        else:
-            gl.glTexSubImage3D(gl.GL_TEXTURE_3D,
-                               0,
-                               offset[2],
-                               offset[1],
-                               offset[0],
-                               data.shape[2],
-                               data.shape[1],
-                               data.shape[0],
-                               format_,
-                               type_,
-                               data)
-            gl.glBindTexture(gl.GL_TEXTURE_3D, 0)
+        self._deferredUpdates.append((format_, data, offset))

--- a/silx/gui/plot/backends/glutils/GLPlotImage.py
+++ b/silx/gui/plot/backends/glutils/GLPlotImage.py
@@ -332,6 +332,7 @@ class GLPlotColormap(_GLPlotData2D):
                                          magFilter=gl.GL_NEAREST,
                                          wrap=(gl.GL_CLAMP_TO_EDGE,
                                                gl.GL_CLAMP_TO_EDGE))
+            self._cmap_texture.prepare()
 
         if self._texture is None:
             internalFormat = self._INTERNAL_FORMATS[self.data.dtype]

--- a/silx/gui/plot/backends/glutils/GLText.py
+++ b/silx/gui/plot/backends/glutils/GLText.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -174,14 +174,15 @@ class Text2D(object):
             if text not in self._sizes:
                 self._sizes[text] = image.shape[1], image.shape[0]
 
-            textures[text] = (
-                Texture(gl.GL_RED,
-                        data=image,
-                        minFilter=gl.GL_NEAREST,
-                        magFilter=gl.GL_NEAREST,
-                        wrap=(gl.GL_CLAMP_TO_EDGE,
-                              gl.GL_CLAMP_TO_EDGE)),
-                offset)
+            texture = Texture(
+                gl.GL_RED,
+                data=image,
+                minFilter=gl.GL_NEAREST,
+                magFilter=gl.GL_NEAREST,
+                wrap=(gl.GL_CLAMP_TO_EDGE,
+                      gl.GL_CLAMP_TO_EDGE))
+            texture.prepare()
+            textures[text] = texture, offset
 
         return textures[text]
 

--- a/silx/gui/plot/backends/glutils/GLTexture.py
+++ b/silx/gui/plot/backends/glutils/GLTexture.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -98,6 +98,7 @@ class Image(object):
                               minFilter=self._MIN_FILTER,
                               magFilter=self._MAG_FILTER,
                               wrap=self._WRAP)
+            texture.prepare()
             vertices = numpy.array((
                 (0., 0., 0., 0.),
                 (self.width, 0., 1., 0.),
@@ -177,6 +178,7 @@ class Image(object):
                         (xOrig, yOrig + hData, 0., vMax),
                         (xOrig + wData, yOrig + hData, uMax, vMax)),
                         dtype=numpy.float32)
+                    texture.prepare()
                     tiles.append((texture, vertices,
                                   {'xOrigData': xOrig, 'yOrigData': yOrig,
                                    'wData': wData, 'hData': hData}))
@@ -203,6 +205,7 @@ class Image(object):
                 texture.update(format_,
                                data[yOrig:yOrig+height, xOrig:xOrig+width],
                                texUnit=texUnit)
+                texture.prepare()
                 # TODO check
                 # width=info['wData'], height=info['hData'],
                 # texUnit=texUnit, unpackAlign=unpackAlign,

--- a/silx/gui/plot3d/scene/primitives.py
+++ b/silx/gui/plot3d/scene/primitives.py
@@ -49,7 +49,7 @@ from . import event
 from . import core
 from . import transform
 from . import utils
-from .function import Colormap, Fog
+from .function import Colormap
 
 _logger = logging.getLogger(__name__)
 
@@ -367,7 +367,7 @@ class Geometry(core.Elem):
                     min_ = numpy.nanmin(attribute, axis=0)
                     max_ = numpy.nanmax(attribute, axis=0)
                 else:
-                     min_, max_ = numpy.zeros((2, attribute.shape[1]), dtype=numpy.float32)
+                    min_, max_ = numpy.zeros((2, attribute.shape[1]), dtype=numpy.float32)
 
                 toCopy = min(len(min_), 3-index)
                 if toCopy != len(min_):

--- a/silx/gui/plot3d/scene/text.py
+++ b/silx/gui/plot3d/scene/text.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -251,6 +251,7 @@ class Text2D(primitives.Geometry):
                     minFilter=gl.GL_NEAREST,
                     magFilter=gl.GL_NEAREST,
                     wrap=gl.GL_CLAMP_TO_EDGE)
+                self._texture.prepare()
                 self._dirtyAlign = True  # To force update of offset
 
         if self._dirtyAlign:


### PR DESCRIPTION
This PR reworks the way OpenGL textures are managed through the `Texture` class by enabling lazy updates.
This does not provide additional publicly available feature, but it is really convenient for extensions requiring direct control over the texture.