### PR TITLE
silx.gui.colors: Fixed issue in Colormap stddev3 autoscale mode and avoided warnings

### DIFF
--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -370,7 +370,20 @@ class _NormalizationMixIn:
         elif mode == Colormap.STDDEV3:
             dmin, dmax = self.autoscaleMinMax(data)
             stdmin, stdmax = self.autoscaleMean3Std(data)
-            vmin, vmax = max(dmin, stdmin), min(dmax, stdmax)
+            if dmin is None:
+                vmin = stdmin
+            elif stdmin is None:
+                vmin = dmin
+            else:
+                vmin = max(dmin, stdmin)
+
+            if dmax is None:
+                vmax = stdmax
+            elif stdmax is None:
+                vmax = dmax
+            else:
+                vmax = min(dmax, stdmax)
+
         else:
             raise ValueError('Unsupported mode: %s' % mode)
 

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -34,6 +34,8 @@ __date__ = "29/01/2019"
 import numpy
 import logging
 import collections
+import warnings
+
 from silx.gui import qt
 from silx.gui.utils import blockSignals
 from silx.math.combo import min_max
@@ -411,7 +413,13 @@ class _NormalizationMixIn:
             normdata[numpy.isfinite(normdata) == False] = numpy.nan
         if normdata.size == 0:  # Fallback
             return None, None
-        mean, std = numpy.nanmean(normdata), numpy.nanstd(normdata)
+
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=RuntimeWarning)
+            # Ignore nanmean "Mean of empty slice" warning and
+            # nanstd "Degrees of freedom <= 0 for slice" warning
+            mean, std = numpy.nanmean(normdata), numpy.nanstd(normdata)
+
         return self.revert(mean - 3 * std, 0., 1.), self.revert(mean + 3 * std, 0., 1.)
 
 

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -453,7 +453,11 @@ class _LinearNormalizationMixIn(_NormalizationMixIn):
             data[numpy.isfinite(data) == False] = numpy.nan
         if data.size == 0:  # Fallback
             return None, None
-        mean, std = numpy.nanmean(data), numpy.nanstd(data)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', category=RuntimeWarning)
+            # Ignore nanmean "Mean of empty slice" warning and
+            # nanstd "Degrees of freedom <= 0 for slice" warning
+            mean, std = numpy.nanmean(data), numpy.nanstd(data)
         return mean - 3 * std, mean + 3 * std
 
 


### PR DESCRIPTION
This fixes issues in the `stddev3` autoscale mode of the `Colormap`.

closes #3294
closes #3288
