### PR TITLE
silx view: Changed NXdata image to keep data aspect ratio by default for images

### DIFF
--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -370,6 +370,7 @@ class ArrayImagePlot(qt.QWidget):
                                                vmin=None, vmax=None,
                                                normalization=Colormap.LINEAR))
         self._plot.getIntensityHistogramAction().setVisible(True)
+        self._plot.setKeepDataAspectRatio(True)
 
         # not closable
         self._selector = NumpyAxesSelector(self)


### PR DESCRIPTION
Easy to fix.

There is still a small issue though: with matplotlib backend (fine with OpenGL), when starting `silx view <file.edf>`, the image is display not as if resetzoom was called. I guess it is due to matplotlib handling the aspect ratio.
To me it does not prevent  

closes #3309