### PR TITLE
WIP: Add option to compute colormap VRange from a roi (plot limits or user roi)

### DIFF
--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -41,7 +41,6 @@ from silx.math import colormap as _colormap
 from silx.utils.exceptions import NotEditableError
 from silx.utils import deprecation
 from silx.resources import resource_filename as _resource_filename
-from silx.utils.enum import Enum as _Enum
 
 
 _logger = logging.getLogger(__file__)
@@ -492,12 +491,6 @@ class _ArcsinhNormalization(_colormap.ArcsinhNormalization, _NormalizationMixIn)
         _NormalizationMixIn.__init__(self)
 
 
-class _AutoscaleMethod(_Enum):
-    ALL_DATA = "all data"
-    VISIBLE_DATA = "visible data"
-    ROI = "roi"
-
-
 class Colormap(qt.QObject):
     """Description of a colormap
 
@@ -556,8 +549,7 @@ class Colormap(qt.QObject):
     _DEFAULT_NAN_COLOR = 255, 255, 255, 0
 
     def __init__(self, name=None, colors=None, normalization=LINEAR, vmin=None,
-                 vmax=None, autoscaleMode=MINMAX,
-                 autoscalMethod=_AutoscaleMethod.ALL_DATA):
+                 vmax=None, autoscaleMode=MINMAX):
         qt.QObject.__init__(self)
         self._editable = True
         self.__gamma = 2.0

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -41,6 +41,7 @@ from silx.math import colormap as _colormap
 from silx.utils.exceptions import NotEditableError
 from silx.utils import deprecation
 from silx.resources import resource_filename as _resource_filename
+from silx.utils.enum import Enum as _Enum
 
 
 _logger = logging.getLogger(__file__)
@@ -489,6 +490,12 @@ class _ArcsinhNormalization(_colormap.ArcsinhNormalization, _NormalizationMixIn)
     def __init__(self):
         _colormap.ArcsinhNormalization.__init__(self)
         _NormalizationMixIn.__init__(self)
+
+
+class _AutoscaleMethod(_Enum):
+    ALL_DATA = "all data"
+    VISIBLE_DATA = "visible data"
+    ROI = "roi"
 
 
 class Colormap(qt.QObject):

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -555,7 +555,9 @@ class Colormap(qt.QObject):
 
     _DEFAULT_NAN_COLOR = 255, 255, 255, 0
 
-    def __init__(self, name=None, colors=None, normalization=LINEAR, vmin=None, vmax=None, autoscaleMode=MINMAX):
+    def __init__(self, name=None, colors=None, normalization=LINEAR, vmin=None,
+                 vmax=None, autoscaleMode=MINMAX,
+                 autoscalMethod=_AutoscaleMethod.ALL_DATA):
         qt.QObject.__init__(self)
         self._editable = True
         self.__gamma = 2.0

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -86,12 +86,18 @@ from silx.gui.qt import inspect as qtinspect
 from silx.gui.widgets.ColormapNameComboBox import ColormapNameComboBox
 from silx.math.histogram import Histogramnd
 from silx.utils import deprecation
-from silx.gui.colors import _AutoscaleMethod
+from silx.utils.enum import Enum as _Enum
 
 _logger = logging.getLogger(__name__)
 
 
 _colormapIconPreview = {}
+
+
+class AutoscaleMethod(_Enum):
+    ALL_DATA = "all data"
+    VISIBLE_DATA = "visible data"
+    ROI = "roi"
 
 
 class _DataRefHolder(items.Item, items.ColormapMixIn):

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -909,10 +909,10 @@ class ColormapDialog(qt.QDialog):
 
         # autoscale mode
         self._autoscaleMethodCB = qt.QComboBox(self)
-        for mode in _AutoscaleMethod:
+        for mode in AutoscaleMethod:
             self._autoscaleMethodCB.addItem(mode.value)
         idx = self._autoscaleMethodCB.findText(
-            _AutoscaleMethod.ALL_DATA.value)
+            AutoscaleMethod.ALL_DATA.value)
         self._autoscaleMethodCB.setCurrentIndex(idx)
 
         # roi group box
@@ -1013,7 +1013,7 @@ class ColormapDialog(qt.QDialog):
 
         :return: _AutoscaleMethod
         """
