### PR TITLE
silx.gui.plot.PlotWidget: Added `PlotWidget.[get|set]Backend` enabling switching backend

### DIFF
--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -142,11 +142,9 @@ class ColorBarWidget(qt.QWidget):
             self._isConnected = True
 
     def setVisible(self, isVisible):
-        # isHidden looks to be always synchronized, while isVisible is not
-        wasHidden = self.isHidden()
-        qt.QWidget.setVisible(self, isVisible)
-        if wasHidden != self.isHidden():
-            self.sigVisibleChanged.emit(not self.isHidden())
+        if isVisible != self.isVisible():
+            qt.QWidget.setVisible(self, isVisible)
+            self.sigVisibleChanged.emit(isVisible)
 
     def showEvent(self, event):
         self._connectPlot()

--- a/silx/gui/plot/ImageView.py
+++ b/silx/gui/plot/ImageView.py
@@ -56,7 +56,7 @@ from ..colors import Colormap
 from ..colors import cursorColorForColormap
 from .tools import LimitsToolBar
 from .Profile import ProfileToolBar
-
+from ...utils.proxy import docstring
 
 _logger = logging.getLogger(__name__)
 
@@ -341,6 +341,10 @@ class ImageView(PlotWindow):
         self._radarView = RadarView(parent=self)
         self._radarView.visibleRectDragged.connect(self._radarViewCB)
 
+        self.__setCentralWidget()
+
+    def __setCentralWidget(self):
+        """Set central widget with all its content"""
         layout = qt.QGridLayout()
         layout.addWidget(self.getWidgetHandle(), 0, 0)
         layout.addWidget(self._histoVPlot.getWidgetHandle(), 0, 1)
@@ -364,6 +368,12 @@ class ImageView(PlotWindow):
         centralWidget = qt.QWidget(self)
         centralWidget.setLayout(layout)
         self.setCentralWidget(centralWidget)
+
+    @docstring(PlotWidget)
+    def setBackend(self, backend):
+        # Use PlotWidget here since we override PlotWindow behavior
+        PlotWidget.setBackend(self, backend)
+        self.__setCentralWidget()
 
     def _dirtyCache(self):
         self._cache = None

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -259,6 +259,7 @@ class PlotWidget(qt.QMainWindow):
 
         self._grid = None
         self._graphTitle = ''
+        self.__graphCursorShape = 'default'
 
         # Set axes margins
         self.__axesDisplayed = True
@@ -3028,11 +3029,19 @@ class PlotWidget(qt.QMainWindow):
 
     # Interaction support
 
+    def getGraphCursorShape(self):
+        """Returns the current cursor shape.
+
+        :rtype: str
+        """
+        return self.__graphCursorShape
+
     def setGraphCursorShape(self, cursor=None):
         """Set the cursor shape.
 
         :param str cursor: Name of the cursor shape
         """
+        self.__graphCursorShape = cursor
         self._backend.setGraphCursorShape(cursor)
 
     @deprecated(replacement='getItems', since_version='0.13')

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -399,6 +399,8 @@ class PlotWidget(qt.QMainWindow):
         :raises ValueError: Unsupported backend descriptor
         :raises RuntimeError: Error while loading a backend
         """
+        backend = self.__getBackendClass(backend)(self, self)
+
         # First save state that is stored in the backend
         xaxis = self.getXAxis()
         xmin, xmax = xaxis.getLimits()
@@ -414,7 +416,7 @@ class PlotWidget(qt.QMainWindow):
             item._removeBackendRenderer(self._backend)
 
         # Switch backend
-        self._backend = self.__getBackendClass(backend)(self, self)
+        self._backend = backend
         widget = self._backend.getWidgetHandle()
         self.setCentralWidget(widget)
         if widget is None:

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -410,10 +410,8 @@ class PlotWidget(qt.QMainWindow):
         isYAxisInverted = xaxis.isInverted()
 
         # Remove all items from previous backend
-        # Mark them for update with new backend
         for item in self.getItems():
             item._removeBackendRenderer(self._backend)
-            item._updated()
 
         # Switch backend
         self._backend = self.__getBackendClass(backend)(self, self)
@@ -461,6 +459,10 @@ class PlotWidget(qt.QMainWindow):
         # Finally restore aspect ratio and limits
         self._backend.setKeepDataAspectRatio(isKeepDataAspectRatio)
         self.setLimits(xmin, xmax, ymin, ymax, y2min, y2max)
+
+        # Mark all items for update with new backend
+        for item in self.getItems():
+            item._updated()
 
     def getBackend(self):
         """Returns the backend currently used by :class:`PlotWidget`.

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -222,8 +222,6 @@ class PlotWidget(qt.QMainWindow):
             self.setWindowTitle('PlotWidget')
 
         # Init the backend
