### PR TITLE
build: Added pyproject.toml to comply to PEP 518

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ include stdeb.cfg
 include build-deb.sh
 include requirements.txt
 include requirements-dev.txt
+include pyproject.toml
 recursive-include silx *.pyx *.pxd *.pxi
 recursive-include silx *.h *.c *.hpp *.cpp
 recursive-include doc/source *.py *.rst *.png *.ico *.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "wheel",
+    "setuptools",
+    "numpy>=1.12",
+    "Cython>=0.21.1"
+]


### PR DESCRIPTION
This PR adds a `pyproject.toml` to the project to comply with [PEP 518](https://www.python.org/dev/peps/pep-0518/).
This enables `pip` to install `silx` in a fresh virtualenv without numpy already installed.