### PR TITLE
Fixed numpy 1.20 compatibility

### DIFF
--- a/doc/source/Tutorials/fit.rst
+++ b/doc/source/Tutorials/fit.rst
@@ -234,7 +234,7 @@ the previous tutorial (See `Weighted fit`_)
     from silx.math.fit.fitmanager import FitManager
 
     # Create synthetic data with a sum of gaussian functions
-    x = numpy.arange(1000).astype(numpy.float)
+    x = numpy.arange(1000).astype(numpy.float64)
     y = 2.4 * x**4 - 10. * x**3 + 15.2 * x**2 - 24.6 * x + 150.
 
     # define our fit function: a generic polynomial of degree 4
@@ -304,7 +304,7 @@ data, generated using another *silx* module: :mod:`silx.math.fit.functions`.
     from silx.math.fit.fitmanager import FitManager
 
     # Create synthetic data with a sum of gaussian functions
-    x = numpy.arange(1000).astype(numpy.float)
+    x = numpy.arange(1000).astype(numpy.float64)
 
     # height, center x, fwhm
     p = [1000, 100., 250,     # 1st peak
@@ -526,7 +526,7 @@ Simple usage
     from silx.gui.fit import FitWidget
     from silx.math.fit.functions import sum_gauss
 
-    x = numpy.arange(2000).astype(numpy.float)
+    x = numpy.arange(2000).astype(numpy.float64)
     constant_bg = 3.14
 
     # gaussian parameters: height, position, fwhm

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -663,7 +663,7 @@ class Colormap(qt.QObject):
             colormap.setNormalization(Colormap.LINEAR)
             colormap.setVRange(vmin=0, vmax=nbColors - 1)
             colors = colormap.applyToData(
-                numpy.arange(nbColors, dtype=numpy.int))
+                numpy.arange(nbColors, dtype=numpy.int32))
             return colors
 
     def getName(self):

--- a/silx/gui/data/test/test_dataviewer.py
+++ b/silx/gui/data/test/test_dataviewer.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -108,7 +108,7 @@ class AbstractDataViewerTests(TestCaseQt):
         self.assertIn(DataViews.IMAGE_MODE, availableModes)
 
     def test_image_bool(self):
-        data = numpy.zeros((10, 10), dtype=numpy.bool)
+        data = numpy.zeros((10, 10), dtype=bool)
         data[::2, ::2] = True
         widget = self.create_widget()
         widget.setData(data)
@@ -117,7 +117,7 @@ class AbstractDataViewerTests(TestCaseQt):
         self.assertIn(DataViews.IMAGE_MODE, availableModes)
 
     def test_image_complex_data(self):
-        data = numpy.arange(3 ** 2, dtype=numpy.complex)
+        data = numpy.arange(3 ** 2, dtype=numpy.complex64)
         data.shape = [3] * 2
         widget = self.create_widget()
         widget.setData(data)
@@ -262,7 +262,7 @@ class TestDataView(TestCaseQt):
         line = [1, 2j, 3 + 3j, 4]
         image = [line, line, line, line]
         cube = [image, image, image, image]
-        data = numpy.array(cube, dtype=numpy.complex)
+        data = numpy.array(cube, dtype=numpy.complex64)
         return data
 
     def createDataViewWithData(self, dataViewClass, data):

--- a/silx/gui/fit/BackgroundWidget.py
+++ b/silx/gui/fit/BackgroundWidget.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 #/*##########################################################################
-# Copyright (C) 2004-2017 V.A. Sole, European Synchrotron Radiation Facility
+# Copyright (C) 2004-2020 V.A. Sole, European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -337,7 +337,7 @@ class BackgroundWidget(qt.QWidget):
         pars = self.getParameters()
 
         # smoothed data
-        y = numpy.ravel(numpy.array(self._y)).astype(numpy.float)
+        y = numpy.ravel(numpy.array(self._y)).astype(numpy.float64)
         if pars["SmoothingFlag"]:
             ysmooth = filters.savitsky_golay(y, pars['SmoothingWidth'])
             f = [0.25, 0.5, 0.25]

--- a/silx/gui/fit/FitWidget.py
+++ b/silx/gui/fit/FitWidget.py
@@ -720,7 +720,7 @@ class FitWidget(qt.QWidget):
 if __name__ == "__main__":
     import numpy
 
