### PR TITLE
Add test for H5Node soft link to an external link bug

### DIFF
--- a/src/silx/gui/hdf5/test/test_hdf5.py
+++ b/src/silx/gui/hdf5/test/test_hdf5.py
@@ -665,11 +665,14 @@ def useH5Model(request, tmpdir_factory):
     h5["group/dataset"] = 50
     h5["link/soft_link"] = h5py.SoftLink("/group/dataset")
     h5["link/soft_link_to_group"] = h5py.SoftLink("/group")
-    h5["link/soft_link_to_link"] = h5py.SoftLink("/link/soft_link")
+    h5["link/soft_link_to_soft_link"] = h5py.SoftLink("/link/soft_link")
+    h5["link/soft_link_to_external_link"] = h5py.SoftLink("/link/external_link")
     h5["link/soft_link_to_file"] = h5py.SoftLink("/")
     h5["group/soft_link_relative"] = h5py.SoftLink("dataset")
     h5["link/external_link"] = h5py.ExternalLink(extH5FileName, "/target/dataset")
-    h5["link/external_link_to_link"] = h5py.ExternalLink(extH5FileName, "/target/link")
+    h5["link/external_link_to_soft_link"] = h5py.ExternalLink(
+        extH5FileName, "/target/link"
+    )
     h5["broken_link/external_broken_file"] = h5py.ExternalLink(
         extH5FileName + "_not_exists", "/target/link"
     )
@@ -754,7 +757,7 @@ class TestH5Item(_TestModelBase):
         self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "Soft")
 
     def testSoftLinkToLink(self):
-        path = ["base.h5", "link", "soft_link_to_link"]
+        path = ["base.h5", "link", "soft_link_to_soft_link"]
         h5item = self.getH5ItemFromPath(self.model, path)
 
         self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "Soft")
@@ -772,7 +775,7 @@ class TestH5Item(_TestModelBase):
         self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "External")
 
     def testExternalLinkToLink(self):
-        path = ["base.h5", "link", "external_link_to_link"]
+        path = ["base.h5", "link", "external_link_to_soft_link"]
         h5item = self.getH5ItemFromPath(self.model, path)
 
         self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "External")
@@ -885,16 +888,30 @@ class TestH5Node(_TestModelBase):
         self.assertEqual(h5node.local_basename, "soft_link")
         self.assertEqual(h5node.local_name, "/link/soft_link")
 
-    def testSoftLinkToLink(self):
-        path = ["base.h5", "link", "soft_link_to_link"]
+    def testSoftLinkToSoftLink(self):
+        path = ["base.h5", "link", "soft_link_to_soft_link"]
         h5node = self.getH5NodeFromPath(self.model, path)
 
         self.assertEqual(h5node.physical_filename, h5node.local_filename)
         self.assertIn("base.h5", h5node.physical_filename)
         self.assertEqual(h5node.physical_basename, "dataset")
         self.assertEqual(h5node.physical_name, "/group/dataset")
-        self.assertEqual(h5node.local_basename, "soft_link_to_link")
-        self.assertEqual(h5node.local_name, "/link/soft_link_to_link")
+        self.assertEqual(h5node.local_basename, "soft_link_to_soft_link")
+        self.assertEqual(h5node.local_name, "/link/soft_link_to_soft_link")
+
+    def testSoftLinkToExternalLink(self):
+        path = ["base.h5", "link", "soft_link_to_external_link"]
+        h5node = self.getH5NodeFromPath(self.model, path)
+
+        with self.assertRaises(KeyError):
+            # h5py bug: #1706
+            self.assertNotEqual(h5node.physical_filename, h5node.local_filename)
+            self.assertIn("base.h5", h5node.local_filename)
+            self.assertIn("base__external.h5", h5node.physical_filename)
+            self.assertEqual(h5node.physical_basename, "dataset")
+            self.assertEqual(h5node.physical_name, "/target/dataset")
+            self.assertEqual(h5node.local_basename, "soft_link_to_external_link")
+            self.assertEqual(h5node.local_name, "/link/soft_link_to_external_link")
 
     def testSoftLinkRelative(self):
         path = ["base.h5", "group", "soft_link_relative"]
@@ -919,19 +936,18 @@ class TestH5Node(_TestModelBase):
         self.assertEqual(h5node.local_basename, "external_link")
         self.assertEqual(h5node.local_name, "/link/external_link")
 
-    def testExternalLinkToLink(self):
-        path = ["base.h5", "link", "external_link_to_link"]
+    def testExternalLinkToSoftLink(self):
+        path = ["base.h5", "link", "external_link_to_soft_link"]
         h5node = self.getH5NodeFromPath(self.model, path)
 
         self.assertNotEqual(h5node.physical_filename, h5node.local_filename)
         self.assertIn("base.h5", h5node.local_filename)
         self.assertIn("base__external.h5", h5node.physical_filename)
-
         self.assertNotEqual(h5node.physical_filename, h5node.local_filename)
         self.assertEqual(h5node.physical_basename, "dataset")
         self.assertEqual(h5node.physical_name, "/target/dataset")
-        self.assertEqual(h5node.local_basename, "external_link_to_link")
-        self.assertEqual(h5node.local_name, "/link/external_link_to_link")
+        self.assertEqual(h5node.local_basename, "external_link_to_soft_link")
+        self.assertEqual(h5node.local_name, "/link/external_link_to_soft_link")
 
     def testExternalBrokenFile(self):
         path = ["base.h5", "broken_link", "external_broken_file"]


### PR DESCRIPTION
Just adds a test that is expected to fail. Does not solve #3219. Upstream problem: https://github.com/h5py/h5py/issues/1706