### PR TITLE
silx.gui.plot.PlotWidget: Add pan interaction to ROI authoring (`select-draw`) interaction mode

### DIFF
--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -1604,6 +1604,8 @@ class DrawSelectMode(FocusManager):
 
     def __init__(self, plot, shape, label, color, width):
         eventHandlerClass = _DRAW_MODES[shape]
+        self._pan = Pan(plot)
+        self._panStart = None
         parameters = {
             'shape': shape,
             'label': label,
@@ -1613,6 +1615,21 @@ class DrawSelectMode(FocusManager):
         super().__init__((
             ItemsInteractionForCombo(plot),
             eventHandlerClass(plot, parameters)))
+
+    def handleEvent(self, eventName, *args, **kwargs):
+        if eventName == 'press' and args[2] == MIDDLE_BTN:
+            self._panStart = args[:2]
+            self._pan.beginDrag(*args)
+            return  # Consume middle click events
+        elif eventName == 'release' and args[2] == MIDDLE_BTN:
+            self._panStart = None
+            self._pan.endDrag(self._panStart, args[:2], MIDDLE_BTN)
+            return  # Consume middle click events
+        elif self._panStart is not None and eventName == 'move':
+            x, y = args[:2]
+            self._pan.drag(x, y, MIDDLE_BTN)
+
+        super().handleEvent(eventName, *args, **kwargs)
 
     def getDescription(self):
         """Returns the dict describing this interactive mode"""

--- a/silx/gui/plot/PlotInteraction.py
+++ b/silx/gui/plot/PlotInteraction.py
@@ -1617,6 +1617,8 @@ class DrawSelectMode(FocusManager):
             eventHandlerClass(plot, parameters)))
 
     def handleEvent(self, eventName, *args, **kwargs):
+        # Hack to add pan interaction to select-draw
+        # See issue Refactor PlotWidget interaction #3292
         if eventName == 'press' and args[2] == MIDDLE_BTN:
             self._panStart = args[:2]
             self._pan.beginDrag(*args)


### PR DESCRIPTION
This PR adds pan interaction to `PlotWidget`'s `select-draw` interaction mode.
The implementation is ugly, yet it looks to work fine and does not change the implementation of other interaction modes.

Having grown quite a bit, PlotWidget interaction needs to be refactored, but that's another story.

closes #3178

