### PR TITLE
silx.test: Enhanced `run_tests` taking arguments to configure test execution.

### DIFF
--- a/silx/test/__init__.py
+++ b/silx/test/__init__.py
@@ -89,10 +89,13 @@ def suite():
     return test_suite
 
 
-def run_tests():
-    """Run test complete test_suite"""
+def run_tests(*args, **kwargs):
+    """Run test complete test_suite
+
+    Provided arguments are passed to :class:`unittest.TextTestRunner`.
+    """
     test_options.configure()
-    runner = unittest.TextTestRunner()
+    runner = unittest.TextTestRunner(*args, **kwargs)
     if not runner.run(suite()).wasSuccessful():
         print("Test suite failed")
         return 1


### PR DESCRIPTION
Minor PR allowing to pass arguments to [`unittest.TextTestRunner`](https://docs.python.org/3/library/unittest.html#unittest.TextTestRunner) through `silx.test.run_tests` (e.g., `verbosity=1`).