### PR TITLE
HDF5 strings: handle h5py 2.x and 3.x

### DIFF
--- a/silx/app/test/test_convert.py
+++ b/silx/app/test/test_convert.py
@@ -40,7 +40,7 @@ import h5py
 import silx
 from .. import convert
 from silx.utils import testutils
-
+from silx.io.utils import h5py_read_dataset
 
 
 # content of a spec file
@@ -137,7 +137,7 @@ class TestConvertCommand(unittest.TestCase):
         self.assertTrue(os.path.isfile(h5name))
 
         with h5py.File(h5name, "r") as h5f:
-            title12 = h5f["/1.2/title"][()]
+            title12 = h5py_read_dataset(h5f["/1.2/title"])
             if sys.version_info < (3, ):
                 title12 = title12.encode("utf-8")
             self.assertEqual(title12,

--- a/silx/gui/data/test/test_textformatter.py
+++ b/silx/gui/data/test/test_textformatter.py
@@ -36,6 +36,7 @@ import six
 from silx.gui.utils.testutils import TestCaseQt
 from silx.gui.utils.testutils import SignalListener
 from ..TextFormatter import TextFormatter
+from silx.io.utils import h5py_read_dataset
 
 import h5py
 
@@ -123,76 +124,80 @@ class TestTextFormatterWithH5py(TestCaseQt):
         dataset = self.h5File.create_dataset(testName, data=data, dtype=dtype)
         return dataset
 
+    def read_dataset(self, d):
+        data = h5py_read_dataset(d)
+        return self.formatter.toString(data, dtype=d.dtype)
+
     def testAscii(self):
         d = self.create_dataset(data=b"abc")
-        result = self.formatter.toString(d[()], dtype=d.dtype)
+        result = self.read_dataset(d)
         self.assertEqual(result, '"abc"')
 
     def testUnicode(self):
         d = self.create_dataset(data=u"i\u2661cookies")
-        result = self.formatter.toString(d[()], dtype=d.dtype)
+        result = self.read_dataset(d)
         self.assertEqual(len(result), 11)
         self.assertEqual(result, u'"i\u2661cookies"')
 
     def testBadAscii(self):
         d = self.create_dataset(data=b"\xF0\x9F\x92\x94")
-        result = self.formatter.toString(d[()], dtype=d.dtype)
+        result = self.read_dataset(d)
         self.assertEqual(result, 'b"\\xF0\\x9F\\x92\\x94"')
 
     def testVoid(self):
         d = self.create_dataset(data=numpy.void(b"abc\xF0"))
-        result = self.formatter.toString(d[()], dtype=d.dtype)
+        result = self.read_dataset(d)
         self.assertEqual(result, 'b"\\x61\\x62\\x63\\xF0"')
 
     def testEnum(self):
         dtype = h5py.special_dtype(enum=('i', {"RED": 0, "GREEN": 1, "BLUE": 42}))
         d = numpy.array(42, dtype=dtype)
         d = self.create_dataset(data=d)
-        result = self.formatter.toString(d[()], dtype=d.dtype)
+        result = self.read_dataset(d)
         self.assertEqual(result, 'BLUE(42)')
 
     def testRef(self):
         dtype = h5py.special_dtype(ref=h5py.Reference)
         d = numpy.array(self.h5File.ref, dtype=dtype)
         d = self.create_dataset(data=d)
-        result = self.formatter.toString(d[()], dtype=d.dtype)
+        result = self.read_dataset(d)
         self.assertEqual(result, 'REF')
 
     def testArrayAscii(self):
         d = self.create_dataset(data=[b"abc"])
-        result = self.formatter.toString(d[()], dtype=d.dtype)
+        result = self.read_dataset(d)
         self.assertEqual(result, '["abc"]')
 
     def testArrayUnicode(self):
         dtype = h5py.special_dtype(vlen=six.text_type)
         d = numpy.array([u"i\u2661cookies"], dtype=dtype)
         d = self.create_dataset(data=d)
-        result = self.formatter.toString(d[()], dtype=d.dtype)
+        result = self.read_dataset(d)
         self.assertEqual(len(result), 13)
         self.assertEqual(result, u'["i\u2661cookies"]')
 
     def testArrayBadAscii(self):
         d = self.create_dataset(data=[b"\xF0\x9F\x92\x94"])
-        result = self.formatter.toString(d[()], dtype=d.dtype)
+        result = self.read_dataset(d)
         self.assertEqual(result, '[b"\\xF0\\x9F\\x92\\x94"]')
 
     def testArrayVoid(self):
         d = self.create_dataset(data=numpy.void([b"abc\xF0"]))
-        result = self.formatter.toString(d[()], dtype=d.dtype)
+        result = self.read_dataset(d)
         self.assertEqual(result, '[b"\\x61\\x62\\x63\\xF0"]')
 
     def testArrayEnum(self):
         dtype = h5py.special_dtype(enum=('i', {"RED": 0, "GREEN": 1, "BLUE": 42}))
         d = numpy.array([42, 1, 100], dtype=dtype)
         d = self.create_dataset(data=d)
-        result = self.formatter.toString(d[()], dtype=d.dtype)
+        result = self.read_dataset(d)
         self.assertEqual(result, '[BLUE(42) GREEN(1) 100]')
 
     def testArrayRef(self):
         dtype = h5py.special_dtype(ref=h5py.Reference)
         d = numpy.array([self.h5File.ref, None], dtype=dtype)
         d = self.create_dataset(data=d)
-        result = self.formatter.toString(d[()], dtype=d.dtype)
+        result = self.read_dataset(d)
         self.assertEqual(result, '[REF NULL_REF]')
 
 

--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -46,12 +46,8 @@ __date__ = "17/07/2018"
 
 logger = logging.getLogger(__name__)
 
-try:
-    vlen_utf8 = h5py.special_dtype(vlen=unicode if sys.version_info[0] == 2 else str)
-    vlen_bytes = h5py.special_dtype(vlen=bytes)
-except AttributeError:
-    # h5py does not support variable-length types
-    vlen_utf8 = vlen_bytes = None
+vlen_utf8 = h5py.special_dtype(vlen=str)
+vlen_bytes = h5py.special_dtype(vlen=bytes)
 
 
 def _prepare_hdf5_write_value(array_like):

--- a/silx/io/nxdata/parse.py
+++ b/silx/io/nxdata/parse.py
@@ -45,7 +45,7 @@ import json
 import numpy
 import six
 
-from silx.io.utils import is_group, is_file, is_dataset
+from silx.io.utils import is_group, is_file, is_dataset, h5py_read_dataset
 
 from ._utils import get_attr_as_unicode, INTERPDIM, nxdata_logger, \
     get_uncertainties_names, get_signal_name, \
@@ -628,7 +628,7 @@ class NXdata(object):
         data_dataset_names = [self.signal_name] + self.axes_dataset_names
         if (title is not None and is_dataset(title) and
                 "title" not in data_dataset_names):
-            return str(title[()])
+            return str(h5py_read_dataset(title))
 
         title = self.group.attrs.get("title")
         if title is None:

--- a/silx/io/test/test_dictdump.py
+++ b/silx/io/test/test_dictdump.py
@@ -279,6 +279,26 @@ class TestH5ToDict(unittest.TestCase):
         self.assertTrue(is_link(ddict["external_link"]))
         self.assertTrue(is_link(ddict["group"]["relative_softlink"]))
 
+    def testStrings(self):
+        ddict = {"dset_bytes": b"bytes",
+                 "dset_utf8": "utf8",
+                 "dset_2bytes": [b"bytes", b"bytes"],
+                 "dset_2utf8": ["utf8", "utf8"],
+                 ("", "attr_bytes"): b"bytes",
+                 ("", "attr_utf8"): "utf8",
+                 ("", "attr_2bytes"): [b"bytes", b"bytes"],
+                 ("", "attr_2utf8"): ["utf8", "utf8"]}
+        dicttoh5(ddict, self.h5_fname, mode="w")
+        adict = h5todict(self.h5_fname, include_attributes=True, asarray=False)
+        self.assertEqual(ddict["dset_bytes"], adict["dset_bytes"])
+        self.assertEqual(ddict["dset_utf8"], adict["dset_utf8"])
+        self.assertEqual(ddict[("", "attr_bytes")], adict[("", "attr_bytes")])
+        self.assertEqual(ddict[("", "attr_utf8")], adict[("", "attr_utf8")])
+        numpy.testing.assert_array_equal(ddict["dset_2bytes"], adict["dset_2bytes"])
+        numpy.testing.assert_array_equal(ddict["dset_2utf8"], adict["dset_2utf8"])
+        numpy.testing.assert_array_equal(ddict[("", "attr_2bytes")], adict[("", "attr_2bytes")])
+        numpy.testing.assert_array_equal(ddict[("", "attr_2utf8")], adict[("", "attr_2utf8")])
+
 
 class TestDictToNx(unittest.TestCase):
     def setUp(self):

--- a/silx/io/test/test_spectoh5.py
+++ b/silx/io/test/test_spectoh5.py
@@ -33,6 +33,7 @@ import h5py
 
 from ..spech5 import SpecH5, SpecH5Group
 from ..convert import convert, write_to_h5
+from ..utils import h5py_read_dataset
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
@@ -129,7 +130,7 @@ class TestConvertSpecHDF5(unittest.TestCase):
 
     def testTitle(self):
         """Test the value of a dataset"""
-        title12 = self.h5f["/1.2/title"][()]
+        title12 = h5py_read_dataset(self.h5f["/1.2/title"])
         self.assertEqual(title12,
                          u"aaaaaa")
 

--- a/silx/io/test/test_utils.py
+++ b/silx/io/test/test_utils.py
@@ -567,7 +567,9 @@ class TestGetData(unittest.TestCase):
 
     def test_hdf5_array_slice_out_of_range(self):
         url = "silx:%s?path=/group/group/array2d&slice=5" % self.h5_filename
-        self.assertRaises(ValueError, utils.get_data, url)
+        # ValueError: h5py 2.x
+        # IndexError: h5py 3.x
+        self.assertRaises((ValueError, IndexError), utils.get_data, url)
 
     def test_edf_using_silx(self):
         url = "silx:%s?/scan_0/instrument/detector_0/data" % self.edf_filename

--- a/silx/io/test/test_utils.py
+++ b/silx/io/test/test_utils.py
@@ -716,6 +716,153 @@ class TestRawFileToH5(unittest.TestCase):
                                            shape=self._dataset_shape))
 
 
