### PR TITLE
Implement mask for bilinear interpolation

### DIFF
--- a/silx/image/bilinear.pyx
+++ b/silx/image/bilinear.pyx
@@ -461,7 +461,7 @@ cdef class BilinearImage:
                             result[i] += sum / cnt
                         else:
                             result[i] += sum
-                else:
+                elif compute_mean:
                     result[i] += NAN
         # Ensures the result is exported as numpy array and not memory view.
         return numpy.asarray(result)

--- a/silx/image/bilinear.pyx
+++ b/silx/image/bilinear.pyx
@@ -33,7 +33,7 @@
 """Bilinear interpolator, peak finder, line-profile for images"""
 __authors__ = ["J. Kieffer"]
 __license__ = "MIT"
-__date__ = "25/11/2020"
+__date__ = "26/11/2020"
 
 # C-level imports
 from libc.stdint cimport uint8_t
@@ -457,10 +457,11 @@ cdef class BilinearImage:
                             cnt += 1
                             sum += val  
                 if cnt:
-                    if compute_mean:
-                        result[i] += sum / cnt
-                    else:
-                        result[i] += sum
-
+                        if compute_mean:
+                            result[i] += sum / cnt
+                        else:
+                            result[i] += sum
+                else:
+                    result[i] += NAN
         # Ensures the result is exported as numpy array and not memory view.
         return numpy.asarray(result)

--- a/silx/image/bilinear.pyx
+++ b/silx/image/bilinear.pyx
@@ -203,9 +203,7 @@ cdef class BilinearImage:
                         scale = ((m0 * (x1 - d0) * (y1 - d1)) 
                                + (m1 * (d0 - x0) * (y1 - d1))
                                + (m2 * (x1 - d0) * (d1 - y0))
-                               + (m3 * (d0 - x0) * (d1 - y0)))/ \
-                                ((x1 - d0) * (y1 - d1) + (d0 - x0) * (y1 - d1)+
-                                 (x1 - d0) * (d1 - y0) + (d0 - x0) * (d1 - y0))
+                               + (m3 * (d0 - x0) * (d1 - y0)))
                         res /= scale
             else:
                 res = (self.data[i0, j0] * (x1 - d0) * (y1 - d1))  \


### PR DESCRIPTION
Provide a mask in the numerical kernel in charge of bilinear interpolation.
Returns Nan when no underlying pixel is unmasked. Interpolates approximately then 1, 2 or 3 underlying pixels are masked.

This is part of #3285 

