### PR TITLE
silx.gui.plot.Stackview: Replaced `setColormap` `autoscale` argument by `scaleColormapRangeToStack` method

### DIFF
--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -778,7 +778,7 @@ class StackView(qt.QMainWindow):
         # specifying a special colormap
         return self._plot.getDefaultColormap()
 
-    def scaleColormapRangeFromStack(self):
+    def scaleColormapRangeToStack(self):
         """Scale colormap range according to current stack data.
 
         If no stack has been set through :meth:`setStack`, this has no effect.
@@ -868,9 +868,9 @@ class StackView(qt.QMainWindow):
                     type_='function',
                     name='setColormap',
                     reason='autoscale argument is replaced by a method',
-                    replacement='scaleColormapRangeFromStack',
+                    replacement='scaleColormapRangeToStack',
                     since_version='0.14')
-                self.scaleColormapRangeFromStack()
+                self.scaleColormapRangeToStack()
 
         cursorColor = cursorColorForColormap(_colormap.getName())
         self._plot.setInteractiveMode('zoom', color=cursorColor)

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -869,14 +869,14 @@ class StackView(qt.QMainWindow):
                                  vmax=vmax,
                                  colors=colors)
 
-            if autoscale:
+            if autoscale is not None:
                 deprecated_warning(
                     type_='function',
                     name='setColormap',
                     reason='autoscale argument is replaced by a method',
                     replacement='scaleColormapRangeToStack',
                     since_version='0.14')
-                self.__autoscaleCmap = True
+            self.__autoscaleCmap = bool(autoscale)
 
         cursorColor = cursorColorForColormap(_colormap.getName())
         self._plot.setInteractiveMode('zoom', color=cursorColor)

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -791,7 +791,7 @@ class StackView(qt.QMainWindow):
             return  # No-op
 
         colormap = self.getColormap()
-        vmin, vmax = colormap.getColormapRange(data=stack)
+        vmin, vmax = colormap.getColormapRange(data=stack[0])
         colormap.setVRange(vmin=vmin, vmax=vmax)
 
     def setColormap(self, colormap=None, normalization=None,
@@ -831,6 +831,8 @@ class StackView(qt.QMainWindow):
         :param numpy.ndarray colors: Only used if name is None.
             Custom colormap colors as Nx3 or Nx4 RGB or RGBA arrays
         """
+        deferredAutoscale = False
+
         # if is a colormap object or a dictionary
         if isinstance(colormap, Colormap) or isinstance(colormap, dict):
             # Support colormap parameter as a dict
@@ -870,7 +872,9 @@ class StackView(qt.QMainWindow):
                     reason='autoscale argument is replaced by a method',
                     replacement='scaleColormapRangeToStack',
                     since_version='0.14')
-                self.scaleColormapRangeToStack()
+                # scaleColormapRangeToStack needs to be called **after**
+                # setDefaultColormap so getColormap returns the right colormap
+                deferredAutoscale = True
 
         cursorColor = cursorColorForColormap(_colormap.getName())
         self._plot.setInteractiveMode('zoom', color=cursorColor)
@@ -881,6 +885,10 @@ class StackView(qt.QMainWindow):
         activeImage = self.getActiveImage()
         if isinstance(activeImage, items.ColormapMixIn):
             activeImage.setColormap(self.getColormap())
+
+        if deferredAutoscale:
+            self.scaleColormapRangeToStack()
+
 
     @deprecated(replacement="getPlotWidget", since_version="0.13")
     def getPlot(self):

--- a/silx/gui/plot/StackView.py
+++ b/silx/gui/plot/StackView.py
@@ -192,6 +192,9 @@ class StackView(qt.QMainWindow):
         imageLegend = '__StackView__image' + str(id(self))
         self._stackItem.setName(imageLegend)
 
+        self.__autoscaleCmap = False
+        """Flag to disable/enable colormap auto-scaling
+        based on the min/max values of the entire 3D volume"""
         self.__dimensionsLabels = ["Dimension 0", "Dimension 1",
                                    "Dimension 2"]
         """These labels are displayed on the X and Y axes.
@@ -545,6 +548,9 @@ class StackView(qt.QMainWindow):
             perspective_changed = True
             self.setPerspective(perspective)
 
+        if self.__autoscaleCmap:
+            self.scaleColormapRangeToStack()
+
         # init plot
         self._stackItem.setStackData(self.__transposed_view, 0, copy=False)
         self._stackItem.setColormap(self.getColormap())
@@ -831,8 +837,6 @@ class StackView(qt.QMainWindow):
         :param numpy.ndarray colors: Only used if name is None.
             Custom colormap colors as Nx3 or Nx4 RGB or RGBA arrays
         """
-        deferredAutoscale = False
-
         # if is a colormap object or a dictionary
         if isinstance(colormap, Colormap) or isinstance(colormap, dict):
             # Support colormap parameter as a dict
@@ -872,9 +876,7 @@ class StackView(qt.QMainWindow):
                     reason='autoscale argument is replaced by a method',
                     replacement='scaleColormapRangeToStack',
                     since_version='0.14')
-                # scaleColormapRangeToStack needs to be called **after**
-                # setDefaultColormap so getColormap returns the right colormap
-                deferredAutoscale = True
+                self.__autoscaleCmap = True
 
         cursorColor = cursorColorForColormap(_colormap.getName())
         self._plot.setInteractiveMode('zoom', color=cursorColor)
@@ -886,7 +888,9 @@ class StackView(qt.QMainWindow):
         if isinstance(activeImage, items.ColormapMixIn):
             activeImage.setColormap(self.getColormap())
 
-        if deferredAutoscale:
+        if self.__autoscaleCmap:
+            # scaleColormapRangeToStack needs to be called **after**
+            # setDefaultColormap so getColormap returns the right colormap
             self.scaleColormapRangeToStack()
 
 

--- a/silx/gui/plot/test/testStackView.py
+++ b/silx/gui/plot/test/testStackView.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -59,6 +59,19 @@ class TestStackView(TestCaseQt):
         self.stackview.close()
         del self.stackview
         super(TestStackView, self).tearDown()
+
+    def testScaleColormapRangeToStack(self):
+        """Test scaleColormapRangeToStack"""
+        self.stackview.setStack(self.mystack)
+        self.stackview.setColormap("viridis")
+        colormap = self.stackview.getColormap()
+
+        # Colormap autoscale to image
+        self.assertEqual(colormap.getVRange(), (None, None))
+        self.stackview.scaleColormapRangeToStack()
+
+        # Colormap range set according to stack range
+        self.assertEqual(colormap.getVRange(), (self.mystack.min(), self.mystack.max()))
 
     def testSetStack(self):
         self.stackview.setStack(self.mystack)


### PR DESCRIPTION
This PR deprecates the `autoscale` argument of `StackView.setColormap` which triggers the scaling of the colormap to the whole stack when `setColormap` or `setStack` is called, and so it is NOT use the whole stack when in autoscale mode as on would expect.
A `scaleColormapRangeToStack` method is added to which sets the range of the colormap to that of the stack.
This does not prevent adding a true autoscale to stack later.

If someone has a better idea to name the `scaleColormapRangeToStack` method, I'd take it.

To me it closes #2835