+class TestH5Strings(unittest.TestCase):
+    """Test HDF5 str and bytes writing and reading"""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.tempdir = tempfile.mkdtemp()
+        cls.vlenstr = h5py.special_dtype(vlen=str)
+        cls.vlenbytes = h5py.special_dtype(vlen=bytes)
+        try:
+            cls.unicode = unicode
+        except NameError:
+            cls.unicode = str
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.tempdir)
+
+    def setUp(self):
+        self.file = h5py.File(os.path.join(self.tempdir, 'file.h5'), mode="w")
+
+    def tearDown(self):
+        self.file.close()
+
+    @classmethod
+    def _make_array(cls, value, n):
+        if isinstance(value, bytes):
+            dtype = cls.vlenbytes
+        elif isinstance(value, cls.unicode):
+            dtype = cls.vlenstr
+        else:
+            return numpy.array([value]*n)
+        return numpy.array([value]*n, dtype=dtype)
+
+    @classmethod
+    def _get_charset(cls, value):
+        if isinstance(value, bytes):
+            return h5py.h5t.CSET_ASCII
+        elif isinstance(value, cls.unicode):
+            return h5py.h5t.CSET_UTF8
+        else:
+            return None
+
+    def _check_dataset(self, value, result=None):
+        # Write+read scalar
+        if result:
+            decode_ascii = True
+        else:
+            decode_ascii = False
+            result = value
+        charset = self._get_charset(value)
+        self.file["data"] = value
+        data = utils.h5py_read_dataset(self.file["data"], decode_ascii=decode_ascii)
+        assert type(data) == type(result), data
+        assert data == result, data
+        if charset:
+            assert self.file["data"].id.get_type().get_cset() == charset
+
+        # Write+read variable length
+        self.file["vlen_data"] = self._make_array(value, 2)
+        data = utils.h5py_read_dataset(self.file["vlen_data"], decode_ascii=decode_ascii, index=0)
+        assert type(data) == type(result), data
+        assert data == result, data
+        data = utils.h5py_read_dataset(self.file["vlen_data"], decode_ascii=decode_ascii)
+        numpy.testing.assert_array_equal(data, [result]*2)
+        if charset:
+            assert self.file["vlen_data"].id.get_type().get_cset() == charset
+
+    def _check_attribute(self, value, result=None):
+        if result:
+            decode_ascii = True
+        else:
+            decode_ascii = False
+            result = value
+        self.file.attrs["data"] = value
+        data = utils.h5py_read_attribute(self.file.attrs, "data", decode_ascii=decode_ascii)
+        assert type(data) == type(result), data
+        assert data == result, data
+
+        self.file.attrs["vlen_data"] = self._make_array(value, 2)
+        data = utils.h5py_read_attribute(self.file.attrs, "vlen_data", decode_ascii=decode_ascii)
+        assert type(data[0]) == type(result), data[0]
+        assert data[0] == result, data[0]
+        numpy.testing.assert_array_equal(data, [result]*2)
+
+    def test_dataset_ascii_bytes(self):
+        self._check_dataset(b"abc")
+
+    def test_attribute_ascii_bytes(self):
+        self._check_attribute(b"abc")
+
+    def test_dataset_ascii_bytes_decode(self):
+        self._check_dataset(b"abc", result="abc")
+
+    def test_attribute_ascii_bytes_decode(self):
+        self._check_attribute(b"abc", result="abc")
+
+    def test_dataset_ascii_str(self):
+        self._check_dataset("abc")
+
+    def test_attribute_ascii_str(self):
+        self._check_attribute("abc")
+
+    def test_dataset_utf8_str(self):
+        self._check_dataset("\u0101bc")
+
+    def test_attribute_utf8_str(self):
+        self._check_attribute("\u0101bc")
+
+    def test_dataset_utf8_bytes(self):
+        # 0xC481 is the byte representation of U+0101
+        self._check_dataset(b"\xc4\x81bc")
+
+    def test_attribute_utf8_bytes(self):
+        # 0xC481 is the byte representation of U+0101
+        self._check_attribute(b"\xc4\x81bc")
+
+    def test_dataset_utf8_bytes_decode(self):
+        # 0xC481 is the byte representation of U+0101
+        self._check_dataset(b"\xc4\x81bc", result="\u0101bc")
+
+    def test_attribute_utf8_bytes_decode(self):
+        # 0xC481 is the byte representation of U+0101
+        self._check_attribute(b"\xc4\x81bc", result="\u0101bc")
+
+    def test_dataset_latin1_bytes(self):
+        # extended ascii character 0xE4
+        self._check_dataset(b"\xe423")
+
+    def test_attribute_latin1_bytes(self):
+        # extended ascii character 0xE4
+        self._check_attribute(b"\xe423")
+
+    def test_dataset_latin1_bytes_decode(self):
+        # U+DCE4: surrogate for extended ascii character 0xE4
+        self._check_dataset(b"\xe423", result="\udce423")
+
+    def test_attribute_latin1_bytes_decode(self):
+        # U+DCE4: surrogate for extended ascii character 0xE4
+        self._check_attribute(b"\xe423", result="\udce423")
+
+    def test_dataset_no_string(self):
+        self._check_dataset(numpy.int64(10))
+
+    def test_attribute_no_string(self):
+        self._check_attribute(numpy.int64(10))
+
+
 def suite():
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
     test_suite = unittest.TestSuite()
