### PR TITLE
silx.gui.hdf5.test.test_hdf5: forgot to add TestH5Item to `suite`

### DIFF
--- a/silx/gui/hdf5/test/test_hdf5.py
+++ b/silx/gui/hdf5/test/test_hdf5.py
@@ -1132,6 +1132,7 @@ def suite():
     test_suite.addTest(loadTests(TestNexusSortFilterProxyModel))
     test_suite.addTest(loadTests(TestHdf5TreeView))
     test_suite.addTest(loadTests(TestH5Node))
+    test_suite.addTest(loadTests(TestH5Item))
     return test_suite
 
 


### PR DESCRIPTION
@vallsv  Locally I have this test failing (not sure if it is related to my changes).

```python
======================================================================
ERROR: testSynchonized (silx.gui.hdf5.test.test_hdf5.TestHdf5TreeModelSignals)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/users/denolf/dev/silx/build/lib.linux-x86_64-3.8/silx/gui/hdf5/test/test_hdf5.py", line 440, in testSynchonized
    self.model.synchronizeH5pyObject(self.h5)
  File "/users/denolf/dev/silx/build/lib.linux-x86_64-3.8/silx/gui/hdf5/Hdf5TreeModel.py", line 613, in synchronizeH5pyObject
    self.synchronizeIndex(qindex)
  File "/users/denolf/dev/silx/build/lib.linux-x86_64-3.8/silx/gui/hdf5/Hdf5TreeModel.py", line 591, in synchronizeIndex
    self.insertFileAsync(filename, index.row(), synchronizingNode=node)
  File "/users/denolf/dev/silx/build/lib.linux-x86_64-3.8/silx/gui/hdf5/Hdf5TreeModel.py", line 679, in insertFileAsync
    qt.silxGlobalThreadPool().start(runnable)
RuntimeError: wrapped C/C++ object of type QThreadPool has been deleted
```