-    x = numpy.arange(1500).astype(numpy.float)
+    x = numpy.arange(1500).astype(numpy.float64)
     constant_bg = 3.14
 
     p = [1000, 100., 30.0,

--- a/silx/gui/plot/ComplexImageView.py
+++ b/silx/gui/plot/ComplexImageView.py
@@ -318,7 +318,7 @@ class ComplexImageView(qt.QWidget):
                           False to use provided data (do not modify!).
         """
         if data is None:
-            data = numpy.zeros((0, 0), dtype=numpy.complex)
+            data = numpy.zeros((0, 0), dtype=numpy.complex64)
 
         previousData = self._plotImage.getComplexData(copy=False)
 

--- a/silx/gui/plot/CurvesROIWidget.py
+++ b/silx/gui/plot/CurvesROIWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1215,14 +1215,14 @@ class ROI(_RegionOfInterestBase):
         if len(idx):
             xw = x[idx]
             yw = y[idx]
-            rawCounts = yw.sum(dtype=numpy.float)
+            rawCounts = yw.sum(dtype=numpy.float64)
             deltaX = xw[-1] - xw[0]
             deltaY = yw[-1] - yw[0]
             if deltaX > 0.0:
                 slope = (deltaY / deltaX)
                 background = yw[0] + slope * (xw - xw[0])
                 netCounts = (rawCounts -
-                             background.sum(dtype=numpy.float))
+                             background.sum(dtype=numpy.float64))
             else:
                 netCounts = 0.0
         else:

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -743,7 +743,7 @@ class MaskToolsWidget(BaseMaskToolsWidget):
                 # Convert from plot to array coords
                 center = (event['points'][0] - self._origin) / self._scale
                 size = event['points'][1] / self._scale
-                center = center.astype(numpy.int)  # (row, col)
+                center = center.astype(numpy.int64)  # (row, col)
                 self._mask.updateEllipse(level, center[1], center[0], size[1], size[0], doMask)
                 self._mask.commit()
 

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -752,7 +752,7 @@ class MaskToolsWidget(BaseMaskToolsWidget):
                 doMask = self._isMasking()
                 # Convert from plot to array coords
                 vertices = (event['points'] - self._origin) / self._scale
-                vertices = vertices.astype(numpy.int)[:, (1, 0)]  # (row, col)
+                vertices = vertices.astype(numpy.int64)[:, (1, 0)]  # (row, col)
                 self._mask.updatePolygon(level, vertices, doMask)
                 self._mask.commit()
 

--- a/silx/gui/plot/ScatterMaskToolsWidget.py
+++ b/silx/gui/plot/ScatterMaskToolsWidget.py
@@ -102,7 +102,7 @@ class ScatterMask(BaseMask):
             self._mask[indices] = level
         else:
             # unmask only where mask level is the specified value
-            indices_stencil = numpy.zeros_like(self._mask, dtype=numpy.bool)
+            indices_stencil = numpy.zeros_like(self._mask, dtype=bool)
             indices_stencil[indices] = True
             self._mask[numpy.logical_and(self._mask == level, indices_stencil)] = 0
         self._notify()

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -378,7 +378,7 @@ class BaseMaskToolsWidget(qt.QWidget):
         """
         super(BaseMaskToolsWidget, self).__init__(parent)
         # register if the user as force a color for the corresponding mask level
-        self._defaultColors = numpy.ones((self._maxLevelNumber + 1), dtype=numpy.bool)
+        self._defaultColors = numpy.ones((self._maxLevelNumber + 1), dtype=bool)
         # overlays colors set by the user
         self._overlayColors = numpy.zeros((self._maxLevelNumber + 1, 3), dtype=numpy.float32)
 

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -628,7 +628,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
         if hasattr(color, 'dtype') and len(color) == len(x):
             # scatter plot
-            if color.dtype not in [numpy.float32, numpy.float]:
+            if color.dtype not in [numpy.float32, numpy.float64]:
                 actualColor = color / 255.
             else:
                 actualColor = color
@@ -748,7 +748,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
         color = numpy.array(color, copy=False)
         assert color.ndim == 2 and len(color) == len(x)
 
-        if color.dtype not in [numpy.float32, numpy.float]:
+        if color.dtype not in [numpy.float32, numpy.float64]:
             color = color.astype(numpy.float32) / 255.
 
         collection = TriMesh(

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -594,7 +594,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
         if (len(color) == 4 and
                 type(color[3]) in [type(1), numpy.uint8, numpy.int8]):
-            color = numpy.array(color, dtype=numpy.float) / 255.
+            color = numpy.array(color, dtype=numpy.float64) / 255.
 
         if yaxis == "right":
             axes = self.ax2

--- a/silx/gui/plot/items/_pick.py
+++ b/silx/gui/plot/items/_pick.py
@@ -48,7 +48,7 @@ class PickingResult(object):
             self._indices = None
         else:
             # Indices is set to None if indices array is empty
-            indices = numpy.array(indices, copy=False, dtype=numpy.int)
+            indices = numpy.array(indices, copy=False, dtype=numpy.int64)
             self._indices = None if indices.size == 0 else indices
 
     def getItem(self):

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -1464,9 +1464,9 @@ class PointsBase(DataItem, SymbolMixIn, AlphaMixIn):
 
             if numpy.any(clipped):
                 # copy to keep original array and convert to float
-                x = numpy.array(x, copy=True, dtype=numpy.float)
+                x = numpy.array(x, copy=True, dtype=numpy.float64)
                 x[clipped] = numpy.nan
-                y = numpy.array(y, copy=True, dtype=numpy.float)
+                y = numpy.array(y, copy=True, dtype=numpy.float64)
                 y[clipped] = numpy.nan
 
                 if xPositive and xerror is not None:

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -1399,18 +1399,18 @@ class PointsBase(DataItem, SymbolMixIn, AlphaMixIn):
                 # expand errorbars to 2xN
                 if error.size == 1:  # Scalar
                     error = numpy.full(
-                        (2, len(value)), error, dtype=numpy.float)
+                        (2, len(value)), error, dtype=numpy.float64)
 
                 elif error.ndim == 1:  # N array
                     newError = numpy.empty((2, len(value)),
-                                           dtype=numpy.float)
+                                           dtype=numpy.float64)
                     newError[0, :] = error
                     newError[1, :] = error
                     error = newError
 
                 elif error.size == 2 * len(value):  # 2xN array
                     error = numpy.array(
-                        error, copy=True, dtype=numpy.float)
+                        error, copy=True, dtype=numpy.float64)
 
                 else:
                     _logger.error("Unhandled error array")

