### PR TITLE
Fixed interactive tests on Windows10

### DIFF
--- a/silx/gui/plot/test/testMaskToolsWidget.py
+++ b/silx/gui/plot/test/testMaskToolsWidget.py
@@ -84,10 +84,15 @@ class TestMaskToolsWidget(PlotWidgetTestCase, ParametricTestCase):
 
         self.mouseMove(plot, pos=(0, 0))
         self.mouseMove(plot, pos=pos0)
-        self.mouseClick(plot, qt.Qt.LeftButton, pos=pos0)
-        self.mouseMove(plot, pos=(0, 0))
+        self.qapp.processEvents()
+        self.mousePress(plot, qt.Qt.LeftButton, pos=pos0)
+        self.qapp.processEvents()
+        self.mouseMove(plot, pos=(pos0[0] + offset // 2, pos0[1] + offset // 2))
         self.mouseMove(plot, pos=pos1)
-        self.mouseClick(plot, qt.Qt.LeftButton, pos=pos1)
+        self.qapp.processEvents()
+        self.mouseRelease(plot, qt.Qt.LeftButton, pos=pos1)
+        self.qapp.processEvents()
+        self.mouseMove(plot, pos=(0, 0))
 
     def _drawPolygon(self):
         """Draw a star polygon in the plot"""
@@ -102,14 +107,14 @@ class TestMaskToolsWidget(PlotWidgetTestCase, ParametricTestCase):
                 (x + offset, y - offset),
                 (x, y + offset)]  # Close polygon
 
-        self.mouseMove(plot, pos=(1, 1))
+        self.mouseMove(plot, pos=(0, 0))
         for pos in star:
             self.mouseMove(plot, pos=pos)
             self.qapp.processEvents()
-            self.mouseClick(plot, qt.Qt.LeftButton, pos=pos)
+            self.mousePress(plot, qt.Qt.LeftButton, pos=pos)
             self.qapp.processEvents()
-            self.mouseMove(plot, pos=pos)
-        self.mouseMove(plot, pos=(1, 1))
+            self.mouseRelease(plot, qt.Qt.LeftButton, pos=pos)
+            self.qapp.processEvents()
 
     def _drawPencil(self):
         """Draw a star polygon in the plot"""
@@ -123,11 +128,10 @@ class TestMaskToolsWidget(PlotWidgetTestCase, ParametricTestCase):
                 (x - offset, y),
                 (x + offset, y - offset)]
 
-        self.mouseMove(plot, pos=(1, 1))
+        self.mouseMove(plot, pos=(0, 0))
         self.mouseMove(plot, pos=star[0])
         self.mousePress(plot, qt.Qt.LeftButton, pos=star[0])
         for pos in star[1:]:
-            self.mouseMove(plot, pos=pos)
             self.mouseMove(plot, pos=pos)
         self.mouseRelease(
             plot, qt.Qt.LeftButton, pos=star[-1])

--- a/silx/gui/plot/test/testMaskToolsWidget.py
+++ b/silx/gui/plot/test/testMaskToolsWidget.py
@@ -102,12 +102,14 @@ class TestMaskToolsWidget(PlotWidgetTestCase, ParametricTestCase):
                 (x + offset, y - offset),
                 (x, y + offset)]  # Close polygon
 
-        self.mouseMove(plot, pos=(0, 0))
+        self.mouseMove(plot, pos=(1, 1))
         for pos in star:
             self.mouseMove(plot, pos=pos)
             self.qapp.processEvents()
             self.mouseClick(plot, qt.Qt.LeftButton, pos=pos)
             self.qapp.processEvents()
+            self.mouseMove(plot, pos=pos)
+        self.mouseMove(plot, pos=(1, 1))
 
     def _drawPencil(self):
         """Draw a star polygon in the plot"""
@@ -121,10 +123,11 @@ class TestMaskToolsWidget(PlotWidgetTestCase, ParametricTestCase):
                 (x - offset, y),
                 (x + offset, y - offset)]
 
-        self.mouseMove(plot, pos=(0, 0))
+        self.mouseMove(plot, pos=(1, 1))
         self.mouseMove(plot, pos=star[0])
         self.mousePress(plot, qt.Qt.LeftButton, pos=star[0])
         for pos in star[1:]:
+            self.mouseMove(plot, pos=pos)
             self.mouseMove(plot, pos=pos)
         self.mouseRelease(
             plot, qt.Qt.LeftButton, pos=star[-1])