-        if backend is None:
-            backend = silx.config.DEFAULT_PLOT_BACKEND
         self._backend = self.__getBackendClass(backend)(self, self)
 
         self.setCallback()  # set _callback
@@ -320,6 +318,9 @@ class PlotWidget(qt.QMainWindow):
         :raise ValueError: In case the backend is not supported
         :raise RuntimeError: If a backend is not available
         """
+        if backend is None:
+            backend = silx.config.DEFAULT_PLOT_BACKEND
+
         if callable(backend):
             return backend
 

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -400,9 +400,9 @@ class PlotWidget(qt.QMainWindow):
         :raises RuntimeError: Error while loading a backend
         """
         # First save state that is stored in the backend
-        xmin, xmax = self.getGraphXLimits()
-        ymin, ymax = self.getGraphYLimits(axis='left')
-        y2min, y2max = self.getGraphYLimits(axis='right')
+        xmin, xmax = self.getXAxis().getLimits()
+        ymin, ymax = self.getYAxis(axis='left').getLimits()
+        y2min, y2max = self.getYAxis(axis='right').getLimits()
         isKeepDataAspectRatio = self.isKeepDataAspectRatio()
         xtimezone = self.getXAxis().getTimeZone()
         isYAxisInverted = self.getYAxis().isInverted()

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -400,12 +400,14 @@ class PlotWidget(qt.QMainWindow):
         :raises RuntimeError: Error while loading a backend
         """
         # First save state that is stored in the backend
-        xmin, xmax = self.getXAxis().getLimits()
+        xaxis = self.getXAxis()
+        xmin, xmax = xaxis.getLimits()
         ymin, ymax = self.getYAxis(axis='left').getLimits()
         y2min, y2max = self.getYAxis(axis='right').getLimits()
         isKeepDataAspectRatio = self.isKeepDataAspectRatio()
-        xtimezone = self.getXAxis().getTimeZone()
-        isYAxisInverted = self.getYAxis().isInverted()
+        xTimeZone = xaxis.getTimeZone()
+        isXAxisTimeSeries = xaxis.getTickMode() == TickMode.TIME_SERIES
+        isYAxisInverted = xaxis.isInverted()
 
         # Remove all items from previous backend
         # Mark them for update with new backend
@@ -445,9 +447,8 @@ class PlotWidget(qt.QMainWindow):
         # Set axes
         xaxis = self.getXAxis()
         self._backend.setGraphXLabel(xaxis.getLabel())
-        self._backend.setXAxisTimeZone(xtimezone)
-        self._backend.setXAxisTimeSeries(
-            xaxis.getTickMode() == TickMode.TIME_SERIES)
+        self._backend.setXAxisTimeZone(xTimeZone)
+        self._backend.setXAxisTimeSeries(isXAxisTimeSeries)
         self._backend.setXAxisLogarithmic(
             xaxis.getScale() == items.Axis.LOGARITHMIC)
 

--- a/silx/gui/plot/PlotWindow.py
+++ b/silx/gui/plot/PlotWindow.py
@@ -273,7 +273,7 @@ class PlotWindow(PlotWidget):
                 self.addAction(action)
 
     def __setCentralWidget(self):
-        """Set central widget to host plot backend and colorbar"""
+        """Set central widget to host plot backend, colorbar, and bottom bar"""
         gridLayout = qt.QGridLayout()
         gridLayout.setSpacing(0)
         gridLayout.setContentsMargins(0, 0, 0, 0)
@@ -304,10 +304,8 @@ class PlotWindow(PlotWidget):
 
     @docstring(PlotWidget)
     def setBackend(self, backend):
-        from silx.gui.utils import blockSignals
-        with blockSignals(self._colorbar):
-            super(PlotWindow, self).setBackend(backend)
-            self.__setCentralWidget()  # Recreate PlotWindow's central widget
+        super(PlotWindow, self).setBackend(backend)
+        self.__setCentralWidget()  # Recreate PlotWindow's central widget
 
     @docstring(PlotWidget)
     def setBackgroundColor(self, color):

--- a/silx/gui/plot/backends/BackendBase.py
+++ b/silx/gui/plot/backends/BackendBase.py
@@ -58,6 +58,7 @@ class BackendBase(object):
         self.__yLimits = {'left': (1., 100.), 'right': (1., 100.)}
         self.__yAxisInverted = False
         self.__keepDataAspectRatio = False
+        self.__xAxisTimeSeries = False
         self._xAxisTimeZone = None
         # Store a weakref to get access to the plot state.
         self._setPlot(plot)
@@ -456,14 +457,14 @@ class BackendBase(object):
 
         :rtype: bool
         """
