### PR TITLE
dictdump: support HDF5 link preservation

### DIFF
--- a/silx/io/test/test_dictdump.py
+++ b/silx/io/test/test_dictdump.py
@@ -376,6 +376,13 @@ class TestDictToNx(unittest.TestCase):
             self.assertEqual(h5file["links/absolute_softlink"][()], 10)
             self.assertEqual(h5file["links/external_link"][()], 10)
 
+    def testUpLinks(self):
+        ddict = {"data": {"group": {"dataset": 10, ">relative_softlink": "dataset"}},
+                 "links": {"group": {"subgroup": {">relative_softlink": "../../../data/group/dataset"}}}}
+        dictdump.dicttonx(ddict, self.h5_fname)
+        with h5py.File(self.h5_fname, "r") as h5file:
+            self.assertEqual(h5file["/links/group/subgroup/relative_softlink"][()], 10)
+
 
 class TestNxToDict(unittest.TestCase):
     def setUp(self):

--- a/silx/io/test/test_dictdump.py
+++ b/silx/io/test/test_dictdump.py
@@ -43,6 +43,7 @@ from .. import dictdump
 from ..dictdump import dicttoh5, dicttojson, dump
 from ..dictdump import h5todict, load
 from ..dictdump import logger as dictdump_logger
+from ..utils import is_link
 
 
 def tree():
@@ -58,15 +59,29 @@ city_attrs["Europe"]["France"]["Grenoble"]["inhabitants"] = inhabitants
 city_attrs["Europe"]["France"]["Grenoble"]["coordinates"] = [45.1830, 5.7196]
 city_attrs["Europe"]["France"]["Tourcoing"]["area"]
 
+ext_attrs = tree()
+ext_attrs["ext_group"]["dataset"] = 10
+ext_filename = "ext.h5"
+
+link_attrs = tree()
+link_attrs["links"]["group"]["dataset"] = 10
+link_attrs["links"]["group"]["relative_softlink"] = h5py.SoftLink("dataset")
+link_attrs["links"]["relative_softlink"] = h5py.SoftLink("group/dataset")
+link_attrs["links"]["absolute_softlink"] = h5py.SoftLink("/links/group/dataset")
+link_attrs["links"]["external_link"] = h5py.ExternalLink(ext_filename, "/ext_group/dataset")
+
 
 class TestDictToH5(unittest.TestCase):
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
         self.h5_fname = os.path.join(self.tempdir, "cityattrs.h5")
+        self.h5_ext_fname = os.path.join(self.tempdir, ext_filename)
 
     def tearDown(self):
         if os.path.exists(self.h5_fname):
             os.unlink(self.h5_fname)
+        if os.path.exists(self.h5_ext_fname):
+            os.unlink(self.h5_ext_fname)
         os.rmdir(self.tempdir)
 
     def testH5CityAttrs(self):
@@ -201,15 +216,81 @@ class TestDictToH5(unittest.TestCase):
             self.assertEqual(h5file["group/group/dataset"].attrs['attr'], 11)
             self.assertEqual(h5file["group/group"].attrs['attr'], 12)
 