@@ -725,6 +872,7 @@ def suite():
     test_suite.addTest(loadTests(TestNodes))
     test_suite.addTest(loadTests(TestGetData))
     test_suite.addTest(loadTests(TestRawFileToH5))
+    test_suite.addTest(loadTests(TestH5Strings))
     return test_suite
 
 

--- a/silx/io/test/test_utils.py
+++ b/silx/io/test/test_utils.py
@@ -802,6 +802,11 @@ class TestH5Strings(unittest.TestCase):
         assert data[0] == result, data[0]
         numpy.testing.assert_array_equal(data, [result]*2)
 
+        data = utils.h5py_read_attributes(self.file.attrs, decode_ascii=decode_ascii)["vlen_data"]
+        assert type(data[0]) == type(result), data[0]
+        assert data[0] == result, data[0]
+        numpy.testing.assert_array_equal(data, [result]*2)
+
     def test_dataset_ascii_bytes(self):
         self._check_dataset(b"abc")
 

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -41,6 +41,8 @@ from silx.utils.proxy import Proxy
 import silx.io.url
 
 import h5py
+import h5py.h5t
+import h5py.h5a
 
 try:
     import h5pyd
@@ -957,3 +959,177 @@ def vol_to_h5_external_dataset(vol_file, output_url, info_file=None,
                                           shape=shape,
                                           dtype=vol_dtype,
                                           overwrite=overwrite)
