### PR TITLE
Version: Use "candidate" in `version_info`

### DIFF
--- a/version.py
+++ b/version.py
@@ -62,18 +62,18 @@ __all__ = ["date", "version_info", "strictversion", "hexversion", "debianversion
 RELEASE_LEVEL_VALUE = {"dev": 0,
                        "alpha": 10,
                        "beta": 11,
-                       "rc": 12,
+                       "candidate": 12,
                        "final": 15}
 
 PRERELEASE_NORMALIZED_NAME = {"dev": "a",
                               "alpha": "a",
                               "beta": "b",
-                              "rc": "rc"}
+                              "candidate": "rc"}
 
 MAJOR = 0
 MINOR = 14
 MICRO = 0
-RELEV = "rc"  # <16
+RELEV = "candidate"  # <16
 SERIAL = 1  # <16
 
 date = __date__
@@ -85,9 +85,10 @@ version_info = _version_info(MAJOR, MINOR, MICRO, RELEV, SERIAL)
 
 strictversion = version = debianversion = "%d.%d.%d" % version_info[:3]
 if version_info.releaselevel != "final":
-    version += "-%s%s" % version_info[-2:]
-    debianversion += "~adev%i" % version_info[-1] if RELEV == "dev" else "~%s%i" % version_info[-2:]
-    strictversion += PRERELEASE_NORMALIZED_NAME[version_info[3]] + str(version_info[-1])
+    _prerelease = PRERELEASE_NORMALIZED_NAME[version_info[3]]
+    version += "-%s%s" % (_prerelease, version_info[-1])
+    debianversion += "~adev%i" % version_info[-1] if RELEV == "dev" else "~%s%i" % (_prerelease, version_info[-1])
+    strictversion += _prerelease + str(version_info[-1])
 
 
 def calc_hexversion(major=0, minor=0, micro=0, releaselevel="dev", serial=0):


### PR DESCRIPTION
This PR restores the use of "candidate" for `version_info` to follow same convention as Python [sys.version_info](https://docs.python.org/3/library/sys.html#sys.version_info) and use `rc` for all other versions information.

It's also good as it is now.