--- a/silx/gui/plot/items/histogram.py
+++ b/silx/gui/plot/items/histogram.py
@@ -157,8 +157,8 @@ class Histogram(DataItem, AlphaMixIn, ColorMixIn, FillMixIn,
                 (x <= 0) if xPositive else False,
                 (y <= 0) if yPositive else False)
             # Make a copy and replace negative points by NaN
-            x = numpy.array(x, dtype=numpy.float)
-            y = numpy.array(y, dtype=numpy.float)
+            x = numpy.array(x, dtype=numpy.float64)
+            y = numpy.array(y, dtype=numpy.float64)
             x[clipped] = numpy.nan
             y[clipped] = numpy.nan
 
@@ -197,7 +197,7 @@ class Histogram(DataItem, AlphaMixIn, ColorMixIn, FillMixIn,
                 clipped_values = numpy.logical_or(clipped_edges[:-1],
                                                   clipped_edges[1:])
             else:
-                clipped_values = numpy.zeros_like(values, dtype=numpy.bool)
+                clipped_values = numpy.zeros_like(values, dtype=bool)
 
             if yPositive:
                 # Replace values <= 0 by NaN, do not modify edges

--- a/silx/gui/plot/items/histogram.py
+++ b/silx/gui/plot/items/histogram.py
@@ -187,12 +187,12 @@ class Histogram(DataItem, AlphaMixIn, ColorMixIn, FillMixIn,
             yPositive = False
 
         if xPositive or yPositive:
-            values = numpy.array(values, copy=True, dtype=numpy.float)
+            values = numpy.array(values, copy=True, dtype=numpy.float64)
 
             if xPositive:
                 # Replace edges <= 0 by NaN and corresponding values by NaN
                 clipped_edges = (edges <= 0)
-                edges = numpy.array(edges, copy=True, dtype=numpy.float)
+                edges = numpy.array(edges, copy=True, dtype=numpy.float64)
                 edges[clipped_edges] = numpy.nan
                 clipped_values = numpy.logical_or(clipped_edges[:-1],
                                                   clipped_edges[1:])

--- a/silx/gui/plot/items/scatter.py
+++ b/silx/gui/plot/items/scatter.py
@@ -861,7 +861,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
 
             if numpy.any(clipped):
                 # copy to keep original array and convert to float
-                value = numpy.array(value, copy=True, dtype=numpy.float)
+                value = numpy.array(value, copy=True, dtype=numpy.float64)
                 value[clipped] = numpy.nan
 
         x, y, xerror, yerror = PointsBase._logFilterData(self, xPositive, yPositive)

--- a/silx/gui/plot/stats/stats.py
+++ b/silx/gui/plot/stats/stats.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -350,7 +350,7 @@ class _CurveContext(_ScatterCurveHistoMixInContext):
             else:
                 mask = (minX <= xData) & (xData <= maxX)
                 mask = mask == 0
-                mask = mask.astype(numpy.int)
+                mask = mask.astype(numpy.int32)
         else:
             mask = numpy.zeros_like(yData)
 

--- a/silx/gui/plot/test/testComplexImageView.py
+++ b/silx/gui/plot/test/testComplexImageView.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -50,7 +50,7 @@ class TestComplexImageView(PlotWidgetTestCase, ParametricTestCase):
 
     def testPlot2DComplex(self):
         """Test API of ComplexImageView widget"""
-        data = numpy.array(((0, 1j), (1, 1 + 1j)), dtype=numpy.complex)
+        data = numpy.array(((0, 1j), (1, 1 + 1j)), dtype=numpy.complex64)
         self.plot.setData(data)
         self.plot.setKeepDataAspectRatio(True)
         self.plot.getPlot().resetZoom()
@@ -76,11 +76,11 @@ class TestComplexImageView(PlotWidgetTestCase, ParametricTestCase):
         self.qWait(100)
 
         # Test no data
-        self.plot.setData(numpy.zeros((0, 0), dtype=numpy.complex))
+        self.plot.setData(numpy.zeros((0, 0), dtype=numpy.complex64))
         self.qWait(100)
 
         # Test float data
-        self.plot.setData(numpy.arange(100, dtype=numpy.float).reshape(10, 10))
+        self.plot.setData(numpy.arange(100, dtype=numpy.float64).reshape(10, 10))
         self.qWait(100)
 
 

--- a/silx/gui/plot/test/testPlotWidget.py
+++ b/silx/gui/plot/test/testPlotWidget.py
@@ -418,7 +418,7 @@ class TestPlotImage(PlotWidgetTestCase, ParametricTestCase):
 
     def testPlotBooleanImage(self):
         """Test that a boolean image is displayed and converted to int8."""
-        data = numpy.zeros((10, 10), dtype=numpy.bool)
+        data = numpy.zeros((10, 10), dtype=bool)
         data[::2, ::2] = True
         self.plot.addImage(data, legend='boolean')
 

--- a/silx/gui/plot/tools/profile/rois.py
+++ b/silx/gui/plot/tools/profile/rois.py
@@ -315,7 +315,7 @@ class _DefaultImageProfileRoiMixIn(core.ProfileRoiMixIn):
             is_uint8 = rgba.dtype.type == numpy.uint8
             # luminosity
             if is_uint8:
-                rgba = rgba.astype(numpy.float)
+                rgba = rgba.astype(numpy.float64)
             currentData = 0.21 * rgba[..., 0] + 0.72 * rgba[..., 1] + 0.07 * rgba[..., 2]
         else:
             currentData = item.getData(copy=False)

--- a/silx/gui/plot3d/ScalarFieldView.py
+++ b/silx/gui/plot3d/ScalarFieldView.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -239,7 +239,7 @@ class SelectedRegion(object):
     def __init__(self, arrayRange, dataBBox,
                  translation=(0., 0., 0.),
                  scale=(1., 1., 1.)):
-        self._arrayRange = numpy.array(arrayRange, copy=True, dtype=numpy.int)
+        self._arrayRange = numpy.array(arrayRange, copy=True, dtype=numpy.int64)
         assert self._arrayRange.shape == (3, 2)
         assert numpy.all(self._arrayRange[:, 1] >= self._arrayRange[:, 0])
 
@@ -1449,7 +1449,7 @@ class ScalarFieldView(Plot3DWindow):
                  min(self._data.shape[1], max(*yrange))),
                 (max(0, min(*xrange_)),
                  min(self._data.shape[2], max(*xrange_))),
-                ), dtype=numpy.int)
+                ), dtype=numpy.int64)
 
         # numpy.equal supports None
         if not numpy.all(numpy.equal(selectedRange, self._selectedRange)):

