### PR TITLE
silx.gui.plot.items: Added item visible bounds feature to PlotWidget items

### DIFF
--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -37,6 +37,7 @@ except ImportError:  # Python2 support
 from copy import deepcopy
 import logging
 import enum
+from typing import Optional, Tuple
 import warnings
 import weakref
 
@@ -301,6 +302,28 @@ class Item(qt.QObject):
         if copy:
             info = deepcopy(info)
         self._info = info
+
+    def getVisibleExtent(self) -> Optional[Tuple[float]]:
+        """Returns visible extent of the item bounding box in the plot area.
+
+        :returns:
+            (xmin, xmax, ymin, ymax) in data coordinates of the visible area or
+            None if item is not visible in the plot area.
+        :rtype: Union[List[float],None]
+        """
+        plot = self.getPlot()
+        bounds = self.getBounds()
+        if plot is None or bounds is None or not self.isVisible():
+            return None
+
+        xmin, xmax = numpy.clip(bounds[:2], *plot.getXAxis().getLimits())
+        ymin, ymax = numpy.clip(
+            bounds[2:], *plot.getYAxis(self.__getYAxis()).getLimits())
+
+        if xmin == xmax or ymin == ymax:  # Outside the plot area
+            return None
+        else:
+            return xmin, xmax, ymin, ymax
 
     def _updated(self, event=None, checkVisibility=True):
         """Mark the item as dirty (i.e., needing update).

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -315,7 +315,7 @@ class Item(qt.QObject):
             info = deepcopy(info)
         self._info = info
 
-    def getVisibleBounds(self) -> Optional[Tuple[float]]:
+    def getVisibleBounds(self) -> Optional[Tuple[float,float,float,float]]:
         """Returns visible bounds of the item bounding box in the plot area.
 
         :returns:

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -372,8 +372,7 @@ class Item(qt.QObject):
 
             plot.installEventFilter(self)
 
-            if plot.isVisible():
-                self._visibleExtentChanged()
+            self._visibleExtentChanged()
 
     def __disconnectFromPlotWidget(self) -> None:
         """Disconnect from PlotWidget signals and remove event filter"""
@@ -402,9 +401,8 @@ class Item(qt.QObject):
             self._sigVisibleExtentChanged.emit()
 
     def eventFilter(self, watched, event):
-        """Event filter to handle PlotWidget show/hide events"""
-        if (watched is self.getPlot() and
-                event.type() in (qt.QEvent.Hide, qt.QEvent.Show)):
+        """Event filter to handle PlotWidget show events"""
+        if watched is self.getPlot() and event.type() == qt.QEvent.Show:
             self._visibleExtentChanged()
         return super().eventFilter(watched, event)
 

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -184,7 +184,7 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
     def setData(self, data):
         """Set the image data
 
-        :param Union[numpy.ndarray,None] data:
+        :param numpy.ndarray data:
         """
         self._data = data
         self._boundsChanged()

--- a/silx/gui/plot/test/testItem.py
+++ b/silx/gui/plot/test/testItem.py
@@ -246,8 +246,8 @@ class TestSymbol(PlotWidgetTestCase):
 class TestVisibleExtent(PlotWidgetTestCase):
     """Test item's visible extent feature"""
 
-    def testGetVisibleExtent(self):
-        """Test Item.getVisibleExtent"""
+    def testGetVisibleBounds(self):
+        """Test Item.getVisibleBounds"""
 
         # Create test items (with a bounding box of x: [1,3], y: [0,2])
         curve = items.Curve()
@@ -272,16 +272,16 @@ class TestVisibleExtent(PlotWidgetTestCase):
                 xaxis.setLimits(0, 100)
                 yaxis.setLimits(0, 100)
                 self.plot.addItem(item)
-                self.assertEqual(item.getVisibleExtent(), (1., 3., 0., 2.))
+                self.assertEqual(item.getVisibleBounds(), (1., 3., 0., 2.))
 
                 xaxis.setLimits(0.5, 2.5)
-                self.assertEqual(item.getVisibleExtent(), (1, 2.5, 0., 2.))
+                self.assertEqual(item.getVisibleBounds(), (1, 2.5, 0., 2.))
 
                 yaxis.setLimits(0.5, 1.5)