--- a/silx/gui/plot/test/testPlotInteraction.py
+++ b/silx/gui/plot/test/testPlotInteraction.py
@@ -68,7 +68,11 @@ class TestSelectPolygon(PlotWidgetTestCase):
 
         for pos in polygon:
             self.mouseMove(plot, pos=pos)
-            self.mouseClick(plot, qt.Qt.LeftButton, pos=pos)
+            self.qapp.processEvents()
+            self.mousePress(plot, qt.Qt.LeftButton, pos=pos)
+            self.qapp.processEvents()
+            self.mouseRelease(plot, qt.Qt.LeftButton, pos=pos)
+            self.qapp.processEvents()
 
         self.plot.sigPlotSignal.disconnect(dump)
         return [args[0] for args in dump.received]

--- a/silx/gui/plot/test/testScatterMaskToolsWidget.py
+++ b/silx/gui/plot/test/testScatterMaskToolsWidget.py
@@ -110,6 +110,7 @@ class TestScatterMaskToolsWidget(PlotWidgetTestCase, ParametricTestCase):
             self.qapp.processEvents()
             self.mouseClick(plot, qt.Qt.LeftButton, pos=pos)
             self.qapp.processEvents()
+            self.mouseMove(plot, pos=pos)
 
     def _drawPencil(self):
         """Draw a star polygon in the plot"""

--- a/silx/gui/plot/test/testScatterMaskToolsWidget.py
+++ b/silx/gui/plot/test/testScatterMaskToolsWidget.py
@@ -86,10 +86,16 @@ class TestScatterMaskToolsWidget(PlotWidgetTestCase, ParametricTestCase):
 
         self.mouseMove(plot, pos=(0, 0))
         self.mouseMove(plot, pos=pos0)
-        self.mouseClick(plot, qt.Qt.LeftButton, pos=pos0)
-        self.mouseMove(plot, pos=(0, 0))
+        self.qapp.processEvents()
+        self.mousePress(plot, qt.Qt.LeftButton, pos=pos0)
+        self.qapp.processEvents()
+
+        self.mouseMove(plot, pos=(pos0[0] + offset // 2, pos0[1] + offset // 2))
         self.mouseMove(plot, pos=pos1)
-        self.mouseClick(plot, qt.Qt.LeftButton, pos=pos1)
+        self.qapp.processEvents()
+        self.mouseRelease(plot, qt.Qt.LeftButton, pos=pos1)
+        self.qapp.processEvents()
+        self.mouseMove(plot, pos=(0, 0))
 
     def _drawPolygon(self):
         """Draw a star polygon in the plot"""
@@ -108,9 +114,10 @@ class TestScatterMaskToolsWidget(PlotWidgetTestCase, ParametricTestCase):
         for pos in star:
             self.mouseMove(plot, pos=pos)
             self.qapp.processEvents()
-            self.mouseClick(plot, qt.Qt.LeftButton, pos=pos)
+            self.mousePress(plot, qt.Qt.LeftButton, pos=pos)
             self.qapp.processEvents()
-            self.mouseMove(plot, pos=pos)
+            self.mouseRelease(plot, qt.Qt.LeftButton, pos=pos)
+            self.qapp.processEvents()
 
     def _drawPencil(self):
         """Draw a star polygon in the plot"""

--- a/silx/gui/plot/tools/test/testROI.py
+++ b/silx/gui/plot/tools/test/testROI.py
@@ -557,8 +557,9 @@ class TestRegionOfInterestManager(TestCaseQt, ParametricTestCase):
         mx, my = self.plot.dataToPixel(*center)
         self.mouseMove(widget, pos=(mx, my))
         self.mousePress(widget, qt.Qt.LeftButton, pos=(mx, my))
+        self.mouseMove(widget, pos=(mx, my+25))
         self.mouseMove(widget, pos=(mx, my+50))
-        self.mouseRelease(widget, qt.Qt.LeftButton, pos=(mx, my))
+        self.mouseRelease(widget, qt.Qt.LeftButton, pos=(mx, my+50))
 
         result = numpy.array(item.getEndPoints())
         # x location is still the same


### PR DESCRIPTION
This PR fixes interactive tests that were failing under Windows10 during 0.14 testing.

This currently targets 0.14 branch. For me, it is not critical to embed but still nice to have (provided it does not break those tests on other platforms.

So far tested on Windows10 with PyQt5 and PySide2.