--- a/silx/gui/plot3d/items/_pick.py
+++ b/silx/gui/plot3d/items/_pick.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -197,7 +197,7 @@ class PickingResult(_PickingResult):
         super(PickingResult, self).__init__(item, indices)
 
         self._objectPositions = numpy.array(
-            positions, copy=False, dtype=numpy.float)
+            positions, copy=False, dtype=numpy.float64)
 
         # Store matrices to generate positions on demand
         primitive = item._getScenePrimitive()

--- a/silx/gui/plot3d/items/volume.py
+++ b/silx/gui/plot3d/items/volume.py
@@ -444,7 +444,7 @@ class Isosurface(Item3D):
             return None  # No intersected triangles
 
         intersections = numpy.array(intersections)[numpy.argsort(depths)]
-        indices = numpy.transpose(numpy.round(intersections).astype(numpy.int))
+        indices = numpy.transpose(numpy.round(intersections).astype(numpy.int64))
         return PickingResult(self, positions=intersections, indices=indices)
 
 

--- a/silx/gui/plot3d/scene/utils.py
+++ b/silx/gui/plot3d/scene/utils.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -540,7 +540,7 @@ def segmentVolumeIntersect(segment, nbins):
     # bin edges/line intersection points
     points = t.reshape(-1, 1) * delta + p0
     centers = (points[:-1] + points[1:]) / 2.
-    bins = numpy.floor(centers).astype(numpy.int)
+    bins = numpy.floor(centers).astype(numpy.int64)
     return bins
 
 

--- a/silx/io/commonh5.py
+++ b/silx/io/commonh5.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -976,7 +976,7 @@ class Group(Node):
             raise TypeError("Path are not supported")
         if data is None:
             if dtype is None:
-                dtype = numpy.float
+                dtype = numpy.float64
             data = numpy.empty(shape=shape, dtype=dtype)
         elif dtype is not None:
             data = data.astype(dtype)

--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -60,7 +60,7 @@ def _prepare_hdf5_write_value(array_like):
     array = numpy.asarray(array_like)
     if numpy.issubdtype(array.dtype, numpy.bytes_):
         return numpy.array(array_like, dtype=vlen_bytes)
-    elif numpy.issubdtype(array.dtype, numpy.unicode):
+    elif numpy.issubdtype(array.dtype, numpy.str_):
         return numpy.array(array_like, dtype=vlen_utf8)
     else:
         return array

--- a/silx/io/fabioh5.py
+++ b/silx/io/fabioh5.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -656,13 +656,13 @@ class FabioReader(object):
             elif result_type.kind == "U":
                 none_value = u""
             elif result_type.kind == "f":
-                none_value = numpy.float("NaN")
+                none_value = numpy.float64("NaN")
             elif result_type.kind == "i":
-                none_value = numpy.int(0)
+                none_value = numpy.int64(0)
             elif result_type.kind == "u":
-                none_value = numpy.int(0)
+                none_value = numpy.int64(0)
             elif result_type.kind == "b":
-                none_value = numpy.bool(False)
+                none_value = numpy.bool_(False)
             else:
                 none_value = None
 

--- a/silx/math/fit/bgtheories.py
+++ b/silx/math/fit/bgtheories.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 #/*##########################################################################
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -281,7 +281,7 @@ def estimate_strip(x, y):
     """
     estimated_par = [CONFIG["StripWidth"],
                      CONFIG["StripIterations"]]
-    constraints = numpy.zeros((len(estimated_par), 3), numpy.float)
+    constraints = numpy.zeros((len(estimated_par), 3), numpy.float64)
     # code = 3: FIXED
     constraints[0][0] = 3
     constraints[1][0] = 3
@@ -295,7 +295,7 @@ def estimate_snip(x, y):
     set constraints to FIXED.
     """
     estimated_par = [CONFIG["SnipWidth"]]
-    constraints = numpy.zeros((len(estimated_par), 3), numpy.float)
+    constraints = numpy.zeros((len(estimated_par), 3), numpy.float64)
     # code = 3: FIXED
     constraints[0][0] = 3
     return estimated_par, constraints
@@ -321,7 +321,7 @@ def estimate_poly(x, y, deg=2):
                      CONFIG["StripWidth"],
                      CONFIG["StripIterations"])
     pcoeffs = numpy.polyfit(x, y, deg)
