### PR TITLE
Concurrent h5py

### DIFF
--- a/doc/source/modules/io/h5py_utils.rst
+++ b/doc/source/modules/io/h5py_utils.rst
@@ -1,0 +1,8 @@
+
+.. currentmodule:: silx.io
+
+:mod:`h5py_utils`: HDF5 I/O utilities
+-----------------------------
+
+.. automodule:: silx.io.h5py_utils
+    :members:

--- a/doc/source/modules/io/index.rst
+++ b/doc/source/modules/io/index.rst
@@ -18,6 +18,7 @@
    spech5.rst
    url.rst
    utils.rst
+   h5py_utils.rst
 
 Top-level functions
 -------------------

--- a/doc/source/modules/utils/index.rst
+++ b/doc/source/modules/utils/index.rst
@@ -9,3 +9,4 @@
     html.rst
     testutils.rst
     weakref.rst
+    retry.rst

--- a/doc/source/modules/utils/retry.rst
+++ b/doc/source/modules/utils/retry.rst
@@ -1,0 +1,7 @@
+.. currentmodule:: silx.utils
+
+:mod:`weakref`
+---------------
+
+.. automodule:: silx.utils.retry
+   :members:

--- a/silx/io/h5py_utils.py
+++ b/silx/io/h5py_utils.py
@@ -1,0 +1,317 @@
+# coding: utf-8
+# /*##########################################################################
+# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+"""
+This module provides utility methods on top of h5py, mainly to handle
+parallel writing and reading.
+"""
+
+__authors__ = ["W. de Nolf"]
+__license__ = "MIT"
+__date__ = "27/01/2020"
+
+
+import os
+import traceback
+import h5py
+
+from .._version import calc_hexversion
+from ..utils import retry as retry_mod
+
+H5PY_HEX_VERSION = calc_hexversion(*h5py.version.version_tuple[:3])
+HDF5_HEX_VERSION = calc_hexversion(*h5py.version.hdf5_version_tuple[:3])
+
+HDF5_SWMR_VERSION = calc_hexversion(*h5py.get_config().swmr_min_hdf5_version[:3])
+HDF5_TRACK_ORDER_VERSION = calc_hexversion(2, 9, 0)
+
+HAS_SWMR = HDF5_HEX_VERSION >= HDF5_SWMR_VERSION
+HAS_TRACK_ORDER = H5PY_HEX_VERSION >= HDF5_TRACK_ORDER_VERSION
+
+
+def _is_h5py_exception(e):
+    for frame in traceback.walk_tb(e.__traceback__):
+        if frame[0].f_locals.get("__package__", None) == "h5py":
+            return True
+    return False
+
+
+def _retry_h5py_error(e):
+    """
+    :param BaseException e:
+    :returns bool:
+    """
+    if _is_h5py_exception(e):
+        if isinstance(e, (OSError, RuntimeError)):
+            return True
+        elif isinstance(e, KeyError):
+            # For example this needs to be retried:
+            # KeyError: 'Unable to open object (bad object header version number)'
+            return "Unable to open object" in str(e)
+    elif isinstance(e, retry_mod.RetryError):
+        return True
+    return False
+
+
+def retry(**kw):
+    """Decorator for a method that needs to be executed until it not longer
+    fails on HDF5 IO. Mainly used for reading an HDF5 file that is being
+    written.
+
+    :param **kw: see `silx.utils.retry`
+    """
+    kw.setdefault("retry_on_error", _retry_h5py_error)
+    return retry_mod.retry(**kw)
+
+
+def retry_contextmanager(**kw):
+    """Decorator to make a context manager from a method that needs to be
+    entered until it not longer fails on HDF5 IO. Mainly used for reading
+    an HDF5 file that is being written.
+
+    :param **kw: see `silx.utils.retry_contextmanager`
+    """
+    kw.setdefault("retry_on_error", _retry_h5py_error)
+    return retry_mod.retry_contextmanager(**kw)
+
+
+def retry_in_subprocess(**kw):
+    """Same as `retry` but it also retries segmentation faults.
+
+    On Window you cannot use this decorator with the "@" syntax:
+
+    .. code-block:: python
+
+        def _method(*args, **kw):
+            ...
+
+        method = retry_in_subprocess()(_method)
+
+    :param **kw: see `silx.utils.retry_in_subprocess`
+    """
+    kw.setdefault("retry_on_error", _retry_h5py_error)
+    return retry_mod.retry_in_subprocess(**kw)
+
+
+def group_has_end_time(h5item):
+    """Returns True when the HDF5 item is a Group with an "end_time"
+    dataset. A reader can use this as an indication that the Group
+    has been fully written (at least if the writer supports this).
+
+    :param Group or Dataset h5item:
+    :returns bool:
+    """
+    if isinstance(h5item, h5py.Group):
+        return "end_time" in h5item
+    else:
+        return False
+
+
+@retry_contextmanager()
+def open_item(filename, name, retry_invalid=False, validate=None):
+    """Yield an HDF5 dataset or group (retry until it can be instantiated).
+
+    :param str filename:
+    :param bool retry_invalid: retry when item is missing or not valid
+    :param callable or None validate:
+    :yields Dataset, Group or None:
+    """
+    with File(filename) as h5file:
+        try:
+            item = h5file[name]
+        except KeyError as e:
+            if "doesn't exist" in str(e):
+                if retry_invalid:
+                    raise retry_mod.RetryError
+                else:
+                    item = None
+            else:
+                raise
+        if callable(validate) and item is not None:
+            if not validate(item):
+                if retry_invalid:
+                    raise retry_mod.RetryError
+                else:
+                    item = None
+        yield item
+
+
+def _top_level_names(filename, include_only=group_has_end_time):
+    """Return all valid top-level HDF5 names.
+
+    :param str filename:
+    :param callable or None include_only:
+    :returns list(str):
+    """
+    with File(filename) as h5file:
+        try:
+            if callable(include_only):
+                return [name for name in h5file["/"] if include_only(h5file[name])]
+            else:
+                return list(h5file["/"])
+        except KeyError:
+            raise retry_mod.RetryError
+
+
+top_level_names = retry()(_top_level_names)
+safe_top_level_names = retry_in_subprocess()(_top_level_names)
+
+
+class File(h5py.File):
+    """Takes care of HDF5 file locking and SWMR mode without the need
+    to handle those explicitely.
+
+    When using this class, you cannot open different files simultatiously
+    with different modes because the locking flag is an environment variable.
+    """
+
+    _HDF5_FILE_LOCKING = None
+    _NOPEN = 0
+    _SWMR_LIBVER = "latest"
+
+    def __init__(
+        self,
+        filename,
+        mode=None,
+        enable_file_locking=None,
+        swmr=None,
+        libver=None,
+        **kwargs
+    ):
+        """The arguments `enable_file_locking` and `swmr` should not be
+        specified explicitly for normal use cases.
+
+        :param str filename:
+        :param str or None mode: read-only by default
+        :param bool or None enable_file_locking: by default it is disabled for `mode='r'`
+                                                 and `swmr=False` and enabled for all
+                                                 other modes.
+        :param bool or None swmr: try both modes when `mode='r'` and `swmr=None`
+        :param **kwargs: see `h5py.File.__init__`
+        """
+        if mode is None:
+            mode = "r"
+        elif mode not in ("r", "w", "w-", "x", "a", "r+"):
+            raise ValueError("invalid mode {}".format(mode))
+        if not HAS_SWMR:
+            swmr = False
+
+        if enable_file_locking is None:
+            enable_file_locking = bool(mode != "r" or swmr)
+        if self._NOPEN:
+            self._check_locking_env(enable_file_locking)
+        else:
+            self._set_locking_env(enable_file_locking)
+
+        if swmr and libver is None:
+            libver = self._SWMR_LIBVER
+
+        if HAS_TRACK_ORDER:
+            kwargs.setdefault("track_order", True)
+        try:
+            super().__init__(filename, mode=mode, swmr=swmr, libver=libver, **kwargs)
+        except OSError as e:
+            #   wlock   wSWMR   rlock   rSWMR   OSError: Unable to open file (...)
+            # 1 TRUE    FALSE   FALSE   FALSE   -
+            # 2 TRUE    FALSE   FALSE   TRUE    -
+            # 3 TRUE    FALSE   TRUE    FALSE   unable to lock file, errno = 11, error message = 'Resource temporarily unavailable'
+            # 4 TRUE    FALSE   TRUE    TRUE    unable to lock file, errno = 11, error message = 'Resource temporarily unavailable'
+            # 5 TRUE    TRUE    FALSE   FALSE   file is already open for write (may use <h5clear file> to clear file consistency flags)
+            # 6 TRUE    TRUE    FALSE   TRUE    -
+            # 7 TRUE    TRUE    TRUE    FALSE   file is already open for write (may use <h5clear file> to clear file consistency flags)
+            # 8 TRUE    TRUE    TRUE    TRUE    -
+            if (
+                mode == "r"
+                and swmr is None
+                and "file is already open for write" in str(e)
+            ):
+                # Try reading in SWMR mode (situation 5 and 7)
+                swmr = True
+                if libver is None:
+                    libver = self._SWMR_LIBVER
+                super().__init__(
+                    filename, mode=mode, swmr=swmr, libver=libver, **kwargs
+                )
+            else:
+                raise
+        else:
+            self._add_nopen(1)
+            try:
+                if mode != "r" and swmr:
+                    # Try setting writer in SWMR mode
+                    self.swmr_mode = True
+            except Exception:
+                self.close()
+                raise
+
+    @classmethod
+    def _add_nopen(cls, v):
+        cls._NOPEN = max(cls._NOPEN + v, 0)
+
+    def close(self):
+        super().close()
+        self._add_nopen(-1)
+        if not self._NOPEN:
+            self._restore_locking_env()
+
+    def _set_locking_env(self, enable):
+        self._backup_locking_env()
+        if enable:
+            os.environ["HDF5_USE_FILE_LOCKING"] = "TRUE"
+        elif enable is None:
+            try:
+                del os.environ["HDF5_USE_FILE_LOCKING"]
+            except KeyError:
+                pass
+        else:
+            os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
+
+    def _get_locking_env(self):
+        v = os.environ.get("HDF5_USE_FILE_LOCKING")
+        if v == "TRUE":
+            return True
+        elif v is None:
+            return None
+        else:
+            return False
+
+    def _check_locking_env(self, enable):
+        if enable != self._get_locking_env():
+            if enable:
+                raise RuntimeError(
+                    "Close all HDF5 files before enabling HDF5 file locking"
+                )
+            else:
+                raise RuntimeError(
+                    "Close all HDF5 files before disabling HDF5 file locking"
+                )
+
+    def _backup_locking_env(self):
+        v = os.environ.get("HDF5_USE_FILE_LOCKING")
+        if v is None:
+            self._HDF5_FILE_LOCKING = None
+        else:
+            self._HDF5_FILE_LOCKING = v == "TRUE"
+
+    def _restore_locking_env(self):
+        self._set_locking_env(self._HDF5_FILE_LOCKING)
+        self._HDF5_FILE_LOCKING = None

--- a/silx/io/test/__init__.py
+++ b/silx/io/test/__init__.py
@@ -40,6 +40,7 @@ from .test_nxdata import suite as test_nxdata_suite
 from .test_commonh5 import suite as test_commonh5_suite
 from .test_rawh5 import suite as test_rawh5_suite
 from .test_url import suite as test_url_suite
+from .test_h5py_utils import suite as test_h5py_utils_suite
 
 
 def suite():
@@ -56,4 +57,5 @@ def suite():
     test_suite.addTest(test_commonh5_suite())
     test_suite.addTest(test_rawh5_suite())
     test_suite.addTest(test_url_suite())
+    test_suite.addTest(test_h5py_utils_suite())
     return test_suite

--- a/silx/io/test/test_h5py_utils.py
+++ b/silx/io/test/test_h5py_utils.py
@@ -1,0 +1,401 @@
+# coding: utf-8
+# /*##########################################################################
+# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+"""Tests for h5py utilities"""
+
+__authors__ = ["W. de Nolf"]
+__license__ = "MIT"
+__date__ = "27/01/2020"
+
+
+import unittest
+import os
+import sys
+import shutil
+import tempfile
+import threading
+import multiprocessing
+from contextlib import contextmanager
+
+from .. import h5py_utils
+from ...utils.retry import RetryError, RetryTimeoutError
+
+IS_WINDOWS = sys.platform == "win32"
+
+
+def _subprocess_context_main(queue, contextmgr, *args, **kw):
+    try:
+        with contextmgr(*args, **kw):
+            queue.put(None)
+            threading.Event().wait()
+    except Exception:
+        queue.put(None)
+        raise
+
+
+@contextmanager
+def _subprocess_context(contextmgr, *args, **kw):
+    timeout = kw.pop("timeout", 10)
+    queue = multiprocessing.Queue(maxsize=1)
+    p = multiprocessing.Process(
+        target=_subprocess_context_main, args=(queue, contextmgr) + args, kwargs=kw
+    )
+    p.start()
+    try:
+        queue.get(timeout=timeout)
+        yield
+    finally:
+        try:
+            p.kill()
+        except AttributeError:
+            p.terminate()
+        p.join(timeout)
+
+
+@contextmanager
+def _open_context(filename, **kw):
+    with h5py_utils.File(filename, **kw) as f:
+        if kw.get("mode") == "w":
+            f["check"] = True
+            f.flush()
+        yield f
+
+
+def _cause_segfault():
+    import ctypes
+
+    i = ctypes.c_char(b"a")
+    j = ctypes.pointer(i)
+    c = 0
+    while True:
+        j[c] = b"a"
+        c += 1
+
+
+def _top_level_names_test(txtfilename, *args, **kw):
+    sys.stderr = open(os.devnull, "w")
+
+    with open(txtfilename, mode="r") as f:
+        counter = int(f.readline().strip())
+
+    nsleep = kw.pop("nsleep")
+    if counter < nsleep:
+        counter += 1
+        with open(txtfilename, mode="w") as f:
+            f.write(str(counter))
+        if counter % 2:
+            raise RetryError
+        else:
+            _cause_segfault()
+    return h5py_utils.top_level_names(*args, **kw)
+
+
+top_level_names_test = h5py_utils.retry_in_subprocess()(_top_level_names_test)
+
+
+def subtests(test):
+    def wrapper(self):
+        for _ in self._subtests():
+            with self.subTest(**self._subtest_options):
+                test(self)
+
+    return wrapper
+
+
+class TestH5pyUtils(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def _subtests(self):
+        self._subtest_options = {"mode": "w"}
+        self.filename_generator = self._filenames()
+        yield
+        self._subtest_options = {"mode": "w", "libver": "latest"}
+        self.filename_generator = self._filenames()
+        yield
+
+    @property
+    def _liber_allows_concurrent_access(self):
+        return self._subtest_options.get("libver") in [None, "earliest", "v18"]
+
+    def _filenames(self):
+        i = 1
+        while True:
+            filename = os.path.join(self.test_dir, "file{}.h5".format(i))
+            with self._open_context(filename) as f:
+                pass
+            yield filename
+            i += 1
+
+    def _new_filename(self):
+        return next(self.filename_generator)
+
+    @contextmanager
+    def _open_context(self, filename, **kwargs):
+        kw = self._subtest_options
+        kw.update(kwargs)
+        with _open_context(filename, **kw) as f:
+
+            yield f
+
+    @contextmanager
+    def _open_context_subprocess(self, filename, **kwargs):
+        kw = self._subtest_options
+        kw.update(kwargs)
+        with _subprocess_context(_open_context, filename, **kw):
+            yield
+
+    def _assert_hdf5_data(self, f):
+        self.assertTrue(f["check"][()])
+
+    def _validate_hdf5_data(self, filename, swmr=False):
+        with self._open_context(filename, mode="r") as f:
+            self.assertEqual(f.swmr_mode, swmr)
+            self._assert_hdf5_data(f)
+
+    @subtests
+    def test_modes_single_process(self):
+        orig = os.environ.get("HDF5_USE_FILE_LOCKING")
+        filename1 = self._new_filename()
+        self.assertEqual(orig, os.environ.get("HDF5_USE_FILE_LOCKING"))
+        filename2 = self._new_filename()
+        self.assertEqual(orig, os.environ.get("HDF5_USE_FILE_LOCKING"))
+        with self._open_context(filename1, mode="r"):
+            with self._open_context(filename2, mode="r"):
+                pass
+            for mode in ["w", "a"]:
+                with self.assertRaises(RuntimeError):
+                    with self._open_context(filename2, mode=mode):
+                        pass
+        self.assertEqual(orig, os.environ.get("HDF5_USE_FILE_LOCKING"))
+        with self._open_context(filename1, mode="a"):
+            for mode in ["w", "a"]:
+                with self._open_context(filename2, mode=mode):
+                    pass
+            with self.assertRaises(RuntimeError):
+                with self._open_context(filename2, mode="r"):
+                    pass
+        self.assertEqual(orig, os.environ.get("HDF5_USE_FILE_LOCKING"))
+
+    @subtests
+    def test_modes_multi_process(self):
+        if not self._liber_allows_concurrent_access:
+            # A concurrent reader with HDF5_USE_FILE_LOCKING=FALSE is
+            # no longer works with HDF5 >=1.10 (you get an exception
+            # when trying to open the file)
+            return
+        filename = self._new_filename()
+
+        # File open by truncating writer
+        with self._open_context_subprocess(filename, mode="w"):
+            with self._open_context(filename, mode="r") as f:
+                self._assert_hdf5_data(f)
+            if IS_WINDOWS:
+                with self._open_context(filename, mode="a") as f:
+                    self._assert_hdf5_data(f)
+            else:
+                with self.assertRaises(OSError):
+                    with self._open_context(filename, mode="a") as f:
+                        pass
+            self._validate_hdf5_data(filename)
+
+        # File open by appending writer
+        with self._open_context_subprocess(filename, mode="a"):
+            with self._open_context(filename, mode="r") as f:
+                self._assert_hdf5_data(f)
+            if IS_WINDOWS:
+                with self._open_context(filename, mode="a") as f:
+                    self._assert_hdf5_data(f)
+            else:
+                with self.assertRaises(OSError):
+                    with self._open_context(filename, mode="a") as f:
+                        pass
+            self._validate_hdf5_data(filename)
+
+        # File open by reader
+        with self._open_context_subprocess(filename, mode="r"):
+            with self._open_context(filename, mode="r") as f:
+                self._assert_hdf5_data(f)
+            with self._open_context(filename, mode="a") as f:
+                pass
+            self._validate_hdf5_data(filename)
+
+        # File open by locking reader
+        with _subprocess_context(
+            _open_context, filename, mode="r", enable_file_locking=True
+        ):
+            with self._open_context(filename, mode="r") as f:
+                self._assert_hdf5_data(f)
+            if IS_WINDOWS:
+                with self._open_context(filename, mode="a") as f:
+                    self._assert_hdf5_data(f)
+            else:
+                with self.assertRaises(OSError):
+                    with self._open_context(filename, mode="a") as f:
+                        pass
+            self._validate_hdf5_data(filename)
+
+    @subtests
+    @unittest.skipIf(not h5py_utils.HAS_SWMR, "SWMR not supported")
+    def test_modes_multi_process_swmr(self):
+        filename = self._new_filename()
+
+        with self._open_context(filename, mode="w", libver="latest") as f:
+            pass
+
+        # File open by SWMR writer
+        with self._open_context_subprocess(filename, mode="a", swmr=True):
+            with self._open_context(filename, mode="r") as f:
+                assert f.swmr_mode
+                self._assert_hdf5_data(f)
+            with self.assertRaises(OSError):
+                with self._open_context(filename, mode="a") as f:
+                    pass
+            self._validate_hdf5_data(filename, swmr=True)
+
+    @subtests
+    def test_retry_defaults(self):
+        filename = self._new_filename()
+
+        names = h5py_utils.top_level_names(filename)
+        self.assertEqual(names, [])
+
+        names = h5py_utils.safe_top_level_names(filename)
+        self.assertEqual(names, [])
+
+        names = h5py_utils.top_level_names(filename, include_only=None)
+        self.assertEqual(names, ["check"])
+
+        names = h5py_utils.safe_top_level_names(filename, include_only=None)
+        self.assertEqual(names, ["check"])
+
+        with h5py_utils.open_item(filename, "/check", validate=lambda x: False) as item:
+            self.assertEqual(item, None)
+
+        with h5py_utils.open_item(filename, "/check", validate=None) as item:
+            self.assertTrue(item[()])
+
+        with self.assertRaises(RetryTimeoutError):
+            with h5py_utils.open_item(
+                filename,
+                "/check",
+                retry_timeout=0.1,
+                retry_invalid=True,
+                validate=lambda x: False,
+            ) as item:
+                pass
+
+        ncall = 0
+
+        def validate(item):
+            nonlocal ncall
+            if ncall >= 1:
+                return True
+            else:
+                ncall += 1
+                raise RetryError
+
+        with h5py_utils.open_item(
+            filename, "/check", validate=validate, retry_timeout=1, retry_invalid=True
+        ) as item:
+            self.assertTrue(item[()])
+
+    @subtests
+    def test_retry_custom(self):
+        filename = self._new_filename()
+        nsleep = 3
+        retry_period = 0.01
+
+        # just to make sure the test doesn't hang
+        overhead = 10
+
+        @h5py_utils.retry_contextmanager()
+        def open_item(filename, name):
+            nonlocal counter
+            if counter < nsleep:
+                counter += 1
+                raise RetryError
+            with h5py_utils.File(filename) as h5file:
+                yield h5file[name]
+
+        counter = 0
+        kw = {
+            "retry_timeout": nsleep * (retry_period + overhead),
+            "retry_period": retry_period,
+        }
+        with open_item(filename, "/check", **kw) as item:
+            self.assertTrue(item[()])
+
+        counter = 0
+        kw = {
+            "retry_timeout": nsleep * (retry_period * 0.9),
+            "retry_period": retry_period,
+        }
+        with self.assertRaises(RetryTimeoutError):
+            with open_item(filename, "/check", **kw) as item:
+                pass
+
+    @subtests
+    def test_retry_in_subprocess(self):
+        filename = self._new_filename()
+        txtfilename = os.path.join(self.test_dir, "counter.txt")
+        nsleep = 3
+        retry_period = 0.01
+
+        # just to make sure the test doesn't hang
+        overhead = 10
+
+        kw = {
+            "retry_timeout": nsleep * (retry_period + overhead),
+            "retry_period": retry_period,
+            "include_only": None,
+            "nsleep": nsleep,
+        }
+        with open(txtfilename, mode="w") as f:
+            f.write("0")
+        names = top_level_names_test(txtfilename, filename, **kw)
+        self.assertEqual(names, ["check"])
+
+        kw = {
+            "retry_timeout": nsleep * (retry_period * 0.9),
+            "retry_period": retry_period,
+            "include_only": None,
+            "nsleep": nsleep,
+        }
+        with open(txtfilename, mode="w") as f:
+            f.write("0")
+        with self.assertRaises(RetryTimeoutError):
+            top_level_names_test(txtfilename, filename, **kw)
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    test_suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestH5pyUtils))
+    return test_suite
+
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/silx/utils/retry.py
+++ b/silx/utils/retry.py
@@ -1,0 +1,254 @@
+# coding: utf-8
+# /*##########################################################################
+# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+"""
+This module provides utility methods for retrying methods until they
+no longer fail.
+"""
+
+__authors__ = ["W. de Nolf"]
+__license__ = "MIT"
+__date__ = "05/02/2020"
+
+
+import time
+from functools import wraps
+from contextlib import contextmanager
+import multiprocessing
+from queue import Empty
+
+
+RETRY_PERIOD = 0.01
+
+
+class RetryTimeoutError(TimeoutError):
+    pass
+
+
+class RetryError(RuntimeError):
+    pass
+
+
+def _default_retry_on_error(e):
+    """
+    :param BaseException e:
+    :returns bool:
+    """
+    return isinstance(e, RetryError)
+
+
+@contextmanager
+def _handle_exception(options):
+    try:
+        yield
+    except BaseException as e:
+        retry_on_error = options.get("retry_on_error")
+        if retry_on_error is not None and retry_on_error(e):
+            options["exception"] = e
+        else:
+            raise
+
+
+def _retry_loop(retry_timeout=None, retry_period=None, retry_on_error=None):
+    """Iterator which is endless or ends with an RetryTimeoutError.
+    It yields a dictionary which can be used to influence the loop.
+
+    :param num retry_timeout:
+    :param num retry_period: sleep before retry
+    :param callable or None retry_on_error: checks whether an exception is
+                                            eligible for retry
+    """
+    has_timeout = retry_timeout is not None
+    options = {"exception": None, "retry_on_error": retry_on_error}
+    if has_timeout:
+        t0 = time.time()
+    while True:
+        yield options
+        if retry_period is not None:
+            time.sleep(retry_period)
+        if has_timeout and (time.time() - t0) > retry_timeout:
+            raise RetryTimeoutError from options.get("exception")
+
+
+def retry(retry_timeout=None, retry_period=None, retry_on_error=_default_retry_on_error):
+    """Decorator for a method that needs to be executed until it not longer
+    fails or until `retry_on_error` returns False.
+
+    The decorator arguments can be overriden by using them when calling the
+    decorated method.
+
+    :param num retry_timeout:
+    :param num retry_period: sleep before retry
+    :param callable or None retry_on_error: checks whether an exception is
+                                            eligible for retry
+    """
+
+    if retry_period is None:
+        retry_period = RETRY_PERIOD
+
+    def decorator(method):
+        @wraps(method)
+        def wrapper(*args, **kw):
+            _retry_timeout = kw.pop("retry_timeout", retry_timeout)
+            _retry_period = kw.pop("retry_period", retry_period)
+            _retry_on_error = kw.pop("retry_on_error", retry_on_error)
+            for options in _retry_loop(
+                retry_timeout=_retry_timeout,
+                retry_period=_retry_period,
+                retry_on_error=_retry_on_error,
+            ):
+                with _handle_exception(options):
+                    return method(*args, **kw)
+
+        return wrapper
+
+    return decorator
+
+
+def retry_contextmanager(
+    retry_timeout=None, retry_period=None, retry_on_error=_default_retry_on_error
+):
+    """Decorator to make a context manager from a method that needs to be
+    entered until it no longer fails or until `retry_on_error` returns False.
+
+    The decorator arguments can be overriden by using them when calling the
+    decorated method.
+
+    :param num retry_timeout:
+    :param num retry_period: sleep before retry
+    :param callable or None retry_on_error: checks whether an exception is
+                                            eligible for retry
+    """
+
+    if retry_period is None:
+        retry_period = RETRY_PERIOD
+
+    def decorator(method):
+        @wraps(method)
+        def wrapper(*args, **kw):
+            _retry_timeout = kw.pop("retry_timeout", retry_timeout)
+            _retry_period = kw.pop("retry_period", retry_period)
+            _retry_on_error = kw.pop("retry_on_error", retry_on_error)
+            for options in _retry_loop(
+                retry_timeout=_retry_timeout,
+                retry_period=_retry_period,
+                retry_on_error=_retry_on_error,
+            ):
+                with _handle_exception(options):
+                    gen = method(*args, **kw)
+                    result = next(gen)
+                    options["retry_on_error"] = None
+                    yield result
+                    try:
+                        next(gen)
+                    except StopIteration:
+                        return
+                    else:
+                        raise RuntimeError(str(method) + " should only yield once")
+
+        return contextmanager(wrapper)
+
+    return decorator
+
+
+def _subprocess_main(queue, method, retry_on_error, *args, **kw):
+    try:
+        result = method(*args, **kw)
+    except BaseException as e:
+        if retry_on_error(e):
+            # As the traceback gets lost, make sure the top-level
+            # exception is RetryError
+            e = RetryError(str(e))
+        queue.put(e)
+    else:
+        queue.put(result)
+
+
+def retry_in_subprocess(
+    retry_timeout=None, retry_period=None, retry_on_error=_default_retry_on_error
+):
+    """Same as `retry` but it also retries segmentation faults.
+
+    On Window you cannot use this decorator with the "@" syntax:
+
+    .. code-block:: python
+
+        def _method(*args, **kw):
+            ...
+
+        method = retry_in_subprocess()(_method)
+
+    :param num retry_timeout:
+    :param num retry_period: sleep before retry
+    :param callable or None retry_on_error: checks whether an exception is
+                                            eligible for retry
+    """
+
+    if retry_period is None:
+        retry_period = RETRY_PERIOD
+
+    def decorator(method):
+        @wraps(method)
+        def wrapper(*args, **kw):
+            _retry_timeout = kw.pop("retry_timeout", retry_timeout)
+            _retry_period = kw.pop("retry_period", retry_period)
+            _retry_on_error = kw.pop("retry_on_error", retry_on_error)
+
+            queue = multiprocessing.Queue(maxsize=1)
+            prockw = {
+                "target": _subprocess_main,
+                "args": (queue, method, retry_on_error) + args,
+                "kwargs": kw,
+            }
+
+            p = multiprocessing.Process(**prockw)
+            p.start()
+            try:
+                for options in _retry_loop(
+                    retry_timeout=_retry_timeout, retry_on_error=_retry_on_error
+                ):
+                    with _handle_exception(options):
+                        if not p.is_alive():
+                            p = multiprocessing.Process(**prockw)
+                            p.start()
+                        try:
+                            result = queue.get(block=True, timeout=_retry_period)
+                        except Empty:
+                            pass
+                        except ValueError:
+                            pass
+                        else:
+                            if isinstance(result, BaseException):
+                                raise result
+                            else:
+                                return result
+            finally:
+                try:
+                    p.kill()
+                except AttributeError:
+                    p.terminate()
+                p.join()
+
+        return wrapper
+
+    return decorator

--- a/silx/utils/test/__init__.py
+++ b/silx/utils/test/__init__.py
@@ -39,6 +39,7 @@ from . import test_number
 from . import test_external_resources
 from . import test_enum
 from . import test_testutils
+from . import test_retry
 
 
 def suite():
@@ -54,4 +55,5 @@ def suite():
     test_suite.addTest(test_external_resources.suite())
     test_suite.addTest(test_enum.suite())
     test_suite.addTest(test_testutils.suite())
+    test_suite.addTest(test_retry.suite())
     return test_suite

--- a/silx/utils/test/test_retry.py
+++ b/silx/utils/test/test_retry.py
@@ -1,0 +1,188 @@
+# coding: utf-8
+# /*##########################################################################
+# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+"""Tests for retry utilities"""
+
+__authors__ = ["W. de Nolf"]
+__license__ = "MIT"
+__date__ = "05/02/2020"
+
+
+import unittest
+import os
+import sys
+import tempfile
+
+from .. import retry
+
+
+def _cause_segfault():
+    import ctypes
+
+    i = ctypes.c_char(b"a")
+    j = ctypes.pointer(i)
+    c = 0
+    while True:
+        j[c] = b"a"
+        c += 1
+
+
+def _submain(filename, kwcheck=None, nsleep=0):
+    assert filename
+    assert kwcheck
+    sys.stderr = open(os.devnull, "w")
+
+    with open(filename, mode="r") as f:
+        counter = int(f.readline().strip())
+
+    if counter < nsleep:
+        counter += 1
+        with open(filename, mode="w") as f:
+            f.write(str(counter))
+        if counter % 2:
+            raise retry.RetryError
+        else:
+            _cause_segfault()
+    return True
+
+
+_wsubmain = retry.retry_in_subprocess()(_submain)
+
+
+class TestRetry(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.ctr_file = os.path.join(self.test_dir, "counter.txt")
+
+    def tearDown(self):
+        if os.path.exists(self.ctr_file):
+            os.unlink(self.ctr_file)
+        os.rmdir(self.test_dir)
+
+    def test_retry(self):
+        nsleep = 3
+        retry_period = 0.01
+
+        # just to make sure the test doesn't hang
+        overhead = 10
+
+        @retry.retry()
+        def method(check, kwcheck=None):
+            assert check
+            assert kwcheck
+            nonlocal counter
+            if counter < nsleep:
+                counter += 1
+                raise retry.RetryError
+            return True
+
+        counter = 0
+        kw = {
+            "kwcheck": True,
+            "retry_timeout": nsleep * (retry_period + overhead),
+            "retry_period": retry_period,
+        }
+        self.assertTrue(method(True, **kw))
+
+        counter = 0
+        kw = {
+            "kwcheck": True,
+            "retry_timeout": nsleep * (retry_period * 0.9),
+            "retry_period": retry_period,
+        }
+        with self.assertRaises(retry.RetryTimeoutError):
+            method(True, **kw)
+
+    def test_retry_contextmanager(self):
+        nsleep = 3
+        retry_period = 0.01
+
+        # just to make sure the test doesn't hang
+        overhead = 10
+
+        @retry.retry_contextmanager()
+        def context(check, kwcheck=None):
+            assert check
+            assert kwcheck
+            nonlocal counter
+            if counter < nsleep:
+                counter += 1
+                raise retry.RetryError
+            yield True
+
+        counter = 0
+        kw = {
+            "kwcheck": True,
+            "retry_timeout": nsleep * (retry_period + overhead),
+            "retry_period": retry_period,
+        }
+        with context(True, **kw) as result:
+            self.assertTrue(result)
+
+        counter = 0
+        kw = {
+            "kwcheck": True,
+            "retry_timeout": nsleep * (retry_period * 0.9),
+            "retry_period": retry_period,
+        }
+        with self.assertRaises(retry.RetryTimeoutError):
+            with context(True, **kw) as result:
+                pass
+
+    def test_retry_in_subprocess(self):
+        nsleep = 3
+        retry_period = 0.01
+
+        # just to make sure the test doesn't hang
+        overhead = 10
+
+        kw = {
+            "nsleep": nsleep,
+            "kwcheck": True,
+            "retry_timeout": nsleep * (retry_period + overhead),
+            "retry_period": retry_period,
+        }
+        with open(self.ctr_file, mode="w") as f:
+            f.write("0")
+        self.assertTrue(_wsubmain(self.ctr_file, **kw))
+
+        kw = {
+            "nsleep": nsleep,
+            "kwcheck": True,
+            "retry_timeout": nsleep * (retry_period - 0.001),
+            "retry_period": retry_period,
+        }
+        with open(self.ctr_file, mode="w") as f:
+            f.write("0")
+        with self.assertRaises(retry.RetryTimeoutError):
+            _wsubmain(self.ctr_file, **kw)
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    test_suite.addTest(unittest.defaultTestLoader.loadTestsFromTestCase(TestRetry))
+    return test_suite
+
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")


### PR DESCRIPTION
Closes #3354

Tested with h5py 2.8, 2.9, 2.10, 3.1

Stress tests: https://gitlab.esrf.fr/denolf/concurrent_h5py

The main API:
* `silx.io.h5py_utils.File`: replace `h5py.File` mainly to handle file locking
* `silx.io.h5py_utils.retry`: retry the method whenever you get an HDF5 IO exception
* `silx.io.h5py_utils.retry_in_subprocess`: retry in a subprocess to capture segfaults
* `silx.io.h5py_utils.retry_contextmanager`: retry entering the context manager

The retry logic can also be used for other things than HDF5 reading:
* `silx.utils.retry.retry`
* `silx.utils.retry.retry_in_subprocess`
* `silx.utils.retry.retry_contextmanager`

Common use case of `silx.io.h5py_utils` for processing a Bliss Nexus file:

```python
import silx.io.h5py_utils

@silx.io.h5py_utils.retry()
def process_scan(filename, name):
    """The method will be executed again if
    any HDF5 IO fails.
    """
    with silx.io.h5py_utils.File(filename) as h5file:
        scan = h5file[name]
        I0 = scan["measurement/I0"][()]
        It = scan["measurement/It"][()]
        return It/I0

scans = silx.io.h5py_utils.safe_top_level_names("myfile.h5")

for name in scans:
    process_scan("myfile.h5", name)
```

