### PR TITLE
Workaround to use only Qt5.7 API

### DIFF
--- a/silx/gui/plot/tools/profile/manager.py
+++ b/silx/gui/plot/tools/profile/manager.py
@@ -83,6 +83,8 @@ class _RunnableComputeProfile(qt.QRunnable):
 
         The threadpool will still execute the runner, but this will process
         nothing.
+
+        This is only used with Qt<5.9 where QThreadPool.tryTake is not available.
         """
         self._cancelled = True
 
@@ -828,7 +830,7 @@ class ProfileManager(qt.QObject):
                 if hasattr(threadPool, "tryTake"):
                     if threadPool.tryTake(runner):
                         self._pendingRunners.remove(runner)
-                else:
+                else:  # Support Qt<5.9
                     runner._lazyCancel()
 
         item = self.getPlotItem()


### PR DESCRIPTION
Here is a workaround for #3244. This remove the use of `tryTake` in a lazy way.

If we want to create a bug fix release, I suggest to only apply that in the branch, and update the supported Qt version on the master branch.

I still have to setup a Qt5.7 env to check it manually.

<!--
You are encouraged to write a PR title that is meaningful by itself.
It will be used to auto-generate the complete changelog.

To highlight a change in the changelog, please add a line starting with `Changelog: ` in the PR description.
It will be used to generate the changelog's summary.

E.g., Changelog: Added new wonderful feature
-->


Changelog: 

- Fix use of `QThreadPool.tryTake` to be Qt5.7 complient