### PR TITLE
silx.gui.utils.glutils: Fixed `isOpenGLAvailable`

### DIFF
--- a/silx/gui/setup.py
+++ b/silx/gui/setup.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -43,6 +43,7 @@ def configuration(parent_package='', top_path=None):
     config.add_subpackage('data')
     config.add_subpackage('dialog')
     config.add_subpackage('utils')
+    config.add_subpackage('utils.glutils')
     config.add_subpackage('utils.test')
 
     return config

--- a/silx/gui/utils/glutils.py
+++ b/silx/gui/utils/glutils.py
@@ -74,7 +74,7 @@ def _runtimeOpenGLCheck(version):
         script_file = shutil.copy(__file__, directory)
         try:
             error = subprocess.check_output(
-                [sys.executable, script_file, major, minor],
+                [sys.executable, '-s', '-S', script_file, major, minor],
                 env=env,
                 timeout=2)
         except subprocess.TimeoutExpired:

--- a/silx/gui/utils/glutils.py
+++ b/silx/gui/utils/glutils.py
@@ -32,7 +32,7 @@ if __name__ == "__main__":
     # When run as a script, remove directory from sys.path
     # This avoids other script in same directory to override Python modules
     sys.path = [path for path in sys.path
-        if os.path.abspath(path) == os.path.abspath(os.path.dirname(__file__))]
+        if os.path.abspath(path) != os.path.abspath(os.path.dirname(__file__))]
 
 import subprocess
 from silx.gui import qt

--- a/silx/gui/utils/glutils.py
+++ b/silx/gui/utils/glutils.py
@@ -31,8 +31,8 @@ import sys
 if __name__ == "__main__":
     # When run as a script, remove directory from sys.path
     # This avoids other script in same directory to override Python modules
-    if os.path.abspath(sys.path[0]) == os.path.abspath(os.path.dirname(__file__)):
-        sys.path.pop(0)
+    sys.path = [path for path in sys.path
+        if os.path.abspath(path) == os.path.abspath(os.path.dirname(__file__))]
 
 import subprocess
 from silx.gui import qt

--- a/silx/gui/utils/glutils/__init__.py
+++ b/silx/gui/utils/glutils/__init__.py
@@ -26,10 +26,8 @@
 """
 
 import os
-import shutil
 import sys
 import subprocess
-import tempfile
 from silx.gui import qt
 
 
@@ -70,24 +68,22 @@ def _runtimeOpenGLCheck(version):
     env['PYTHONPATH'] = os.pathsep.join(
         [os.path.abspath(p) for p in sys.path])
 
-    with tempfile.TemporaryDirectory() as directory:
-        script_file = shutil.copy(__file__, directory)
-        try:
-            error = subprocess.check_output(
-                [sys.executable, '-s', '-S', script_file, major, minor],
-                env=env,
-                timeout=2)
-        except subprocess.TimeoutExpired:
-            status = False
-            error = "Qt OpenGL widget hang"
-            if sys.platform.startswith('linux'):
-                error += ':\nIf connected remotely, GLX forwarding might be disabled.'
-        except subprocess.CalledProcessError as e:
-            status = False
-            error = "Qt OpenGL widget error: retcode=%d, error=%s" % (e.returncode, e.output)
-        else:
-            status = True
-            error = error.decode()
+    try:
+        error = subprocess.check_output(
+            [sys.executable, '-s', '-S', __file__, major, minor],
+            env=env,
+            timeout=2)
+    except subprocess.TimeoutExpired:
+        status = False
+        error = "Qt OpenGL widget hang"
+        if sys.platform.startswith('linux'):
+            error += ':\nIf connected remotely, GLX forwarding might be disabled.'
+    except subprocess.CalledProcessError as e:
+        status = False
+        error = "Qt OpenGL widget error: retcode=%d, error=%s" % (e.returncode, e.output)
+    else:
+        status = True
+        error = error.decode()
     return _isOpenGLAvailableResult(status, error)
 
 

--- a/silx/gui/utils/glutils/__init__.py
+++ b/silx/gui/utils/glutils/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2020 European Synchrotron Radiation Facility
+# Copyright (c) 2020-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Should fix issues with import when running `isOpenGLAvailable`. PR 3184 was apparently not enough.

It still needs testing.
Alternative can be to import `subprocess` lazily in `def _runtimeOpenGLCheck(version)`

Related to #3182
