### PR TITLE
silx view VDS and external data

### DIFF
--- a/silx/gui/hdf5/Hdf5Item.py
+++ b/silx/gui/hdf5/Hdf5Item.py
@@ -614,17 +614,28 @@ class Hdf5Item(Hdf5Node):
         if role == qt.Qt.TextAlignmentRole:
             return qt.Qt.AlignTop | qt.Qt.AlignLeft
         if role == qt.Qt.DisplayRole:
+            # Mark as link
             link = self.linkClass
             if link is None:
-                return ""
+                pass
+            elif link == silx.io.utils.H5Type.HARD_LINK:
+                pass
             elif link == silx.io.utils.H5Type.EXTERNAL_LINK:
                 return "External"
             elif link == silx.io.utils.H5Type.SOFT_LINK:
                 return "Soft"
-            elif link == silx.io.utils.H5Type.HARD_LINK:
-                return ""
             else:
                 return link.__name__
+            # Mark as external data
+            if self.h5Class == silx.io.utils.H5Type.DATASET:
+                obj = self.obj
+                if hasattr(obj, "is_virtual"):
+                    if obj.is_virtual:
+                        return "Virtual"
+                if hasattr(obj, "external"):
+                    if obj.external:
+                        return "ExtRaw"
+            return ""
         if role == qt.Qt.ToolTipRole:
             return None
         return None

--- a/silx/gui/hdf5/Hdf5Item.py
+++ b/silx/gui/hdf5/Hdf5Item.py
@@ -100,7 +100,7 @@ class Hdf5Item(Hdf5Node):
         """Returns the class of the stored object.
 
         When the object is in lazy loading, this method should be able to
-        return the type of the futrue loaded object. It allows to delay the
+        return the type of the future loaded object. It allows to delay the
         real load of the object.
 
         :rtype: silx.io.utils.H5Type
@@ -114,7 +114,7 @@ class Hdf5Item(Hdf5Node):
         """Returns the class of the stored object.
 
         When the object is in lazy loading, this method should be able to
-        return the type of the futrue loaded object. It allows to delay the
+        return the type of the future loaded object. It allows to delay the
         real load of the object.
 
         :rtype: h5py.File or h5py.Dataset or h5py.Group

--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -589,11 +589,11 @@ class TestNexusSortFilterProxyModel(TestCaseQt):
         self.assertListEqual(names, ["100aaa", "aaa100"])
 
 
-class TestH5Node(TestCaseQt):
+class _TestModelBase(TestCaseQt):
 
     @classmethod
     def setUpClass(cls):
-        super(TestH5Node, cls).setUpClass()
+        super(_TestModelBase, cls).setUpClass()
 
         cls.tmpDirectory = tempfile.mkdtemp()
         cls.h5Filename = cls.createResource(cls.tmpDirectory)
@@ -603,12 +603,17 @@ class TestH5Node(TestCaseQt):
     @classmethod
     def createResource(cls, directory):
         filename = os.path.join(directory, "base.h5")
-        externalFilename = os.path.join(directory, "base__external.h5")
+        extH5FileName = os.path.join(directory, "base__external.h5")
+        extDatFileName = os.path.join(directory, "base__external.dat")
 
-        externalh5 = h5py.File(externalFilename, mode="w")
+        externalh5 = h5py.File(extH5FileName, mode="w")
         externalh5["target/dataset"] = 50
         externalh5["target/link"] = h5py.SoftLink("/target/dataset")
+        externalh5["/ext/vds0"] = [0, 1]
+        externalh5["/ext/vds1"] = [2, 3]
         externalh5.close()
+
+        numpy.array([0,1,10,10,2,3]).tofile(extDatFileName)
 
         h5 = h5py.File(filename, mode="w")
         h5["group/dataset"] = 50
@@ -617,12 +622,19 @@ class TestH5Node(TestCaseQt):
         h5["link/soft_link_to_link"] = h5py.SoftLink("/link/soft_link")
         h5["link/soft_link_to_file"] = h5py.SoftLink("/")
         h5["group/soft_link_relative"] = h5py.SoftLink("dataset")
