### PR TITLE
Misc. CI: Fixed testing on macos

### DIFF
--- a/ci/requirements-pinned.txt
+++ b/ci/requirements-pinned.txt
@@ -8,3 +8,6 @@ pybind11  # Required to build pyopencl
 # downloaded from https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyopencl
 # Anyway, we don't test OpenCL on appveyor
 pyopencl == 2020.3.1; sys_platform == 'win32'
+
+# pyopencl 2021.1 does not build on macos10.15
+pyopencl == 2020.3.1; sys_platform == 'darwin'


### PR DESCRIPTION
Pin-point pyopencl on macos since v2021.1 requires macos11.

This should fix CI.
