### PR TITLE
Add Qt properties for plot widget colors

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -636,6 +636,16 @@ class PlotWidget(qt.QMainWindow):
             self._dataBackgroundColor = color
             self._backgroundColorsUpdated()
 
+    dataBackgroundColor = qt.Property(
+        qt.QColor, getDataBackgroundColor, setDataBackgroundColor
+    )
+
+    backgroundColor = qt.Property(qt.QColor, getBackgroundColor, setBackgroundColor)
+
+    foregroundColor = qt.Property(qt.QColor, getForegroundColor, setForegroundColor)
+
+    gridColor = qt.Property(qt.QColor, getGridColor, setGridColor)
+
     def showEvent(self, event):
         if self._autoreplot and self._dirty:
             self._backend.postRedisplay()


### PR DESCRIPTION
This PR expose PlotWidget colors as Qt properties. That's a low cost addition to be able to custom style using qss syntax

Here is an example to edit the style of the whole plots.
```
styleSheet = """
PlotWidget {
    qproperty-backgroundColor: #19232d;
    qproperty-dataBackgroundColor: #19232d;
    qproperty-foregroundColor: #B0B0B0;
}"""
qapp.setStyleSheet(styleSheet)
```
Here we can see that the plot from the colormap dialog was also patched.
![Capture d’écran de 2020-11-14 13-44-18](https://user-images.githubusercontent.com/7579321/99147366-be946e00-2680-11eb-8daf-b9c91badc754.png)


Changelog: 
- Expose PlotWidget colors as Qt properties
