### PR TITLE
silx.gui.plot: Fixed RegionOfInterest `contains`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Change Log
 0.14.0: 2020/12/11
 ------------------
 
+This is the first version of `silx` supporting `h5py` >= v3.0.
+
 * `silx.gui`:
 
   * Added support for HDF5 external data (virtual and raw) (PR #3222)
@@ -91,7 +93,6 @@ Change Log
 
 * Miscellaneous:
 
-  * Add support for `h5py >= 3.0`
   * HDF5 strings: handle h5py 2.x and 3.x (PR #3240)
   * Fixed cython 3 compatibility and deprecation warning (PR #3164, #3189)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,15 +6,18 @@ Change Log
 
 This is the first version of `silx` supporting `h5py` >= v3.0.
 
+* `silx view`:
+
+  * Added `-f` command line option, Fixed collapsing browsing panel (PR #3176)
+
 * `silx.gui`:
 
   * Added support for HDF5 external data (virtual and raw) (PR #3222)
   * Added lazy update handling of OpenGL textures (PR #3205)
   * Deprecated `silx.gui.plot.matplotlib` module (use `silx.gui.utils.matplotlib` instead) (PR #3158)
-  * Improve memory allocation by using already defined `fontMetrics` instread of creating a new one (PR #3239)
-  * Make TextFormatter compatible with h5py>=3 (PR #3253)
-  * Fixed matplotlib 3.3.0rc1 deprecation warnings (PR #3145)
-  * Fixed collapsing browsing panel in silx view, Added `-f` command line option (PR #3176)
+  * Improved memory allocation by using already defined `fontMetrics` instread of creating a new one (PR #3239)
+  * Make `TextFormatter` compatible with `h5py`>=3 (PR #3253)
+  * Fixed `matplotlib` 3.3.0rc1 deprecation warnings (PR #3145)
   * Fixed `glutils.isOpenGLAvailable` issue (PR #3184)
 
   * `silx.gui.colors.Colormap`:
@@ -26,28 +29,25 @@ This is the first version of `silx` supporting `h5py` >= v3.0.
 
   * `silx.gui.plot`:
 
+    * Added the feature to compute statistics inside a specific region of interest (PR #3056)
     * Added `DATA_BOUNDS` visualization parameter for `Scatter` item histogram bounds (PR #3180)
     * Added an action to switch on/off OpenGL rendering on a plot (PR #3261)
-    * Add test for ROI interaction mode (PR #3283)
-    * Added the feature to compute statistics inside a specific region of interest (PR #3056)
-    * Improved image profile tool to support PlotWidget item extension (PR #3150)
+    * Added test for ROI interaction mode (PR #3283)
+    * Added saving of error bars when saving a plot (PR #3199)
+    * Improved image profile tool to support `PlotWidget` item extension (PR #3150)
     * Improved `Stackview`: replaced `setColormap` `autoscale` argument by `scaleColormapRangeToStack` method (PR #3279)
     * Updated `3 stddev` autoscale algorithm, clamp it with the minmax data in order to improve the contrast (PR #3284)
-    * Save error bars when saving a plot (PR #3199)
-    * Split ROI module into 3: base/common/arc_roi (PR #3283)
-    * Fixed ColormapDialog custom range input (PR #3153)
+    * Updated ROI module: splitted into 3 modules base/common/arc_roi (PR #3283)
+    * Fixed `ColormapDialog` custom range input (PR #3153)
     * Fixed support of curves with infinite data (PR #3175)
     * Fixed issue when changing ROI mode while a ROI is being created (PR #3186)
     * Fixed `RegionOfInterest` refresh when highlighted (PR #3197)
     * Fixed arc roi shape: make sure start and end points are part of the shape (PR #3257)
-    * Fixed issue in Colormap `3 stdev` autoscale mode and avoided warnings (PR #3295)
+    * Fixed issue in `Colormap` `3 stdev` autoscale mode and avoided warnings (PR #3295)
 
     * Major improvements of `PlotWidget`:
 
-      * Added support for float16 texture in OpenGL backend (PR #3194)
       * Added `get|setAxesMargins` methods to control margin ratios around plot area (PR #3196)
-      * Added a `DataItem` base class for items having a "data extent" in the plot (PR #3212)
-      * Added item visible bounds feature to PlotWidget items (PR #3223)
       * Added `PlotWidget.[get|set]Backend` enabling switching backend (PR #3255)
       * Added multi interaction mode for ROIs (can be switched with a single click on an handle, or the context menu) (PR #3260)
       * Added polar interaction mode for arc ROI (PR #3260)
@@ -55,12 +55,15 @@ This is the first version of `silx` supporting `h5py` >= v3.0.
       * Added context menu to the selected ROI to remove it (PR #3260)
       * Added pan interaction to ROI authoring (`select-draw`) interaction mode (PR #3291)
       * Added support of right axis label with OpenGL backend (PR #3293)
+      * Added item visible bounds feature to PlotWidget items (PR #3223)
+      * Added a `DataItem` base class for items having a "data extent" in the plot (PR #3212)
+      * Added support for float16 texture in OpenGL backend (PR #3194)
       * Improved support of high-DPI screen in OpenGL backend (PR #3203)
-      * Use points rather than pixels for marker size and line width with OpenGL backend (PR #3203)
-      * Expose PlotWidget colors as Qt properties (PR #3269)
+      * Updated: Use points rather than pixels for marker size and line width with OpenGL backend (PR #3203)
+      * Updated: Expose `PlotWidget` colors as Qt properties (PR #3269)
       * Fixed time serie axis for range < 2.5 microseconds (PR #3195)
       * Fixed initial size of OpenGL backend (PR #3209)
-      * Fixed PlotWidget image items displayed below the grid by default (PR #3235)
+      * Fixed `PlotWidget` image items displayed below the grid by default (PR #3235)
       * Fixed OpenGL backend image display with sqrt colormap normalization (PR #3248)
       * Fixed support of shapes with multiple polygons in the OpenGL backend (PR #3259)
       * Fixes duplicated callback on ROIs (there was one for each ROI managed created on the plot) (PR #3260)
@@ -78,7 +81,7 @@ This is the first version of `silx` supporting `h5py` >= v3.0.
 * `silx.io`:
 
   * Added support for HDF5 link preservation in `dictdump` (PR #3224)
-  * Added support for numpy arrays of 'numbers' (PR #3251)
+  * Added support for numpy arrays of `numbers` (PR #3251)
   * Make `h5todict` resilient to issues in the HDF5 file (PR #3162)
 
 * `silx.math`:
@@ -93,8 +96,8 @@ This is the first version of `silx` supporting `h5py` >= v3.0.
 
 * Miscellaneous:
 
-  * HDF5 strings: handle h5py 2.x and 3.x (PR #3240)
-  * Fixed cython 3 compatibility and deprecation warning (PR #3164, #3189)
+  * Added HDF5 strings: handle `h5py` 2.x and 3.x (PR #3240)
+  * Fixed `cython` 3 compatibility and deprecation warning (PR #3164, #3189)
 
 
 0.13.0: 2020/06/23

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,6 +61,7 @@ Change Log
       * Added context menu to the selected ROI to remove it (PR #3260)
       * Added pan interaction to ROI authoring (`select-draw`) interaction mode (PR #3291)
       * Added support of right axis label with OpenGL backend (PR #3293)
+      * Fixed RegionOfInterest `contains` methods (PR #3336)
 
   * `silx.gui.colors.plot3d`:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,14 +6,14 @@ Change Log
 
 * `silx.gui`:
 
-  * Fixed matplotlib 3.3.0rc1 deprecation warnings (PR #3145)
-  * Deprecated `silx.gui.plot.matplotlib` module (use `silx.gui.utils.matplotlib` instead) (PR #3158)
-  * Fixed collapsing browsing panel in silx view, Added `-f` command line option (PR #3176)
-  * Fixed `glutils.isOpenGLAvailable` issue (PR #3184)
   * Added support for HDF5 external data (virtual and raw) (PR #3222)
+  * Added lazy update handling of OpenGL textures (PR #3205)
+  * Deprecated `silx.gui.plot.matplotlib` module (use `silx.gui.utils.matplotlib` instead) (PR #3158)
   * Improve memory allocation by using already defined `fontMetrics` instread of creating a new one (PR #3239)
   * Make TextFormatter compatible with h5py>=3 (PR #3253)
-  * Added lazy update handling of OpenGL textures (PR #3205)
+  * Fixed matplotlib 3.3.0rc1 deprecation warnings (PR #3145)
+  * Fixed collapsing browsing panel in silx view, Added `-f` command line option (PR #3176)
+  * Fixed `glutils.isOpenGLAvailable` issue (PR #3184)
 
   * `silx.gui.colors.Colormap`:
 
@@ -24,43 +24,44 @@ Change Log
 
   * `silx.gui.plot`:
 
+    * Added `DATA_BOUNDS` visualization parameter for `Scatter` item histogram bounds (PR #3180)
+    * Added an action to switch on/off OpenGL rendering on a plot (PR #3261)
+    * Add test for ROI interaction mode (PR #3283)
+    * Added the feature to compute statistics inside a specific region of interest (PR #3056)
     * Improved image profile tool to support PlotWidget item extension (PR #3150)
+    * Improved `Stackview`: replaced `setColormap` `autoscale` argument by `scaleColormapRangeToStack` method (PR #3279)
+    * Updated `3 stddev` autoscale algorithm, clamp it with the minmax data in order to improve the contrast (PR #3284)
+    * Save error bars when saving a plot (PR #3199)
+    * Split ROI module into 3: base/common/arc_roi (PR #3283)
     * Fixed ColormapDialog custom range input (PR #3153)
     * Fixed support of curves with infinite data (PR #3175)
     * Fixed issue when changing ROI mode while a ROI is being created (PR #3186)
-    * Added `DATA_BOUNDS` visualization parameter for `Scatter` item histogram bounds (PR #3180)
     * Fixed `RegionOfInterest` refresh when highlighted (PR #3197)
     * Fixed arc roi shape: make sure start and end points are part of the shape (PR #3257)
-    * Save error bars when saving a plot (PR #3199)
-    * Added an action to switch on/off OpenGL rendering on a plot (PR #3261)
-    * Split ROI module into 3: base/common/arc_roi (PR #3283)
-    * Add test for ROI interaction mode (PR #3283)
-    * Improved `Stackview`: replaced `setColormap` `autoscale` argument by `scaleColormapRangeToStack` method (PR #3279)
-    * Updated `3 stddev` autoscale algorithm, clamp it with the minmax data in order to improve the contrast (PR #3284)
-    * Added the feature to compute statistics inside a specific region of interest (PR #3056)
     * Fixed issue in Colormap `3 stdev` autoscale mode and avoided warnings (PR #3295)
+
     * Major improvements of `PlotWidget`:
 
       * Added support for float16 texture in OpenGL backend (PR #3194)
-      * Fixed time serie axis for range < 2.5 microseconds (PR #3195)
       * Added `get|setAxesMargins` methods to control margin ratios around plot area (PR #3196)
-      * Fixed initial size of OpenGL backend (PR #3209)
       * Added a `DataItem` base class for items having a "data extent" in the plot (PR #3212)
       * Added item visible bounds feature to PlotWidget items (PR #3223)
-      * Improved support of high-DPI screen in OpenGL backend (PR #3203)
-      * Use points rather than pixels for marker size and line width with OpenGL backend (PR #3203)
-      * Fixed PlotWidget image items displayed below the grid by default (PR #3235)
-      * Fixed OpenGL backend image display with sqrt colormap normalization (PR #3248)
       * Added `PlotWidget.[get|set]Backend` enabling switching backend (PR #3255)
-      * Fixed support of shapes with multiple polygons in the OpenGL backend (PR #3259)
-      * Expose PlotWidget colors as Qt properties (PR #3269)
       * Added multi interaction mode for ROIs (can be switched with a single click on an handle, or the context menu) (PR #3260)
       * Added polar interaction mode for arc ROI (PR #3260)
-      * Fixes duplicated callback on ROIs (there was one for each ROI managed created on the plot) (PR #3260)
       * Added `PlotWidget.sigDefaultContextMenu` to allow to feed the default context menu (PR #3260)
       * Added context menu to the selected ROI to remove it (PR #3260)
       * Added pan interaction to ROI authoring (`select-draw`) interaction mode (PR #3291)
       * Added support of right axis label with OpenGL backend (PR #3293)
+      * Improved support of high-DPI screen in OpenGL backend (PR #3203)
+      * Use points rather than pixels for marker size and line width with OpenGL backend (PR #3203)
+      * Expose PlotWidget colors as Qt properties (PR #3269)
+      * Fixed time serie axis for range < 2.5 microseconds (PR #3195)
+      * Fixed initial size of OpenGL backend (PR #3209)
+      * Fixed PlotWidget image items displayed below the grid by default (PR #3235)
+      * Fixed OpenGL backend image display with sqrt colormap normalization (PR #3248)
+      * Fixed support of shapes with multiple polygons in the OpenGL backend (PR #3259)
+      * Fixes duplicated callback on ROIs (there was one for each ROI managed created on the plot) (PR #3260)
       * Fixed RegionOfInterest `contains` methods (PR #3336)
 
   * `silx.gui.colors.plot3d`:
@@ -75,8 +76,8 @@ Change Log
 * `silx.io`:
 
   * Added support for HDF5 link preservation in `dictdump` (PR #3224)
-  * Make `h5todict` resilient to issues in the HDF5 file (PR #3162)
   * Added support for numpy arrays of 'numbers' (PR #3251)
+  * Make `h5todict` resilient to issues in the HDF5 file (PR #3162)
 
 * `silx.math`:
 
@@ -84,16 +85,15 @@ Change Log
 
 * `silx.opencl`:
 
-  * Fixed Sift test on modern GPU (PR #3262)
   * Added textures availability check (PR #3273)
   * Added a warning when there is an issue in the Ocl destruction (PR #3280)
+  * Fixed Sift test on modern GPU (PR #3262)
 
 * Miscellaneous:
 
-  * Fixed cython 3 compatibility and deprecation warning (PR #3164, #3189)
-  * HDF5 strings: handle h5py 2.x and 3.x (PR #3240)
   * Add support for `h5py >= 3.0`
-
+  * HDF5 strings: handle h5py 2.x and 3.x (PR #3240)
+  * Fixed cython 3 compatibility and deprecation warning (PR #3164, #3189)
 
 
 0.13.0: 2020/06/23

--- a/silx/gui/plot/items/_roi_base.py
+++ b/silx/gui/plot/items/_roi_base.py
@@ -105,7 +105,7 @@ class _RegionOfInterestBase(qt.QObject):
                  interest.
         :rtype: bool
         """
-        raise NotImplementedError("Base class")
+        return False  # Override in subclass to perform actual test
 
 
 class RoiInteractionMode(object):
@@ -490,10 +490,6 @@ class RegionOfInterest(_RegionOfInterestBase, core.HighlightedMixIn):
         """"Called when the ROI creation interaction was started.
         """
         pass
-
-    @docstring(_RegionOfInterestBase)
-    def contains(self, position):
-        raise NotImplementedError("Base class")
 
     def creationFinalized(self):
         """"Called when the ROI creation interaction was finalized.

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -336,7 +336,7 @@ class LineROI(HandleBasedROI, items.LineMixIn):
                                   seg2_start_pt=top_right, seg2_end_pt=top_left) or
             segments_intersection(seg1_start_pt=line_pt1, seg1_end_pt=line_pt2,
                                   seg2_start_pt=top_left, seg2_end_pt=bottom_left)
-        )
+        ) is not None
 
     def __str__(self):
         start, end = self.getEndPoints()

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -117,7 +117,8 @@ class PointROI(RegionOfInterest, items.SymbolMixIn):
 
     @docstring(_RegionOfInterestBase)
     def contains(self, position):
-        raise NotImplementedError('Base class')
+        roiPos = self.getPosition()
+        return position[0] == roiPos[0] and position[1] == roiPos[1]
 
     def _pointPositionChanged(self, event):
         """Handle position changed events of the marker"""
@@ -318,11 +319,12 @@ class LineROI(HandleBasedROI, items.LineMixIn):
         top_left = position[0], position[1] + 1
         top_right = position[0] + 1, position[1] + 1
 
-        line_pt1 = self._points[0]
-        line_pt2 = self._points[1]
+        points = self.__shape.getPoints()
+        line_pt1 = points[0]
+        line_pt2 = points[1]
 
-        bb1 = _BoundingBox.from_points(self._points)
-        if bb1.contains(position) is False:
+        bb1 = _BoundingBox.from_points(points)
+        if not bb1.contains(position):
             return False
 
         return (
@@ -402,7 +404,7 @@ class HorizontalLineROI(RegionOfInterest, items.LineMixIn):
 
     @docstring(_RegionOfInterestBase)
     def contains(self, position):
-        return position[1] == self.getPosition()[1]
+        return position[1] == self.getPosition()
 
     def _linePositionChanged(self, event):
         """Handle position changed events of the marker"""
@@ -471,7 +473,7 @@ class VerticalLineROI(RegionOfInterest, items.LineMixIn):
 
     @docstring(RegionOfInterest)
     def contains(self, position):
-        return position[0] == self.getPosition()[0]
+        return position[0] == self.getPosition()
 
     def _linePositionChanged(self, event):
         """Handle position changed events of the marker"""
@@ -811,6 +813,10 @@ class CircleROI(HandleBasedROI, items.LineMixIn):
             center = self.getCenter()
             self.setRadius(numpy.linalg.norm(center - current))
 
+    @docstring(HandleBasedROI)
+    def contains(self, position):
+        return numpy.linalg.norm(self.getCenter(), position) <= self.getRadius()
+
     def __str__(self):
         center = self.getCenter()
         radius = self.getRadius()
@@ -1071,6 +1077,10 @@ class EllipseROI(HandleBasedROI, items.LineMixIn):
         """Handle position changed events of the center marker"""
         if event is items.ItemChangedType.POSITION:
             self._updateGeometry()
+
+    @docstring(HandleBasedROI)
+    def contains(self, position):
+        return False  # TODO
 
     def __str__(self):
         center = self.getCenter()
@@ -1494,6 +1504,10 @@ class HorizontalRangeROI(RegionOfInterest, items.LineMixIn):
         if event is items.ItemChangedType.POSITION:
             marker = self.sender()
             self.setCenter(marker.getXPosition())
+
+    @docstring(HandleBasedROI)
+    def contains(self, position):
+        return self.getMin() <= position[0] <= self.getMax()
 
     def __str__(self):
         vrange = self.getRange()

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -815,7 +815,7 @@ class CircleROI(HandleBasedROI, items.LineMixIn):
 
     @docstring(HandleBasedROI)
     def contains(self, position):
-        return numpy.linalg.norm(self.getCenter(), position) <= self.getRadius()
+        return numpy.linalg.norm(self.getCenter() - position) <= self.getRadius()
 
     def __str__(self):
         center = self.getCenter()

--- a/silx/gui/plot/items/roi.py
+++ b/silx/gui/plot/items/roi.py
@@ -1080,7 +1080,11 @@ class EllipseROI(HandleBasedROI, items.LineMixIn):
 
     @docstring(HandleBasedROI)
     def contains(self, position):
-        return False  # TODO
+        major, minor = self.getMajorRadius(), self.getMinorRadius()
+        delta = self.getOrientation()
+        x, y = position - self.getCenter()
+        return ((x*numpy.cos(delta) + y*numpy.sin(delta))**2/major**2 +
+                (x*numpy.sin(delta) - y*numpy.cos(delta))**2/minor**2) <= 1
 
     def __str__(self):
         center = self.getCenter()

--- a/silx/gui/plot/tools/test/testROI.py
+++ b/silx/gui/plot/tools/test/testROI.py
@@ -136,6 +136,31 @@ class TestRoiItems(TestCaseQt):
         numpy.testing.assert_allclose(item.getCenter(), center)
         numpy.testing.assert_allclose(item.getRadius(), newRadius)
 
+    def testCircle_contains(self):
+        center = numpy.array([2, -1])
+        radius = 1.
+        item = roi_items.CircleROI()
+        item.setGeometry(center=center, radius=radius)
+        self.assertTrue(item.contains([1, -1]))
+        self.assertFalse(item.contains([0, 0]))
+        self.assertTrue(item.contains([2, 0]))
+        self.assertFalse(item.contains([3.01, -1]))
+
+    def testEllipse_contains(self):
+        center = numpy.array([-2, 0])
+        item = roi_items.EllipseROI()
+        item.setCenter(center)
+        item.setOrientation(numpy.pi / 4.0)
+        item.setMajorRadius(2)
+        item.setMinorRadius(1)
+        print(item.getMinorRadius(), item.getMajorRadius())
+        self.assertFalse(item.contains([0, 0]))
+        self.assertTrue(item.contains([-1, 1]))
+        self.assertTrue(item.contains([-3, 0]))
+        self.assertTrue(item.contains([-2, 0]))
+        self.assertTrue(item.contains([-2, 1]))
+        self.assertFalse(item.contains([-4, 1]))
+
     def testRectangle_isIn(self):
         origin = numpy.array([0, 0])
         size = numpy.array([10, 20])


### PR DESCRIPTION
This PR fixes crashes on right click with profiles and ROIs by implementing `contains` methods.
Those methods are exact, so their use in interaction might not be ideal since it is almost impossible.

Still todo: ellipse and testing.

closes #3335
