### PR TITLE
ColormapDialog: add an option to compute min / max value from visible data or a RectangleROI

### DIFF
--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -925,15 +925,7 @@ class Colormap(qt.QObject):
             vmax = None
 
         if vmin is None or vmax is None:  # Handle autoscale
-            from .plot.items.core import ColormapMixIn  # avoid cyclic import
-            if isinstance(data, ColormapMixIn):
-                min_, max_ = data._getColormapAutoscaleRange(self)
-                # Make sure min_, max_ are not None
-                min_ = normalizer.DEFAULT_RANGE[0] if min_ is None else min_
-                max_ = normalizer.DEFAULT_RANGE[1] if max_ is None else max_
-            else:
-                min_, max_ = normalizer.autoscale(
-                    data, mode=self.getAutoscaleMode())
+            min_, max_ = self.computeMinMax(data=data)
 
             if vmin is None:  # Set vmin respecting provided vmax
                 vmin = min_ if vmax is None else min(min_, vmax)
@@ -942,6 +934,19 @@ class Colormap(qt.QObject):
                 vmax = max(max_, vmin)  # Handle max_ <= 0 for log scale
 
         return vmin, vmax
+
+    def computeMinMax(self, data):
+        normalizer = self._getNormalizer()
+        from .plot.items.core import ColormapMixIn  # avoid cyclic import
+        if isinstance(data, ColormapMixIn):
+            min_, max_ = data._getColormapAutoscaleRange(self)
+            # Make sure min_, max_ are not None
+            min_ = normalizer.DEFAULT_RANGE[0] if min_ is None else min_
+            max_ = normalizer.DEFAULT_RANGE[1] if max_ is None else max_
+        else:
+            min_, max_ = normalizer.autoscale(
+                data, mode=self.getAutoscaleMode())
+        return min_, max_
 
     def getVRange(self):
         """Get the bounds of the colormap

--- a/silx/gui/colors.py
+++ b/silx/gui/colors.py
@@ -936,6 +936,13 @@ class Colormap(qt.QObject):
         return vmin, vmax
 
     def computeMinMax(self, data):
+        """
+        Compute min and max on provided data according to the active
+        normalizer.
+
+        :param data:
+        :return: (min, max)
+        """
         normalizer = self._getNormalizer()
         from .plot.items.core import ColormapMixIn  # avoid cyclic import
         if isinstance(data, ColormapMixIn):

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -1699,11 +1699,24 @@ class ColormapDialog(qt.QDialog):
             size = (maxX-minX, maxY-minY)
         self.setMinMaxFromRectROI(origin=origin, size=size)
 
-    def setMinMaxFromRectROI(self, origin, size):
+    def setMinMaxFromRectROI(self, origin: tuple, size: tuple):
+        """
+        Compute min / max value on data from a rectangle roi of origin
+        and size and set those values as active.
+
+        :param tuple origin:
+        :param tuple size:
+        """
         min, max = self.computeMinMaxFromRect(origin=origin, size=size)
         self.getColormap().setVRange(min, max)
 
-    def computeMinMaxFromRect(self, origin, size) -> tuple:
+    def computeMinMaxFromRect(self, origin: tuple, size: tuple) -> tuple:
+        """
+        Compute min and max value for the "active" data or item
+        :param tuple origin:
+        :param tuple size:
+        :return: min, max
+        """
         colormap = self.getColormap()
         data = None
         origin = numpy.array(origin)

--- a/silx/gui/plot/tools/roifiltering.py
+++ b/silx/gui/plot/tools/roifiltering.py
@@ -1,0 +1,100 @@
+# coding: utf-8
+# /*##########################################################################
+#
+# Copyright (c) 2018-2020 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""This module provides ROI interaction for :class:`~silx.gui.plot.PlotWidget`.
+"""
+
+__authors__ = ["H. Payno"]
+__license__ = "MIT"
+__date__ = "08/01/2020"
+
+
+import numpy
+
+
+class DataFiltererBase:
+    def __init__(self, data_item, roi_item):
+        self._data_item = data_item
+        self._roi_item = roi_item
+        self.__data = None
+        self.__mask = self._build_mask()
+
+    @property
+    def data_item(self):
+        return self._data_item
+
+    @property
+    def roi_item(self):
+        return self._roi_item
+
+    @property
+    def mask(self):
+        return self.__mask
+
+    @property
+    def data(self):
+        return self.__data
+
+    def _build_mask(self):
+        raise NotImplemented("Base class")
+
+
+class CurveDataFilter(DataFiltererBase):
+
+    def _build_mask(self):
+        minX, maxX = self.roi_item.getFrom(), self.roi_item.getTo()
+        xData, yData = self.data_item.getData(copy=True)[0:2]
+
+        mask = (minX <= xData) & (xData <= maxX)
+        mask = mask == 0
+        return mask
+
+
+class ScatterFilter(DataFiltererBase):
+    def _build_mask(self):
+        xData = self.data_item.getXData(copy=True)
+        if self.roi_item:
+            return (xData < self.roi_item.getFrom()) | (xData > self.roi_item.getTo())
+        else:
+            return numpy.zeros_like(xData)
+
+
+class ImageFilter(DataFiltererBase):
+    def _build_mask(self):
+        data = self.data_item.getData()
+        minX, maxX = 0, data.shape[1]
+        minY, maxY = 0, data.shape[0]
+
+        XMinBound = max(minX, 0)
+        YMinBound = max(minY, 0)
+        XMaxBound = min(maxX, data.shape[1])
+        YMaxBound = min(maxY, data.shape[0])
+
+        mask = numpy.zeros_like(data)
+        for x in range(XMinBound, XMaxBound):
+            for y in range(YMinBound, YMaxBound):
+                _x = (x * self.data_item.getScale()[0]) + self.data_item.getOrigin()[0]
+                _y = (y * self.data_item.getScale()[1]) + self.data_item.getOrigin()[1]
+                mask[y, x] = not self.roi_item.contains((_x, _y))
+        return mask