+    def testLinks(self):
+        with h5py.File(self.h5_ext_fname, "w") as h5file:
+            dictdump.dicttoh5(ext_attrs, h5file)
+        with h5py.File(self.h5_fname, "w") as h5file:
+            dictdump.dicttoh5(link_attrs, h5file)
+        with h5py.File(self.h5_fname, "r") as h5file:
+            self.assertEqual(h5file["links/group/dataset"][()], 10)
+            self.assertEqual(h5file["links/group/relative_softlink"][()], 10)
+            self.assertEqual(h5file["links/relative_softlink"][()], 10)
+            self.assertEqual(h5file["links/absolute_softlink"][()], 10)
+            self.assertEqual(h5file["links/external_link"][()], 10)
+
+
+class TestH5ToDict(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.mkdtemp()
+        self.h5_fname = os.path.join(self.tempdir, "cityattrs.h5")
+        self.h5_ext_fname = os.path.join(self.tempdir, ext_filename)
+        dicttoh5(city_attrs, self.h5_fname)
+        dicttoh5(link_attrs, self.h5_fname, mode="a")
+        dicttoh5(ext_attrs, self.h5_ext_fname)
+
+    def tearDown(self):
+        if os.path.exists(self.h5_fname):
+            os.unlink(self.h5_fname)
+        if os.path.exists(self.h5_ext_fname):
+            os.unlink(self.h5_ext_fname)
+        os.rmdir(self.tempdir)
+
+    def testExcludeNames(self):
+        ddict = h5todict(self.h5_fname, path="/Europe/France",
+                         exclude_names=["ourcoing", "inhab", "toto"])
+        self.assertNotIn("Tourcoing", ddict)
+        self.assertIn("Grenoble", ddict)
+
+        self.assertNotIn("inhabitants", ddict["Grenoble"])
+        self.assertIn("coordinates", ddict["Grenoble"])
+        self.assertIn("area", ddict["Grenoble"])
+
+    def testAsArrayTrue(self):
+        """Test with asarray=True, the default"""
+        ddict = h5todict(self.h5_fname, path="/Europe/France/Grenoble")
+        self.assertTrue(numpy.array_equal(ddict["inhabitants"], numpy.array(inhabitants)))
+
+    def testAsArrayFalse(self):
+        """Test with asarray=False"""
+        ddict = h5todict(self.h5_fname, path="/Europe/France/Grenoble", asarray=False)
+        self.assertEqual(ddict["inhabitants"], inhabitants)
+
+    def testDereferenceLinks(self):
+        ddict = h5todict(self.h5_fname, path="links", dereference_links=True)
+        self.assertTrue(ddict["absolute_softlink"], 10)
+        self.assertTrue(ddict["relative_softlink"], 10)
+        self.assertTrue(ddict["external_link"], 10)
+        self.assertTrue(ddict["group"]["relative_softlink"], 10)
+
+    def testPreserveLinks(self):
+        ddict = h5todict(self.h5_fname, path="links", dereference_links=False)
+        self.assertTrue(is_link(ddict["absolute_softlink"]))
+        self.assertTrue(is_link(ddict["relative_softlink"]))
+        self.assertTrue(is_link(ddict["external_link"]))
+        self.assertTrue(is_link(ddict["group"]["relative_softlink"]))
+
 
 class TestDictToNx(unittest.TestCase):
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
         self.h5_fname = os.path.join(self.tempdir, "nx.h5")
+        self.h5_ext_fname = os.path.join(self.tempdir, "nx_ext.h5")
 
     def tearDown(self):
         if os.path.exists(self.h5_fname):
             os.unlink(self.h5_fname)
+        if os.path.exists(self.h5_ext_fname):
+            os.unlink(self.h5_ext_fname)
         os.rmdir(self.tempdir)
 
     def testAttributes(self):
@@ -281,35 +362,18 @@ class TestDictToNx(unittest.TestCase):
             self.assertEqual(h5file["group/group"].attrs['attr'], 12)
 
 
-class TestH5ToDict(unittest.TestCase):
+class TestNxToDict(unittest.TestCase):
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()
-        self.h5_fname = os.path.join(self.tempdir, "cityattrs.h5")
-        dicttoh5(city_attrs, self.h5_fname)
+        self.h5_fname = os.path.join(self.tempdir, "nx.h5")
+        self.h5_ext_fname = os.path.join(self.tempdir, "nx_ext.h5")
 
     def tearDown(self):
-        os.unlink(self.h5_fname)
+        if os.path.exists(self.h5_fname):
+            os.unlink(self.h5_fname)
+        if os.path.exists(self.h5_ext_fname):
+            os.unlink(self.h5_ext_fname)
         os.rmdir(self.tempdir)
-
-    def testExcludeNames(self):
-        ddict = h5todict(self.h5_fname, path="/Europe/France",
-                         exclude_names=["ourcoing", "inhab", "toto"])
-        self.assertNotIn("Tourcoing", ddict)
-        self.assertIn("Grenoble", ddict)
-
-        self.assertNotIn("inhabitants", ddict["Grenoble"])
-        self.assertIn("coordinates", ddict["Grenoble"])
-        self.assertIn("area", ddict["Grenoble"])
-
-    def testAsArrayTrue(self):
-        """Test with asarray=True, the default"""
-        ddict = h5todict(self.h5_fname, path="/Europe/France/Grenoble")
-        self.assertTrue(numpy.array_equal(ddict["inhabitants"], numpy.array(inhabitants)))
-
-    def testAsArrayFalse(self):
-        """Test with asarray=False"""
-        ddict = h5todict(self.h5_fname, path="/Europe/France/Grenoble", asarray=False)
-        self.assertEqual(ddict["inhabitants"], inhabitants)
 
 
 class TestDictToJson(unittest.TestCase):
@@ -436,6 +500,7 @@ def suite():
     test_suite.addTest(loadTests(TestDictToNx))
     test_suite.addTest(loadTests(TestDictToJson))
     test_suite.addTest(loadTests(TestH5ToDict))
+    test_suite.addTest(loadTests(TestNxToDict))
     return test_suite
 
 

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -757,6 +757,26 @@ def is_softlink(obj):
     return t == H5Type.SOFT_LINK
 
 
+def is_externallink(obj):
+    """
+    True if the object is a h5py.ExternalLink-like object.
+
+    :param obj: An object
+    """
+    t = get_h5_class(obj)
+    return t == H5Type.EXTERNAL_LINK
+
+
+def is_link(obj):
+    """
+    True if the object is a h5py link-like object.
+
+    :param obj: An object
+    """
+    t = get_h5_class(obj)
+    return t in {H5Type.SOFT_LINK, H5Type.EXTERNAL_LINK}
+
+
 def get_data(url):
     """Returns a numpy data from an URL.
 


### PR DESCRIPTION
closes #3213 

HDF5 link support:

 * `dicttoh5`: values `h5py.SoftLink` and `h5py.ExternalLink` are supported
 * `h5todict`: `dereference_links` option. `True` by default, otherwise the dict will contain `h5py.SoftLink` and `h5py.ExternalLink` instances.

HDF5 attribute support:

 * `h5todict`: `include_attributes` option. `False` by default, otherwise the dict will contain attributes as tuple keys.

Nexus wrappers: support `">"` notation and refactor

* `h5_to_nexus_dict`:
  * convert tuple keys to `"@"` key notation
  * convert `h5py.SoftLink` and `h5py.ExternalLink` values to `">"` key notation (value is a URL as a string)
* `nexus_to_h5_dict`:
  * convert `"@"` key notation to tuple keys
  * convert `">"` key notation (value is a URL as a string) to  `h5py.SoftLink` and `h5py.ExternalLink` values
  * add up-link support for soft link with the `">"` key notation (resolved to absolute link)
* `nxtodict`: same as `h5_to_nexus_dict(h5todict(ddict))`
* `dicttonx`: same as `dicttoh5(nexus_to_h5_dict(ddict))`