### PR TITLE
silx.gui.plot.PlotWidget: Fixed `setBackend` method.

### DIFF
--- a/silx/gui/plot/PlotWidget.py
+++ b/silx/gui/plot/PlotWidget.py
@@ -415,7 +415,8 @@ class PlotWidget(qt.QMainWindow):
         isKeepDataAspectRatio = self.isKeepDataAspectRatio()
         xTimeZone = xaxis.getTimeZone()
         isXAxisTimeSeries = xaxis.getTickMode() == TickMode.TIME_SERIES
-        isYAxisInverted = xaxis.isInverted()
+
+        isYAxisInverted = self.getYAxis().isInverted()
 
         # Remove all items from previous backend
         for item in self.getItems():


### PR DESCRIPTION
This PR fixes a typo in `PlotWidget.setBackend` which prevented to keep Y axis inverted when changing the backend.

Closes #3319