### PR TITLE
Clamp stddev*3 with minmax of the data

### DIFF
--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -366,7 +366,9 @@ class _NormalizationMixIn:
         if mode == Colormap.MINMAX:
             vmin, vmax = self.autoscaleMinMax(data)
         elif mode == Colormap.STDDEV3:
-            vmin, vmax = self.autoscaleMean3Std(data)
+            dmin, dmax = self.autoscaleMinMax(data)
+            stdmin, stdmax = self.autoscaleMean3Std(data)
+            vmin, vmax = max(dmin, stdmin), min(dmax, stdmax)
         else:
             raise ValueError('Unsupported mode: %s' % mode)
 
@@ -538,7 +540,8 @@ class Colormap(qt.QObject):
     """constant for autoscale using min/max data range"""
 
     STDDEV3 = 'stddev3'
-    """constant for autoscale using mean +/- 3*std(data)"""
+    """constant for autoscale using mean +/- 3*std(data)
+    with a clamp on min/max of the data"""
 
     AUTOSCALE_MODES = (MINMAX, STDDEV3)
     """Tuple of managed auto scale algorithms"""

--- a/silx/gui/test/test_colors.py
+++ b/silx/gui/test/test_colors.py
@@ -570,20 +570,25 @@ class TestAutoscaleRange(ParametricTestCase):
 
     def testAutoscaleRange(self):
         nan = numpy.nan
+        data_std_inside = numpy.array([0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2])
+        data_std_inside_nan = numpy.array([0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, numpy.nan])
         data = [
             # Positive values
             (Colormap.LINEAR, Colormap.MINMAX, numpy.array([10, 20, 50]), (10, 50)),
             (Colormap.LOGARITHM, Colormap.MINMAX, numpy.array([10, 50, 100]), (10, 100)),
-            (Colormap.LINEAR, Colormap.STDDEV3, numpy.array([10, 100]), (-80, 190)),
-            (Colormap.LOGARITHM, Colormap.STDDEV3, numpy.array([10, 100]), (1, 1000)),
+            (Colormap.LINEAR, Colormap.STDDEV3, data_std_inside, (0.026671473215424735, 1.9733285267845753)),
+            (Colormap.LOGARITHM, Colormap.STDDEV3, data_std_inside, (1, 1.6733506885453602)),
+            (Colormap.LINEAR, Colormap.STDDEV3, numpy.array([10, 100]), (10, 100)),
+            (Colormap.LOGARITHM, Colormap.STDDEV3, numpy.array([10, 100]), (10, 100)),
+
             # With nan
             (Colormap.LINEAR, Colormap.MINMAX, numpy.array([10, 20, 50, nan]), (10, 50)),
             (Colormap.LOGARITHM, Colormap.MINMAX, numpy.array([10, 50, 100, nan]), (10, 100)),
-            (Colormap.LINEAR, Colormap.STDDEV3, numpy.array([10, 100, nan]), (-80, 190)),
-            (Colormap.LOGARITHM, Colormap.STDDEV3, numpy.array([10, 100, nan]), (1, 1000)),
+            (Colormap.LINEAR, Colormap.STDDEV3, data_std_inside_nan, (0.026671473215424735, 1.9733285267845753)),
+            (Colormap.LOGARITHM, Colormap.STDDEV3, data_std_inside_nan, (1, 1.6733506885453602)),
             # With negative
             (Colormap.LOGARITHM, Colormap.MINMAX, numpy.array([10, 50, 100, -50]), (10, 100)),
-            (Colormap.LOGARITHM, Colormap.STDDEV3, numpy.array([10, 100, -10]), (1, 1000)),
+            (Colormap.LOGARITHM, Colormap.STDDEV3, numpy.array([10, 100, -10]), (10, 100)),
         ]
         for norm, mode, array, expectedRange in data:
             with self.subTest(norm=norm, mode=mode, array=array):


### PR DESCRIPTION
This PR changes the 3*STDDEV autoscale in order to improve the contrast on range where there is no data.

The result of the 3*STDDEV is now clamped with the minmax data (the real range of the data).

As result is the data is only positive close to 0, the 3*STDDEV will not be netagtive (or smaller than the data).

I still ask if it is better to change the 3*STD or to create another algorithm (in order to be able to use or not this clamp).
If you have an opinion.

Tests still have to be fixed.

Bellow we can see that we win some contrast.
![Screenshot from 2020-11-24 16-49-56](https://user-images.githubusercontent.com/7579321/100119006-b43f5480-2e76-11eb-8c7a-f072dc883627.png)

Changelog:
- Update stddev*3 autoscale algorithm
   - Clamp it with the minmax data in order to improve the contrast