### PR TITLE
Polar arc roi

### DIFF
--- a/examples/plotInteractiveImageROI.py
+++ b/examples/plotInteractiveImageROI.py
@@ -38,6 +38,7 @@ from silx.gui import qt
 from silx.gui.plot import Plot2D
 from silx.gui.plot.tools.roi import RegionOfInterestManager
 from silx.gui.plot.tools.roi import RegionOfInterestTableWidget
+from silx.gui.plot.tools.roi import RoiModeSelectorAction
 from silx.gui.plot.items.roi import RectangleROI
 from silx.gui.plot.items import LineMixIn, SymbolMixIn
 from silx.gui.plot.actions import control as control_actions
@@ -106,11 +107,33 @@ for roiClass in roiManager.getSupportedRoiClasses():
     action = roiManager.getInteractionModeAction(roiClass)
     roiToolbar.addAction(action)
 
+class AutoHideToolBar(qt.QToolBar):
+    """A toolbar which hide itself if no actions are visible"""
+
+    def actionEvent(self, event):
+        if event.type() == qt.QEvent.ActionChanged:
+            self._updateVisibility()
+        return qt.QToolBar.actionEvent(self, event)
+
+    def _updateVisibility(self):
+        visible = False
+        for action in self.actions():
+            if action.isVisible():
+                visible = True
+                break
+        self.setVisible(visible)
+
+roiToolbarEdit = AutoHideToolBar()
+modeSelectorAction = RoiModeSelectorAction()
+modeSelectorAction.setRoiManager(roiManager)
+roiToolbarEdit.addAction(modeSelectorAction)
+
 # Add the region of interest table and the buttons to a dock widget
 widget = qt.QWidget()
 layout = qt.QVBoxLayout()
 widget.setLayout(layout)
 layout.addWidget(roiToolbar)
+layout.addWidget(roiToolbarEdit)
 layout.addWidget(roiTable)
 
 

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -205,7 +205,7 @@ class PlotWidget(qt.QMainWindow):
     It provides the visible state.
     """
 
-    sigDefaultContextMenu = qt.Signal(qt.QMenu)
+    _sigDefaultContextMenu = qt.Signal(qt.QMenu)
     """Signal emitted when the default context menu of the plot is feed.
 
     It provides the menu which will be displayed.
@@ -507,7 +507,7 @@ class PlotWidget(qt.QMainWindow):
             action = ClosePolygonInteractionAction(plot=self, parent=menu)
             menu.addAction(action)
 
-        self.sigDefaultContextMenu.emit(menu)
+        self._sigDefaultContextMenu.emit(menu)
 
         # Make sure the plot is updated, especially when the plot is in
         # draw interaction mode