-        return _AutoscaleMethod.from_value(
+        return AutoscaleMethod.from_value(
             self._autoscaleMethodCB.currentText())
 
     def setAutoscaleMethod(self, value):
@@ -1022,7 +1022,7 @@ class ColormapDialog(qt.QDialog):
 
         :param Union[_AutoscaleMethod, str] value:
         """
-        value = _AutoscaleMethod.from_value(value)
+        value = AutoscaleMethod.from_value(value)
         idx = self._autoscaleMethodCB.findText(value.value)
         self._autoscaleMethodCB.setCurrentIndex(idx)
 
@@ -1080,16 +1080,15 @@ class ColormapDialog(qt.QDialog):
         self.getColormap().sigChanged.emit()
 
     def _updateROI(self):
-        # update from the visible area
         method = self.getAutoscaleMethod()
-        if method is _AutoscaleMethod.VISIBLE_DATA:
+        if method is AutoscaleMethod.VISIBLE_DATA:
             minX, maxX = self._getItem().getPlot().getXAxis().getLimits()
             minY, maxY = self._getItem().getPlot().getYAxis().getLimits()
             self._roiForColormapRange.setGeometry(origin=(minX, minY),
                                                   size=(maxX-minX, maxY-minY))
             self._roiForColormapRange.setVisible(False)
             self._roiForColormapRange.setEditable(False)
-        elif method is _AutoscaleMethod.ROI:
+        elif method is AutoscaleMethod.ROI:
             self._roiForColormapRange.setGeometry(origin=self._roiGroupBox.getOrigin(),
                                                   size=self._roiGroupBox.getSize())
             self._roiForColormapRange.setVisible(self._roiGroupBox.getDisplay())

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -87,6 +87,9 @@ from silx.gui.widgets.ColormapNameComboBox import ColormapNameComboBox
 from silx.math.histogram import Histogramnd
 from silx.utils import deprecation
 from silx.utils.enum import Enum as _Enum
+from silx.math.geometry import Rectangle
+from silx.gui.plot.items.roi import RectangleROI
+from silx.gui.plot.tools.roi import RegionOfInterestManager
 
 _logger = logging.getLogger(__name__)
 

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -973,7 +973,7 @@ class ColormapDialog(qt.QDialog):
         label.setToolTip("Mode for autoscale. Algorithm used to find range in auto scale.")
         formLayout.addItem(qt.QSpacerItem(1, 1, qt.QSizePolicy.Fixed, qt.QSizePolicy.Fixed))
         formLayout.addRow(label, autoScaleCombo)
-        formLayout.addRow('Autoscale method', self._autoscaleMethodCB)
+        formLayout.addRow('Autoscale from', self._autoscaleMethodCB)
         formLayout.addRow(self._roiGroupBox)
         formLayout.addRow(self._buttonsModal)
         formLayout.addRow(self._buttonsNonModal)
@@ -1033,8 +1033,7 @@ class ColormapDialog(qt.QDialog):
             self._updateROI()
 
         self._getItem().clearColormapRangeCache()
-        # self._invalidateData()
-        self._invalidateColormap()
+        self.getColormap().sigChanged.emit()
 
     def _updateROI(self):
         # update from the visible area

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -1860,15 +1860,34 @@ class _ROIGroupBox(qt.QGroupBox):
         """
         return self._widthDSB.value(), self._heightDSB.value()
 
-    def displayROI(self) -> bool:
+    def getDisplay(self) -> bool:
         """
 
         :return: True if the ROi display is requested
         """
         return self._displayCB.isChecked()
 
+    def setDisplay(self, display: bool) -> None:
+        """
+
+        :param bool display: if True the ROi will be displayed
+        """
+        self._displayCB.setChecked(display)
+
+    def getName(self) -> str:
+        """
+
+        :return: ROi name
+        :rtype: str
+        """
+        return self._nameQLE.text()
+
+    def setName(self, name: str) -> None:
+        """
+
+        :param str name: ROI name
+        """
+        self._nameQLE.setText(name)
+
     def _ROIModificationRequested(self, *args, **kwargs):
         self.sigROIChanged.emit()
-
-    def getROIName(self) -> str:
-        return self._nameQLE.text()

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -1066,13 +1066,16 @@ class ColormapDialog(qt.QDialog):
             self._getItem()._setROIForAutoscale(None)
         elif self.getAutoscaleMethod() in (AutoscaleMethod.VISIBLE_DATA,
                                            AutoscaleMethod.ROI):
-            # TODO: Rectangle should also be relative to the item
-            # origin & scale
+            rectangle_roi_origin = numpy.array(
+                self._getRoiForColormapRange().getOrigin())
+            item_data_origin = numpy.array(self._getItem().getOrigin())
+
             self._getItem()._setROIForAutoscale(
-                Rectangle(
-                    origin=self._getRoiForColormapRange().getOrigin(),
+                roi=Rectangle(
+                    origin=rectangle_roi_origin - item_data_origin,
                     size=self._getRoiForColormapRange().getSize(),
-                )
+                ),
+                scale=self._getItem().getScale()
             )
         else:
             raise ValueError('Method {} is not managed'.format(method))

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -52,7 +52,7 @@ from ... import qt
 from ... import colors
 from ...colors import Colormap
 from ._pick import PickingResult
-from silx.gui.colors import _AutoscaleMethod
+from silx.math.geometry import Rectangle
 
 from silx import config
 
@@ -603,7 +603,7 @@ class ColormapMixIn(ItemMixInBase):
         self._colormap.sigChanged.connect(self._colormapChanged)
         self.__data = None
         self.__cacheColormapRange = {}  # Store {normalization: range}
-        self._roiForAutoscale = None
+        self._roiForAutoscale = None    # store as None or as a Rectangle
 
     def clearColormapRangeCache(self):
         self.__cacheColormapRange = {}  # Reset cache
@@ -630,10 +630,9 @@ class ColormapMixIn(ItemMixInBase):
         self._colormapChanged()
 
     def _setROIForAutoscale(self, roi):
-        from silx.gui.plot.items.roi import RectangleROI
-        if not isinstance(roi, (RectangleROI, type(None))):
-            raise TypeError('only manage rectangle ROI and not {}'
-                            ''.format(type(roi)))
+        if not isinstance(roi, (Rectangle, type(None))):
+            raise TypeError('only manage instance of {} and not {}'
+                            ''.format(Rectangle, type(roi)))
         self._roiForAutoscale = roi
 
     def _colormapChanged(self):
@@ -682,7 +681,7 @@ class ColormapMixIn(ItemMixInBase):
                                copy=copy)
 
     def _filter_data(self, raw_data):
