### PR TITLE
Build: Fixed continuous integration after addition of pyproject.toml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,10 +119,15 @@ before_script:
       fi
 
     # Install built package
-    # Make sure silx does not come from cache or pypi
+    # For wheel: Make sure silx does not come from cache or pypi
     # At this point all install_requires dependencies MUST be installed
     # as this is installing only from dist
-    - pip install --pre --find-links dist/ --no-cache-dir --no-index silx $PIP_INSTALL_EXTRA_ARGS
+    - if [ "BUILD_COMMAND" == "sdist" ];
+      then
+          pip install --pre --find-links dist/ silx $PIP_INSTALL_EXTRA_ARGS;
+      else
+          pip install --pre --find-links dist/ --no-cache-dir --no-index silx $PIP_INSTALL_EXTRA_ARGS;
+      fi
 
     # Print Python info
     - python ci/info_platform.py


### PR DESCRIPTION
This PR should fix CI that is broken since PR #3227 (having a pyproject.toml changes the way to install from source).