### PR TITLE
silx view: Fixed zoom reseting when scrolling a NXdata 3D stack

### DIFF
--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -511,7 +511,7 @@ class ArrayImagePlot(qt.QWidget):
             self._plot.getYAxis().setScale('linear')
             self._plot.addImage(image, legend=legend,
                                 origin=origin, scale=scale,
-                                replace=True)
+                                replace=True, resetzoom=False)
         else:
             xaxisscale, yaxisscale = self._axis_scales
 


### PR DESCRIPTION
Simple fix to avoid zoom reset when scrolling a stack viewed with `_NXdataImageView`.

closes  #3350