### PR TITLE
silx.gui.dialog.ColormapDialog: Added scale to visible or selected area buttons

### DIFF
--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -1684,6 +1684,8 @@ class ColormapDialog(qt.QDialog):
         colormap = self.getColormap()
         enabled = self._item is not None and colormap is not None and colormap.isEditable()
         self._visibleAreaButton.setEnabled(enabled)
+        if not enabled:
+            self._selectedAreaButton.setChecked(False)
         self._selectedAreaButton.setEnabled(enabled)
 
     def _handleScaleToVisibleAreaClicked(self):
@@ -1706,6 +1708,11 @@ class ColormapDialog(qt.QDialog):
             self._roiForColormapManager.stop()
             self._roiForColormapManager = None
 
+        if not checked:  # Reset button status
+            self._selectedAreaButton.setWaiting(False)
+            self._selectedAreaButton.setText("Selection")
+            return
+
         item = self._getItem()
         if item is None:
             self._selectedAreaButton.setChecked(False)
@@ -1716,19 +1723,17 @@ class ColormapDialog(qt.QDialog):
             self._selectedAreaButton.setChecked(False)
             return  # no-op
 
-        self._selectedAreaButton.setWaiting(checked)
-        if checked:
-            self._selectedAreaButton.setText("Draw Area...")
-            self._roiForColormapManager = RegionOfInterestManager(parent=plotWidget)
-            cmap = self.getColormap()
-            self._roiForColormapManager.setColor(
-                'black' if cmap is None else cursorColorForColormap(cmap.getName()))
-            self._roiForColormapManager.sigInteractiveModeFinished.connect(
-                self.__roiInteractiveModeFinished)
-            self._roiForColormapManager.sigInteractiveRoiFinalized.connect(self.__roiFinalized)
-            self._roiForColormapManager.start(RectangleROI)
-        else:
-            self._selectedAreaButton.setText("Selection")
+        self._selectedAreaButton.setWaiting(True)
+        self._selectedAreaButton.setText("Draw Area...")
+
+        self._roiForColormapManager = RegionOfInterestManager(parent=plotWidget)
+        cmap = self.getColormap()
+        self._roiForColormapManager.setColor(
+            'black' if cmap is None else cursorColorForColormap(cmap.getName()))
+        self._roiForColormapManager.sigInteractiveModeFinished.connect(
+            self.__roiInteractiveModeFinished)
+        self._roiForColormapManager.sigInteractiveRoiFinalized.connect(self.__roiFinalized)
+        self._roiForColormapManager.start(RectangleROI)
 
     def __roiInteractiveModeFinished(self):
         self._selectedAreaButton.setChecked(False)

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -1369,11 +1369,12 @@ class ColormapDialog(qt.QDialog):
 
         data = item.getColormappedData(copy=False)
 
+        xmin, xmax, ymin, ymax = bounds
+
         if isinstance(item, items.ImageBase):
             ox, oy = item.getOrigin()
             sx, sy = item.getScale()
 
-            xmin, xmax, ymin, ymax = bounds
             ystart = max(0, int((ymin - oy) / sy))
             ystop = max(0, int(numpy.ceil((ymax - oy) / sy)))
             xstart = max(0, int((xmin - ox) / sx))
@@ -1382,7 +1383,12 @@ class ColormapDialog(qt.QDialog):
             subset = data[ystart:ystop, xstart:xstop]
 
         elif isinstance(item, items.Scatter):
-            pass  # TODO
+            x = item.getXData(copy=False)
+            y = item.getYData(copy=False)
+            subset = data[
+                numpy.logical_and(
+                    numpy.logical_and(xmin <= x, x <= xmax),
+                    numpy.logical_and(ymin <= y, y <= ymax))]
 
         if subset.size == 0:
             return  # no-op

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -1396,8 +1396,7 @@ class ColormapDialog(qt.QDialog):
             return  # no-op
 
         vmin, vmax = colormap._computeAutoscaleRange(subset)
-        colormap.setVRange(vmin, vmax)
-        #self._setColormapRange(vmin, vmax)
+        self._setColormapRange(vmin, vmax)
 
     def _updateWidgetRange(self):
         """Update the colormap range displayed into the widget."""

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -984,8 +984,10 @@ class ColormapDialog(qt.QDialog):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self._visibleAreaButton)
         layout.addWidget(self._selectedAreaButton)
-        label = qt.QLabel('Scale to:', self)
-        formLayout.addRow(label, layout)
+        self._scaleToAreaGroup = qt.QGroupBox('Scale to:', self)
+        self._scaleToAreaGroup.setLayout(layout)
+        self._scaleToAreaGroup.setVisible(False)
+        formLayout.addRow(self._scaleToAreaGroup)
 
         formLayout.addRow(self._buttonsModal)
         formLayout.addRow(self._buttonsNonModal)
@@ -1683,6 +1685,7 @@ class ColormapDialog(qt.QDialog):
         """Set the state of scale to buttons according to current item and colormap"""
         colormap = self.getColormap()
         enabled = self._item is not None and colormap is not None and colormap.isEditable()
+        self._scaleToAreaGroup.setVisible(enabled)
         self._visibleAreaButton.setEnabled(enabled)
         if not enabled:
             self._selectedAreaButton.setChecked(False)


### PR DESCRIPTION
This PR proposes an alternative to #3349. Compared to it it also supports mean+/-3std and takes a smaller footprint in the `ColormapDialog`.

It provides 2 on-demand colormap range scaling:
- From the currently visible area of the item that is registered to the `ColormapDialog`
- From a rectangular selection on the registered item. When pressing the "Selection" button, its text changes to "Draw area..." with a waiting icon and waits for user input. This mode is cancelled by pressing again the button or changing the plot interaction mode (e.g., select zoom mode).

Both uses the current autoscale mode (i.e., min/max or mean+/-3std).
It works for `Scatter` and `ImageData`.

![Screen Shot 2021-01-28 at 11 25 30](https://user-images.githubusercontent.com/9449698/106124839-d184ed80-615b-11eb-9219-d17e6a458143.png)

closes #2429
