### PR TITLE
silx.gui.data: Make TextFormatter compatible with h5py>=3

### DIFF
--- a/silx/gui/data/TextFormatter.py
+++ b/silx/gui/data/TextFormatter.py
@@ -267,6 +267,9 @@ class TextFormatter(qt.QObject):
         if vlen is not None:
             if vlen == six.text_type:
                 # HDF5 UTF8
+                # With h5py>=3 reading dataset returns bytes
+                if isinstance(data, (bytes, numpy.bytes_)):
+                    data = data.decode("utf-8")
                 return self.__formatText(data)
             elif vlen == six.binary_type:
                 # HDF5 ASCII
@@ -289,7 +292,7 @@ class TextFormatter(qt.QObject):
         elif isinstance(data, list):
             text = [self.toString(d) for d in data]
             return "[" + " ".join(text) + "]"
-        elif isinstance(data, (numpy.ndarray)):
+        elif isinstance(data, numpy.ndarray):
             if dtype is None:
                 dtype = data.dtype
             if data.shape == ():

--- a/silx/gui/data/TextFormatter.py
+++ b/silx/gui/data/TextFormatter.py
@@ -269,7 +269,10 @@ class TextFormatter(qt.QObject):
                 # HDF5 UTF8
                 # With h5py>=3 reading dataset returns bytes
                 if isinstance(data, (bytes, numpy.bytes_)):
-                    data = data.decode("utf-8")
+                    try:
+                        data = data.decode("utf-8")
+                    except UnicodeDecodeError:
+                        self.__formatSafeAscii(data)
                 return self.__formatText(data)
             elif vlen == six.binary_type:
                 # HDF5 ASCII

--- a/silx/gui/data/test/test_textformatter.py
+++ b/silx/gui/data/test/test_textformatter.py
@@ -125,8 +125,7 @@ class TestTextFormatterWithH5py(TestCaseQt):
         return dataset
 
     def read_dataset(self, d):
-        data = h5py_read_dataset(d)
-        return self.formatter.toString(data, dtype=d.dtype)
+        return self.formatter.toString(d[()], dtype=d.dtype)
 
     def testAscii(self):
         d = self.create_dataset(data=b"abc")

--- a/tools/create_h5_sample.py
+++ b/tools/create_h5_sample.py
@@ -159,9 +159,36 @@ def create_hdf5_types(group):
 
     # H5T_STRING
 
-    main_group["text/ascii"] = b"abcd"
-    main_group["text/bad_ascii"] = b"ab\xEFcd\xFF"
-    main_group["text/utf8"] = u"me \u2661 tu"
+    group = main_group.create_group("text")
+    group.create_dataset(
+        "ascii_vlen", data=b"abcd", dtype=h5py.string_dtype('ascii'))
+    group.create_dataset(
+        "bad_ascii_vlen", data=b"ab\xEFcd\xFF", dtype=h5py.string_dtype('ascii'))
+    group.create_dataset(
+        "ascii_fixed", data=b"Fixed ascii", dtype=h5py.string_dtype('ascii', 20))
+    group.create_dataset(
+        "array_ascii_vlen",
+        data=['a', 'bc', 'def', 'ghij', 'klmn'],
+        dtype=h5py.string_dtype('ascii'))
+    group.create_dataset(
+        "array_ascii_fixed",
+        data=['abcde', 'fghij'],
+        dtype=h5py.string_dtype('ascii', 5))
+
+    group.create_dataset(
+        "utf8_vlen", data=u"me \u2661 tu", dtype=h5py.string_dtype('utf-8'))
+    group.create_dataset(
+        "utf8_fixed",
+        data=u"me \u2661 tu".encode('utf-8'),
+        dtype=h5py.string_dtype('utf-8', 20))
+    group.create_dataset(
+        "array_utf8_vlen",
+        data=['a', 'bc', 'def', 'ghij', 'klmn'],
+        dtype=h5py.string_dtype('utf-8'))
+    group.create_dataset(
+        "array_utf8_fixed",
+        data=['abcde', 'fghij'],
+        dtype=h5py.string_dtype('utf-8', 5))
 
     # H5T_BITFIELD
 


### PR DESCRIPTION
First, this PR extends the  `tools/create_h5_sample.py` to create more text datasets to test with.
Then, it makes the `TextFormatter` work across `h5py` 2 and 3.
Finally it reverts changes made in PR #3240 about `test_textformatter.py` to test wht this PR provides.

It looks to work fine in `silx view` from what I tested with both h5py 2.10 and 3.


closes #3245