-        return self.raw_data
+        return raw_data
 
     def _getColormapAutoscaleRange(self, colormap=None):
         """Returns the autoscale range for current data and colormap.

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -629,7 +629,7 @@ class ColormapMixIn(ItemMixInBase):
             self._colormap.sigChanged.connect(self._colormapChanged)
         self._colormapChanged()
 
-    def _setROIForAutoscale(self, roi):
+    def _setROIForAutoscale(self, roi, scale):
         if not isinstance(roi, (Rectangle, type(None))):
             raise TypeError('only manage instance of {} and not {}'
                             ''.format(Rectangle, type(roi)))

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -677,8 +677,11 @@ class ColormapMixIn(ItemMixInBase):
         if self.__data is None:
             return None
         else:
-            return numpy.array(self._filter_data(self.__data),
-                               copy=copy)
+            filtered_data = self._filter_data(self.__data)
+            if filtered_data is None:
+                return None
+            else:
+                return numpy.array(filtered_data, copy=copy)
 
     def _filter_data(self, raw_data):
         return raw_data

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -381,8 +381,8 @@ class ImageData(ImageBase, ColormapMixIn):
     def _filter_data(self, raw_data):
         if self._roiForAutoscale is None:
             return raw_data
-        roi = self._roiForAutoscale
 
+        roi = self._roiForAutoscale
         roi_origin = roi.getOrigin()
         roi_size = roi.getSize()
         minX, maxX = roi_origin[0] - roi_size[0], roi_origin[0] + roi_size[0]

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -384,15 +384,13 @@ class ImageData(ImageBase, ColormapMixIn):
         roi = self._roiForAutoscale
         roi_origin = roi.origin
         roi_size = roi.size
-        minX, maxX = roi_origin[0] - roi_size[0], roi_origin[0] + roi_size[0]
-        minY, maxY = roi_origin[1] - roi_size[1], roi_origin[1] + roi_size[1]
+        minX, maxX = roi_origin[0], roi_origin[0] + roi_size[0]
+        minY, maxY = roi_origin[1], roi_origin[1] + roi_size[1]
 
-        origin = self.getOrigin()
-        scale = self.getScale()
-        XMinBound = int((minX - origin[0]) / scale[0])
-        YMinBound = int((minY - origin[1]) / scale[1])
-        XMaxBound = int((maxX - origin[0]) / scale[0])
-        YMaxBound = int((maxY - origin[1]) / scale[1])
+        XMinBound = int(minX)
+        YMinBound = int(minY)
+        XMaxBound = int(maxX)
+        YMaxBound = int(maxY)
 
         XMinBound = max(XMinBound, 0)
         YMinBound = max(YMinBound, 0)

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -42,7 +42,6 @@ import numpy
 from ....utils.proxy import docstring
 from .core import (DataItem, LabelsMixIn, DraggableMixIn, ColormapMixIn,
                    AlphaMixIn, ItemChangedType)
-from silx.gui.colors import _AutoscaleMethod
 
 _logger = logging.getLogger(__name__)
 
@@ -383,8 +382,8 @@ class ImageData(ImageBase, ColormapMixIn):
             return raw_data
 
         roi = self._roiForAutoscale
-        roi_origin = roi.getOrigin()
-        roi_size = roi.getSize()
+        roi_origin = roi.origin
+        roi_size = roi.size
         minX, maxX = roi_origin[0] - roi_size[0], roi_origin[0] + roi_size[0]
         minY, maxY = roi_origin[1] - roi_size[1], roi_origin[1] + roi_size[1]
 

--- a/silx/math/geometry/__init__.py
+++ b/silx/math/geometry/__init__.py
@@ -1,0 +1,52 @@
+# coding: utf-8
+# /*##########################################################################
+# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+
+__authors__ = ["H. Payno"]
+__license__ = "MIT"
+__date__ = "22/10/2020"
+
+
+class Rectangle:
+    """
+    Define a simple Rectangle from an origin and a size
+    """
+    def __init__(self, origin: tuple = (0, 0), size: tuple = (0, 0)):
+        self._origin = origin
+        self._size = size
+
+    @property
+    def origin(self):
+        return self._origin
+
+    @origin.setter
+    def origin(self, origin):
+        self._origin = origin
+
+    @property
+    def size(self):
+        return self._size
+
+    @size.setter
+    def size(self, size_):
+        self._size = size_

--- a/silx/math/setup.py
+++ b/silx/math/setup.py
@@ -36,6 +36,7 @@ from numpy.distutils.misc_util import Configuration
 def configuration(parent_package='', top_path=None):
     config = Configuration('math', parent_package, top_path)
     config.add_subpackage('test')
+    config.add_subpackage('geometry')
     config.add_subpackage('fit')
     config.add_subpackage('medianfilter')
     config.add_subpackage('fft')


### PR DESCRIPTION
INFO
====
This will:
- add an optional `_roiForAutoscale` variable to the ColormapMixIn. This is for now a RectanleROI. @vallsv suggest to use a 'simpler' ROI (origin + size) in order for the variable to be 'pure' data. And not an object. Would simplify the conception for future. In this case I guess RectangleROI should inherit / or contain from this data structure
- add a `_filter_data` function to filter item data according to the roi if it is set. For now only Scatter2D and ImageData will overwrite it.
- roi should be a RectangleROI

related to #2429 and https://gitlab.esrf.fr/tomotools/tomwer/-/issues/494

- I guess there is something to be done with `_filter_data` and taking a roi as a parameter to have a common treatment with statistics.
- setting the roi to the item should be check twice because I am not sure I didn't mess origin / scale management or 'reference'
- Scatter origin is also probably miss handled
TODO
=====
- [x] update `ColormapDialog` interface
- manage
    - [x] handle `ImageData`
    - [ ] handle `Scatter`
    - [x] plot limits (using an 'invisible roi'): name `from visible data`
    - [x] user defined roi (can be edited): name `from roi`
    - the current mode would be renamed from `all data`
    - [ ] display options 'visible data' and `roi` only if the item type is compatible (`ImageData` or `Scatter`)

- [ ] test
    - [x] `ImageData`
    - [ ] `Scatter`
- [ ] doc

- ~~[ ] instead of redefining a definition of `Rectangle` it would be better to add a dependency to a library defining those geometric primitive. Don't reinvent the wheel~~ If done will be part of another PR

Screenshot
=========

An idea of the possible update at the gui side

![Screenshot from 2020-10-22 17-13-52](https://user-images.githubusercontent.com/12907796/96892582-10831300-148a-11eb-8ec9-f010e3208c9e.png)

![Screenshot from 2020-10-22 17-14-02](https://user-images.githubusercontent.com/12907796/96892584-10831300-148a-11eb-9c96-6e5546d8011d.png)