--- a/silx/gui/plot/tools/roifiltering.py
+++ b/silx/gui/plot/tools/roifiltering.py
@@ -60,7 +60,7 @@ class DataFiltererBase:
         raise NotImplemented("Base class")
 
 
-class CurveDataFilter(DataFiltererBase):
+class CurveFilter(DataFiltererBase):
 
     def _build_mask(self):
         minX, maxX = self.roi_item.getFrom(), self.roi_item.getTo()

--- a/silx/gui/plot/tools/roifiltering.py
+++ b/silx/gui/plot/tools/roifiltering.py
@@ -46,7 +46,6 @@ class DataFiltererBase:
             raise TypeError("data_item should be an instance of `DataItem`")
         self._data_item = data_item
         self._roi_item = roi_item
-        self.__data = None
         self.__mask = None
 
     @property
@@ -62,10 +61,6 @@ class DataFiltererBase:
         if self.__mask is None:
             self.__mask = self._build_mask()
         return self.__mask
-
-    @property
-    def data(self):
-        return self.__data
 
     def _build_mask(self):
         raise NotImplemented("Base class")

--- a/silx/gui/plot/tools/roifiltering.py
+++ b/silx/gui/plot/tools/roifiltering.py
@@ -34,6 +34,9 @@ import numpy
 
 
 class DataFiltererBase:
+    """Base class for filtering data from an instance of a `DataItem` with
+    an instance of a `RegionOfInterest`
+    """
     def __init__(self, data_item, roi_item):
         self._data_item = data_item
         self._roi_item = roi_item
@@ -61,6 +64,9 @@ class DataFiltererBase:
 
 
 class CurveFilter(DataFiltererBase):
+    """
+    Filter `Curve` item
+    """
 
     def _build_mask(self):
         minX, maxX = self.roi_item.getFrom(), self.roi_item.getTo()
@@ -85,6 +91,10 @@ class HistogramFilter(DataFiltererBase):
 
 
 class ScatterFilter(DataFiltererBase):
+    """
+    Filter `Scatter` item
+    """
+
     def _build_mask(self):
         xData = self.data_item.getXData(copy=True)
         if self.roi_item:
@@ -94,6 +104,10 @@ class ScatterFilter(DataFiltererBase):
 
 
 class ImageFilter(DataFiltererBase):
+    """
+    Filter `Image` item
+    """
+
     def _build_mask(self):
         data = self.data_item.getData()
         minX, maxX = 0, data.shape[1]

--- a/silx/gui/plot/tools/roifiltering.py
+++ b/silx/gui/plot/tools/roifiltering.py
@@ -71,6 +71,19 @@ class CurveDataFilter(DataFiltererBase):
         return mask
 
 
+class HistogramFilter(DataFiltererBase):
+    """
+    Filter `Histogram` item
+    """
+    def _build_mask(self):
+        yData, edges = self.data_item.getData(copy=True)[0:2]
+        xData = self.data_item._revertComputeEdges(x=edges,
+                                                   histogramType=self.data_item.getAlignment())
+        mask = (self.roi_item._fromdata <= xData) & (xData <= self.roi_item._todata)
+        mask = mask == 0
+        return mask
+
+
 class ScatterFilter(DataFiltererBase):
     def _build_mask(self):
         xData = self.data_item.getXData(copy=True)

--- a/silx/gui/plot/tools/roifiltering.py
+++ b/silx/gui/plot/tools/roifiltering.py
@@ -31,6 +31,8 @@ __date__ = "08/01/2020"
 
 
 import numpy
+from ..items.roi import _RegionOfInterestBase
+from ..items.core import DataItem
 
 
 class DataFiltererBase:
@@ -38,10 +40,14 @@ class DataFiltererBase:
     an instance of a `RegionOfInterest`
     """
     def __init__(self, data_item, roi_item):
+        if not isinstance(roi_item, _RegionOfInterestBase):
+            raise TypeError("roi_item should be an instance of `_RegionOfInterestBase`")
+        if not isinstance(data_item, DataItem):
+            raise TypeError("data_item should be an instance of `DataItem`")
         self._data_item = data_item
         self._roi_item = roi_item
         self.__data = None
-        self.__mask = self._build_mask()
+        self.__mask = None
 
     @property
     def data_item(self):
@@ -53,6 +59,8 @@ class DataFiltererBase:
 
     @property
     def mask(self):
+        if self.__mask is None:
+            self.__mask = self._build_mask()
         return self.__mask
 
     @property


### PR DESCRIPTION
TODO
=====

- [x] update interface to add a button to set min and max from a ROi or from the visible data (and with the active item)
- [x] handle ImageData
- [x] handle Scatter
- [x] create a util to compute `DataItem` mask with a ROI (silx.gui.plot.tools.roifiltering). This is only doing minimalistic operations just to avoid code duplication. Maybe this could include in the future more processing from stats.
- [x] add test
- [x] add doc

Changelog: ColormapDialog can now compute min / max value from visible data or a RectangleROI

Screenshots
==========

![image](https://user-images.githubusercontent.com/12907796/103650550-844c9c00-4f60-11eb-9956-628c75022698.png)

![image](https://user-images.githubusercontent.com/12907796/103650603-93334e80-4f60-11eb-9dce-59953ee6d32a.png)

More
====

- closes https://gitlab.esrf.fr/tomotools/tomwer/-/issues/494