-        raise NotImplementedError()
+        return self.__xAxisTimeSeries
 
     def setXAxisTimeSeries(self, isTimeSeries):
         """Set whether the X-axis is a time series
 
         :param bool flag: True to switch to time series, False for regular axis.
         """
-        raise NotImplementedError()
+        self.__xAxisTimeSeries = bool(isTimeSeries)
 
     def setXAxisLogarithmic(self, flag):
         """Set the X axis scale between linear and log.

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -1877,26 +1877,6 @@ class TestPlotItemLog(PlotWidgetTestCase):
 class TestPlotWidgetSwitchBackend(PlotWidgetTestCase):
     """Test [get|set]Backend to switch backend"""
 
-    def testSwitchEmptyPlot(self):
-        """Test switching an empty plot"""
-        backends = ['none', 'mpl']
-        if test_options.WITH_GL_TEST:
-            backends.insert(0, 'gl')
-
-        self.plot.resetZoom()
-        xlimits = self.plot.getXAxis().getLimits()
-        ylimits = self.plot.getYAxis().getLimits()
-        isKeepAspectRatio = self.plot.isKeepDataAspectRatio()
-
-        for backend in backends:
-            with self.subTest():
-                self.plot.setBackend(backend)
-                self.plot.replot()
-                self.assertEqual(self.plot.getXAxis().getLimits(), xlimits)
-                self.assertEqual(self.plot.getYAxis().getLimits(), ylimits)
-                self.assertEqual(
-                    self.plot.isKeepDataAspectRatio(), isKeepAspectRatio)
-
     def testSwitchBackend(self):
         """Test switching a plot with a few items"""
         backends = {'none': 'BackendBase', 'mpl': 'BackendMatplotlibQt'}

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -1934,7 +1934,8 @@ def suite():
         for testClass in testClasses:
             test_suite.addTest(parameterize(testClass, backend='gl'))
 
-    test_suite.addTest(TestPlotWidgetSwitchBackend)
+    test_suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(
+        TestPlotWidgetSwitchBackend))
 
     return test_suite
 

--- a/silx/gui/plot/test/testPlotWindow.py
+++ b/silx/gui/plot/test/testPlotWindow.py
@@ -33,11 +33,11 @@ import unittest
 import numpy
 
 from silx.gui.utils.testutils import TestCaseQt, getQToolButtonFromAction
+from silx.test.utils import test_options
 
 from silx.gui import qt
 from silx.gui.plot import PlotWindow
 from silx.gui.colors import Colormap
-
 
 class TestPlotWindow(TestCaseQt):
     """Base class for tests of PlotWindow."""
@@ -154,6 +154,25 @@ class TestPlotWindow(TestCaseQt):
             Colormap._computeAutoscaleRange = old
         self.assertEqual(self._count, 1)
         del self._count
+
+    @unittest.skipUnless(test_options.WITH_GL_TEST,
+                         test_options.WITH_QT_TEST_REASON)
+    def testSwitchBackend(self):
+        """Test switching an empty plot"""
+        self.plot.resetZoom()
+        xlimits = self.plot.getXAxis().getLimits()
+        ylimits = self.plot.getYAxis().getLimits()
+        isKeepAspectRatio = self.plot.isKeepDataAspectRatio()
+
+        for backend in ('gl', 'mpl'):
+            with self.subTest():
+                self.plot.setBackend(backend)
+                self.plot.replot()
+                self.assertEqual(self.plot.getXAxis().getLimits(), xlimits)
+                self.assertEqual(self.plot.getYAxis().getLimits(), ylimits)
+                self.assertEqual(
+                    self.plot.isKeepDataAspectRatio(), isKeepAspectRatio)
+
 
 def suite():
     test_suite = unittest.TestSuite()


### PR DESCRIPTION
This PR allows to switch the backend of a `PlotWidget` while using it.
It adds 2 methods: `setBackend` and `getBackend` to provide this feature.

It was a lot simpler to do than expected (and than when I first tried to do it a while ago).

It should already provide "full" support of state switching.
From what I quickly tested it looks to work fine.

There is an issue with widgets messing up with `PlotWidget`'s central widget (e.g., adding the colorbar there), that needs be to fixed somehow.
It also requires adding a few automated tests, but it is already ready for early testers.

closes #3159

