### PR TITLE
silx.gui.utils.testutils: Fixed handling of QApplication instance in tests.

### DIFF
--- a/silx/gui/utils/testutils.py
+++ b/silx/gui/utils/testutils.py
@@ -142,8 +142,6 @@ class TestCaseQt(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         sys.excepthook = cls._oldExceptionHook
-        if cls._qapp is not None:
-            cls._qapp = None
 
     def setUp(self):
         """Get the list of existing widgets."""


### PR DESCRIPTION
There is no reason not to keep the QApplication once we created it, and this is causing troubles.

closes #3228