+
+
+
+def h5py_decode_value(value, encoding="utf-8", errors="surrogateescape"):
+    """Keep bytes when value cannot be decoded
+
+    :param value: bytes or array of bytes
+    :param encoding str:
+    :param errors str:
+    """
+    try:
+        if numpy.isscalar(value):
+            return value.decode(encoding, errors=errors)
+        str_item = [b.decode(encoding, errors=errors) for b in value.flat]
+        return numpy.array(str_item, dtype=object).reshape(value.shape)
+    except UnicodeDecodeError:
+        return value
+
+
+def h5py_encode_value(value, encoding="utf-8", errors="surrogateescape"):
+    """Keep string when value cannot be encoding
+
+    :param value: string or array of strings
+    :param encoding str:
+    :param errors str:
+    """
+    try:
+        if numpy.isscalar(value):
+            return value.encode(encoding, errors=errors)
+        bytes_item = [s.encode(encoding, errors=errors) for s in value.flat]
+        return numpy.array(bytes_item, dtype=object).reshape(value.shape)
+    except UnicodeEncodeError:
+        return value
+
+
+class H5pyDatasetReadWrapper:
+    """Wrapper to handle H5T_STRING decoding on-the-fly when reading
+    a dataset. Uniform behaviour for h5py 2.x and h5py 3.x
+
+    h5py abuses H5T_STRING with ASCII character set
+    to store `bytes`: dset[()] = b"..."
+    Therefore an H5T_STRING with ASCII encoding is not decoded by default.
+    """
+
+    H5PY_AUTODECODE_NONASCII = int(h5py.version.version.split(".")[0]) < 3
+
+    def __init__(self, dset, decode_ascii=False):
+        """
+        :param h5py.Dataset dset:
+        :param bool decode_ascii:
+        """
+        try:
+            string_info = h5py.h5t.check_string_dtype(dset.dtype)
+        except AttributeError:
+            # h5py < 2.10
+            try:
+                idx = dset.id.get_type().get_cset()
+            except AttributeError:
+                # Not an H5T_STRING
+                encoding = None
+            else:
+                encoding = ["ascii", "utf-8"][idx]
+        else:
+            # h5py >= 2.10
+            try:
+                encoding = string_info.encoding
+            except AttributeError:
+                # Not an H5T_STRING
+                encoding = None
+        if encoding == "ascii" and not decode_ascii:
+            encoding = None
+        if encoding != "ascii" and self.H5PY_AUTODECODE_NONASCII:
+            # Decoding is already done by the h5py library
+            encoding = None
+        if encoding == "ascii":
+            # ASCII can be decoded as UTF-8
+            encoding = "utf-8"
+        self._encoding = encoding
+        self._dset = dset
+
+    def __getitem__(self, args):
+        value = self._dset[args]
+        if self._encoding:
+            return h5py_decode_value(value, encoding=self._encoding)
+        else:
+            return value
+
+
+class H5pyAttributesReadWrapper:
+    """Wrapper to handle H5T_STRING decoding on-the-fly when reading
+    an attribute. Uniform behaviour for h5py 2.x and h5py 3.x
+
+    h5py abuses H5T_STRING with ASCII character set
+    to store `bytes`: dset[()] = b"..."
+    Therefore an H5T_STRING with ASCII encoding is not decoded by default.
+    """
+
+    H5PY_AUTODECODE = int(h5py.version.version.split(".")[0]) >= 3
+
+    def __init__(self, attrs, decode_ascii=False):
+        """
+        :param h5py.Dataset dset:
+        :param bool decode_ascii:
+        """
+        self._attrs = attrs
+        self._decode_ascii = decode_ascii
+
+    def __getitem__(self, args):
+        value = self._attrs[args]
+
+        # Get the string encoding (if a string)
+        try:
+            dtype = self._attrs.get_id(args).dtype
+        except AttributeError:
+            # h5py < 2.10
+            attr_id = h5py.h5a.open(self._attrs._id, self._attrs._e(args))
+            try:
+                idx = attr_id.get_type().get_cset()
+            except AttributeError:
+                # Not an H5T_STRING
+                return value
+            else:
+                encoding = ["ascii", "utf-8"][idx]
+        else:
+            # h5py >= 2.10
+            try:
+                encoding = h5py.h5t.check_string_dtype(dtype).encoding
+            except AttributeError:
+                # Not an H5T_STRING
+                return value
+
+        if self.H5PY_AUTODECODE:
+            if encoding == "ascii" and not self._decode_ascii:
+                # Undo decoding by the h5py library
+                return h5py_encode_value(value, encoding="utf-8")
+            return value
+        else:
+            if encoding != "ascii":
+                # Decoding is already done by the h5py library
+                return value
+            if encoding == "ascii" and not self._decode_ascii:
+                return value
+            if encoding == "ascii":
+                # ASCII can be decoded as UTF-8
+                encoding = "utf-8"
+            return h5py_decode_value(value, encoding=encoding)
+
+    def items(self):
+        for k in self._attrs.keys():
+            yield k, self[k]
+
+
+def h5py_read_dataset(dset, index=tuple(), decode_ascii=False):
+    """Read data from dataset object. UTF-8 strings will be
+    decoded while ASCII strings will only be decoded when
+    `decode_ascii=True`.
+
+    :param h5py.Dataset dset:
+    :param index: slicing (all by default)
+    :param bool decode_ascii:
+    """
+    return H5pyDatasetReadWrapper(dset, decode_ascii=decode_ascii)[index]
+
+
+def h5py_read_attribute(attrs, name, decode_ascii=False):
+    """Read data from dataset object. UTF-8 strings will be
+    decoded while ASCII strings will only be decoded when
+    `decode_ascii=True`.
+
+    :param h5py.AttributeManager attrs:
+    :param index: slicing (all by default)
+    :param bool decode_ascii:
+    """
+    return H5pyAttributesReadWrapper(attrs, decode_ascii=decode_ascii)[name]

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -1124,12 +1124,12 @@ def h5py_read_dataset(dset, index=tuple(), decode_ascii=False):
 
 
 def h5py_read_attribute(attrs, name, decode_ascii=False):
