### PR TITLE
Misc.CI: Run tests on macos 11.0 with github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
             BUILD_COMMAND: sdist
             QT_BINDING: PyQt5
           - name-suffix: "PySide2 wheel"
-            os: macos-latest
+            os: macos-11.0
             python-version: 3.8
             BUILD_COMMAND: bdist_wheel
             QT_BINDING: PySide2


### PR DESCRIPTION
This should make it pass on macos where pyopencl needs to be compiled and latest pyoepncl version seems to require macos 11.0.