--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -205,6 +205,12 @@ class PlotWidget(qt.QMainWindow):
     It provides the visible state.
     """
 
+    sigDefaultContextMenu = qt.Signal(qt.QMenu)
+    """Signal emitted when the default context menu of the plot is feed.
+
+    It provides the menu which will be displayed.
+    """
+
     def __init__(self, parent=None, backend=None):
         self._autoreplot = False
         self._dirty = False
@@ -500,6 +506,8 @@ class PlotWidget(qt.QMainWindow):
             from .actions.control import ClosePolygonInteractionAction  # Avoid cyclic import
             action = ClosePolygonInteractionAction(plot=self, parent=menu)
             menu.addAction(action)
+
+        self.sigDefaultContextMenu.emit(menu)
 
         # Make sure the plot is updated, especially when the plot is in
         # draw interaction mode

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -2180,9 +2180,20 @@ class ArcROI(HandleBasedROI, items.LineMixIn):
         self.__modeId = "curvature"
 
     def availableModes(self):
+        """Returns the list of available interaction modes
+
+        :rtype: List[str]
+        """
         return ["curvature", "polar", "move"]
 
     def setMode(self, modeId):
+        """Set the interaction mode.
+
+        :param str modeId:
+            - `curvature` mode: 3-points to define a circle
+            - `polar` mode, which can move start and stop angles + the radius
+            - `move` mode, which only provides handle to move the shape (in case the center is not visible)
+        """
         self.__modeId = modeId
         if modeId == "curvature":
             self._handleStart.setSymbol("o")
@@ -2207,6 +2218,12 @@ class ArcROI(HandleBasedROI, items.LineMixIn):
         self._updateHandles()
 
     def getMode(self):
+        """Returns the interaction mode.
+
+        See :meth:`availableModes`.
+
+        :rtype: str
+        """
         return self.__modeId
 
     def _updated(self, event=None, checkVisibility=True):

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -2824,18 +2824,21 @@ class ArcROI(HandleBasedROI, items.LineMixIn, InteractionModeMixIn):
             return False
         rel_pos = position[1] - center[1], position[0] - center[0]
         angle = numpy.arctan2(*rel_pos)
+        # angle is inside [-pi, pi]
+
+        # Normalize the start angle between [-pi, pi]
+        # with a positive angle range
         start_angle = self.getStartAngle()
         end_angle = self.getEndAngle()
+        azim_range = end_angle - start_angle
+        if azim_range < 0:
+            start_angle = end_angle
+            azim_range = -azim_range
+        start_angle = numpy.mod(start_angle + numpy.pi, 2 * numpy.pi) - numpy.pi
 
-        if start_angle < end_angle:
-            # I never succeed to find a condition where start_angle < end_angle
-            # so this is untested
-            is_in_angle = start_angle <= angle <= end_angle
-        else:
-            if end_angle < -numpy.pi and angle > 0:
-                angle = angle - (numpy.pi * 2.0)
-            is_in_angle = end_angle <= angle <= start_angle
-        return is_in_angle
+        if angle < start_angle:
+            angle += 2 * numpy.pi
+        return start_angle <= angle <= start_angle + azim_range
 
     def translate(self, x, y):
         self._geometry = self._geometry.translated(x, y)

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -2061,6 +2061,52 @@ class ArcROI(HandleBasedROI, items.LineMixIn):
                                radius, self.weight,
                                self.startAngle, self.endAngle, self._closed)
 
+        def withStartAngle(self, startAngle):
+            vector = numpy.array([numpy.cos(startAngle), numpy.sin(startAngle)])
+            startPoint = self.center + vector * self.radius
+
+            # Never add more than 180 to maintain coherency
+            deltaAngle = startAngle - self.startAngle
+            if deltaAngle > numpy.pi:
+                deltaAngle -= numpy.pi * 2
+            elif deltaAngle < -numpy.pi:
+                deltaAngle += numpy.pi * 2
+
+            startAngle = self.startAngle + deltaAngle
+            return self.create(
+                self.center,
+                startPoint,
+                self.endPoint,
+                self.radius,
+                self.weight,
+                startAngle,
+                self.endAngle,
+                self._closed,
+            )
+
+        def withEndAngle(self, endAngle):
+            vector = numpy.array([numpy.cos(endAngle), numpy.sin(endAngle)])
+            endPoint = self.center + vector * self.radius
+
+            # Never add more than 180 to maintain coherency
+            deltaAngle = endAngle - self.endAngle
+            if deltaAngle > numpy.pi:
+                deltaAngle -= numpy.pi * 2
+            elif deltaAngle < -numpy.pi:
+                deltaAngle += numpy.pi * 2
+
+            endAngle = self.endAngle + deltaAngle
+            return self.create(
+                self.center,
+                self.startPoint,
+                endPoint,
+                self.radius,
+                self.weight,
+                self.startAngle,
+                endAngle,
+                self._closed,
+            )
+
         def translated(self, x, y):
             delta = numpy.array([x, y])
             center = None if self.center is None else self.center + delta

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -2242,11 +2242,8 @@ class ArcROI(HandleBasedROI, items.LineMixIn, InteractionModeMixIn):
         self._handleLabel = self.addLabelHandle()
 
         self._handleStart = self.addHandle()
-        self._handleStart.setSymbol("o")
         self._handleMid = self.addHandle()
-        self._handleMid.setSymbol("o")
         self._handleEnd = self.addHandle()
-        self._handleEnd.setSymbol("o")
         self._handleWeight = self.addHandle()
         self._handleWeight._setConstraint(self._arcCurvatureMarkerConstraint)
         self._handleMove = self.addTranslateHandle()
@@ -2262,6 +2259,7 @@ class ArcROI(HandleBasedROI, items.LineMixIn, InteractionModeMixIn):
         self.addItem(shape)
 
         self._initInteractionMode(self.ThreePointMode)
+        self._interactiveModeUpdated(self.ThreePointMode)
 
     ThreePointMode = RoiInteractionMode("3 points", "Provides 3 points to define the main radius circle")
     PolarMode = RoiInteractionMode("Polar", "Provides anchors to edit the ROI in polar coords")
@@ -2282,16 +2280,16 @@ class ArcROI(HandleBasedROI, items.LineMixIn, InteractionModeMixIn):
         :param RoiInteractionMode modeId:
         """
         if modeId is self.ThreePointMode:
+            self._handleStart.setSymbol("s")
+            self._handleMid.setSymbol("s")
+            self._handleEnd.setSymbol("s")
+            self._handleWeight.setSymbol("d")
+            self._handleMove.setSymbol("+")
+        elif modeId is self.PolarMode:
             self._handleStart.setSymbol("o")
             self._handleMid.setSymbol("o")
             self._handleEnd.setSymbol("o")
-            self._handleWeight.setSymbol("s")
-            self._handleMove.setSymbol("+")
-        elif modeId is self.PolarMode:
-            self._handleStart.setSymbol("d")
-            self._handleMid.setSymbol("d")
-            self._handleEnd.setSymbol("d")
-            self._handleWeight.setSymbol("s")
+            self._handleWeight.setSymbol("d")
             self._handleMove.setSymbol("+")
         elif modeId is self.MoveMode:
             self._handleStart.setSymbol("")
@@ -2538,11 +2536,11 @@ class ArcROI(HandleBasedROI, items.LineMixIn, InteractionModeMixIn):
                 self._handleEnd.setSymbol("x")
         else:
             if modeId is self.ThreePointMode:
+                self._handleStart.setSymbol("s")
+                self._handleEnd.setSymbol("s")
+            elif modeId is self.PolarMode:
                 self._handleStart.setSymbol("o")
                 self._handleEnd.setSymbol("o")
-            elif modeId is self.PolarMode:
-                self._handleStart.setSymbol("d")
-                self._handleEnd.setSymbol("d")
             if modeId is self.MoveMode:
                 self._handleStart.setSymbol("")
                 self._handleEnd.setSymbol("")

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -432,12 +432,12 @@ class RegionOfInterestManager(qt.QObject):
             self.setCurrentRoi(None)
 
     def __updateMode(self, roi):
-        if hasattr(roi, "availableModes"):
-            available = roi.availableModes()
-            mode = roi.getMode()
+        if isinstance(roi, roi_items.InteractionModeMixIn):
+            available = roi.availableInteractionModes()
+            mode = roi.getInteractionMode()
             imode = available.index(mode)
             mode = available[(imode + 1) % len(available)]
-            roi.setMode(mode)
+            roi.setInteractionMode(mode)
 
     # RegionOfInterest API
 

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -409,7 +409,7 @@ class RegionOfInterestManager(qt.QObject):
 
         parent.sigItemRemoved.connect(self._itemRemoved)
 
-        parent.sigDefaultContextMenu.connect(self._feedContextMenu)
+        parent._sigDefaultContextMenu.connect(self._feedContextMenu)
 
     @classmethod
     def getSupportedRoiClasses(cls):

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -597,8 +597,15 @@ class RegionOfInterestManager(qt.QObject):
         """Called wen the default plot context menu is about to be displayed"""
         roi = self.getCurrentRoi()
         if roi is not None:
-            if isinstance(roi, roi_items.InteractionModeMixIn):
-                self._contextMenuForInteractionMode(menu, roi)
+            if roi.isEditable():
+                # Filter by data position
+                # FIXME: It would be better to use GUI coords for it
+                plot = self.parent()
+                pos = plot.getWidgetHandle().mapFromGlobal(qt.QCursor.pos())
+                data = plot.pixelToData(pos.x(), pos.y())
+                if roi.contains(data):
+                    if isinstance(roi, roi_items.InteractionModeMixIn):
+                        self._contextMenuForInteractionMode(menu, roi)
 
     def _contextMenuForInteractionMode(self, menu, roi):
         availableModes = roi.availableInteractionModes()

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -607,6 +607,12 @@ class RegionOfInterestManager(qt.QObject):
                     if isinstance(roi, roi_items.InteractionModeMixIn):
                         self._contextMenuForInteractionMode(menu, roi)
 
+                removeAction = qt.QAction(menu)
+                removeAction.setText("Remove %s" % roi.getName())
+                callback = functools.partial(self.removeRoi, roi)
+                removeAction.triggered.connect(callback)
+                menu.addAction(removeAction)
+
     def _contextMenuForInteractionMode(self, menu, roi):
         availableModes = roi.availableInteractionModes()
         currentMode = roi.getInteractionMode()

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -213,6 +213,9 @@ class RoiModeSelector(qt.QWidget):
             self.__roi.sigInteractionModeChanged.connect(self._modeChanged)
         self._updateAvailableModes()
 