-        h5["link/external_link"] = h5py.ExternalLink(externalFilename, "/target/dataset")
-        h5["link/external_link_to_link"] = h5py.ExternalLink(externalFilename, "/target/link")
-        h5["broken_link/external_broken_file"] = h5py.ExternalLink(externalFilename + "_not_exists", "/target/link")
-        h5["broken_link/external_broken_link"] = h5py.ExternalLink(externalFilename, "/target/not_exists")
+        h5["link/external_link"] = h5py.ExternalLink(extH5FileName, "/target/dataset")
+        h5["link/external_link_to_link"] = h5py.ExternalLink(extH5FileName, "/target/link")
+        h5["broken_link/external_broken_file"] = h5py.ExternalLink(extH5FileName + "_not_exists", "/target/link")
+        h5["broken_link/external_broken_link"] = h5py.ExternalLink(extH5FileName, "/target/not_exists")
         h5["broken_link/soft_broken_link"] = h5py.SoftLink("/group/not_exists")
         h5["broken_link/soft_link_to_broken_link"] = h5py.SoftLink("/group/not_exists")
+        layout = h5py.VirtualLayout((2,2), dtype=int)
+        layout[0] = h5py.VirtualSource("base__external.h5", name="/ext/vds0", shape=(2,), dtype=int)
+        layout[1] = h5py.VirtualSource("base__external.h5", name="/ext/vds1", shape=(2,), dtype=int)
+        h5.create_group("/ext")
+        h5["/ext"].create_virtual_dataset("virtual", layout)
+        external = [("base__external.dat", 0, 2*8), ("base__external.dat", 4*8, 2*8)]
+        h5["/ext"].create_dataset("raw", shape=(2,2), dtype=int, external=external)
         h5.close()
 
         return filename
@@ -640,7 +652,7 @@ class TestH5Node(TestCaseQt):
         cls.qWaitForDestroy(ref)
         cls.h5File.close()
         shutil.rmtree(cls.tmpDirectory)
