### PR TITLE
Few clean up on mask tool

### DIFF
--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -663,11 +663,17 @@ class MaskToolsWidget(BaseMaskToolsWidget):
         if os.path.exists(filename) and "HDF5" not in nameFilter:
             try:
                 os.remove(filename)
-            except IOError:
+            except IOError as e:
                 msg = qt.QMessageBox(self)
+                msg.setWindowTitle("Removing existing file")
                 msg.setIcon(qt.QMessageBox.Critical)
+
+                if hasattr(e, "strerror"):
+                    strerror = e.strerror
+                else:
+                    strerror = sys.exc_info()[1]
                 msg.setText("Cannot save.\n"
-                            "Input Output Error: %s" % (sys.exc_info()[1]))
+                            "Input Output Error: %s" % strerror)
                 msg.exec_()
                 return
 
@@ -678,8 +684,14 @@ class MaskToolsWidget(BaseMaskToolsWidget):
             self.save(filename, extension[1:])
         except Exception as e:
             msg = qt.QMessageBox(self)
+            msg.setWindowTitle("Saving mask file")
             msg.setIcon(qt.QMessageBox.Critical)
-            msg.setText("Cannot save file %s\n%s" % (filename, e.args[0]))
+
+            if hasattr(e, "strerror"):
+                strerror = e.strerror
+            else:
+                strerror = sys.exc_info()[1]
+            msg.setText("Cannot save file %s\n%s" % (filename, strerror))
             msg.exec_()
 
     def resetSelectionMask(self):

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -116,7 +116,8 @@ class ImageMask(BaseMask):
         """
         if kind == 'edf':
             edfFile = EdfFile(filename, access="w+")
-            edfFile.WriteImage({}, self.getMask(copy=False), Append=0)
+            header = {"program_name": "silx-mask"}
+            edfFile.WriteImage(header, self.getMask(copy=False), Append=0)
 
         elif kind == 'tif':
             tiffFile = TiffIO(filename, mode='w')

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -677,7 +677,6 @@ class MaskToolsWidget(BaseMaskToolsWidget):
         try:
             self.save(filename, extension[1:])
         except Exception as e:
-            raise
             msg = qt.QMessageBox(self)
             msg.setIcon(qt.QMessageBox.Critical)
             msg.setText("Cannot save file %s\n%s" % (filename, e.args[0]))

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -568,7 +568,9 @@ class MaskToolsWidget(BaseMaskToolsWidget):
         filename = dialog.selectedFiles()[0]
         dialog.close()
 
+        # Update the directory according to the user selection
         self.maskFileDir = os.path.dirname(filename)
+
         try:
             self.load(filename)
         except RuntimeWarning as e:
@@ -668,7 +670,9 @@ class MaskToolsWidget(BaseMaskToolsWidget):
                 msg.exec_()
                 return
 
+        # Update the directory according to the user selection
         self.maskFileDir = os.path.dirname(filename)
+
         try:
             self.save(filename, extension[1:])
         except Exception as e:

--- a/silx/gui/plot/ScatterMaskToolsWidget.py
+++ b/silx/gui/plot/ScatterMaskToolsWidget.py
@@ -477,11 +477,17 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
         if os.path.exists(filename):
             try:
                 os.remove(filename)
-            except IOError:
+            except IOError as e:
                 msg = qt.QMessageBox(self)
+                msg.setWindowTitle("Removing existing file")
                 msg.setIcon(qt.QMessageBox.Critical)
+
+                if hasattr(e, "strerror"):
+                    strerror = e.strerror
+                else:
+                    strerror = sys.exc_info()[1]
                 msg.setText("Cannot save.\n"
-                            "Input Output Error: %s" % (sys.exc_info()[1]))
+                            "Input Output Error: %s" % strerror)
                 msg.exec_()
                 return
 
@@ -492,8 +498,14 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
             self.save(filename, extension[1:])
         except Exception as e:
             msg = qt.QMessageBox(self)
+            msg.setWindowTitle("Saving mask file")
             msg.setIcon(qt.QMessageBox.Critical)
-            msg.setText("Cannot save file %s\n%s" % (filename, e.args[0]))
+
+            if hasattr(e, "strerror"):
+                strerror = e.strerror
+            else:
+                strerror = sys.exc_info()[1]
+            msg.setText("Cannot save file %s\n%s" % (filename, strerror))
             msg.exec_()
 
     def resetSelectionMask(self):

--- a/silx/gui/plot/ScatterMaskToolsWidget.py
+++ b/silx/gui/plot/ScatterMaskToolsWidget.py
@@ -431,7 +431,9 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
         filename = dialog.selectedFiles()[0]
         dialog.close()
 
+        # Update the directory according to the user selection
         self.maskFileDir = os.path.dirname(filename)
+
         try:
             self.load(filename)
         # except RuntimeWarning as e:
@@ -483,7 +485,9 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
                 msg.exec_()
                 return
 
+        # Update the directory according to the user selection
         self.maskFileDir = os.path.dirname(filename)
+
         try:
             self.save(filename, extension[1:])
         except Exception as e:

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -459,6 +459,18 @@ class BaseMaskToolsWidget(qt.QWidget):
             self._levelWidget.setVisible(self._multipleMasks != 'single')
             self._clearAllBtn.setVisible(self._multipleMasks != 'single')
 
+    def setMaskFileDirectory(self, path):
+        """Set the default directory to use by load/save GUI tools
+
+        The directory is also updated by the user, if he change the location
+        of the dialog.
+        """
+        self.maskFileDir = path
+
+    def getMaskFileDirectory(self):
+        """Get the default directory used by load/save GUI tools"""
+        return self.maskFileDir
+
     @property
     def maskFileDir(self):
         """The directory from which to load/save mask from/to files."""


### PR DESCRIPTION
This PR update small stuffs in the silx mask tool.

- Use getter/setter for mask directory (for consistency)
- Setup a program_name for mask saved as EDF
- Fix inhibited message when there was a problem while saving
- Rework the message box when there is a problem while saving

I have used `program_name` as defined in https://manual.nexusformat.org/classes/base_classes/NXentry.html

It is feeded with `silx-mask`

```
In [1]: import fabio                                                                                                                                                                
In [2]: img = fabio.open("mask.edf")                                                                                                                                                
In [3]: img.header                                                                                                                                                                  
Out[3]: 
{
  "HeaderID": "EH:000001:000000:000000",
  "Image": "1",
  "ByteOrder": "LowByteFirst",
  "DataType": "UnsignedByte",
  "Dim_1": "1024",
  "Dim_2": "1024",
  "Size": "1048576",
  "program_name": "silx-mask"
}
```

Closes #3301
Closes #3300
Closes #3298
Closes #3217


Changelog:
- Add `program_name` to the EDF mask created with silx mask tool
- Normalize mask tool API to setup default directory