-                self.assertEqual(item.getVisibleExtent(), (1, 2.5, 0.5, 1.5))
+                self.assertEqual(item.getVisibleBounds(), (1, 2.5, 0.5, 1.5))
 
                 item.setVisible(False)
-                self.assertIsNone(item.getVisibleExtent())
+                self.assertIsNone(item.getVisibleBounds())
 
                 self.plot.clear()
 
@@ -291,9 +291,9 @@ class TestVisibleExtent(PlotWidgetTestCase):
         image.setData(numpy.arange(6).reshape(2, 3))
 
         listener = SignalListener()
-        image._sigVisibleExtentChanged.connect(listener)
-        image._setVisibleExtentTracking(True)
-        self.assertTrue(image._isVisibleExtentTracking())
+        image._sigVisibleBoundsChanged.connect(listener)
+        image._setVisibleBoundsTracking(True)
+        self.assertTrue(image._isVisibleBoundsTracking())
 
         self.plot.addItem(image)
         self.assertEqual(listener.callCount(), 1)

--- a/silx/gui/plot/test/testItem.py
+++ b/silx/gui/plot/test/testItem.py
@@ -35,6 +35,7 @@ import numpy
 
 from silx.gui.utils.testutils import SignalListener
 from silx.gui.plot.items import ItemChangedType
+from silx.gui.plot import items
 from .utils import PlotWidgetTestCase
 
 
@@ -242,11 +243,53 @@ class TestSymbol(PlotWidgetTestCase):
         self.assertEqual('Diamond', name)
 
 
+class TestVisibleExtent(PlotWidgetTestCase):
+    """Test item's visible extent feature"""
+
+    def testGetVisibleExtent(self):
+        """Test Item.getVisibleExtent"""
+
+        # Create test items (with a bounding box of x: [1,3], y: [0,2])
+        curve = items.Curve()
+        curve.setData((1, 2, 3), (0, 1, 2))
+
+        histogram = items.Histogram()
+        histogram.setData((0, 1, 2), (1, 5/3, 7/3, 3))
+
+        image = items.ImageData()
+        image.setOrigin((1, 0))
+        image.setData(numpy.arange(4).reshape(2, 2))
+
+        scatter = items.Scatter()
+        scatter.setData((1, 2, 3), (0, 1, 2), (1, 2, 3))
+
+        bbox = items.BoundingRect()
+        bbox.setBounds((1, 3, 0, 2))
+
+        xaxis, yaxis = self.plot.getXAxis(), self.plot.getYAxis()
+        for item in (curve, histogram, image, scatter, bbox):
+            with self.subTest(item=item):
+                xaxis.setLimits(0, 100)
+                yaxis.setLimits(0, 100)
+                self.plot.addItem(item)
+                self.assertEqual(item.getVisibleExtent(), (1., 3., 0., 2.))
+
+                xaxis.setLimits(0.5, 2.5)
+                self.assertEqual(item.getVisibleExtent(), (1, 2.5, 0., 2.))
+
+                yaxis.setLimits(0.5, 1.5)
+                self.assertEqual(item.getVisibleExtent(), (1, 2.5, 0.5, 1.5))
+
+                item.setVisible(False)
+                self.assertIsNone(item.getVisibleExtent())
+
+                self.plot.clear()
+
 def suite():
     test_suite = unittest.TestSuite()
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
-    test_suite.addTest(loadTests(TestSigItemChangedSignal))
-    test_suite.addTest(loadTests(TestSymbol))
+    for klass in (TestSigItemChangedSignal, TestSymbol, TestVisibleExtent):
+        test_suite.addTest(loadTests(klass))
     return test_suite
 
 


### PR DESCRIPTION
This PR adds method `Item.getVisibleBounds`~~`Extent`~~ to PlotWidget items to retrieve the visible extent of the item bounding box in the plot area.
It also adds a private API to enable tracking changes of this visible extent through the `Item._sigVisibleBounds`~~`Extent`~~`Changed` signal.
This signal is only triggered when enabling "visible extent tracking" through `Item._setVisibleBounds`~~`Extent`~~`Tracking` and which can be retrieved through`Item._isVisibleBounds`~~`Extent`~~`Tracking`.