### PR TITLE
[io][dictdump] handle providing numpy arrays of 'numbers'

### DIFF
--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -60,12 +60,15 @@ def _prepare_hdf5_write_value(array_like):
     array = numpy.asarray(array_like)
     if vlen_bytes:
         # Fix-length string type to variable-length type
-        kind = array.dtype.kind.lower()
-        if kind in ["s", "u"]:
-            if kind == "s":
-                return numpy.array(array_like, dtype=vlen_bytes)
-            else:
-                return numpy.array(array_like, dtype=vlen_utf8)
+        if numpy.issubdtype(array.dtype, numpy.number):
+            return array
+        else:
+            kind = array.dtype.kind.lower()
+            if kind in ["s", "u"]:
+                if kind == "s":
+                    return numpy.array(array_like, dtype=vlen_bytes)
+                else:
+                    return numpy.array(array_like, dtype=vlen_utf8)
     return array
 
 
@@ -252,7 +255,7 @@ def dicttoh5(treedict, h5file, h5path='/',
 
         # deal with h5 attributes which have tuples as keys in treedict
         for key in filter(lambda k: isinstance(k, tuple), treedict):
-            assert len(key)==2, "attribute must be defined by 2 values"
+            assert len(key) == 2, "attribute must be defined by 2 values"
             h5name = h5path + key[0]
             attr_name = key[1]
 

--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -58,17 +58,12 @@ def _prepare_hdf5_write_value(array_like):
     :return: ``numpy.ndarray`` ready to be written as an HDF5 dataset
     """
     array = numpy.asarray(array_like)
-    if numpy.issubdtype(array.dtype, numpy.number):
-        return array
+    if numpy.issubdtype(array.dtype, numpy.bytes_):
+        return numpy.array(array_like, dtype=vlen_bytes)
+    elif numpy.issubdtype(array.dtype, numpy.unicode):
+        return numpy.array(array_like, dtype=vlen_utf8)
     else:
-        # Fix-length string type to variable-length type
-        kind = array.dtype.kind.lower()
-        if kind in ["s", "u"]:
-            if kind == "s":
-                return numpy.array(array_like, dtype=vlen_bytes)
-            else:
-                return numpy.array(array_like, dtype=vlen_utf8)
-    return array
+        return array
 
 
 class _SafeH5FileWrite(object):

--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -58,17 +58,16 @@ def _prepare_hdf5_write_value(array_like):
     :return: ``numpy.ndarray`` ready to be written as an HDF5 dataset
     """
     array = numpy.asarray(array_like)
-    if vlen_bytes:
+    if numpy.issubdtype(array.dtype, numpy.number):
+        return array
+    else:
         # Fix-length string type to variable-length type
-        if numpy.issubdtype(array.dtype, numpy.number):
-            return array
-        else:
-            kind = array.dtype.kind.lower()
-            if kind in ["s", "u"]:
-                if kind == "s":
-                    return numpy.array(array_like, dtype=vlen_bytes)
-                else:
-                    return numpy.array(array_like, dtype=vlen_utf8)
+        kind = array.dtype.kind.lower()
+        if kind in ["s", "u"]:
+            if kind == "s":
+                return numpy.array(array_like, dtype=vlen_bytes)
+            else:
+                return numpy.array(array_like, dtype=vlen_utf8)
     return array
 
 

--- a/silx/io/test/test_dictdump.py
+++ b/silx/io/test/test_dictdump.py
@@ -44,6 +44,7 @@ from ..dictdump import dicttoh5, dicttojson, dump
 from ..dictdump import h5todict, load
 from ..dictdump import logger as dictdump_logger
 from ..utils import is_link
+from ..utils import h5py_read_dataset
 
 
 def tree():
@@ -227,6 +228,18 @@ class TestDictToH5(unittest.TestCase):
             self.assertEqual(h5file["links/relative_softlink"][()], 10)
             self.assertEqual(h5file["links/absolute_softlink"][()], 10)
             self.assertEqual(h5file["links/external_link"][()], 10)
+
+    def testDumpNumpyArray(self):
+        ddict = {
+            'darks': {
+                '0': numpy.array([[0, 0, 0], [0, 0, 0]], dtype=numpy.uint16)
+            }
+        }
+        with h5py.File(self.h5_fname, "w") as h5file:
+            dictdump.dicttoh5(ddict, h5file)
+        with h5py.File(self.h5_fname, "r") as h5file:
+            numpy.testing.assert_array_equal(h5py_read_dataset(h5file["darks"]["0"]),
+                                             ddict['darks']['0'])
 
 
 class TestH5ToDict(unittest.TestCase):


### PR DESCRIPTION
First check if the array is a numpy array of 'number' else do the previous treatment.
Otherwise the test added (testDumpNumpyArray) fails with h5py 3.0:

======================================================================
ERROR: testDumpNumpyArray (silx.io.test.test_dictdump.TestDictToH5)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/payno/dev/silx/build/lib.linux-x86_64-3.7/silx/io/test/test_dictdump.py", line 239, in testDumpNumpyArray
    dictdump.dicttoh5(ddict, h5file)
  File "/home/payno/dev/silx/build/lib.linux-x86_64-3.7/silx/io/dictdump.py", line 226, in dicttoh5
    create_dataset_args=create_dataset_args)
  File "/home/payno/dev/silx/build/lib.linux-x86_64-3.7/silx/io/dictdump.py", line 255, in dicttoh5
    data=data)
  File "/home/payno/.local/share/virtualenvs/silx_venv/lib/python3.7/site-packages/h5py/_hl/group.py", line 153, in create_dataset
    dsid = dataset.make_new_dset(group, shape, dtype, data, name, **kwds)
  File "/home/payno/.local/share/virtualenvs/silx_venv/lib/python3.7/site-packages/h5py/_hl/dataset.py", line 137, in make_new_dset
    dset_id.write(h5s.ALL, h5s.ALL, data)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "h5py/h5d.pyx", line 232, in h5py.h5d.DatasetID.write
  File "h5py/_proxy.pyx", line 145, in h5py._proxy.dset_rw
  File "h5py/_conv.pyx", line 443, in h5py._conv.str2vlen
  File "h5py/_conv.pyx", line 94, in h5py._conv.generic_converter
  File "h5py/_conv.pyx", line 248, in h5py._conv.conv_str2vlen
TypeError: Can't implicitly convert non-string objects to strings

<!--
You are encouraged to write a PR title that is meaningful by itself.
It will be used to auto-generate the complete changelog.

To highlight a change in the changelog, please add a line starting with `Changelog: ` in the PR description.
It will be used to generate the changelog's summary.

E.g., Changelog: Added new wonderful feature
-->


Changelog: 