-    cons = numpy.zeros((deg + 1, 3), numpy.float)
+    cons = numpy.zeros((deg + 1, 3), numpy.float64)
     return pcoeffs, cons
 
 

--- a/silx/math/fit/fitmanager.py
+++ b/silx/math/fit/fitmanager.py
@@ -1036,7 +1036,7 @@ def test():
     from . import bgtheories
 
     # Create synthetic data with a sum of gaussian functions
-    x = numpy.arange(1000).astype(numpy.float)
+    x = numpy.arange(1000).astype(numpy.float64)
 
     p = [1000, 100., 250,
          255, 690., 45,

--- a/silx/math/fit/fitmanager.py
+++ b/silx/math/fit/fitmanager.py
@@ -727,12 +727,12 @@ class FitManager(object):
         :param xmax: Upper value of x values to use for fitting
         """
         if y is None:
-            self.xdata0 = numpy.array([], numpy.float)
-            self.ydata0 = numpy.array([], numpy.float)
-            # self.sigmay0 = numpy.array([], numpy.float)
-            self.xdata = numpy.array([], numpy.float)
-            self.ydata = numpy.array([], numpy.float)
-            # self.sigmay = numpy.array([], numpy.float)
+            self.xdata0 = numpy.array([], numpy.float64)
+            self.ydata0 = numpy.array([], numpy.float64)
+            # self.sigmay0 = numpy.array([], numpy.float64)
+            self.xdata = numpy.array([], numpy.float64)
+            self.ydata = numpy.array([], numpy.float64)
+            # self.sigmay = numpy.array([], numpy.float64)
 
         else:
             self.ydata0 = numpy.array(y)
@@ -886,7 +886,7 @@ class FitManager(object):
         :return: Output of the fit function with ``x`` as input and ``pars``
             as fit parameters.
         """
-        result = numpy.zeros(numpy.shape(x), numpy.float)
+        result = numpy.zeros(numpy.shape(x), numpy.float64)
 
         if self.selectedbg is not None:
             bg_pars_list = self.bgtheories[self.selectedbg].parameters

--- a/silx/math/fit/fittheories.py
+++ b/silx/math/fit/fittheories.py
@@ -524,7 +524,7 @@ class FitTheories(object):
         # get the number of found peaks
         npeaks = len(fittedpar) // 3
         estimated_parameters = []
-        estimated_constraints = numpy.zeros((4 * npeaks, 3), numpy.float)
+        estimated_constraints = numpy.zeros((4 * npeaks, 3), numpy.float64)
         for i in range(npeaks):
             for j in range(3):
                 estimated_parameters.append(fittedpar[3 * i + j])
@@ -579,7 +579,7 @@ class FitTheories(object):
         fittedpar, cons = self.estimate_height_position_fwhm(x, y)
         npeaks = len(fittedpar) // 3
         newpar = []
-        newcons = numpy.zeros((4 * npeaks, 3), numpy.float)
+        newcons = numpy.zeros((4 * npeaks, 3), numpy.float64)
         # find out related parameters proper index
         if not self.config['NoConstraintsFlag']:
             if self.config['SameFwhmFlag']:
@@ -640,7 +640,7 @@ class FitTheories(object):
         fittedpar, cons = self.estimate_height_position_fwhm(x, y)
         npeaks = len(fittedpar) // 3
         newpar = []
-        newcons = numpy.zeros((5 * npeaks, 3), numpy.float)
+        newcons = numpy.zeros((5 * npeaks, 3), numpy.float64)
         # find out related parameters proper index
         if not self.config['NoConstraintsFlag']:
             if self.config['SameFwhmFlag']:
@@ -741,7 +741,7 @@ class FitTheories(object):
         fittedpar, cons = self.estimate_height_position_fwhm(x, y)
         npeaks = len(fittedpar) // 3
         newpar = []
-        newcons = numpy.zeros((8 * npeaks, 3), numpy.float)
+        newcons = numpy.zeros((8 * npeaks, 3), numpy.float64)
         main_peak = 0
         # find out related parameters proper index
         if not self.config['NoConstraintsFlag']:
@@ -841,7 +841,7 @@ class FitTheories(object):
                 newcons[8 * i + 7, 1] = self.config['MinStepTailHeightRatio']
                 newcons[8 * i + 7, 2] = self.config['MaxStepTailHeightRatio']
             # if self.config['NoConstraintsFlag'] == 1:
-            #   newcons=numpy.zeros((8*npeaks, 3),numpy.float)
+            #   newcons=numpy.zeros((8*npeaks, 3),numpy.float64)
         if npeaks > 0:
             if g_term:
                 if self.config['PositiveHeightAreaFlag']:
@@ -983,7 +983,7 @@ class FitTheories(object):
         position = (xx[0] + xx[-1]) / 2.0
         fwhm = xx[-1] - xx[0]
         largest = [height, position, fwhm, beamfwhm]
-        cons = numpy.zeros((4, 3), numpy.float)
+        cons = numpy.zeros((4, 3), numpy.float64)
         # Setup constrains
         if not self.config['NoConstraintsFlag']:
             # Setup height constrains
@@ -1123,7 +1123,7 @@ class FitTheories(object):
         npeaks = len(peaks)
         if not npeaks:
             fittedpar = []
-            cons = numpy.zeros((len(fittedpar), 3), numpy.float)
+            cons = numpy.zeros((len(fittedpar), 3), numpy.float64)
             return fittedpar, cons
 
         fittedpar = [0.0, 0.0, 0.0, 0.0, 0.0]
@@ -1153,7 +1153,7 @@ class FitTheories(object):
         fittedpar[4] = search_fwhm
 
         # setup constraints
-        cons = numpy.zeros((5, 3), numpy.float)
+        cons = numpy.zeros((5, 3), numpy.float64)
         cons[0, 0] = CFIXED  # the number of gaussians
         if npeaks == 1:
             cons[1, 0] = CFIXED  # the delta between peaks
@@ -1337,7 +1337,7 @@ function, parameters list, configuration function and description.
 
 def test(a):
     from silx.math.fit import fitmanager
-    x = numpy.arange(1000).astype(numpy.float)
+    x = numpy.arange(1000).astype(numpy.float64)
     p = [1500, 100., 50.0,
          1500, 700., 50.0]
     y_synthetic = functions.sum_gauss(x, *p) + 1

--- a/silx/math/fit/fittheories.py
+++ b/silx/math/fit/fittheories.py
@@ -213,7 +213,7 @@ class FitTheories(object):
 
         """
         pcoeffs = numpy.polyfit(x, y, n)
-        constraints = numpy.zeros((n + 1, 3), numpy.float)
+        constraints = numpy.zeros((n + 1, 3), numpy.float64)
         return pcoeffs, constraints
 
     def estimate_quadratic(self, x, y):
@@ -298,7 +298,7 @@ class FitTheories(object):
         :return: List of peak indices
         """
         # add padding
-        ysearch = numpy.ones((len(y) + 2 * fwhm,), numpy.float)
+        ysearch = numpy.ones((len(y) + 2 * fwhm,), numpy.float64)
         ysearch[0:fwhm] = y[0]
         ysearch[-1:-fwhm - 1:-1] = y[len(y)-1]
         ysearch[fwhm:fwhm + len(y)] = y[:]
@@ -389,7 +389,7 @@ class FitTheories(object):
             xw = x
             yw = y - bg
 
-            cons = numpy.zeros((len(param), 3), numpy.float)
+            cons = numpy.zeros((len(param), 3), numpy.float64)
 
             # peak height must be positive
             cons[0:len(param):3, 0] = CPOSITIVE
@@ -405,10 +405,10 @@ class FitTheories(object):
                 shape = [max(1, int(x)) for x in (param[1:len(param):3])]
                 cons[1:len(param):3, 1] = min(xw) * numpy.ones(
                                                         shape,
-                                                        numpy.float)
+                                                        numpy.float64)
                 cons[1:len(param):3, 2] = max(xw) * numpy.ones(
                                                         shape,
-                                                        numpy.float)
+                                                        numpy.float64)
 
             # ensure fwhm is positive
             cons[2:len(param):3, 0] = CPOSITIVE