-    """Read data from dataset object. UTF-8 strings will be
+    """Read data from attributes. UTF-8 strings will be
     decoded while ASCII strings will only be decoded when
     `decode_ascii=True`.
 
     :param h5py.AttributeManager attrs:
-    :param index: slicing (all by default)
+    :param str name: attribute name
     :param bool decode_ascii:
     """
     return H5pyAttributesReadWrapper(attrs, decode_ascii=decode_ascii)[name]

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -835,10 +835,10 @@ def get_data(url):
                 raise ValueError("Data path from URL '%s' is not a dataset" % url.path())
 
             if data_slice is not None:
-                data = data[data_slice]
+                data = h5py_read_dataset(data, index=data_slice)
             else:
                 # works for scalar and array
-                data = data[()]
+                data = h5py_read_dataset(data)
 
     elif url.scheme() == "fabio":
         import fabio

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -1094,17 +1094,13 @@ class H5pyAttributesReadWrapper:
             if encoding == "ascii" and not self._decode_ascii:
                 # Undo decoding by the h5py library
                 return h5py_encode_value(value, encoding="utf-8")
-            return value
         else:
-            if encoding != "ascii":
-                # Decoding is already done by the h5py library
-                return value
-            if encoding == "ascii" and not self._decode_ascii:
-                return value
-            if encoding == "ascii":
-                # ASCII can be decoded as UTF-8
-                encoding = "utf-8"
-            return h5py_decode_value(value, encoding=encoding)
+            if encoding == "ascii" and self._decode_ascii:
+                # Decode ASCII as UTF-8 for consistency
+                return h5py_decode_value(value, encoding="utf-8")
+
+        # Decoding is already done by the h5py library
+        return value
 
     def items(self):
         for k in self._attrs.keys():

--- a/silx/io/utils.py
+++ b/silx/io/utils.py
@@ -1129,3 +1129,14 @@ def h5py_read_attribute(attrs, name, decode_ascii=False):
     :param bool decode_ascii:
     """
     return H5pyAttributesReadWrapper(attrs, decode_ascii=decode_ascii)[name]
