### PR TITLE
silx.gui.plot: Fixed PlotWidget image items displayed below the grid by default

### DIFF
--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1018,7 +1018,11 @@ class BackendMatplotlib(BackendBase.BackendBase):
             lambda item: item.isVisible() and item._backendRenderer is not None)
         count = len(items)
         for index, item in enumerate(items):
-            zorder = 1. + index / count
+            if item.getZValue() < 0.5:
+                # Make sure matplotlib z order is below the grid (with z=0.5)
+                zorder = 0.5 * index / count
+            else:  # Make sure matplotlib z order is above the grid (> 0.5)
+                zorder = 1. + index / count
             if zorder != item._backendRenderer.get_zorder():
                 item._backendRenderer.set_zorder(zorder)
 


### PR DESCRIPTION
This PR restore behavior of silx 0.11.0 regarding sorting of items and grid with the matplotlib backend.
Items with a z value <= 0 are displayed below the grid, items with a z value >= 1 are displayed above.
Images have a default z value of 0 while curves have a default z value of 1.

closes #3233