@@ -420,7 +420,7 @@ class FitTheories(object):
                                       full_output=True)
 
         # set final constraints based on config parameters
-        cons = numpy.zeros((len(fittedpar), 3), numpy.float)
+        cons = numpy.zeros((len(fittedpar), 3), numpy.float64)
         peak_index = 0
         for i in range(len(peaks)):
             # Setup height area constrains
@@ -931,7 +931,7 @@ class FitTheories(object):
                        self.config["FwhmPoints"] * (x[1] - x[0])]    # fwhm: default value
 
         # Setup constrains
-        newcons = numpy.zeros((3, 3), numpy.float)
+        newcons = numpy.zeros((3, 3), numpy.float64)
         if not self.config['NoConstraintsFlag']:
                 # Setup height constrains
             if self.config['PositiveHeightAreaFlag']:
@@ -1056,7 +1056,7 @@ class FitTheories(object):
                        x[len(x)//2],                                 # center: middle of x range
                        self.config["FwhmPoints"] * (x[1] - x[0])]    # fwhm: default value
 
-        newcons = numpy.zeros((3, 3), numpy.float)
+        newcons = numpy.zeros((3, 3), numpy.float64)
         # Setup constrains
         if not self.config['NoConstraintsFlag']:
                 # Setup height constraints

--- a/silx/math/fit/functions.pyx
+++ b/silx/math/fit/functions.pyx
@@ -1,6 +1,6 @@
 # coding: utf-8
 #/*##########################################################################
-# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -977,7 +977,7 @@ def periodic_gauss(x, *pars):
         raise IndexError("No parameters specified. " +
                          "At least 5 parameters are required.")
 
-    newpars = numpy.zeros((pars[0], 3), numpy.float)
+    newpars = numpy.zeros((pars[0], 3), numpy.float64)
     for i in range(int(pars[0])):
         newpars[i, 0] = pars[2]
         newpars[i, 1] = pars[3] + i * pars[1]