+
+
+def h5py_read_attributes(attrs, decode_ascii=False):
+    """Read data from attributes. UTF-8 strings will be
+    decoded while ASCII strings will only be decoded when
+    `decode_ascii=True`.
+
+    :param h5py.AttributeManager attrs:
+    :param bool decode_ascii:
+    """
+    return dict(H5pyAttributesReadWrapper(attrs, decode_ascii=decode_ascii).items())


### PR DESCRIPTION
closes #3218 

More than just accommodating the H5T_STRING decoding changes in h5py 3.0.0rc1, this MR makes H5T_STRING decoding uniform for h5py>=2.8.0. Also the decoding behavior of datasets and attributes is made uniform.

`silx.io.test.test_utils.TestH5Strings` demonstrates the behavior.

Implementation
--------------------

Inspired by the `AsStrWrapper` of h5py 3.0 this MR introduces 2 utility classes and 3 utility methods:

  * `H5pyDatasetReadWrapper`:
     * wraps any dataset, regardless of the `dtype`
     * NON-ASCII H5T_STRING: decode
     * ASCII H5T_STRING: decode when requested
     * when decoding fails, return the bytes
  * `H5pyAttributesReadWrapper`:
     * wraps an AttributeManager
     * NON-ASCII H5T_STRING: decode
     * ASCII H5T_STRING: decode when requested
     * when decoding fails, return the bytes
  * `h5py_read_dataset`: use wrapper and read
  * `h5py_read_attribute`: use wrapper and read
  * `h5py_read_attributes`: use wrapper and read

Discussion
---------------

Whether ASCII H5T_STRING should be decoded by default or not, depends on what our priority is:

 1. **return the same `dtype` as written**: when the file is written by h5py, the only way we can obtain ASCII H5T_STRING is from writing `bytes`
    * Hence do not decode ASCII H5T_STRING (`decode_ascii=False`).
    * If non-h5py code creates an ASCII H5T_STRING with the intention of actually writing a string, `decode_ascii=False` is not appropriate.
 2. **strict HDF5 type**: H5T_STRING means a string so return `str`.
    * Hence decode ASCII H5T_STRING (`decode_ascii=True`).
    * If someone abuses H5T_STRING to save an array of bytes (h5py does this), `decode_ascii=True` is not appropriate.

In this MR I made choice 1 (decoding ASCII H5T_STRING is optional).

Other changes in this MR:
-----------------------------------
  * Fix the tests that failed for h5py 3.0.0rc1
  * Use wrappers in `h5todict`
  * `h5todict` always saves variable-length strings

Future: 
---------
We will probably have to use the wrappers in more places in silx. I only did it in `h5todict` and all the places that broke CI.
