### PR TITLE
[OpenCL] Check textures availability

### DIFF
--- a/silx/opencl/backprojection.py
+++ b/silx/opencl/backprojection.py
@@ -164,9 +164,7 @@ class Backprojection(OpenclProcessing):
     def _allocate_memory(self):
         # Host memory
         self.slice = np.zeros(self.dimrec_shape, dtype=np.float32)
-        self.is_cpu = False
-        if self.device.type == "CPU":
-            self.is_cpu = True
+        self._use_textures = self.check_textures_availability()
 
         # Device memory
         self.buffers = [
@@ -180,7 +178,7 @@ class Backprojection(OpenclProcessing):
         self.d_sino = self.cl_mem["d_sino"]  # shorthand
 
         # Texture memory (if relevant)
-        if not(self.is_cpu):
+        if not(self._use_textures):
             self._allocate_textures()
 
         # Local memory
@@ -209,7 +207,7 @@ class Backprojection(OpenclProcessing):
             _idivup(int(self.dimrec_shape[0]), 32) * self.wg[1]
         )
         # Prepare arguments for the kernel call
-        if self.is_cpu:
+        if self._use_textures:
             d_sino_ref = self.d_sino.data
         else:
             d_sino_ref = self.d_sino_tex
@@ -281,7 +279,7 @@ class Backprojection(OpenclProcessing):
         sino2 = sino
         if not(sino.flags["C_CONTIGUOUS"] and sino.dtype == np.float32):
             sino2 = np.ascontiguousarray(sino, dtype=np.float32)
