### PR TITLE
silx.gui.plot: Fixed `PlotWindow` display of the colorbar

### DIFF
--- a/silx/gui/plot/ColorBar.py
+++ b/silx/gui/plot/ColorBar.py
@@ -142,9 +142,8 @@ class ColorBarWidget(qt.QWidget):
             self._isConnected = True
 
     def setVisible(self, isVisible):
-        if isVisible != self.isVisible():
-            qt.QWidget.setVisible(self, isVisible)
-            self.sigVisibleChanged.emit(isVisible)
+        qt.QWidget.setVisible(self, isVisible)
+        self.sigVisibleChanged.emit(isVisible)
 
     def showEvent(self, event):
         self._connectPlot()


### PR DESCRIPTION
This PR restores previous `PlotWindow` behavior that colorbar is hidden by default.

closes #3329