-        super(TestH5Node, cls).tearDownClass()
+        super(_TestModelBase, cls).tearDownClass()
 
     def getIndexFromPath(self, model, path):
         """
@@ -658,9 +670,114 @@ class TestH5Node(TestCaseQt):
                 raise RuntimeError("Path not found")
         return index
 
-    def getH5NodeFromPath(self, model, path):
+    def getH5ItemFromPath(self, model, path):
         index = self.getIndexFromPath(model, path)
-        item = model.data(index, hdf5.Hdf5TreeModel.H5PY_ITEM_ROLE)
+        return model.data(index, hdf5.Hdf5TreeModel.H5PY_ITEM_ROLE)
+
+
+class TestH5Item(_TestModelBase):
+
+    def testFile(self):
+        path = ["base.h5"]
+        h5item = self.getH5ItemFromPath(self.model, path)
+
+        self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "")
+
+    def testGroup(self):
+        path = ["base.h5", "group"]
+        h5item = self.getH5ItemFromPath(self.model, path)
+
+        self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "")
+
+    def testDataset(self):
+        path = ["base.h5", "group", "dataset"]
+        h5item = self.getH5ItemFromPath(self.model, path)
+
+        self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "")
+
+    def testSoftLink(self):
+        path = ["base.h5", "link", "soft_link"]
+        h5item = self.getH5ItemFromPath(self.model, path)
+
+        self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "Soft")
+
+    def testSoftLinkToLink(self):
+        path = ["base.h5", "link", "soft_link_to_link"]
+        h5item = self.getH5ItemFromPath(self.model, path)
+
+        self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "Soft")
+
+    def testSoftLinkRelative(self):
+        path = ["base.h5", "group", "soft_link_relative"]
+        h5item = self.getH5ItemFromPath(self.model, path)
+
+        self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "Soft")
+
+    def testExternalLink(self):
+        path = ["base.h5", "link", "external_link"]
+        h5item = self.getH5ItemFromPath(self.model, path)
+
+        self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "External")
+
+    def testExternalLinkToLink(self):
+        path = ["base.h5", "link", "external_link_to_link"]
+        h5item = self.getH5ItemFromPath(self.model, path)
+
+        self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "External")
+
+    def testExternalBrokenFile(self):
+        path = ["base.h5", "broken_link", "external_broken_file"]
+        h5item = self.getH5ItemFromPath(self.model, path)
+
+        self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "External")
+
+    def testExternalBrokenLink(self):
+        path = ["base.h5", "broken_link", "external_broken_link"]
+        h5item = self.getH5ItemFromPath(self.model, path)
+
+        self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "External")
+
+    def testSoftBrokenLink(self):
+        path = ["base.h5", "broken_link", "soft_broken_link"]
+        h5item = self.getH5ItemFromPath(self.model, path)
+
+        self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "Soft")
+
+    def testSoftLinkToBrokenLink(self):
+        path = ["base.h5", "broken_link", "soft_link_to_broken_link"]
+        h5item = self.getH5ItemFromPath(self.model, path)
+
+        self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "Soft")
+
+    def testDatasetFromSoftLinkToGroup(self):
+        path = ["base.h5", "link", "soft_link_to_group", "dataset"]
+        h5item = self.getH5ItemFromPath(self.model, path)
+
+        self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "")
+
+    def testDatasetFromSoftLinkToFile(self):
+        path = ["base.h5", "link", "soft_link_to_file", "link", "soft_link_to_group", "dataset"]
+        h5item = self.getH5ItemFromPath(self.model, path)
+
+        self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "")
+
+    def testExternalVirtual(self):
+        path = ["base.h5", "ext", "virtual"]
+        h5item = self.getH5ItemFromPath(self.model, path)
+
+        self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "Virtual")
+
+    def testExternalRaw(self):
+        path = ["base.h5", "ext", "raw"]
+        h5item = self.getH5ItemFromPath(self.model, path)
+
+        self.assertEqual(h5item.dataLink(qt.Qt.DisplayRole), "ExtRaw")
+
+
+class TestH5Node(_TestModelBase):
+
+    def getH5NodeFromPath(self, model, path):
+        item = self.getH5ItemFromPath(model, path)
         h5node = hdf5.H5Node(item)
         return h5node
 
@@ -823,6 +940,28 @@ class TestH5Node(TestCaseQt):
         self.assertEqual(h5node.physical_name, "/group/dataset")
         self.assertEqual(h5node.local_basename, "dataset")
         self.assertEqual(h5node.local_name, "/link/soft_link_to_file/link/soft_link_to_group/dataset")
+
+    def testExternalVirtual(self):
+        path = ["base.h5", "ext", "virtual"]
+        h5node = self.getH5NodeFromPath(self.model, path)
+
+        self.assertEqual(h5node.physical_filename, h5node.local_filename)
+        self.assertIn("base.h5", h5node.physical_filename)
+        self.assertEqual(h5node.physical_basename, "virtual")
+        self.assertEqual(h5node.physical_name, "/ext/virtual")
+        self.assertEqual(h5node.local_basename, "virtual")
+        self.assertEqual(h5node.local_name, "/ext/virtual")
+
+    def testExternalRaw(self):
+        path = ["base.h5", "ext", "raw"]
+        h5node = self.getH5NodeFromPath(self.model, path)
+
+        self.assertEqual(h5node.physical_filename, h5node.local_filename)
+        self.assertIn("base.h5", h5node.physical_filename)
+        self.assertEqual(h5node.physical_basename, "raw")
+        self.assertEqual(h5node.physical_name, "/ext/raw")
+        self.assertEqual(h5node.local_basename, "raw")
+        self.assertEqual(h5node.local_name, "/ext/raw")
 
 
 class TestHdf5TreeView(TestCaseQt):

--- a/silx/io/commonh5.py
+++ b/silx/io/commonh5.py
@@ -376,6 +376,24 @@ class Dataset(Node):
         There is no chunks."""
         return None
 
+    @property
+    def is_virtual(self):
+        """Checks virtual data as provided by `h5py.Dataset`"""
+        return False
+
+    def virtual_sources(self):
+        """Returns virtual dataset sources as provided by `h5py.Dataset`.
+
+        :rtype: list"""
+        raise RuntimeError("Not a virtual dataset")
+
+    @property
+    def external(self):
+        """Returns external sources as provided by `h5py.Dataset`.
+
+        :rtype: list or None"""
+        return None
+
     def __array__(self, dtype=None):
         # Special case for (0,)*-shape datasets
         if numpy.product(self.shape) == 0:


### PR DESCRIPTION
closes #3214 

Add support for external data (virtual and raw, nothing to do with external links) to `silx view`:
* add "Virtual" or "ExtRaw" to the Link column (added tests)
* add "external sources" section to the table view (no tests for this)

Data generated with [this script](https://gitlab.esrf.fr/-/snippets/226) looks like this:
![image](https://user-images.githubusercontent.com/7264703/95975429-73cfce00-0e16-11eb-8e98-c9c81a1e024a.png)