+    def isEmpty(self):
+        return not self._label.isVisibleTo(self)
+
     def _updateAvailableModes(self):
         roi = self.getRoi()
         if isinstance(roi, roi_items.InteractionModeMixIn):
@@ -272,6 +275,7 @@ class RoiModeSelectorAction(qt.QWidgetAction):
         if manager is not None:
             roi = manager.getCurrentRoi()
             widget.setRoi(roi)
+            self.setVisible(not widget.isEmpty())
         return widget
 
     def deleteWidget(self, widget):
@@ -303,8 +307,11 @@ class RoiModeSelectorAction(qt.QWidgetAction):
 
         :param ProfileRoiMixIn roi: A profile ROI
         """
+        widget = None
         for widget in self.createdWidgets():
             widget.setRoi(roi)
+        if widget is not None:
+            self.setVisible(not widget.isEmpty())
 
 
 class RegionOfInterestManager(qt.QObject):

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -400,25 +400,36 @@ class RegionOfInterestManager(qt.QObject):
 
     def _plotSignals(self, event):
         """Handle mouse interaction for ROI addition"""
-        if event['event'] in ('markerClicked', 'markerMoving'):
+        clicked = False
+        roi = None
+        if event["event"] in ("markerClicked", "markerMoving"):
             plot = self.parent()
-            legend = event['label']
+            legend = event["label"]
             marker = plot._getMarker(legend=legend)
             roi = self.__getRoiFromMarker(marker)
-            if roi is not None and roi.isSelectable():
-                self.setCurrentRoi(roi)
-            else:
-                self.setCurrentRoi(None)
-        elif event['event'] == 'mouseClicked' and event['button'] == 'left':
+        elif event["event"] == "mouseClicked" and event["button"] == "left":
             # Marker click is only for dnd
             # This also can click on a marker
+            clicked = event["event"] == "mouseClicked"
             plot = self.parent()
-            marker = plot._getMarkerAt(event['xpixel'], event['ypixel'])
+            marker = plot._getMarkerAt(event["xpixel"], event["ypixel"])
             roi = self.__getRoiFromMarker(marker)
-            if roi is not None and roi.isSelectable():
-                self.setCurrentRoi(roi)
+        else:
+            return
+
+        if roi not in self._rois:
+            # The ROI is not own by this manager
+            return
+
+        if roi is not None and roi.isSelectable():
+            currentRoi = self.getCurrentRoi()
+            if currentRoi is roi:
+                if clicked:
+                    self.__updateMode(roi)
             else:
-                self.setCurrentRoi(None)
+                self.setCurrentRoi(roi)
+        else:
+            self.setCurrentRoi(None)
 
     def __updateMode(self, roi):
         if hasattr(roi, "availableModes"):

--- a/silx/gui/plot/tools/roi.py
+++ b/silx/gui/plot/tools/roi.py
@@ -420,6 +420,14 @@ class RegionOfInterestManager(qt.QObject):
             else:
                 self.setCurrentRoi(None)
 
+    def __updateMode(self, roi):
+        if hasattr(roi, "availableModes"):
+            available = roi.availableModes()
+            mode = roi.getMode()
+            imode = available.index(mode)
+            mode = available[(imode + 1) % len(available)]
+            roi.setMode(mode)
+
     # RegionOfInterest API
 
     def getRois(self):


### PR DESCRIPTION
This MR provide multi interaction mode for ROIs, and especially for arc ROI.

The arc ROI have to provide a way to setup the cercle with 3 points and with polar values.
That's useful to match different use cases (when the center is visible or not, for instance)

To manage that this requires too much handles, which make the result unusable.

So this PR provides a way to switch from an interaction mode to another.

As result the arc ROI provides for now
- `curvature` mode, 3-points to define a circle
- `polar`, which can move start and stop angles + the radius  
- `move` which only provides handle to move the shape (in case the center is not visible), (which could be removed one day when we will be able to dnd the shape itself)

Changelog: 
- Added multi interaction mode for ROIs (can be switched with a single click on an handle, or the context menu)
- Added polar interaction mode for arc ROI
- Fixes duplicated callback on ROIs (there was one for each ROI managed created on the plot)
- Added `PlotWidget.sigDefaultContextMenu` to allow to feed the default context menu
- Added context menu to the selected ROI to remove it