-        if self.is_cpu:
+        if self._use_textures:
             ev = pyopencl.enqueue_copy(
                                         self.queue,
                                         self.d_sino.data,
@@ -301,7 +299,7 @@ class Backprojection(OpenclProcessing):
         return EventDescription(what, ev)
 
     def _transfer_device_to_texture(self, d_sino):
-        if self.is_cpu:
+        if self._use_textures:
             if id(self.d_sino) == id(d_sino):
                 return
             ev = pyopencl.enqueue_copy(
@@ -335,7 +333,7 @@ class Backprojection(OpenclProcessing):
         with self.sem:
             events.append(self._transfer_to_texture(sino))
             # Call the backprojection kernel
-            if self.is_cpu:
+            if self._use_textures:
                 kernel_to_call = self.kernels.backproj_cpu_kernel
             else:
                 kernel_to_call = self.kernels.backproj_kernel

--- a/silx/opencl/backprojection.py
+++ b/silx/opencl/backprojection.py
@@ -178,7 +178,7 @@ class Backprojection(OpenclProcessing):
         self.d_sino = self.cl_mem["d_sino"]  # shorthand
 
         # Texture memory (if relevant)
-        if not(self._use_textures):
+        if self._use_textures:
             self._allocate_textures()
 
         # Local memory
@@ -207,7 +207,7 @@ class Backprojection(OpenclProcessing):
             _idivup(int(self.dimrec_shape[0]), 32) * self.wg[1]
         )
         # Prepare arguments for the kernel call
-        if self._use_textures:
+        if not(self._use_textures):
             d_sino_ref = self.d_sino.data
         else:
             d_sino_ref = self.d_sino_tex
@@ -279,7 +279,7 @@ class Backprojection(OpenclProcessing):
         sino2 = sino
         if not(sino.flags["C_CONTIGUOUS"] and sino.dtype == np.float32):
             sino2 = np.ascontiguousarray(sino, dtype=np.float32)
-        if self._use_textures:
+        if not(self._use_textures):
             ev = pyopencl.enqueue_copy(
                                         self.queue,
                                         self.d_sino.data,
@@ -299,7 +299,7 @@ class Backprojection(OpenclProcessing):
         return EventDescription(what, ev)
 
     def _transfer_device_to_texture(self, d_sino):
-        if self._use_textures:
+        if not(self._use_textures):
             if id(self.d_sino) == id(d_sino):
                 return
             ev = pyopencl.enqueue_copy(
@@ -333,7 +333,7 @@ class Backprojection(OpenclProcessing):
         with self.sem:
             events.append(self._transfer_to_texture(sino))
             # Call the backprojection kernel
-            if self._use_textures:
+            if not(self._use_textures):
                 kernel_to_call = self.kernels.backproj_cpu_kernel
             else:
                 kernel_to_call = self.kernels.backproj_kernel

--- a/silx/opencl/backprojection.py
+++ b/silx/opencl/backprojection.py
@@ -197,7 +197,14 @@ class Backprojection(OpenclProcessing):
             self.cl_mem["d_axes"][:] = np.ones(self.num_projs, dtype="f") * self.axis_pos
 
     def _init_kernels(self):
-        OpenclProcessing.compile_kernels(self, self.kernel_files)
+        compile_options = None
+        if not(self._use_textures):
+            compile_options = "-DDONT_USE_TEXTURES"
+        OpenclProcessing.compile_kernels(
+            self,
+            self.kernel_files,
+            compile_options=compile_options
+        )
         # check that workgroup can actually be (16, 16)
         self.compiletime_workgroup_size = self.kernels.max_workgroup_size("backproj_cpu_kernel")
         # Workgroup and ndrange sizes are always the same

--- a/silx/opencl/backprojection.py
+++ b/silx/opencl/backprojection.py
@@ -242,15 +242,7 @@ class Backprojection(OpenclProcessing):
         """
         Allocate the texture for the sinogram.
         """
-        self.d_sino_tex = pyopencl.Image(
-            self.ctx,
-            mf.READ_ONLY | mf.USE_HOST_PTR,
-            pyopencl.ImageFormat(
-                pyopencl.channel_order.INTENSITY,
-                pyopencl.channel_type.FLOAT
-            ),
-            hostbuf=np.zeros(self.shape[::-1], dtype=np.float32)
-        )
+        self.d_sino_tex = self.allocate_texture(self.shape)
 
     def _init_filter(self, filter_name):
         """Filter initialization

--- a/silx/opencl/common.py
+++ b/silx/opencl/common.py
@@ -602,7 +602,7 @@ def check_textures_availability(ctx):
     :param ctx: OpenCL context
     """
     try:
-        dummy_texture = allocate_texture((16, 16))
+        dummy_texture = allocate_texture(ctx, (16, 16))
         # Need to further access some attributes (pocl)
         dummy_height = dummy_texture.height
         textures_available = True

--- a/silx/opencl/common.py
+++ b/silx/opencl/common.py
@@ -573,6 +573,53 @@ def allocate_cl_buffers(buffers, device=None, context=None):
     return mem
 
 
+def allocate_texture(ctx, shape, hostbuf=None, support_1D=False):
+    """
+    Allocate an OpenCL image ("texture").
+
+    :param ctx: OpenCL context
+    :param shape: Shape of the image. Note that pyopencl and OpenCL < 1.2
+        do not support 1D images, so 1D images are handled as 2D with one row
+    :param support_1D: force the image to be 1D if the shape has only one dim
+    """
+    if len(shape) == 1 and not(support_1D):
+        shape = (1,) + shape
+    return pyopencl.Image(
+        ctx,
+        pyopencl.mem_flags.READ_ONLY | pyopencl.mem_flags.USE_HOST_PTR,
+        pyopencl.ImageFormat(
+            pyopencl.channel_order.INTENSITY,
+            pyopencl.channel_type.FLOAT
+        ),
+        hostbuf=numpy.zeros(shape[::-1], dtype=numpy.float32)
+    )
+
+
+def check_textures_availability(ctx):
+    """
+    Check whether textures are supported on the current OpenCL context.
+
+    :param ctx: OpenCL context
+    """
+    try:
+        dummy_texture = allocate_texture((16, 16))
+        # Need to further access some attributes (pocl)
+        dummy_height = dummy_texture.height
+        textures_available = True
+        del dummy_texture, dummy_height
+    except (pyopencl.RuntimeError, pyopencl.LogicError):
+        textures_available = False
+    # Nvidia Fermi GPUs (compute capability 2.X) do not support opencl read_imagef
+    # There is no way to detect this until a kernel is compiled
+    try:
+        cc = ctx.devices[0].compute_capability_major_nv
+        textures_available &= (cc >= 3)
+    except (pyopencl.LogicError, AttributeError): # probably not a Nvidia GPU
+        pass
+    #
+    return textures_available
+
+
 def measure_workgroup_size(device):
     """Measure the actual size of the workgroup
 

--- a/silx/opencl/convolution.py
+++ b/silx/opencl/convolution.py
@@ -93,14 +93,6 @@ class Convolution(OpenclProcessing):
         self.extra_options.update(extra_opts)
         self.use_textures = not(self.extra_options["dont_use_textures"])
         self.use_textures &= self.check_textures_availability()
-        # Nvidia Fermi GPUs (compute capability 2.X) do not support opencl read_imagef
-        try:
-            cc = self.ctx.devices[0].compute_capability_major_nv
-            self.use_textures *= (cc >= 3)
-        except cl.LogicError: # probably not a Nvidia GPU
-            pass
-        except AttributeError: # probably not a Nvidia GPU
-            pass
 
     def _get_dimensions(self, shape, kernel):
         self.shape = shape

--- a/silx/opencl/convolution.py
+++ b/silx/opencl/convolution.py
@@ -91,9 +91,8 @@ class Convolution(OpenclProcessing):
         }
         extra_opts = extra_options or {}
         self.extra_options.update(extra_opts)
-        self.is_cpu = (self.device.type == "CPU")
         self.use_textures = not(self.extra_options["dont_use_textures"])
-        self.use_textures *= not(self.is_cpu)
+        self.use_textures &= self.check_textures_availability()
         # Nvidia Fermi GPUs (compute capability 2.X) do not support opencl read_imagef
         try:
             cc = self.ctx.devices[0].compute_capability_major_nv

--- a/silx/opencl/processing.py
+++ b/silx/opencl/processing.py
@@ -152,8 +152,10 @@ class OpenclProcessing(object):
     def check_textures_availability(self):
         try:
             dummy_texture = self.allocate_texture((16, 16))
+            # Need to further access some attributes (pocl + Nvidia Fermi hardware)
+            dummy_height = dummy_texture.height
             textures_available = True
-            del dummy_texture
+            del dummy_texture, dummy_height
         except (pyopencl.RuntimeError, pyopencl.LogicError):
             textures_available = False
         return textures_available

--- a/silx/opencl/processing.py
+++ b/silx/opencl/processing.py
@@ -152,7 +152,7 @@ class OpenclProcessing(object):
     def check_textures_availability(self):
         try:
             dummy_texture = self.allocate_texture((16, 16))
-            # Need to further access some attributes (pocl + Nvidia Fermi hardware)
+            # Need to further access some attributes (pocl)
             dummy_height = dummy_texture.height
             textures_available = True
             del dummy_texture, dummy_height

--- a/silx/opencl/processing.py
+++ b/silx/opencl/processing.py
@@ -149,6 +149,15 @@ class OpenclProcessing(object):
         self.program = None
         self.kernels = None
 
+    def check_textures_availability(self):
+        try:
+            dummy_texture = self.allocate_texture((16, 16))
+            textures_available = True
+            del dummy_texture
+        except pyopencl._cl.RuntimeError:
+            textures_available = False
+        return textures_available
+
     def __del__(self):
         """Destructor: release all buffers and programs
         """

--- a/silx/opencl/processing.py
+++ b/silx/opencl/processing.py
@@ -154,7 +154,7 @@ class OpenclProcessing(object):
             dummy_texture = self.allocate_texture((16, 16))
             textures_available = True
             del dummy_texture
-        except pyopencl.RuntimeError, pyopencl.LogicError:
+        except (pyopencl.RuntimeError, pyopencl.LogicError):
             textures_available = False
         return textures_available
 

--- a/silx/opencl/processing.py
+++ b/silx/opencl/processing.py
@@ -154,7 +154,7 @@ class OpenclProcessing(object):
             dummy_texture = self.allocate_texture((16, 16))
             textures_available = True
             del dummy_texture
-        except pyopencl._cl.RuntimeError:
+        except pyopencl.RuntimeError, pyopencl.LogicError:
             textures_available = False
         return textures_available
 

--- a/silx/opencl/processing.py
+++ b/silx/opencl/processing.py
@@ -158,6 +158,14 @@ class OpenclProcessing(object):
             del dummy_texture, dummy_height
         except (pyopencl.RuntimeError, pyopencl.LogicError):
             textures_available = False
+        # Nvidia Fermi GPUs (compute capability 2.X) do not support opencl read_imagef
+        # There is no way to detect this until a kernel is compiled
+        try:
+            cc = self.ctx.devices[0].compute_capability_major_nv
+            textures_available &= (cc >= 3)
+        except (pyopencl.LogicError, AttributeError): # probably not a Nvidia GPU
+            pass
+        #
         return textures_available
 
     def __del__(self):

--- a/silx/opencl/projection.py
+++ b/silx/opencl/projection.py
@@ -129,9 +129,7 @@ class Projection(OpenclProcessing):
             int(self.dimgrid_y) * self.wg[1]  # int(): pyopencl <= 2015.1
         )
 
-        self.is_cpu = False
-        if self.device.type == "CPU":
-            self.is_cpu = True
+        self._use_textures = self.check_textures_availability()
 
         # Allocate memory
         self.buffers = [
@@ -150,14 +148,14 @@ class Projection(OpenclProcessing):
         )
         self._tmp_extended_img = np.zeros((self.shape[0] + 2, self.shape[1] + 2),
                                           dtype=np.float32)
-        if self.is_cpu:
+        if not(self._use_textures):
             self.allocate_slice()
         else:
             self.allocate_textures()
         self.allocate_buffers()
         self._ex_sino = np.zeros((self._dimrecy, self._dimrecx),
                                  dtype=np.float32)
-        if self.is_cpu:
+        if not(self._use_textures):
             self.cl_mem["d_slice"].fill(0.)
             # enqueue_fill_buffer has issues if opencl 1.2 is not present
             # ~ pyopencl.enqueue_fill_buffer(
@@ -212,7 +210,7 @@ class Projection(OpenclProcessing):
         image2 = image
         if not(image.flags["C_CONTIGUOUS"] and image.dtype == np.float32):
             image2 = np.ascontiguousarray(image)
-        if self.is_cpu:
+        if not(self._use_textures):
             # TODO: create NoneEvent
             return self.transfer_to_slice(image2)
             # ~ return pyopencl.enqueue_copy(
@@ -232,7 +230,7 @@ class Projection(OpenclProcessing):
                    )
 
     def transfer_device_to_texture(self, d_image):
-        if self.is_cpu:
+        if not(self._use_textures):
             # TODO this copy should not be necessary
             return self.cpy2d_to_slice(d_image)
         else:
@@ -355,14 +353,14 @@ class Projection(OpenclProcessing):
                 assert image.ndim == 2, "Treat only 2D images"
                 assert image.shape[0] == self.shape[0], "image shape is OK"
                 assert image.shape[1] == self.shape[1], "image shape is OK"
-                if not(self.is_cpu):
+                if self._use_textures:
                     self.transfer_to_texture(image)
                     slice_ref = self.d_image_tex
                 else:
                     self.transfer_to_slice(image)
                     slice_ref = self.cl_mem["d_slice"].data
             else:
-                if self.is_cpu:
+                if not(self._use_textures):
                     slice_ref = self.cl_mem["d_slice"].data
                 else:
                     slice_ref = self.d_image_tex
@@ -388,7 +386,7 @@ class Projection(OpenclProcessing):
             )
 
             # Call the kernel
-            if self.is_cpu:
+            if not(self._use_textures):
                 event_pj = self.kernels.forward_kernel_cpu(
                     self.queue,
                     self.ndrange,

--- a/silx/opencl/projection.py
+++ b/silx/opencl/projection.py
@@ -180,7 +180,14 @@ class Projection(OpenclProcessing):
         # Shorthands
         self._d_sino = self.cl_mem["_d_sino"]
 
-        OpenclProcessing.compile_kernels(self, self.kernel_files)
+        compile_options = None
+        if not(self._use_textures):
+            compile_options = "-DDONT_USE_TEXTURES"
+        OpenclProcessing.compile_kernels(
+            self,
+            self.kernel_files,
+            compile_options=compile_options
+        )
         # check that workgroup can actually be (16, 16)
         self.compiletime_workgroup_size = self.kernels.max_workgroup_size("forward_kernel_cpu")
 
@@ -192,7 +199,7 @@ class Projection(OpenclProcessing):
         pyopencl.enqueue_copy(self.queue, self.cl_mem["d_angles"], angles2)
 
     def allocate_slice(self):
-        ary = parray.zeros(self.queue, (self.shape[1] + 2, self.shape[1] + 2), np.float32)
+        ary = parray.empty(self.queue, (self.shape[1] + 2, self.shape[1] + 2), np.float32)
         ary.fill(0)
         self.add_to_cl_mem({"d_slice": ary})
 

--- a/silx/opencl/test/test_backprojection.py
+++ b/silx/opencl/test/test_backprojection.py
@@ -96,8 +96,9 @@ class TestFBP(unittest.TestCase):
         # Therefore, we cannot expect results to be the "same" (up to float32
         # numerical error)
         self.tol = 5e-2
-        if not(self.fbp._use_textures):
+        if not(self.fbp._use_textures) or self.device.type == "CPU":
             # Precision is less when using CPU
+            # (either CPU textures or "manual" linear interpolation)
             self.tol *= 2
 
     def tearDown(self):

--- a/silx/opencl/test/test_backprojection.py
+++ b/silx/opencl/test/test_backprojection.py
@@ -96,7 +96,7 @@ class TestFBP(unittest.TestCase):
         # Therefore, we cannot expect results to be the "same" (up to float32
         # numerical error)
         self.tol = 5e-2
-        if self.fbp.is_cpu:
+        if not(self.fbp._use_textures):
             # Precision is less when using CPU
             self.tol *= 2
 

--- a/silx/opencl/test/test_backprojection.py
+++ b/silx/opencl/test/test_backprojection.py
@@ -96,7 +96,7 @@ class TestFBP(unittest.TestCase):
         # Therefore, we cannot expect results to be the "same" (up to float32
         # numerical error)
         self.tol = 5e-2
-        if not(self.fbp._use_textures) or self.device.type == "CPU":
+        if not(self.fbp._use_textures) or self.fbp.device.type == "CPU":
             # Precision is less when using CPU
             # (either CPU textures or "manual" linear interpolation)
             self.tol *= 2

--- a/silx/opencl/test/test_convolution.py
+++ b/silx/opencl/test/test_convolution.py
@@ -49,7 +49,7 @@ try:
 except ImportError:
     scipy_convolve = None
 import unittest
-from ..common import ocl
+from ..common import ocl, check_textures_availability
 if ocl:
     import pyopencl as cl
     import pyopencl.array as parray
@@ -113,20 +113,8 @@ class TestConvolution(unittest.TestCase):
         )
 
     def instantiate_convol(self, shape, kernel, axes=None):
-        def is_fermi_device(dev):
-            try:
-                res = (dev.compute_capability_major_nv < 3)
-            except cl.LogicError:
-                res = False
-            except AttributeError:
-                res = False
-            return res
-        if (self.mode == "constant") and (
-            not(self.param["use_textures"])
-                or (self.ctx.devices[0].type == cl._cl.device_type.CPU)
-                or (is_fermi_device(self.ctx.devices[0]))
-            ):
-                self.skipTest("mode=constant not implemented without textures")
+        if (self.mode == "constant") and not(check_textures_availability(self.ctx)):
+            self.skipTest("mode=constant not implemented without textures")
         C = Convolution(
             shape, kernel,
             mode=self.mode,

--- a/silx/opencl/test/test_convolution.py
+++ b/silx/opencl/test/test_convolution.py
@@ -113,8 +113,12 @@ class TestConvolution(unittest.TestCase):
         )
 
     def instantiate_convol(self, shape, kernel, axes=None):
-        if (self.mode == "constant") and not(check_textures_availability(self.ctx)):
-            self.skipTest("mode=constant not implemented without textures")
+        if self.mode == "constant":
+            if not (self.param["use_textures"]) or (
+                self.param["use_textures"]
+                and not (check_textures_availability(self.ctx))
+            ):
+                self.skipTest("mode=constant not implemented without textures")
         C = Convolution(
             shape, kernel,
             mode=self.mode,

--- a/silx/resources/opencl/backproj.cl
+++ b/silx/resources/opencl/backproj.cl
@@ -55,11 +55,6 @@ kernel void backproj_kernel(
     const int tidy = get_local_id(1); //threadIdx.y;
     const int bidy = get_group_id(1); //blockIdx.y;
 
-    //~ local float shared[768];
-    //~ float  * sh_sin  = shared;
-    //~ float  * sh_cos  = shared+256;
-    //~ float  * sh_axis = sh_cos+256;
-
     local float sh_cos[256];
     local float sh_sin[256];
     local float sh_axis[256];
@@ -134,7 +129,7 @@ static float linear_interpolation(float2 vals,
 {
     if (xm == xp)
         return vals.s0;
-    else 
+    else
         return (vals.s0 * (xp - x)) + (vals.s1 * (x - xm));
 }
 
@@ -197,36 +192,36 @@ kernel void backproj_cpu_kernel(
         h1 = (acorr05 + (bx00+0)*pcos - (by00+1)*psin);
         h2 = (acorr05 + (bx00+1)*pcos - (by00+0)*psin);
         h3 = (acorr05 + (bx00+1)*pcos - (by00+1)*psin);
-	
-	
-	float x;
-	int ym, xm, xp;
-	ym = proj;
-	float2 vals;
 
-	if(h0>=0 && h0<num_bins) { 
-	    x = CLIP_MAX(h0, num_bins); 
-	    FLOORCEIL_x(x);
-	    vals = ADJACENT_PIXELS_VALS(d_sino, num_bins, ym, xm, xp);
-	    res0 += linear_interpolation(vals, x, xm, xp);
-	}
+
+        float x;
+        int ym, xm, xp;
+        ym = proj;
+        float2 vals;
+
+        if(h0>=0 && h0<num_bins) {
+            x = CLIP_MAX(h0, num_bins);
+            FLOORCEIL_x(x);
+            vals = ADJACENT_PIXELS_VALS(d_sino, num_bins, ym, xm, xp);
+            res0 += linear_interpolation(vals, x, xm, xp);
+        }
         if(h1>=0 && h1<num_bins) {
-	    x = CLIP_MAX(h1, num_bins); 
-	    FLOORCEIL_x(x);
-	    vals = ADJACENT_PIXELS_VALS(d_sino, num_bins, ym, xm, xp);
-	    res1 += linear_interpolation(vals, x, xm, xp);
+            x = CLIP_MAX(h1, num_bins);
+            FLOORCEIL_x(x);
+            vals = ADJACENT_PIXELS_VALS(d_sino, num_bins, ym, xm, xp);
+            res1 += linear_interpolation(vals, x, xm, xp);
         }
         if(h2>=0 && h2<num_bins) {
-	    x = CLIP_MAX(h2, num_bins); 
-	    FLOORCEIL_x(x);
-	    vals = ADJACENT_PIXELS_VALS(d_sino, num_bins, ym, xm, xp);
-	    res2 += linear_interpolation(vals, x, xm, xp);
+            x = CLIP_MAX(h2, num_bins);
+            FLOORCEIL_x(x);
+            vals = ADJACENT_PIXELS_VALS(d_sino, num_bins, ym, xm, xp);
+            res2 += linear_interpolation(vals, x, xm, xp);
         }
         if(h3>=0 && h3<num_bins) {
-	    x = CLIP_MAX(h3, num_bins); 
-	    FLOORCEIL_x(x);
-	    vals = ADJACENT_PIXELS_VALS(d_sino, num_bins, ym, xm, xp);
-	    res3 += linear_interpolation(vals, x, xm, xp);
+            x = CLIP_MAX(h3, num_bins);
+            FLOORCEIL_x(x);
+            vals = ADJACENT_PIXELS_VALS(d_sino, num_bins, ym, xm, xp);
+            res3 += linear_interpolation(vals, x, xm, xp);
         }
     }
     d_SLICE[ 32*get_num_groups(0)*(bidy*32+tidy*2+0) + bidx*32 + tidx*2 + 0] = res0;
@@ -234,252 +229,4 @@ kernel void backproj_cpu_kernel(
     d_SLICE[ 32*get_num_groups(0)*(bidy*32+tidy*2+0) + bidx*32 + tidx*2 + 1] = res2;
     d_SLICE[ 32*get_num_groups(0)*(bidy*32+tidy*2+1) + bidx*32 + tidx*2 + 1] = res3;
 }
-
-
-
-
-
-
-
-/*******************************************************************************/
-/************************** OLD STUFF, for tinkering  **************************/
-/*******************************************************************************/
-
-
-
-
-/// arr(xm, ym), arr(xm, yp), arr(xp, yp), arr(xp, ym)
-//~ #define ADJACENT_PIXELS_VALS2(arr, Nx, xm, xp, ym, yp) ((float4) (arr[ym*Nx + xm], arr[yp*Nx + xm], arr[yp*Nx + xp], arr[ym*Nx + xp]))
-
-
-/**  xm, xp, ym, yp  **/
-//~ #define ADJACENT_PIXELS_COORDS(x, y) ((int4)((int) floor(x), (int) ceil(x), (int) floor(y), (int) ceil(y)))
-
-/**
-        (xm, ym)        (xp, ym)
-                 (x, y)
-        (xm, yp)        (xp, yp)
-**/
-/// arr(xm, ym), arr(xm, yp), arr(xp, yp), arr(xp, ym)
-//~ #define ADJACENT_PIXELS_VALS(arr, Nx, coords) ((float4) (arr[coords.s2*Nx + coords.s0], arr[coords.s3*Nx + coords.s0], arr[coords.s3*Nx + coords.s1], arr[coords.s2*Nx + coords.s1]))
-
-
-/**  xm, xp  **/
-//~ #define ADJACENT_PIXELS_COORDS2(x) ((int2)((int) floor(x), (int) ceil(x)))
-
-
-
-/*
-float bilinear_interpolation(
-    float x,  // x position in the image
-    float y,  // y position in the image
-    int Nx,   // image width 
-    int Ny,   // image height
-    int4 adj_coords, 
-    float4 adj_vals
-) {
-    float val;
-    float tol = 0.001f; // CHECKME
-    val = y - adj_coords.s2;
-    if ((x - adj_coords.s0) < tol && (y - adj_coords.s2) < tol) val = adj_vals.s0; 
-    else if ((adj_coords.s1 - x) < tol && (adj_coords.s3 - y) < tol) val = adj_vals.s2; 
-    else {
-        // Mirror - TODO: clamp ?
-        if (adj_coords.s0 < 0) adj_coords.s0 = 0;
-        if (adj_coords.s1 >= Nx) adj_coords.s1 = Nx - 1;
-        if (adj_coords.s2 < 0) adj_coords.s2 = 0;
-        if (adj_coords.s3 >= Ny) adj_coords.s3 = Ny -1;
-	if (adj_coords.s0 >= Nx) adj_coords.s0 = Nx - 1;
-	if (adj_coords.s2 >= Ny) adj_coords.s2 = Ny -1;
-        // Interp
-        val = adj_vals.s1*(adj_coords.s1-x)*(y-adj_coords.s2)
-                    + adj_vals.s2 *(x-adj_coords.s0)*(y-adj_coords.s2)
-                    + adj_vals.s0 *(adj_coords.s1-x)*(adj_coords.s3-y) 
-                    + adj_vals.s3 *(x-adj_coords.s0)*(adj_coords.s3-y); 
-
-    }
-    return val;
-}
-*/
-
-
-/*
-__kernel void backproj_cpu_kernel_good(
-    int num_proj,
-    int num_bins,
-    float axis_position,
-    __global float *d_SLICE,
-    __global float* d_sino,
-    float gpu_offset_x,
-    float gpu_offset_y,
-    __global float * d_cos_s, // precalculated cos(theta[i])
-    __global float * d_sin_s, // precalculated sin(theta[i])
-    __global float * d_axis_s, // array of axis positions (n_projs)
-    __local float* shared2)     // 768B of local mem
-{
-    const int tidx = get_local_id(0); //threadIdx.x;
-    const int bidx = get_group_id(0); //blockIdx.x;
-    const int tidy = get_local_id(1); //threadIdx.y;
-    const int bidy = get_group_id(1); //blockIdx.y;
-
-    //~ __local float shared[768];
-    //~ float  * sh_sin  = shared;
-    //~ float  * sh_cos  = shared+256;
-    //~ float  * sh_axis = sh_cos+256;
-
-    __local float sh_cos[256];
-    __local float sh_sin[256];
-    __local float sh_axis[256];
-
-    float pcos, psin;
-    float h0, h1, h2, h3;
-    const float apos_off_x= gpu_offset_x - axis_position ;
-    const float apos_off_y= gpu_offset_y - axis_position ;
-    float acorr05;
-    float res0 = 0, res1 = 0, res2 = 0, res3 = 0;
-
-    const float bx00 = (32 * bidx + 2 * tidx + 0 + apos_off_x  ) ;
-    const float by00 = (32 * bidy + 2 * tidy + 0 + apos_off_y  ) ;
-
-    int read=0;
-    for(int proj=0; proj<num_proj; proj++) {
-        if(proj>=read) {
-            barrier(CLK_LOCAL_MEM_FENCE);
-            int ip = tidy*16+tidx;
-            if( read+ip < num_proj) {
-                sh_cos [ip] = d_cos_s[read+ip] ;
-                sh_sin [ip] = d_sin_s[read+ip] ;
-                sh_axis[ip] = d_axis_s[read+ip] ;
-            }
-            read=read+256; // 256=16*16 block size
-            barrier(CLK_LOCAL_MEM_FENCE);
-        }
-        pcos = sh_cos[256-read + proj] ;
-        psin = sh_sin[256-read + proj] ;
-
-        acorr05 = sh_axis[256 - read + proj] ;
-
-        h0 = (acorr05 + bx00*pcos - by00*psin);
-        h1 = (acorr05 + (bx00+0)*pcos - (by00+1)*psin);
-        h2 = (acorr05 + (bx00+1)*pcos - (by00+0)*psin);
-        h3 = (acorr05 + (bx00+1)*pcos - (by00+1)*psin);
-	
-	
-	float x, val;
-	float tol = 0.001f; // CHECKME
-	float y = proj + 0.5f;
-	int ym = (int) floor(y);
-	int yp = (int) ceil(y);
-	int xm, xp;
-	
-	//
-	int i0, i1, j0, j1;
-	float d0, d1, x0, x1, y0, y1;
-	d0 = fmin(fmax(proj+0*0.5f, 0.0f), (num_proj - 1.0f));
-	x0 = floor(d0);
-	x1 = ceil(d0);
-	i0 = (int) x0;
-	i1 = (int) x1;
-
-	if(h0>=0 && h0<num_bins) { 
-            d1 = fmin(fmax(h0+0*0.5f, 0.0f), (num_bins - 1.0f));
-	    y0 = floor(d1);
-	    y1 = ceil(d1);
-	    j0 = (int) y0;
-	    j1 = (int) y1;
-	    
-	    if ((i0 == i1) && (j0 == j1))
-		val = d_sino[i0*num_bins + j0]; //self.data[i0, j0]
-	    else if (i0 == i1)
-		val = (d_sino[i0*num_bins + j0] * (y1 - d1)) + (d_sino[i0*num_bins + j1] * (d1 - y0)); // self.data[i0, j0], self.data[i0, j1]
-	    else if (j0 == j1)
-		val = (d_sino[i0*num_bins + j0] * (x1 - d0)) + (d_sino[i1*num_bins + j0] * (d0 - x0)); // i0, j0  ;  i1, j0
-	    else
-		val = (d_sino[i0*num_bins + j0] * (x1 - d0) * (y1 - d1))  // i0, j0
-		    + (d_sino[i1*num_bins + j0] * (d0 - x0) * (y1 - d1))  // i1, j0
-		    + (d_sino[i0*num_bins + j1] * (x1 - d0) * (d1 - y0))  // i0, j1
-		    + (d_sino[i1*num_bins + j1] * (d0 - x0) * (d1 - y0));  // i1, j1
-
-	    res0 += val;
-	}
-        if(h1>=0 && h1<num_bins) {
-	    //~ int4 coords = ADJACENT_PIXELS_COORDS(h1 +0.5f, proj +0.5f);
-	    //~ res1 += bilinear_interpolation(h1 +0.5f, proj +0.5f, num_bins, num_proj, coords, ADJACENT_PIXELS_VALS(d_sino, num_bins, coords)); //tex2D(texProjes,h1 +0.5f,proj +0.5f);
-            d1 = fmin(fmax(h1+0*0.5f, 0.0f), (num_bins - 1.0f));
-	    y0 = floor(d1);
-	    y1 = ceil(d1);
-	    j0 = (int) y0;
-	    j1 = (int) y1;
-	    
-	    if ((i0 == i1) && (j0 == j1))
-		val = d_sino[i0*num_bins + j0]; //self.data[i0, j0]
-	    else if (i0 == i1)
-		val = (d_sino[i0*num_bins + j0] * (y1 - d1)) + (d_sino[i0*num_bins + j1] * (d1 - y0)); // self.data[i0, j0], self.data[i0, j1]
-	    else if (j0 == j1)
-		val = (d_sino[i0*num_bins + j0] * (x1 - d0)) + (d_sino[i1*num_bins + j0] * (d0 - x0)); // i0, j0  ;  i1, j0
-	    else
-		val = (d_sino[i0*num_bins + j0] * (x1 - d0) * (y1 - d1))  // i0, j0
-		    + (d_sino[i1*num_bins + j0] * (d0 - x0) * (y1 - d1))  // i1, j0
-		    + (d_sino[i0*num_bins + j1] * (x1 - d0) * (d1 - y0))  // i0, j1
-		    + (d_sino[i1*num_bins + j1] * (d0 - x0) * (d1 - y0));  // i1, j1
-
-
-	    res1 += val;
-        }
-        if(h2>=0 && h2<num_bins) {
-	    //~ int4 coords = ADJACENT_PIXELS_COORDS(h2 +0.5f, proj +0.5f);
-	    //~ res2 += 0; //bilinear_interpolation(h2 +0.5f, proj +0.5f, num_bins, num_proj, coords, ADJACENT_PIXELS_VALS(d_sino, num_bins, coords)); //tex2D(texProjes,h2 +0.5f,proj +0.5f);
-            d1 = fmin(fmax(h2+0*0.5f, 0.0f), (num_bins - 1.0f));
-	    y0 = floor(d1);
-	    y1 = ceil(d1);
-	    j0 = (int) y0;
-	    j1 = (int) y1;
-	    
-	    if ((i0 == i1) && (j0 == j1))
-		val = d_sino[i0*num_bins + j0]; //self.data[i0, j0]
-	    else if (i0 == i1)
-		val = (d_sino[i0*num_bins + j0] * (y1 - d1)) + (d_sino[i0*num_bins + j1] * (d1 - y0)); // self.data[i0, j0], self.data[i0, j1]
-	    else if (j0 == j1)
-		val = (d_sino[i0*num_bins + j0] * (x1 - d0)) + (d_sino[i1*num_bins + j0] * (d0 - x0)); // i0, j0  ;  i1, j0
-	    else
-		val = (d_sino[i0*num_bins + j0] * (x1 - d0) * (y1 - d1))  // i0, j0
-		    + (d_sino[i1*num_bins + j0] * (d0 - x0) * (y1 - d1))  // i1, j0
-		    + (d_sino[i0*num_bins + j1] * (x1 - d0) * (d1 - y0))  // i0, j1
-		    + (d_sino[i1*num_bins + j1] * (d0 - x0) * (d1 - y0));  // i1, j1
-
-	    res2+= val;
-        }
-        if(h3>=0 && h3<num_bins) {
-	    //~ int4 coords = ADJACENT_PIXELS_COORDS(h3 +0.5f, proj +0.5f);
-	    //~ res3 += 0; //bilinear_interpolation(h3 +0.5f, proj +0.5f, num_bins, num_proj, coords, ADJACENT_PIXELS_VALS(d_sino, num_bins, coords)); //tex2D(texProjes,h3 +0.5f,proj +0.5f);
-            d1 = fmin(fmax(h3+0*0.5f, 0.0f), (num_bins - 1.0f));
-	    y0 = floor(d1);
-	    y1 = ceil(d1);
-	    j0 = (int) y0;
-	    j1 = (int) y1;
-	    
-	    if ((i0 == i1) && (j0 == j1))
-		val = d_sino[i0*num_bins + j0]; //self.data[i0, j0]
-	    else if (i0 == i1)
-		val = (d_sino[i0*num_bins + j0] * (y1 - d1)) + (d_sino[i0*num_bins + j1] * (d1 - y0)); // self.data[i0, j0], self.data[i0, j1]
-	    else if (j0 == j1)
-		val = (d_sino[i0*num_bins + j0] * (x1 - d0)) + (d_sino[i1*num_bins + j0] * (d0 - x0)); // i0, j0  ;  i1, j0
-	    else
-		val = (d_sino[i0*num_bins + j0] * (x1 - d0) * (y1 - d1))  // i0, j0
-		    + (d_sino[i1*num_bins + j0] * (d0 - x0) * (y1 - d1))  // i1, j0
-		    + (d_sino[i0*num_bins + j1] * (x1 - d0) * (d1 - y0))  // i0, j1
-		    + (d_sino[i1*num_bins + j1] * (d0 - x0) * (d1 - y0));  // i1, j1
-
-	    res3 += val;
-        }
-    }
-    d_SLICE[ 32*get_num_groups(0)*(bidy*32+tidy*2+0) + bidx*32 + tidx*2 + 0] = res0;
-    d_SLICE[ 32*get_num_groups(0)*(bidy*32+tidy*2+1) + bidx*32 + tidx*2 + 0] = res1;
-    d_SLICE[ 32*get_num_groups(0)*(bidy*32+tidy*2+0) + bidx*32 + tidx*2 + 1] = res2;
-    d_SLICE[ 32*get_num_groups(0)*(bidy*32+tidy*2+1) + bidx*32 + tidx*2 + 1] = res3;
-}
-*/
-
-
-
 

--- a/silx/resources/opencl/backproj.cl
+++ b/silx/resources/opencl/backproj.cl
@@ -35,7 +35,7 @@
 /************************ GPU VERSION (with textures) **************************/
 /*******************************************************************************/
 
-
+#ifndef DONT_USE_TEXTURES
 kernel void backproj_kernel(
     int num_proj,
     int num_bins,
@@ -102,7 +102,7 @@ kernel void backproj_kernel(
     d_SLICE[ 32*get_num_groups(0)*(bidy*32+tidy*2+0) + bidx*32 + tidx*2 + 1] = res2;
     d_SLICE[ 32*get_num_groups(0)*(bidy*32+tidy*2+1) + bidx*32 + tidx*2 + 1] = res3;
 }
-
+#endif
 
 
 

--- a/silx/resources/opencl/proj.cl
+++ b/silx/resources/opencl/proj.cl
@@ -28,7 +28,7 @@
 /************************ GPU VERSION (with textures) **************************/
 /*******************************************************************************/
 
-
+#ifndef DONT_USE_TEXTURES
 kernel void  forward_kernel(
         global float *d_Sino,
         read_only image2d_t d_slice,
@@ -163,7 +163,7 @@ kernel void  forward_kernel(
         d_Sino[dimrecx*(bidy*16 + tidy) + (bidx*16 + tidx)] = res;
     }
 }
-
+#endif
 
 
 /*******************************************************************************/


### PR DESCRIPTION
This PR adds a mechanism for checking textures (openCL "images") availability.

Depending on the underlying openCL implementation, we can never be sure that textures are actually available, before explicitly trying to create one.  
For example, with `pocl`:  `backprojector.ctx.devices[0].get_info(cl.device_info.IMAGE_SUPPORT)`  returns `1` while `backprojector.check_texture_availability()` returns `False`.

Close #2700, #3243

Changelog: OpenCL: add textures availability check
