### PR TITLE
Add masked_value in created EDF masks

### DIFF
--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -116,7 +116,7 @@ class ImageMask(BaseMask):
         """
         if kind == 'edf':
             edfFile = EdfFile(filename, access="w+")
-            header = {"program_name": "silx-mask"}
+            header = {"program_name": "silx-mask", "masked_value": "nonzero"}
             edfFile.WriteImage(header, self.getMask(copy=False), Append=0)
 
         elif kind == 'tif':


### PR DESCRIPTION
This PR added a `masked_value` header to the created EDF mask files in order to provide something kind of generic for Lima.
