### PR TITLE
Fix 3332 - issue with silx view when NXclass attribute is not recognized

### DIFF
--- a/silx/gui/hdf5/Hdf5Item.py
+++ b/silx/gui/hdf5/Hdf5Item.py
@@ -383,12 +383,16 @@ class Hdf5Item(Hdf5Node):
                 text = text.strip('"')
                 # Check NX_class formatting
                 lower = text.lower()
+                formatedNX_class = None
                 if lower.startswith('nx'):
                     formatedNX_class = 'NX' + lower[2:]
                 if lower == 'nxcansas':
                     formatedNX_class = 'NXcanSAS'  # That's the only class with capital letters...
-                if text != formatedNX_class:
-                    _logger.error("NX_class: %s is malformed (should be %s)",
+                if formatedNX_class is None:
+                    _logger.error("NX_class: '%s' is malformed",
+                                  text)
+                elif text != formatedNX_class:
+                    _logger.error("NX_class: '%s' is malformed (should be '%s')",
                                   text,
                                   formatedNX_class)
                 text = formatedNX_class

--- a/silx/gui/hdf5/Hdf5Item.py
+++ b/silx/gui/hdf5/Hdf5Item.py
@@ -383,15 +383,12 @@ class Hdf5Item(Hdf5Node):
                 text = text.strip('"')
                 # Check NX_class formatting
                 lower = text.lower()
-                formatedNX_class = None
+                formatedNX_class = ""
                 if lower.startswith('nx'):
                     formatedNX_class = 'NX' + lower[2:]
                 if lower == 'nxcansas':
                     formatedNX_class = 'NXcanSAS'  # That's the only class with capital letters...
-                if formatedNX_class is None:
-                    _logger.error("NX_class: '%s' is malformed",
-                                  text)
-                elif text != formatedNX_class:
+                if text != formatedNX_class:
                     _logger.error("NX_class: '%s' is malformed (should be '%s')",
                                   text,
                                   formatedNX_class)


### PR DESCRIPTION
Fix handling of `nexusClassName` property from `silx.gui.hdf5.hdf5item.Hdf5Item` if node contains an `NX_class` unrecognized.

closes #3332