### PR TITLE
use Python3 for all developer tools

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python3
+# coding: utf8
 """
 Bootstrap helps you to test scripts without installing them
 by patching your PYTHONPATH on the fly
@@ -10,8 +10,7 @@ example: ./bootstrap.py ipython
 __authors__ = ["Frédéric-Emmanuel Picca", "Jérôme Kieffer"]
 __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"
-__date__ = "26/07/2018"
-
+__date__ = "30/09/2020"
 
 import argparse
 import distutils.util
@@ -20,7 +19,6 @@ import os
 import subprocess
 import sys
 import tempfile
-
 
 logging.basicConfig()
 logger = logging.getLogger("bootstrap")
@@ -69,6 +67,7 @@ def _get_available_scripts(path):
 
 
 if sys.version_info[0] >= 3:  # Python3
+
     def execfile(fullpath, globals=None, locals=None):
         "Python3 implementation for execfile"
         with open(fullpath) as f:

--- a/run_tests.py
+++ b/run_tests.py
@@ -1,8 +1,8 @@
-#!/usr/bin/env python
-# coding: utf-8
+#!/usr/bin/env python3
+# coding: utf8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,7 @@ Test coverage dependencies: coverage, lxml.
 """
 
 __authors__ = ["Jérôme Kieffer", "Thomas Vincent"]
-__date__ = "02/03/2018"
+__date__ = "30/09/2020"
 __license__ = "MIT"
 
 import distutils.util
@@ -87,7 +87,6 @@ logger.setLevel(logging.WARNING)
 
 logger.info("Python %s %s", sys.version, tuple.__itemsize__ * 8)
 
-
 try:
     import resource
 except ImportError:
@@ -98,6 +97,7 @@ try:
     import importlib
     importer = importlib.import_module
 except ImportError:
+
     def importer(name):
         module = __import__(name)
         # returns the leaf module, instead of the root module
@@ -106,7 +106,6 @@ except ImportError:
         for subname in subnames:
             module = getattr(module, subname)
             return module
-
 
 try:
     import numpy
@@ -350,10 +349,8 @@ if __name__ == "__main__":  # Needed for multiprocessing support on Windows
     PROJECT_VERSION = getattr(project_module, 'version', '')
     PROJECT_PATH = project_module.__path__[0]
 
-
     test_options = get_test_options(project_module)
     """Contains extra configuration for the tests."""
-
 
     epilog = """Environment variables:
     WITH_QT_TEST=False to disable graphical tests
@@ -392,7 +389,6 @@ if __name__ == "__main__":  # Needed for multiprocessing support on Windows
                         help="Test names to run (Default: %s)" % default_test_name)
     options = parser.parse_args()
     sys.argv = [sys.argv[0]]
-
 
     test_verbosity = 1
     use_buffer = True
@@ -467,7 +463,6 @@ if __name__ == "__main__":  # Needed for multiprocessing support on Windows
     else:
         logger.warning("No test options available.")
 
-
     if not options.test_name:
         # Do not use test loader to avoid cryptic exception
         # when an error occur during import
@@ -486,7 +481,6 @@ if __name__ == "__main__":  # Needed for multiprocessing support on Windows
         exit_status = 0
     else:
         exit_status = 1
-
 
     if options.coverage:
         cov.stop()

--- a/version.py
+++ b/version.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # coding: utf-8
 # /*##########################################################################
 #
@@ -53,7 +53,7 @@ from __future__ import absolute_import, print_function, division
 __authors__ = ["Jérôme Kieffer"]
 __license__ = "MIT"
 __copyright__ = "European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "28/02/2018"
+__date__ = "30/09/2020"
 __status__ = "production"
 __docformat__ = 'restructuredtext'
 __all__ = ["date", "version_info", "strictversion", "hexversion", "debianversion",
@@ -114,7 +114,6 @@ def calc_hexversion(major=0, minor=0, micro=0, releaselevel="dev", serial=0):
 
 
 hexversion = calc_hexversion(*version_info)
-
 
 if __name__ == "__main__":
     print(version)


### PR DESCRIPTION
Changelog: Switch to Python3 for all development tools.
