### PR TITLE
silx.gui.plot.PlotWidget: Fixed OpenGL backend image display with sqrt colormap normalization

### DIFF
--- a/silx/gui/plot/backends/glutils/GLPlotImage.py
+++ b/silx/gui/plot/backends/glutils/GLPlotImage.py
@@ -291,7 +291,7 @@ class GLPlotColormap(_GLPlotData2D):
         if self.normalization == 'log':
             assert self._cmapRange[0] > 0. and self._cmapRange[1] > 0.
         elif self.normalization == 'sqrt':
-            assert self._cmapRange[0] >= 0. and self._cmapRange[1] > 0.
+            assert self._cmapRange[0] >= 0. and self._cmapRange[1] >= 0.
         return self._cmapRange
 
     @cmapRange.setter


### PR DESCRIPTION
This PR fixes a typo which causes a bug for displaying all zeros image with sqrt colormap normalization in the OpenGL backend of the PlotWidget.

closes #3242
