### PR TITLE
Backport silx.gui.utils.glutils.isOpenGLAvailable fix to 0.14 branch

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+0.14.1b0: 2021/01/25
+--------------------
+
+This is a bug-fix version of silx.
+
+* silx.gui.utils.glutils: Fixed `isOpenGLAvailable` (PR #3356)
+
+
 0.14.0: 2020/12/11
 ------------------
 

--- a/silx/gui/setup.py
+++ b/silx/gui/setup.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -43,6 +43,7 @@ def configuration(parent_package='', top_path=None):
     config.add_subpackage('data')
     config.add_subpackage('dialog')
     config.add_subpackage('utils')
+    config.add_subpackage('utils.glutils')
     config.add_subpackage('utils.test')
 
     return config

--- a/silx/gui/utils/glutils/__init__.py
+++ b/silx/gui/utils/glutils/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2020 European Synchrotron Radiation Facility
+# Copyright (c) 2020-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,13 +27,6 @@
 
 import os
 import sys
-
-if __name__ == "__main__":
-    # When run as a script, remove directory from sys.path
-    # This avoids other script in same directory to override Python modules
-    if os.path.abspath(sys.path[0]) == os.path.abspath(os.path.dirname(__file__)):
-        sys.path.pop(0)
-
 import subprocess
 from silx.gui import qt
 
@@ -77,7 +70,7 @@ def _runtimeOpenGLCheck(version):
 
     try:
         error = subprocess.check_output(
-            [sys.executable, __file__, major, minor],
+            [sys.executable, '-s', '-S', __file__, major, minor],
             env=env,
             timeout=2)
     except subprocess.TimeoutExpired:

--- a/version.py
+++ b/version.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -72,8 +72,8 @@ PRERELEASE_NORMALIZED_NAME = {"dev": "a",
 
 MAJOR = 0
 MINOR = 14
-MICRO = 0
-RELEV = "final"  # <16
+MICRO = 1
+RELEV = "beta"  # <16
 SERIAL = 0  # <16
 
 date = __date__


### PR DESCRIPTION
Backport PR #3356 to 0.14 branch, and prepare for a 0.14.1b0 tag.