--- a/silx/math/fit/leastsq.py
+++ b/silx/math/fit/leastsq.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -205,7 +205,7 @@ def leastsq(model, xdata, ydata, p0, sigma=None,
         if sigma is not None:
             sigma = numpy.asarray_chkfinite(sigma)
         else:
-            sigma = numpy.ones((ydata.shape), dtype=numpy.float)
+            sigma = numpy.ones((ydata.shape), dtype=numpy.float64)
         ydata.shape = -1
         sigma.shape = -1
     else:
@@ -215,7 +215,7 @@ def leastsq(model, xdata, ydata, p0, sigma=None,
         if sigma is not None:
             sigma = numpy.asarray(sigma)
         else:
-            sigma = numpy.ones((ydata.shape), dtype=numpy.float)
+            sigma = numpy.ones((ydata.shape), dtype=numpy.float64)
         sigma.shape = -1
         # get rid of NaN in input data
         idx = numpy.isfinite(ydata)
@@ -291,7 +291,7 @@ def leastsq(model, xdata, ydata, p0, sigma=None,
     if epsfcn is None:
         epsfcn = numpy.finfo(numpy.float).eps
     else:
-        epsfcn = max(epsfcn, numpy.finfo(numpy.float).eps)
+        epsfcn = max(epsfcn, numpy.finfo(numpy.float64).eps)
 
     # check if constraints have been passed as text
     constrained_fit = False
@@ -383,7 +383,7 @@ def leastsq(model, xdata, ydata, p0, sigma=None,
                 newpar = fitparam + deltapar [0]
             else:
                 newpar = parameters.__copy__()
-                pwork = numpy.zeros(deltapar.shape, numpy.float)
+                pwork = numpy.zeros(deltapar.shape, numpy.float64)
                 for i in range(n_free):
                     if constraints is None:
                         pwork [0] [i] = fitparam [i] + deltapar [0] [i]
@@ -595,9 +595,9 @@ def chisq_alpha_beta(model, parameters, x, y, weight, constraints=None,
             Sequence with the indices of the original parameters considered in the calculations.
     """
     if epsfcn is None:
-        epsfcn = numpy.finfo(numpy.float).eps
+        epsfcn = numpy.finfo(numpy.float64).eps
     else:
-        epsfcn = max(epsfcn, numpy.finfo(numpy.float).eps)
+        epsfcn = max(epsfcn, numpy.finfo(numpy.float64).eps)
     #nr0, nc = data.shape
     n_param = len(parameters)
     if constraints is None:
@@ -644,9 +644,9 @@ def chisq_alpha_beta(model, parameters, x, y, weight, constraints=None,
                     print("Initial value = %f" % parameters[i])
                     print("Limits are %f and %f" % (pmin, pmax))
                     print("Parameter will be kept at its starting value")
-    fitparam = numpy.array(fitparam, numpy.float)
-    alpha = numpy.zeros((n_free, n_free), numpy.float)
-    beta = numpy.zeros((1, n_free), numpy.float)
+    fitparam = numpy.array(fitparam, numpy.float64)
+    alpha = numpy.zeros((n_free, n_free), numpy.float64)
+    beta = numpy.zeros((1, n_free), numpy.float64)
     #delta = (fitparam + numpy.equal(fitparam, 0.0)) * 0.00001
     delta = (fitparam + numpy.equal(fitparam, 0.0)) * numpy.sqrt(epsfcn)
     nr  = y.size
@@ -803,7 +803,7 @@ def _get_sigma_parameters(parameters, sigma0, constraints):
     if constraints is None:
         return sigma0
     n_free = 0
-    sigma_par = numpy.zeros(parameters.shape, numpy.float)
+    sigma_par = numpy.zeros(parameters.shape, numpy.float64)
     for i in range(len(constraints)):
         if constraints[i][0] == CFREE:
             sigma_par [i] = sigma0[n_free]

--- a/silx/math/fit/leastsq.py
+++ b/silx/math/fit/leastsq.py
@@ -132,7 +132,7 @@ def leastsq(model, xdata, ydata, p0, sigma=None,
         calculating the numerical derivatives (for model_deriv=None).
         Normally the actual step length will be sqrt(epsfcn)*x
         Original Gefit module was using epsfcn 1.0e-5 while default value
-        is now numpy.finfo(numpy.float).eps as in scipy
+        is now numpy.finfo(numpy.float64).eps as in scipy
     :type epsfcn: *optional*, float
 
     :param deltachi: float
@@ -289,7 +289,7 @@ def leastsq(model, xdata, ydata, p0, sigma=None,
     nparameters = len(parameters)
 
     if epsfcn is None:
-        epsfcn = numpy.finfo(numpy.float).eps
+        epsfcn = numpy.finfo(numpy.float64).eps
     else:
         epsfcn = max(epsfcn, numpy.finfo(numpy.float64).eps)
 
@@ -567,7 +567,7 @@ def chisq_alpha_beta(model, parameters, x, y, weight, constraints=None,
         calculating the numerical derivatives (for model_deriv=None).
         Normally the actual step length will be sqrt(epsfcn)*x
         Original Gefit module was using epsfcn 1.0e-10 while default value
-        is now numpy.finfo(numpy.float).eps as in scipy
+        is now numpy.finfo(numpy.float64).eps as in scipy
     :type epsfcn: *optional*, float
 
     :param left_derivative:
@@ -860,7 +860,7 @@ def main(argv=None):
         return numpy.exp(x * numpy.less(abs(x), 250)) -\
                1.0 * numpy.greater_equal(abs(x), 250)
 
-    xx = numpy.arange(npoints, dtype=numpy.float)
+    xx = numpy.arange(npoints, dtype=numpy.float64)
     yy = gauss(xx, *[10.5, 2, 1000.0, 20., 15])
     sy = numpy.sqrt(abs(yy))
     parameters = [0.0, 1.0, 900.0, 25., 10]

--- a/silx/math/fit/test/test_fit.py
+++ b/silx/math/fit/test/test_fit.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -57,7 +57,7 @@ class Test_leastsq(unittest.TestCase):
         self.my_exp = myexp
 
         def gauss(x, *params):
-            params = numpy.array(params, copy=False, dtype=numpy.float)
+            params = numpy.array(params, copy=False, dtype=numpy.float64)
             result = params[0] + params[1] * x
             for i in range(2, len(params), 3):
                 p = params[i:(i+3)]
@@ -69,7 +69,7 @@ class Test_leastsq(unittest.TestCase):
 
         def gauss_derivative(x, params, idx):
             if idx == 0:
-                return numpy.ones(len(x), numpy.float)
+                return numpy.ones(len(x), numpy.float64)
             if idx == 1:
                 return x
             gaussian_peak = (idx - 2) // 3
@@ -140,7 +140,7 @@ class Test_leastsq(unittest.TestCase):
         parameters_actual = [10.5, 2, 10000.0, 20., 150, 5000, 900., 300]
         x = numpy.arange(10000.)
         y = self.gauss(x, *parameters_actual)
-        delta = numpy.sqrt(numpy.finfo(numpy.float).eps)
+        delta = numpy.sqrt(numpy.finfo(numpy.float64).eps)
         for i in range(len(parameters_actual)):
             p = parameters_actual * 1
             if p[i] == 0:

--- a/silx/math/fit/test/test_fitmanager.py
+++ b/silx/math/fit/test/test_fitmanager.py
@@ -125,7 +125,7 @@ class TestFitmanager(ParametricTestCase):
         """Test fit manager on synthetic data using a gaussian function
         and a linear background"""
         # Create synthetic data with a sum of gaussian functions
-        x = numpy.arange(1000).astype(numpy.float)
+        x = numpy.arange(1000).astype(numpy.float64)
 
         p = [1000, 100., 250,
              255, 650., 45,
@@ -186,7 +186,7 @@ class TestFitmanager(ParametricTestCase):
         """Test FitManager using a custom fit function defined in an external
         file and imported with FitManager.loadtheories"""
         # Create synthetic data with a sum of gaussian functions
-        x = numpy.arange(100).astype(numpy.float)
+        x = numpy.arange(100).astype(numpy.float64)
 
         # a, b, c are the fit parameters
         # d is a known scaling parameter that is set using configure()
@@ -233,7 +233,7 @@ class TestFitmanager(ParametricTestCase):
         """Test FitManager using a custom fit function defined in an external
         file and imported with FitManager.loadtheories (legacy PyMca format)"""
         # Create synthetic data with a sum of gaussian functions
-        x = numpy.arange(100).astype(numpy.float)
+        x = numpy.arange(100).astype(numpy.float64)
 
         # a, b, c are the fit parameters
         # d is a known scaling parameter that is set using configure()
@@ -279,7 +279,7 @@ class TestFitmanager(ParametricTestCase):
         """Test FitManager using a custom fit function imported with
         FitManager.addtheory"""
         # Create synthetic data with a sum of gaussian functions
-        x = numpy.arange(100).astype(numpy.float)
+        x = numpy.arange(100).astype(numpy.float64)
 
         # a, b, c are the fit parameters
         # d is a known scaling parameter that is set using configure()
@@ -369,7 +369,7 @@ class TestFitmanager(ParametricTestCase):
         for theory_name, theory_fun in (('Step Down', sum_stepdown),
                                         ('Step Up', sum_stepup)):
             # Create synthetic data with a sum of gaussian functions
-            x = numpy.arange(1000).astype(numpy.float)
+            x = numpy.arange(1000).astype(numpy.float64)
 
             # ('Height', 'Position', 'FWHM')
             p = [1000, 439, 250]
@@ -407,7 +407,7 @@ def cubic(x, a, b, c, d):
 class TestPolynomials(unittest.TestCase):
     """Test polynomial fit theories and fit background"""
     def setUp(self):
-        self.x = numpy.arange(100).astype(numpy.float)
+        self.x = numpy.arange(100).astype(numpy.float64)
 
     def testQuadraticBg(self):
         gaussian_params = [100, 45, 8]

--- a/silx/opencl/projection.py
+++ b/silx/opencl/projection.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -115,7 +115,7 @@ class Projection(OpenclProcessing):
         self.offset_x = -np.float32((self.shape[1] - 1) / 2. - self.axis_pos)  # TODO: custom
         self.offset_y = -np.float32((self.shape[0] - 1) / 2. - self.axis_pos)  # TODO: custom
         # Reset axis_pos once offset are computed
-        self.axis_pos0 = np.float((self.shape[1] - 1) / 2.)
+        self.axis_pos0 = np.float64((self.shape[1] - 1) / 2.)
 
         # Workgroup, ndrange and shared size
         self.dimgrid_x = _idivup(self.dwidth, 16)

--- a/silx/sx/_plot.py
+++ b/silx/sx/_plot.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -371,7 +371,7 @@ def scatter(x=None, y=None, value=None, size=None,
             assert len(x) == len(value)
 
         else:
-            value = numpy.ones(len(x), dtype=numpy.float) * value
+            value = numpy.ones(len(x), dtype=numpy.float64) * value
 
         plt.setData(x, y, value)
         item = plt.getScatterItem()


### PR DESCRIPTION
This PR fixes `numpy` v1.20.0rc1 deprecation warnings throughout `silx`.

Here are the replacements I made most of the time:
- `numpy.bool` -> `bool`
- `numpy.float` -> `numpy.float64`
- `numpy.complex` -> `numpy.complex64`
- `numpy.int` -> `numpy.int64` (sometimes `numpy.int32`)

Changes that requires proper review:
- `silx/io/dictdump.py`
- `silx/io/fabioh5.py`
- `silx/opencl/projection.py`

closes #3327
