### PR TITLE
silx.gui.plot: Added mask support to Image items and use it in plot tools (histogram, profile, colormap)

### DIFF
--- a/silx/gui/data/DataViews.py
+++ b/silx/gui/data/DataViews.py
@@ -1042,6 +1042,8 @@ class _Plot2dView(DataView):
         widget.setKeepDataAspectRatio(True)
         widget.getXAxis().setLabel('X')
         widget.getYAxis().setLabel('Y')
+        maskToolsWidget = widget.getMaskToolsDockWidget().widget()
+        maskToolsWidget.setItemMaskUpdated(True)
         return widget
 
     def clear(self):
@@ -1156,6 +1158,8 @@ class _ComplexImageView(DataView):
         widget.getPlot().setKeepDataAspectRatio(True)
         widget.getXAxis().setLabel('X')
         widget.getYAxis().setLabel('Y')
+        maskToolsWidget = widget.getPlot().getMaskToolsDockWidget().widget()
+        maskToolsWidget.setItemMaskUpdated(True)
         return widget
 
     def clear(self):
@@ -1254,6 +1258,8 @@ class _StackView(DataView):
         widget.setLabels(self.axesNames(None, None))
         # hide default option panel
         widget.setOptionVisible(False)
+        maskToolWidget = widget.getPlotWidget().getMaskToolsDockWidget().widget()
+        maskToolWidget.setItemMaskUpdated(True)
         return widget
 
     def clear(self):

--- a/silx/gui/data/NXdataWidgets.py
+++ b/silx/gui/data/NXdataWidgets.py
@@ -371,6 +371,8 @@ class ArrayImagePlot(qt.QWidget):
                                                normalization=Colormap.LINEAR))
         self._plot.getIntensityHistogramAction().setVisible(True)
         self._plot.setKeepDataAspectRatio(True)
+        maskToolWidget = self._plot.getMaskToolsDockWidget().widget()
+        maskToolWidget.setItemMaskUpdated(True)
 
         # not closable
         self._selector = NumpyAxesSelector(self)
@@ -587,6 +589,8 @@ class ArrayComplexImagePlot(qt.QWidget):
 
         self._plot.getPlot().getIntensityHistogramAction().setVisible(True)
         self._plot.setKeepDataAspectRatio(True)
+        maskToolWidget = self._plot.getPlot().getMaskToolsDockWidget().widget()
+        maskToolWidget.setItemMaskUpdated(True)
 
         # not closable
         self._selector = NumpyAxesSelector(self)
@@ -769,6 +773,9 @@ class ArrayStackPlot(qt.QWidget):
         self.__x_axis_name = None
 
         self._stack_view = StackView(self)
+        maskToolWidget = self._stack_view.getPlotWidget().getMaskToolsDockWidget().widget()
+        maskToolWidget.setItemMaskUpdated(True)
+
         self._hline = qt.QFrame(self)
         self._hline.setFrameStyle(qt.QFrame.HLine)
         self._hline.setFrameShadow(qt.QFrame.Sunken)

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -438,7 +438,6 @@ class _ColormapHistogram(qt.QWidget):
         if data is None:
             return None, None
         dataRange = self._getNormalizedDataRange()
-        print("dataRange is ", dataRange)
         if dataRange[0] is None or dataRange[1] is None:
             return None, None
         counts, edges = self.parent().computeHistogram(data, scale=norm, dataRange=dataRange)
@@ -466,7 +465,6 @@ class _ColormapHistogram(qt.QWidget):
 
         # Try to use the one defined in the dialog
         dataRange = self.parent()._getDataRange()
-        print("_ColormapHistogram._computeNormalizedDataRange: parent()._getDataRange() is ", dataRange)
         if dataRange is not None:
             if norm in (Colormap.LINEAR, Colormap.GAMMA, Colormap.ARCSINH):
                 return dataRange[0], dataRange[2]
@@ -479,7 +477,6 @@ class _ColormapHistogram(qt.QWidget):
 
         # Try to use the histogram defined in the dialog
         histo = self.parent()._getHistogram()
-        print("_ColormapHistogram._computeNormalizedDataRange: parent()._getHistogram() is ", histo)
         if histo is not None:
             _histo, edges = histo
             normalizer = Colormap(normalization=norm)._getNormalizer()
@@ -491,15 +488,12 @@ class _ColormapHistogram(qt.QWidget):
                 return dataRange.minimum, dataRange.maximum
 
         item = self.parent()._getItem()
-        print("_ColormapHistogram._computeNormalizedDataRange: parent()._getItem() is ", item)
         if item is not None:
             # Trick to reach data range using colormap cache
             cm = Colormap()
             cm.setVRange(None, None)
             cm.setNormalization(norm)
-            print("             colormap is ", cm)
             dataRange = item._getColormapAutoscaleRange(cm)
-            print("             datRange is ", dataRange)
             return dataRange
 
         # If there is no item, there is no data
@@ -777,8 +771,6 @@ class _ColormapHistogram(qt.QWidget):
                 histogram = numpy.array(histogram, copy=True)
                 bin_edges = numpy.array(bin_edges, copy=True)
                 norm_histogram = histogram / numpy.nanmax(histogram)
-#                 print(bin_edges)
-#                 print(histogram, numpy.nanmax(histogram))
                 self._plot.addHistogram(norm_histogram,
                                         bin_edges,
                                         legend="Data",
@@ -1251,11 +1243,9 @@ class ColormapDialog(qt.QDialog):
 
     def _getArray(self):
         data = self._getData()
-        print("in _getArray data is", data)
         if data is not None:
             return data
         item = self._getItem()
-        print("in _getArray item is", item)
         if item is not None:
             return item.getColormappedData(copy=False)
         return None

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -770,7 +770,8 @@ class _ColormapHistogram(qt.QWidget):
             else:
                 histogram = numpy.array(histogram, copy=True)
                 bin_edges = numpy.array(bin_edges, copy=True)
-                norm_histogram = histogram / numpy.nanmax(histogram)
+                with numpy.errstate(invalid='ignore'):
+                    norm_histogram = histogram / numpy.nanmax(histogram)
                 self._plot.addHistogram(norm_histogram,
                                         bin_edges,
                                         legend="Data",

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -61,7 +61,7 @@ The updates of the colormap description are also available through the signal:
 
 __authors__ = ["V.A. Sole", "T. Vincent", "H. Payno"]
 __license__ = "MIT"
-__date__ = "01/12/2020"
+__date__ = "07/12/2020"
 
 import enum
 import logging
@@ -438,6 +438,7 @@ class _ColormapHistogram(qt.QWidget):
         if data is None:
             return None, None
         dataRange = self._getNormalizedDataRange()
+        print("dataRange is ", dataRange)
         if dataRange[0] is None or dataRange[1] is None:
             return None, None
         counts, edges = self.parent().computeHistogram(data, scale=norm, dataRange=dataRange)
@@ -465,6 +466,7 @@ class _ColormapHistogram(qt.QWidget):
 
         # Try to use the one defined in the dialog
         dataRange = self.parent()._getDataRange()
+        print("parent()._getDataRange() is ", dataRange)
         if dataRange is not None:
             if norm in (Colormap.LINEAR, Colormap.GAMMA, Colormap.ARCSINH):
                 return dataRange[0], dataRange[2]
@@ -477,6 +479,7 @@ class _ColormapHistogram(qt.QWidget):
 
         # Try to use the histogram defined in the dialog
         histo = self.parent()._getHistogram()
+        print("parent()._getHistogram() is ", histo)
         if histo is not None:
             _histo, edges = histo
             normalizer = Colormap(normalization=norm)._getNormalizer()
@@ -488,6 +491,7 @@ class _ColormapHistogram(qt.QWidget):
                 return dataRange.minimum, dataRange.maximum
 
         item = self.parent()._getItem()
+        print("parent()._getItem() is ", item)
         if item is not None:
             # Trick to reach data range using colormap cache
             cm = Colormap()
@@ -770,7 +774,9 @@ class _ColormapHistogram(qt.QWidget):
             else:
                 histogram = numpy.array(histogram, copy=True)
                 bin_edges = numpy.array(bin_edges, copy=True)
-                norm_histogram = histogram / max(histogram)
+                norm_histogram = histogram / numpy.nanmax(histogram)
+#                 print(bin_edges)
+#                 print(histogram, numpy.nanmax(histogram))
                 self._plot.addHistogram(norm_histogram,
                                         bin_edges,
                                         legend="Data",
@@ -1243,9 +1249,11 @@ class ColormapDialog(qt.QDialog):
 
     def _getArray(self):
         data = self._getData()
+        print("in _getArray data is", data)
         if data is not None:
             return data
         item = self._getItem()
+        print("in _getArray item is", item)
         if item is not None:
             return item.getColormappedData(copy=False)
         return None

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -466,7 +466,7 @@ class _ColormapHistogram(qt.QWidget):
 
         # Try to use the one defined in the dialog
         dataRange = self.parent()._getDataRange()
-        print("parent()._getDataRange() is ", dataRange)
+        print("_ColormapHistogram._computeNormalizedDataRange: parent()._getDataRange() is ", dataRange)
         if dataRange is not None:
             if norm in (Colormap.LINEAR, Colormap.GAMMA, Colormap.ARCSINH):
                 return dataRange[0], dataRange[2]
@@ -479,7 +479,7 @@ class _ColormapHistogram(qt.QWidget):
 
         # Try to use the histogram defined in the dialog
         histo = self.parent()._getHistogram()
-        print("parent()._getHistogram() is ", histo)
+        print("_ColormapHistogram._computeNormalizedDataRange: parent()._getHistogram() is ", histo)
         if histo is not None:
             _histo, edges = histo
             normalizer = Colormap(normalization=norm)._getNormalizer()
@@ -491,14 +491,15 @@ class _ColormapHistogram(qt.QWidget):
                 return dataRange.minimum, dataRange.maximum
 
         item = self.parent()._getItem()
-        print("parent()._getItem() is ", item)
+        print("_ColormapHistogram._computeNormalizedDataRange: parent()._getItem() is ", item)
         if item is not None:
             # Trick to reach data range using colormap cache
             cm = Colormap()
             cm.setVRange(None, None)
             cm.setNormalization(norm)
-            print("Colormap is ", cm,)
+            print("             colormap is ", cm)
             dataRange = item._getColormapAutoscaleRange(cm)
+            print("             datRange is ", dataRange)
             return dataRange
 
         # If there is no item, there is no data

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -59,12 +59,9 @@ The updates of the colormap description are also available through the signal:
 :attr:`ColormapDialog.sigColormapChanged`.
 """  # noqa
 
-from __future__ import division
-
 __authors__ = ["V.A. Sole", "T. Vincent", "H. Payno"]
 __license__ = "MIT"
-__date__ = "27/11/2018"
-
+__date__ = "01/12/2020"
 
 import enum
 import logging
@@ -91,7 +88,6 @@ from silx.gui.plot.items.roi import RectangleROI
 from silx.gui.plot.tools.roi import RegionOfInterestManager
 
 _logger = logging.getLogger(__name__)
-
 
 _colormapIconPreview = {}
 
@@ -513,6 +509,7 @@ class _ColormapHistogram(qt.QWidget):
         :returns: Tuple{float, float}
         """
         scale = self._plot.getXAxis().getScale()
+
         def isDisplayable(pos):
             if pos is None:
                 return False
@@ -1130,9 +1127,9 @@ class ColormapDialog(qt.QDialog):
         if data.ndim == 3:  # RGB(A) images
             _logger.info('Converting current image from RGB(A) to grayscale\
                 in order to compute the intensity distribution')
-            data = (data[:, :, 0] * 0.299 +
-                    data[:, :, 1] * 0.587 +
-                    data[:, :, 2] * 0.114)
+            data = (data[:,:, 0] * 0.299 +
+                    data[:,:, 1] * 0.587 +
+                    data[:,:, 2] * 0.114)
 
         # bad hack: get 256 continuous bins in the case we have a B&W
         normalizeData = True
@@ -1177,7 +1174,7 @@ class ColormapDialog(qt.QDialog):
         bins = histogram.edges[0]
         if normalizeData:
             if scale == Colormap.LOGARITHM:
-                bins = 10**bins
+                bins = 10 ** bins
         return histogram.histo, bins
 
     def _getItem(self):

--- a/silx/gui/dialog/ColormapDialog.py
+++ b/silx/gui/dialog/ColormapDialog.py
@@ -61,7 +61,7 @@ The updates of the colormap description are also available through the signal:
 
 __authors__ = ["V.A. Sole", "T. Vincent", "H. Payno"]
 __license__ = "MIT"
-__date__ = "07/12/2020"
+__date__ = "08/12/2020"
 
 import enum
 import logging
@@ -497,6 +497,7 @@ class _ColormapHistogram(qt.QWidget):
             cm = Colormap()
             cm.setVRange(None, None)
             cm.setNormalization(norm)
+            print("Colormap is ", cm,)
             dataRange = item._getColormapAutoscaleRange(cm)
             return dataRange
 

--- a/silx/gui/plot/Colormap.py
+++ b/silx/gui/plot/Colormap.py
@@ -25,11 +25,9 @@
 """Deprecated module providing the Colormap object
 """
 
-from __future__ import absolute_import
-
 __authors__ = ["T. Vincent", "H.Payno"]
 __license__ = "MIT"
-__date__ = "24/04/2018"
+__date__ = "27/11/2020"
 
 import silx.utils.deprecation
 

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -418,7 +418,15 @@ class MaskToolsWidget(BaseMaskToolsWidget):
             # Disable drawing tool
             self.browseAction.trigger()
 
-        if self.getSelectionMask(copy=False) is not None:
+        if self.isItemMaskUpdated():  # No "after-care"
+            self._data = numpy.zeros((0, 0), dtype=numpy.uint8)
+            self._mask.setDataItem(None)
+            self._mask.reset()
+
+            if self.plot.getImage(self._maskName):
+                self.plot.remove(self._maskName, kind='image')
+
+        elif self.getSelectionMask(copy=False) is not None:
             self.plot.sigActiveImageChanged.connect(
                 self._activeImageChangedAfterCare)
 
@@ -445,7 +453,7 @@ class MaskToolsWidget(BaseMaskToolsWidget):
         else:
             self._defaultOverlayColor = rgba('black')
 
-    def _activeImageChangedAfterCare(self, *args):  # TODO
+    def _activeImageChangedAfterCare(self, *args):
         """Check synchro of active image and mask when mask widget is hidden.
 
         If active image has no more the same size as the mask, the mask is
@@ -516,6 +524,7 @@ class MaskToolsWidget(BaseMaskToolsWidget):
                 else:  # Image item has a mask: set it in tool
                     self.setSelectionMask(
                         image.getMaskData(copy=False), copy=True)
+                    self._mask.resetHistory()
             self.__imageUpdated()
             if self.isVisible():
                 image.sigItemChanged.connect(self.__imageChanged)

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -316,13 +316,6 @@ class MaskToolsWidget(BaseMaskToolsWidget):
         if numpy.array_equal(mask, self.getSelectionMask()):
             return mask.shape
 
-        # ensure all mask attributes are synchronized with the active image
-        # and connect listener
-        activeImage = self.plot.getActiveImage()
-        if activeImage is not None and activeImage.getName() != self._maskName:
-            self._activeImageChanged()
-            self.plot.sigActiveImageChanged.connect(self._activeImageChanged)
-
         if self._data.shape[0:2] == (0, 0) or mask.shape == self._data.shape[0:2]:
             self._mask.setMask(mask, copy=copy)
             self._mask.commit()
@@ -366,20 +359,29 @@ class MaskToolsWidget(BaseMaskToolsWidget):
             self.plot.remove(self._maskName, kind='image')
 
     def showEvent(self, event):
+        print('show', self.isVisible())
         try:
             self.plot.sigActiveImageChanged.disconnect(
                 self._activeImageChangedAfterCare)
         except (RuntimeError, TypeError):
             pass
-        self._activeImageChanged()  # Init mask + enable/disable widget
+
+        # Sync with current active image
+        self._setMaskedImage(self.plot.getActiveImage())
         self.plot.sigActiveImageChanged.connect(self._activeImageChanged)
 
     def hideEvent(self, event):
+        print('hide', self.isVisible())
         try:
             self.plot.sigActiveImageChanged.disconnect(
                 self._activeImageChanged)
         except (RuntimeError, TypeError):
             pass
+
+        image = self.getMaskedItem()
+        if image is not None:
+            image.sigItemChanged.disconnect(self.__imageChanged)
+
         if self.isMaskInteractionActivated():
             # Disable drawing tool
             self.browseAction.trigger()
@@ -387,6 +389,17 @@ class MaskToolsWidget(BaseMaskToolsWidget):
         if self.getSelectionMask(copy=False) is not None:
             self.plot.sigActiveImageChanged.connect(
                 self._activeImageChangedAfterCare)
+
+    def _activeImageChanged(self, previous, current):
+        """Reacts upon active image change.
+
+        Only handle change of active image items here.
+        """
+        if previous != current:
+            image = self.plot.getActiveImage()
+            if image is not None and image.getName() == self._maskName:
+                image = None  # Active image is the mask
+            self._setMaskedImage(image)
 
     def _setOverlayColorForImage(self, image):
         """Set the color of overlay adapted to image
@@ -400,7 +413,7 @@ class MaskToolsWidget(BaseMaskToolsWidget):
         else:
             self._defaultOverlayColor = rgba('black')
 
-    def _activeImageChangedAfterCare(self, *args):
+    def _activeImageChangedAfterCare(self, *args):  # TODO
         """Check synchro of active image and mask when mask widget is hidden.
 
         If active image has no more the same size as the mask, the mask is
@@ -440,41 +453,83 @@ class MaskToolsWidget(BaseMaskToolsWidget):
                 self._mask.setDataItem(activeImage)
                 self._updatePlotMask()
 
-    def _activeImageChanged(self, *args):
-        """Update widget and mask according to active image changes"""
-        activeImage = self.plot.getActiveImage()
-        if (activeImage is None or activeImage.getName() == self._maskName or
-                activeImage.getData(copy=False).size == 0):
-            # No active image or active image is the mask or image has no data...
+    def _setMaskedImage(self, image, ignorePrevious=False):
+        """Change the image that is used a reference to author the mask"""
+        if not ignorePrevious:
+            previous = self.getMaskedItem()
+            if previous is not None and self.isVisible():
+                # Disconnect from previous image
+                try:
+                    previous.sigItemChanged.disconnect(self.__imageChanged)
+                except TypeError:
+                    pass  # TODO fixme should not happen
+
+        # Set the image
+        self._mask.setDataItem(image)
+
+        if image is None:  # No image, disable mask
             self.setEnabled(False)
 
             self._data = numpy.zeros((0, 0), dtype=numpy.uint8)
             self._mask.reset()
             self._mask.commit()
 
-        else:  # There is an active image
-            self.setEnabled(True)
+            self._updateInteractiveMode()
 
-            self._setOverlayColorForImage(activeImage)
+        else:  # Update and connect to image's sigItemChanged
+            self.__imageUpdated()
+            if self.isVisible():
+                image.sigItemChanged.connect(self.__imageChanged)
 
-            self._setMaskColors(self.levelSpinBox.value(),
-                                self.transparencySlider.value() /
-                                self.transparencySlider.maximum())
+    def __imageChanged(self, event):
+        """Reacts upon image item changes"""
+        image = self._mask.getDataItem()
+        if image is None:
+            _logger.error("Mask is not attached to an image")
+            return
 
-            self._origin = activeImage.getOrigin()
-            self._scale = activeImage.getScale()
-            self._z = activeImage.getZValue() + 1
-            self._data = activeImage.getData(copy=False)
-            self._mask.setDataItem(activeImage)
-            if self._data.shape[:2] != self._mask.getMask(copy=False).shape:
-                self._mask.reset(self._data.shape[:2])
-                self._mask.commit()
-            else:
-                # Refresh in case origin, scale, z changed
-                self._updatePlotMask()
+        if event in (items.ItemChangedType.COLORMAP,
+                     items.ItemChangedType.DATA,
+                     items.ItemChangedType.POSITION,
+                     items.ItemChangedType.SCALE,
+                     items.ItemChangedType.VISIBLE,
+                     items.ItemChangedType.ZVALUE):
+            self.__imageUpdated()
 
-            # Threshold tools only available for data with colormap
-            self.thresholdGroup.setEnabled(self._data.ndim == 2)
+        elif event == items.ItemChangedType.MASK:
+            # Update mask from the image item
+            self.setSelectionMask(image.getMaskData(copy=False), copy=True)
+
+    def __imageUpdated(self):
+        """Synchronize mask with current state of the image"""
+        image = self._mask.getDataItem()
+        if image is None:
+            _logger.error("No active image while expecting one")
+            return
+
+        self._setOverlayColorForImage(image)
+
+        self._setMaskColors(self.levelSpinBox.value(),
+                            self.transparencySlider.value() /
+                            self.transparencySlider.maximum())
+
+        self._origin = image.getOrigin()
+        self._scale = image.getScale()
+        self._z = image.getZValue() + 1
+        self._data = image.getData(copy=False)
+        self._mask.setDataItem(image)
+        if self._data.shape[:2] != self._mask.getMask(copy=False).shape:
+            self._mask.reset(self._data.shape[:2])
+            self._mask.commit()
+        else:
+            # Refresh in case origin, scale, z changed
+            self._updatePlotMask()
+
+        # Visible and with data
+        self.setEnabled(image.isVisible() and self._data.size != 0)
+
+        # Threshold tools only available for data with colormap
+        self.thresholdGroup.setEnabled(self._data.ndim == 2)
 
         self._updateInteractiveMode()
 

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -508,6 +508,14 @@ class MaskToolsWidget(BaseMaskToolsWidget):
             self._updateInteractiveMode()
 
         else:  # Update and connect to image's sigItemChanged
+            if self.isItemMaskUpdated():
+                if image.getMaskData(copy=False) is None:
+                    # Image item has no mask: use current mask from the tool
+                    image.setMaskData(
+                        self.getSelectionMask(copy=False), copy=True)
+                else:  # Image item has a mask: set it in tool
+                    self.setSelectionMask(
+                        image.getMaskData(copy=False), copy=True)
             self.__imageUpdated()
             if self.isVisible():
                 image.sigItemChanged.connect(self.__imageChanged)

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -103,6 +103,13 @@ class ImageMask(BaseMask):
         """
         return self._dataItem.getData(copy=False)
 
+    def commit(self):
+        """Append the current mask to history if changed"""
+        super().commit()
+        item = self.getDataItem()
+        if item is not None:
+            item.setMaskData(self.getMask(copy=True), copy=False)
+
     def save(self, filename, kind):
         """Save current mask in a file
 

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -32,11 +32,9 @@ This widget is meant to work with :class:`silx.gui.plot.PlotWidget`.
 """
 from __future__ import division
 
-
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "15/02/2019"
-
+__date__ = "27/11/2020"
 
 import os
 import sys
@@ -59,9 +57,7 @@ from silx.third_party.TiffIO import TiffIO
 
 import fabio
 
-
 _logger = logging.getLogger(__name__)
-
 
 _HDF5_EXT_STR = ' '.join(['*' + ext for ext in NEXUS_HDF5_EXT])
 
@@ -91,6 +87,7 @@ class ImageMask(BaseMask):
 
     This is meant for internal use by :class:`MaskToolsWidget`.
     """
+
     def __init__(self, image=None):
         """
 
@@ -193,7 +190,7 @@ class ImageMask(BaseMask):
         selection = self._mask[max(0, row):row + height + 1,
                                max(0, col):col + width + 1]
         if mask:
-            selection[:, :] = level
+            selection[:,:] = level
         else:
             selection[selection == level] = 0
         self._notify()
@@ -339,7 +336,7 @@ class MaskToolsWidget(BaseMaskToolsWidget):
                                       dtype=numpy.uint8)
             height = min(self._data.shape[0], mask.shape[0])
             width = min(self._data.shape[1], mask.shape[1])
-            resizedMask[:height, :width] = mask[:height, :width]
+            resizedMask[:height,:width] = mask[:height,:width]
             self._mask.setMask(resizedMask, copy=False)
             self._mask.commit()
             return resizedMask.shape
@@ -809,6 +806,7 @@ class MaskToolsDockWidget(BaseMaskToolsDockWidget):
     :param plot: The PlotWidget this widget is operating on
     :paran str name: The title of this widget
     """
+
     def __init__(self, parent=None, plot=None, name='Mask'):
         widget = MaskToolsWidget(plot=plot)
         super(MaskToolsDockWidget, self).__init__(parent, name, widget)

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -485,16 +485,15 @@ class MaskToolsWidget(BaseMaskToolsWidget):
                 self._mask.setDataItem(activeImage)
                 self._updatePlotMask()
 
-    def _setMaskedImage(self, image, ignorePrevious=False):
+    def _setMaskedImage(self, image):
         """Change the image that is used a reference to author the mask"""
-        if not ignorePrevious:
-            previous = self.getMaskedItem()
-            if previous is not None and self.isVisible():
-                # Disconnect from previous image
-                try:
-                    previous.sigItemChanged.disconnect(self.__imageChanged)
-                except TypeError:
-                    pass  # TODO fixme should not happen
+        previous = self.getMaskedItem()
+        if previous is not None and self.isVisible():
+            # Disconnect from previous image
+            try:
+                previous.sigItemChanged.disconnect(self.__imageChanged)
+            except TypeError:
+                pass  # TODO fixme should not happen
 
         # Set the image
         self._mask.setDataItem(image)

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -34,7 +34,7 @@ from __future__ import division
 
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "27/11/2020"
+__date__ = "08/12/2020"
 
 import os
 import sys
@@ -359,7 +359,6 @@ class MaskToolsWidget(BaseMaskToolsWidget):
             self.plot.remove(self._maskName, kind='image')
 
     def showEvent(self, event):
-        print('show', self.isVisible())
         try:
             self.plot.sigActiveImageChanged.disconnect(
                 self._activeImageChangedAfterCare)
@@ -371,7 +370,6 @@ class MaskToolsWidget(BaseMaskToolsWidget):
         self.plot.sigActiveImageChanged.connect(self._activeImageChanged)
 
     def hideEvent(self, event):
-        print('hide', self.isVisible())
         try:
             self.plot.sigActiveImageChanged.disconnect(
                 self._activeImageChanged)

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -411,7 +411,7 @@ class MaskToolsWidget(BaseMaskToolsWidget):
         if image is not None:
             try:
                 image.sigItemChanged.disconnect(self.__imageChanged)
-            except TypeError:
+            except (RuntimeError, TypeError):
                 pass  # TODO should not happen
 
         if self.isMaskInteractionActivated():

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -308,6 +308,8 @@ class MaskToolsWidget(BaseMaskToolsWidget):
                 self._mask.sigStateChanged.disconnect(self.__maskStateChanged)
             self.__itemMaskUpdated = enabled
             if self.__itemMaskUpdated:
+                # Synchronize item and tool mask
+                self._setMaskedImage(self._mask.getDataItem())
                 self._mask.sigStateChanged.connect(self.__maskStateChanged)
 
     def isItemMaskUpdated(self) -> bool:

--- a/silx/gui/plot/MaskToolsWidget.py
+++ b/silx/gui/plot/MaskToolsWidget.py
@@ -380,7 +380,10 @@ class MaskToolsWidget(BaseMaskToolsWidget):
 
         image = self.getMaskedItem()
         if image is not None:
-            image.sigItemChanged.disconnect(self.__imageChanged)
+            try:
+                image.sigItemChanged.disconnect(self.__imageChanged)
+            except TypeError:
+                pass  # TODO should not happen
 
         if self.isMaskInteractionActivated():
             # Disable drawing tool

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -29,7 +29,7 @@ from __future__ import division
 
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "12/04/2019"
+__date__ = "27/11/2020"
 
 import os
 import weakref
@@ -81,8 +81,8 @@ class BaseMask(qt.QObject):
         if dataItem is not None:
             self.setDataItem(dataItem)
             self.reset(self.getDataValues().shape)
-
         super(BaseMask, self).__init__()
+        self.sigChanged.connect(self.setDataMask)
 
     def setDataItem(self, item):
         """Set a data item
@@ -103,6 +103,12 @@ class BaseMask(qt.QObject):
         :rtype: numpy.ndarray
         """
         raise NotImplementedError("To be implemented in subclass")
+
+    def setDataMask(self):
+        """Update the mask stored inside the DataItem (if possible)
+        """
+        if "setMask" in dir(self._dataItem):
+            self._dataItem.setMask(self.getMask())
 
     def _notify(self):
         """Notify of mask change."""
@@ -211,7 +217,7 @@ class BaseMask(qt.QObject):
         """
         if shape is None:
             # assume dimensionality never changes
-            shape = (0, ) * len(self._mask.shape)   # empty array
+            shape = (0,) * len(self._mask.shape)  # empty array
         shapeChanged = (shape != self._mask.shape)
         self._mask = numpy.zeros(shape, dtype=numpy.uint8)
         if shapeChanged:
@@ -935,11 +941,11 @@ class BaseMaskToolsWidget(qt.QWidget):
         colors = numpy.empty((self._maxLevelNumber + 1, 4), dtype=numpy.float32)
 
         # Set color
-        colors[:, :3] = self._defaultOverlayColor[:3]
+        colors[:,:3] = self._defaultOverlayColor[:3]
 
         # check if some colors has been directly set by the user
         mask = numpy.equal(self._defaultColors, False)
-        colors[mask, :3] = self._overlayColors[mask, :3]
+        colors[mask,:3] = self._overlayColors[mask,:3]
 
         # Set alpha
         colors[:, -1] = alpha / 2.

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -29,7 +29,7 @@ from __future__ import division
 
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "27/11/2020"
+__date__ = "01/12/2020"
 
 import os
 import weakref
@@ -107,8 +107,8 @@ class BaseMask(qt.QObject):
     def setDataMask(self):
         """Update the mask stored inside the DataItem (if possible)
         """
-        if "setMask" in dir(self._dataItem):
-            self._dataItem.setMask(self.getMask())
+        if "setMaskData" in dir(self._dataItem):
+            self._dataItem.setMaskData(self.getMask(copy=False), copy=False)
 
     def _notify(self):
         """Notify of mask change."""

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -82,7 +82,6 @@ class BaseMask(qt.QObject):
             self.setDataItem(dataItem)
             self.reset(self.getDataValues().shape)
         super(BaseMask, self).__init__()
-        self.sigChanged.connect(self.setDataMask)
 
     def setDataItem(self, item):
         """Set a data item
@@ -110,12 +109,6 @@ class BaseMask(qt.QObject):
         :rtype: numpy.ndarray
         """
         raise NotImplementedError("To be implemented in subclass")
-
-    def setDataMask(self):
-        """Update the mask stored inside the DataItem (if possible)
-        """
-        if "setMaskData" in dir(self._dataItem):
-            self._dataItem.setMaskData(self.getMask(copy=True), copy=False)
 
     def _notify(self):
         """Notify of mask change."""

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -60,6 +60,9 @@ class BaseMask(qt.QObject):
     sigChanged = qt.Signal()
     """Signal emitted when the mask has changed"""
 
+    sigStateChanged = qt.Signal()
+    """Signal emitted for each mask commit/undo/redo operation"""
+
     sigUndoable = qt.Signal(bool)
     """Signal emitted when undo becomes possible/impossible"""
 
@@ -158,6 +161,7 @@ class BaseMask(qt.QObject):
 
             if len(self._history) == 2:
                 self.sigUndoable.emit(True)
+        self.sigStateChanged.emit()
 
     def undo(self):
         """Restore previous mask if any"""
@@ -170,6 +174,7 @@ class BaseMask(qt.QObject):
                 self.sigRedoable.emit(True)
             if len(self._history) == 1:  # Last value in history
                 self.sigUndoable.emit(False)
+            self.sigStateChanged.emit()
 
     def redo(self):
         """Restore previously undone modification if any"""
@@ -182,8 +187,9 @@ class BaseMask(qt.QObject):
                 self.sigRedoable.emit(False)
             if len(self._history) == 2:  # Something to undo
                 self.sigUndoable.emit(True)
+            self.sigStateChanged.emit()
 
-                # Whole mask operations
+    # Whole stack operations
 
     def clear(self, level):
         """Set all values of the given mask level to 0.

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -189,7 +189,7 @@ class BaseMask(qt.QObject):
                 self.sigUndoable.emit(True)
             self.sigStateChanged.emit()
 
-    # Whole stack operations
+    # Whole mask operations
 
     def clear(self, level):
         """Set all values of the given mask level to 0.

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -92,6 +92,13 @@ class BaseMask(qt.QObject):
         """
         self._dataItem = item
 
+    def getDataItem(self):
+        """Returns current plot item the mask is on.
+
+        :rtype: Union[~silx.gui.plot.items.Item,None]
+        """
+        return self._dataItem
+
     def getDataValues(self):
         """Return data values, as a numpy array with the same shape
         as the mask.
@@ -107,8 +114,8 @@ class BaseMask(qt.QObject):
     def setDataMask(self):
         """Update the mask stored inside the DataItem (if possible)
         """
-        if "setMaskData" in dir(self._dataItem):
-            self._dataItem.setMaskData(self.getMask(copy=False), copy=False)
+        if "setMaskData" in dir(self._dataItem):  # TODO avoid this
+            self._dataItem.setMaskData(self.getMask())
 
     def _notify(self):
         """Notify of mask change."""
@@ -420,6 +427,13 @@ class BaseMaskToolsWidget(qt.QWidget):
     def _emitSigMaskChanged(self):
         """Notify mask changes"""
         self.sigMaskChanged.emit()
+
+    def getMaskedItem(self):
+        """Returns the item that is currently being masked
+
+        :rtype: Union[~silx.gui.plot.items.Item,None]
+        """
+        return self._mask.getDataItem()
 
     def getSelectionMask(self, copy=True):
         """Get the current mask as a numpy array.

--- a/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -29,7 +29,7 @@ from __future__ import division
 
 __authors__ = ["T. Vincent", "P. Knobel"]
 __license__ = "MIT"
-__date__ = "01/12/2020"
+__date__ = "08/12/2020"
 
 import os
 import weakref
@@ -114,8 +114,8 @@ class BaseMask(qt.QObject):
     def setDataMask(self):
         """Update the mask stored inside the DataItem (if possible)
         """
-        if "setMaskData" in dir(self._dataItem):  # TODO avoid this
-            self._dataItem.setMaskData(self.getMask())
+        if "setMaskData" in dir(self._dataItem):
+            self._dataItem.setMaskData(self.getMask(copy=True), copy=False)
 
     def _notify(self):
         """Notify of mask change."""

--- a/silx/gui/plot/actions/control.py
+++ b/silx/gui/plot/actions/control.py
@@ -374,22 +374,7 @@ class ColormapAction(PlotAction):
             return
         image = self.plot.getActiveImage()
 
-        if isinstance(image, items.ImageComplexData):
-            # Specific init for complex images
-            colormap = image.getColormap()
-
-            mode = image.getComplexMode()
-            if mode in (items.ImageComplexData.ComplexMode.AMPLITUDE_PHASE,
-                        items.ImageComplexData.ComplexMode.LOG10_AMPLITUDE_PHASE):
-                data = image.getData(
-                    copy=False, mode=items.ImageComplexData.ComplexMode.PHASE)
-            else:
-                data = image.getData(copy=False)
-
-            # Set histogram and range if any
-            self._dialog.setData(data)
-
-        elif isinstance(image, items.ColormapMixIn):
+        if isinstance(image, items.ColormapMixIn):
             # Set dialog from active image
             colormap = image.getColormap()
             # Set histogram and range if any

--- a/silx/gui/plot/actions/histogram.py
+++ b/silx/gui/plot/actions/histogram.py
@@ -192,21 +192,7 @@ class PixelIntensitiesHistoAction(PlotToolAction):
             self._cleanUp()
             return
 
-        if isinstance(item, items.ImageBase):
-            array = item.getData(copy=False)
-            if array.ndim == 3:  # RGB(A) images
-                _logger.info('Converting current image from RGB(A) to grayscale\
-                    in order to compute the intensity distribution')
-                array = (array[:,:, 0] * 0.299 +
-                         array[:,:, 1] * 0.587 +
-                         array[:,:, 2] * 0.114)
-
-            # Apply mask if any
-            mask = item.getMaskData(copy=False)
-            if mask is not None:
-                array = array[numpy.logical_not(mask)]
-
-        elif isinstance(item, items.Scatter):
+        if isinstance(item, (items.ImageBase, items.Scatter)):
             array = item.getValueData(copy=False)
         else:
             assert(False)

--- a/silx/gui/plot/actions/histogram.py
+++ b/silx/gui/plot/actions/histogram.py
@@ -202,7 +202,6 @@ class PixelIntensitiesHistoAction(PlotToolAction):
                          array[:,:, 2] * 0.114)
             elif "getMask" in dir(item):
                 mask = item.getMask(copy=False)
-                print(mask)
                 if mask is not None:
                     array = array[numpy.logical_not(mask)]
 

--- a/silx/gui/plot/actions/histogram.py
+++ b/silx/gui/plot/actions/histogram.py
@@ -34,7 +34,7 @@ The following QAction are available:
 from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent", "P. Knobel"]
-__date__ = "27/11/2020"
+__date__ = "01/12/2020"
 __license__ = "MIT"
 
 import numpy
@@ -200,8 +200,8 @@ class PixelIntensitiesHistoAction(PlotToolAction):
                 array = (array[:,:, 0] * 0.299 +
                          array[:,:, 1] * 0.587 +
                          array[:,:, 2] * 0.114)
-            elif "getMask" in dir(item):
-                mask = item.getMask(copy=False)
+            elif "getMaskData" in dir(item):
+                mask = item.getMaskData(copy=False)
                 if mask is not None:
                     array = array[numpy.logical_not(mask)]
 

--- a/silx/gui/plot/actions/histogram.py
+++ b/silx/gui/plot/actions/histogram.py
@@ -200,10 +200,11 @@ class PixelIntensitiesHistoAction(PlotToolAction):
                 array = (array[:,:, 0] * 0.299 +
                          array[:,:, 1] * 0.587 +
                          array[:,:, 2] * 0.114)
-            elif "getMaskData" in dir(item):  # TODO not needed
-                mask = item.getMaskData(copy=False)
-                if mask is not None:
-                    array = array[numpy.logical_not(mask)]
+
+            # Apply mask if any
+            mask = item.getMaskData(copy=False)
+            if mask is not None:
+                array = array[numpy.logical_not(mask)]
 
         elif isinstance(item, items.Scatter):
             array = item.getValueData(copy=False)

--- a/silx/gui/plot/actions/histogram.py
+++ b/silx/gui/plot/actions/histogram.py
@@ -200,7 +200,7 @@ class PixelIntensitiesHistoAction(PlotToolAction):
                 array = (array[:,:, 0] * 0.299 +
                          array[:,:, 1] * 0.587 +
                          array[:,:, 2] * 0.114)
-            elif "getMaskData" in dir(item):
+            elif "getMaskData" in dir(item):  # TODO not needed
                 mask = item.getMaskData(copy=False)
                 if mask is not None:
                     array = array[numpy.logical_not(mask)]

--- a/silx/gui/plot/actions/histogram.py
+++ b/silx/gui/plot/actions/histogram.py
@@ -173,7 +173,7 @@ class PixelIntensitiesHistoAction(PlotToolAction):
         self.computeIntensityDistribution()
 
     def _itemUpdated(self, event):
-        if event == items.ItemChangedType.DATA:
+        if event in (items.ItemChangedType.DATA, items.ItemChangedType.MASK):
             self.computeIntensityDistribution()
 
     def _cleanUp(self):

--- a/silx/gui/plot/actions/histogram.py
+++ b/silx/gui/plot/actions/histogram.py
@@ -34,7 +34,7 @@ The following QAction are available:
 from __future__ import division
 
 __authors__ = ["V.A. Sole", "T. Vincent", "P. Knobel"]
-__date__ = "10/10/2018"
+__date__ = "27/11/2020"
 __license__ = "MIT"
 
 import numpy
@@ -197,9 +197,18 @@ class PixelIntensitiesHistoAction(PlotToolAction):
             if array.ndim == 3:  # RGB(A) images
                 _logger.info('Converting current image from RGB(A) to grayscale\
                     in order to compute the intensity distribution')
-                array = (array[:, :, 0] * 0.299 +
-                         array[:, :, 1] * 0.587 +
-                         array[:, :, 2] * 0.114)
+                array = (array[:,:, 0] * 0.299 +
+                         array[:,:, 1] * 0.587 +
+                         array[:,:, 2] * 0.114)
+            elif "getMask" in dir(item):
+                mask = item.getMask(copy=False)
+                print(mask)
+                if mask is not None:
+                    print(mask.shape, array.shape)
+                    print(mask.size)
+                    array = array[numpy.logical_not(mask)]
+                    print(mask.shape, array.shape)
+
         elif isinstance(item, items.Scatter):
             array = item.getValueData(copy=False)
         else:

--- a/silx/gui/plot/actions/histogram.py
+++ b/silx/gui/plot/actions/histogram.py
@@ -204,10 +204,7 @@ class PixelIntensitiesHistoAction(PlotToolAction):
                 mask = item.getMask(copy=False)
                 print(mask)
                 if mask is not None:
-                    print(mask.shape, array.shape)
-                    print(mask.size)
                     array = array[numpy.logical_not(mask)]
-                    print(mask.shape, array.shape)
 
         elif isinstance(item, items.Scatter):
             array = item.getValueData(copy=False)

--- a/silx/gui/plot/items/complex.py
+++ b/silx/gui/plot/items/complex.py
@@ -184,18 +184,18 @@ class ImageComplexData(ImageBase, ColormapMixIn, ComplexMixIn):
     def setComplexMode(self, mode):
         changed = super(ImageComplexData, self).setComplexMode(mode)
         if changed:
+            self._valueDataChanged()
+
             # Backward compatibility
             self._updated(ItemChangedType.VISUALIZATION_MODE)
-
-            # Send data updated as value returned by getData has changed
-            self._updated(ItemChangedType.DATA)
 
             # Update ColormapMixIn colormap
             colormap = self._colormaps[self.getComplexMode()]
             if colormap is not super(ImageComplexData, self).getColormap():
                 super(ImageComplexData, self).setColormap(colormap)
 
-            self._setColormappedData(self.getData(copy=False), copy=False)
+            # Send data updated as value returned by getData has changed
+            self._updated(ItemChangedType.DATA)
         return changed
 
     def _setAmplitudeRangeInfo(self, max_=None, delta=2):
@@ -267,9 +267,17 @@ class ImageComplexData(ImageBase, ColormapMixIn, ComplexMixIn):
         mode = self.getComplexMode()
         dataForMode = self.__convertComplexData(data, self.getComplexMode())
         self._dataByModesCache = {mode: dataForMode}
-        self._setColormappedData(dataForMode, copy=False)
 
         super().setData(data)
+
+    def _updated(self, event=None, checkVisibility=True):
+        # Synchronizes colormapped data if changed
+        # ItemChangedType.COMPLEX_MODE triggers ItemChangedType.DATA
+        # No need to handle it twice.
+        if event in (ItemChangedType.DATA, ItemChangedType.MASK):
+            self._setColormappedData(
+                self.getValueData(copy=False), copy=False)
+        super()._updated(event=event, checkVisibility=checkVisibility)
 
     def getComplexData(self, copy=True):
         """Returns the image complex data

--- a/silx/gui/plot/items/complex.py
+++ b/silx/gui/plot/items/complex.py
@@ -275,8 +275,18 @@ class ImageComplexData(ImageBase, ColormapMixIn, ComplexMixIn):
         # ItemChangedType.COMPLEX_MODE triggers ItemChangedType.DATA
         # No need to handle it twice.
         if event in (ItemChangedType.DATA, ItemChangedType.MASK):
-            self._setColormappedData(
-                self.getValueData(copy=False), copy=False)
+            # Color-mapped data is NOT the `getValueData` for some modes
+            if self.getComplexMode() in (
+                    self.ComplexMode.AMPLITUDE_PHASE,
+                    self.ComplexMode.LOG10_AMPLITUDE_PHASE):
+                data = self.getData(copy=False, mode=self.ComplexMode.PHASE)
+                mask = self.getMaskData(copy=False)
+                if mask is not None:
+                    data = numpy.copy(data)
+                    data[mask != 0] = numpy.nan
+            else:
+                data = self.getValueData(copy=False)
+            self._setColormappedData(data, copy=False)
         super()._updated(event=event, checkVisibility=checkVisibility)
 
     def getComplexData(self, copy=True):

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -695,9 +695,6 @@ class ColormapMixIn(ItemMixInBase):
             self.__cacheColormapRange[key] = vRange
         return vRange
 
-    def _flushColormapCache(self):
-        self.__cacheColormapRange = {}
-
 
 class SymbolMixIn(ItemMixInBase):
     """Mix-in class for items with symbol type"""

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -27,7 +27,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "26/11/2020"
+__date__ = "07/12/2020"
 
 import collections
 try:
@@ -669,6 +669,11 @@ class ColormapMixIn(ItemMixInBase):
         if self.__data is None:
             return None
         else:
+#             if "_mask" in self.__dict__ and self._mask is not None:
+#                 masked = numpy.array(self.__data, dtype=numpy.float32, copy=True)
+#                 masked[numpy.where(self._mask)] = numpy.NaN
+#                 return masked
+#             else:
             return numpy.array(self.__data, copy=copy)
 
     def _getColormapAutoscaleRange(self, colormap=None):
@@ -691,9 +696,16 @@ class ColormapMixIn(ItemMixInBase):
         key = normalization, autoscaleMode
         vRange = self.__cacheColormapRange.get(key, None)
         if vRange is None:
+            if (data is not None) and data.size:
+                print("Data is now: ", numpy.nanmin(data), numpy.nanmax(data), numpy.sum(numpy.logical_not(numpy.isfinite(data))))
             vRange = colormap._computeAutoscaleRange(data)
+            print("calculated vRange:", vRange)
             self.__cacheColormapRange[key] = vRange
         return vRange
+
+    def _flushColormapCache(self):
+        print("flush colormap cache")
+        __cacheColormapRange = {}
 
 
 class SymbolMixIn(ItemMixInBase):

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1406,7 +1406,7 @@ class PointsBase(DataItem, SymbolMixIn, AlphaMixIn):
 
                 elif error.ndim == 1:  # N array
                     newError = numpy.empty((2, len(value)),
-                                           dtype=numpy.float)
+                                           dtype=numpy.float64)
                     newError[0,:] = error
                     newError[1,:] = error
                     error = newError

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -27,7 +27,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "29/01/2019"
+__date__ = "26/11/2020"
 
 import collections
 try:
@@ -109,6 +109,9 @@ class ItemChangedType(enum.Enum):
 
     DATA = 'dataChanged'
     """Item's data changed flag"""
+
+    MASK = 'maskChanged'
+    """Item's mask changed flag"""
 
     HIGHLIGHTED = 'highlightedChanged'
     """Item's highlight state changed flag."""
@@ -315,7 +318,7 @@ class Item(qt.QObject):
             info = deepcopy(info)
         self._info = info
 
-    def getVisibleBounds(self) -> Optional[Tuple[float,float,float,float]]:
+    def getVisibleBounds(self) -> Optional[Tuple[float, float, float, float]]:
         """Returns visible bounds of the item bounding box in the plot area.
 
         :returns:
@@ -503,8 +506,8 @@ class DataItem(Item):
             self._boundsChanged(checkVisibility=False)
         super().setVisible(visible)
 
-
 # Mix-in classes ##############################################################
+
 
 class ItemMixInBase(object):
     """Base class for Item mix-in"""
@@ -1232,7 +1235,7 @@ class ScatterVisualizationMixIn(ItemMixInBase):
 
     def __init__(self):
         self.__visualization = self.Visualization.POINTS
-        self.__parameters = dict(  # Init parameters to None
+        self.__parameters = dict(# Init parameters to None
             (parameter, None) for parameter in self.VisualizationParameter)
         self.__parameters[self.VisualizationParameter.BINNED_STATISTIC_FUNCTION] = 'mean'
 
@@ -1403,9 +1406,9 @@ class PointsBase(DataItem, SymbolMixIn, AlphaMixIn):
 
                 elif error.ndim == 1:  # N array
                     newError = numpy.empty((2, len(value)),
-                                           dtype=numpy.float64)
-                    newError[0, :] = error
-                    newError[1, :] = error
+                                           dtype=numpy.float)
+                    newError[0,:] = error
+                    newError[1,:] = error
                     error = newError
 
                 elif error.size == 2 * len(value):  # 2xN array
@@ -1634,6 +1637,7 @@ class PointsBase(DataItem, SymbolMixIn, AlphaMixIn):
 
 class BaselineMixIn(object):
     """Base class for Baseline mix-in"""
+
     def __init__(self, baseline=None):
         self._baseline = baseline
 

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -708,7 +708,7 @@ class ColormapMixIn(ItemMixInBase):
 
     def _flushColormapCache(self):
         print("flush colormap cache")
-        __cacheColormapRange = {}
+        self.__cacheColormapRange = {}
 
 
 class SymbolMixIn(ItemMixInBase):

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -683,31 +683,19 @@ class ColormapMixIn(ItemMixInBase):
             colormap = self.getColormap()
 
         data = self.getColormappedData(copy=False)
-        if data is None:
-            print(type(self), "in ColormapMixIn_getColormapAutoscaleRange, data is None")
-        elif data.size == 0:
-            print(type(self), "in ColormapMixIn_getColormapAutoscaleRange, data is", data)
-        else:
-            print(type(self), "in ColormapMixIn_getColormapAutoscaleRange, data is", data.size,
-                  numpy.nanmin(data), numpy.nanmax(data), numpy.logical_not(numpy.isfinite(data)).sum())
         if colormap is None or data is None:
             return None, None
 
         normalization = colormap.getNormalization()
         autoscaleMode = colormap.getAutoscaleMode()
         key = normalization, autoscaleMode
-        print("ColormapMixIn.__cacheColormapRange cache content:", self.__cacheColormapRange)
         vRange = self.__cacheColormapRange.get(key, None)
         if vRange is None:
-            if (data is not None) and data.size:
-                print("Data is now: ", numpy.nanmin(data), numpy.nanmax(data), numpy.sum(numpy.logical_not(numpy.isfinite(data))))
             vRange = colormap._computeAutoscaleRange(data)
-            print("calculated vRange:", vRange)
             self.__cacheColormapRange[key] = vRange
         return vRange
 
     def _flushColormapCache(self):
-        print("flush colormap cache")
         self.__cacheColormapRange = {}
 
 

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -27,7 +27,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "07/12/2020"
+__date__ = "08/12/2020"
 
 import collections
 try:
@@ -669,11 +669,6 @@ class ColormapMixIn(ItemMixInBase):
         if self.__data is None:
             return None
         else:
-#             if "_mask" in self.__dict__ and self._mask is not None:
-#                 masked = numpy.array(self.__data, dtype=numpy.float32, copy=True)
-#                 masked[numpy.where(self._mask)] = numpy.NaN
-#                 return masked
-#             else:
             return numpy.array(self.__data, copy=copy)
 
     def _getColormapAutoscaleRange(self, colormap=None):
@@ -688,6 +683,13 @@ class ColormapMixIn(ItemMixInBase):
             colormap = self.getColormap()
 
         data = self.getColormappedData(copy=False)
+        if data is None:
+            print(type(self), "in ColormapMixIn_getColormapAutoscaleRange, data is None")
+        elif data.size == 0:
+            print(type(self), "in ColormapMixIn_getColormapAutoscaleRange, data is", data)
+        else:
+            print(type(self), "in ColormapMixIn_getColormapAutoscaleRange, data is", data.size,
+                  numpy.nanmin(data), numpy.nanmax(data), numpy.logical_not(numpy.isfinite(data)).sum())
         if colormap is None or data is None:
             return None, None
 

--- a/silx/gui/plot/items/core.py
+++ b/silx/gui/plot/items/core.py
@@ -696,6 +696,7 @@ class ColormapMixIn(ItemMixInBase):
         normalization = colormap.getNormalization()
         autoscaleMode = colormap.getAutoscaleMode()
         key = normalization, autoscaleMode
+        print("ColormapMixIn.__cacheColormapRange cache content:", self.__cacheColormapRange)
         vRange = self.__cacheColormapRange.get(key, None)
         if vRange is None:
             if (data is not None) and data.size:

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -208,10 +208,10 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
         if mask is not None and self._data is not None:
             if mask.size and mask.shape != self._data.shape[:2]:
                 _logger.warning("Unconsistent shape between mask and data %s, %s", mask.shape, self._data.shape)
-        if id(mask) != id(self._mask):
-            self._masked = None
-            self._mask = None if mask is None else numpy.array(mask, copy=copy)
-            self._updated(ItemChangedType.MASK)
+        self._masked = None
+        self._mask = None if mask is None else numpy.array(mask, copy=copy)
+        #if mask is not self._masked:
+        self._updated(ItemChangedType.MASK)
 
     def getMaskedData(self):
         """Retirieve the NaN-masked image

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -28,7 +28,7 @@ of the :class:`Plot`.
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "27/11/2020"
+__date__ = "30/11/2020"
 
 try:
     from collections import abc
@@ -190,7 +190,7 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
         self._updated(ItemChangedType.DATA)
         self._masked = None
 
-    def getMask(self, copy=True):
+    def getMaskData(self, copy=True):
         """Returns the mask data
 
         :param bool copy: True (Default) to get a copy,
@@ -199,7 +199,7 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
         """
         return None if self._mask is None else numpy.array(self._mask, copy=copy)
 
-    def setMask(self, mask):
+    def setMaskData(self, mask, copy=True):
         """Set the image data
 
         :param numpy.ndarray data:
@@ -208,10 +208,9 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
             if mask.size and mask.shape != self._data.shape[:2]:
                 _logger.warning("Unconsistent shape between mask and data %s, %s", mask.shape, self._data.shape)
         self._masked = None
-        self._mask = mask
-#       TODO: Why does this break tests ?
-#         if mask is not self._masked:
-#             self._updated(ItemChangedType.MASK)
+        self._mask = None if mask is None else numpy.array(mask, copy=copy)
+        if mask is not self._masked:
+            self._updated(ItemChangedType.MASK)
 
     def getMasked(self):
         """Retirieve the NaN-masked image

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -285,7 +285,7 @@ class ImageData(ImageBase, ColormapMixIn):
         ColormapMixIn.__init__(self)
         self._alternativeImage = None
         self.__alpha = None
-        self.sigItemChanged.connect(self._maskChanged)
+#         self.sigItemChanged.connect(self._maskChanged)
 
     def _addBackendRenderer(self, backend):
         """Update backend renderer"""
@@ -438,10 +438,14 @@ class ImageData(ImageBase, ColormapMixIn):
 
         super().setData(data)
 
-    def _maskChanged(self, event=None):
-        print("in ImageData._maskChanged")
-        if event == ItemChangedType.MASK:
-            self._flushColormapCache()
+    def setMaskData(self, mask, copy=True):
+        """Set the image data
+
+        :param numpy.ndarray data:
+        """
+        print("in ImageData.setMaskData")
+        super().setMaskData(mask, copy=copy)
+        self._flushColormapCache()
 
     def getColormappedData(self, copy=True):
         print("in ImageData.getColormappedData")

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -28,7 +28,7 @@ of the :class:`Plot`.
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "26/11/2020"
+__date__ = "27/11/2020"
 
 try:
     from collections import abc
@@ -197,7 +197,7 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
                           False to use internal representation (do not modify!)
         :rtype: numpy.ndarray
         """
-        return numpy.array(self._mask, copy=copy)
+        return None if self._mask is None else numpy.array(self._mask, copy=copy)
 
     def setMask(self, mask):
         """Set the image data
@@ -205,7 +205,7 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
         :param numpy.ndarray data:
         """
         if mask is not None and self._data is not None:
-            if  mask.shape == self._data.shape[:2]:
+            if mask.shape != self._data.shape[:2]:
                 _logger.warning("Unconsistent shape between mask and data")
         self._masked = None
         self._mask = mask

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -284,7 +284,6 @@ class ImageData(ImageBase, ColormapMixIn):
         ColormapMixIn.__init__(self)
         self._alternativeImage = None
         self.__alpha = None
-#         self.sigItemChanged.connect(self._maskChanged)
 
     def _addBackendRenderer(self, backend):
         """Update backend renderer"""

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -232,7 +232,7 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
                 _logger.warning("Inconsistent shape between mask and data %s, %s", mask.shape, shape)
                 # Clip/extent is done lazily in getMaskData
         elif self._mask is None:
-                return  # No update
+            return  # No update
 
         self._mask = mask
         self._valueDataChanged()

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -100,6 +100,7 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
             data = numpy.zeros((0, 0, 4), dtype=numpy.uint8)
         self._data = data
         self._mask = mask
+        self.__valueDataCache = None  # Store default data
         self._origin = (0., 0.)
         self._scale = (1., 1.)
 
@@ -186,6 +187,7 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
         """
         previousShape = self._data.shape
         self._data = data
+        self._valueDataChanged()
         self._boundsChanged()
         self._updated(ItemChangedType.DATA)
 
@@ -233,7 +235,42 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
                 return  # No update
 
         self._mask = mask
+        self._valueDataChanged()
         self._updated(ItemChangedType.MASK)
+
+    def _valueDataChanged(self):
+        """Clear cache of default data array"""
+        self.__valueDataCache = None
+
+    def _getValueData(self, copy=True):
+        """Return data used by :meth:`getValueData`
+
+        :param bool copy:
+        :rtype: numpy.ndarray
+        """
+        return self.getData(copy=copy)
+
+    def getValueData(self, copy=True):
+        """Return data (converted to int or float) with mask applied.
+
+        Masked values are set to Not-A-Number.
+        It returns a 2D array of values (int or float).
+
+        :param bool copy:
+        :rtype: numpy.ndarray
+        """
+        if self.__valueDataCache is None:
+            data = self._getValueData(copy=False)
+            mask = self.getMaskData(copy=False)
+            if mask is not None:
+                if numpy.issubdtype(data.dtype, numpy.floating):
+                    dtype = data.dtype
+                else:
+                    dtype = numpy.float64
+                data = numpy.array(data, dtype=dtype, copy=True)
+                data[mask != 0] = numpy.NaN
+            self.__valueDataCache = data
+        return numpy.array(self.__valueDataCache, copy=copy)
 
     def getRgbaImageData(self, copy=True):
         """Get the displayed RGB(A) image
@@ -298,7 +335,6 @@ class ImageData(ImageBase, ColormapMixIn):
         ColormapMixIn.__init__(self)
         self._alternativeImage = None
         self.__alpha = None
-        self.__maskedDataCache = None  # Store masked data
 
     def _addBackendRenderer(self, backend):
         """Update backend renderer"""
@@ -406,8 +442,6 @@ class ImageData(ImageBase, ColormapMixIn):
             _logger.warning(
                 'Converting complex image to absolute value to plot it.')
             data = numpy.absolute(data)
-        self.__maskedDataCache = None  # Clear masked data cache
-        self._setColormappedData(self.getMaskedData(copy=False), copy=False)
 
         if alternative is not None:
             alternative = numpy.array(alternative, copy=copy)
@@ -427,29 +461,13 @@ class ImageData(ImageBase, ColormapMixIn):
 
         super().setData(data)
 
-    def setMaskData(self, mask, copy=True):
-        """Set the image data
-
-        :param numpy.ndarray data:
-        """
-        self.__maskedDataCache = None  # Clear masked data cache
-        super().setMaskData(mask, copy=copy)
-        self._setColormappedData(self.getMaskedData(copy=False), copy=False)
-
-    def getMaskedData(self, copy=True):
-        """Return masked data as an array of float32 if masked.
-
-        :param bool copy:
-        :rtype: numpy.ndarray
-        """
-        if self.__maskedDataCache is None:
-            data = self.getData(copy=False)
-            mask = self.getMaskData(copy=False)
-            if mask is not None:
-                data = numpy.array(data, dtype=numpy.float32, copy=True)
-                data[mask != 0] = numpy.NaN
-            self.__maskedDataCache = data
-        return numpy.array(self.__maskedDataCache, copy=copy)
+    def _updated(self, event=None, checkVisibility=True):
+        # Synchronizes colormapped data if changed
+        if event in (ItemChangedType.DATA, ItemChangedType.MASK):
+            self._setColormappedData(
+                self.getValueData(copy=False),
+                copy=False)
+        super()._updated(event=event, checkVisibility=checkVisibility)
 
 
 class ImageRgba(ImageBase):
@@ -495,6 +513,20 @@ class ImageRgba(ImageBase):
         assert data.ndim == 3
         assert data.shape[-1] in (3, 4)
         super().setData(data)
+
+    def _getValueData(self, copy=True):
+        """Compute the intensity of the RGBA image as default data.
+
+        Conversion: https://en.wikipedia.org/wiki/YCbCr#ITU-R_BT.601_conversion
+
+        :param bool copy:
+        """
+        rgba = self.getRgbaImageData(copy=False).astype(numpy.float32) / 255.
+        intensity = (rgba[:, :, 0] * 0.299 +
+                     rgba[:, :, 1] * 0.587 +
+                     rgba[:, :, 2] * 0.114)
+        intensity *= rgba[:, :, 3]
+        return intensity
 
 
 class MaskImageData(ImageData):

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -521,11 +521,11 @@ class ImageRgba(ImageBase):
 
         :param bool copy:
         """
-        rgba = self.getRgbaImageData(copy=False).astype(numpy.float32) / 255.
+        rgba = self.getRgbaImageData(copy=False).astype(numpy.float32)
         intensity = (rgba[:, :, 0] * 0.299 +
                      rgba[:, :, 1] * 0.587 +
                      rgba[:, :, 2] * 0.114)
-        intensity *= rgba[:, :, 3]
+        intensity *= rgba[:, :, 3] / 255.
         return intensity
 
 

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -229,7 +229,7 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
 
             shape = self.getData(copy=False).shape[:2]
             if mask.shape != shape:
-                _logger.warning("Unconsistent shape between mask and data %s, %s", mask.shape, shape)
+                _logger.warning("Inconsistent shape between mask and data %s, %s", mask.shape, shape)
                 # Clip/extent is done lazily in getMaskData
         elif self._mask is None:
                 return  # No update

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -100,6 +100,7 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
             data = numpy.zeros((0, 0, 4), dtype=numpy.uint8)
         self._data = data
         self._mask = mask
+        self._masked = None  # NaN masked float32 representation if the data
         self._origin = (0., 0.)
         self._scale = (1., 1.)
 
@@ -187,6 +188,7 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
         self._data = data
         self._boundsChanged()
         self._updated(ItemChangedType.DATA)
+        self._masked = None
 
     def getMask(self, copy=True):
         """Returns the mask data
@@ -205,8 +207,21 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
         if mask is not None and self._data is not None:
             if  mask.shape == self._data.shape[:2]:
                 _logger.warning("Unconsistent shape between mask and data")
+        self._masked = None
         self._mask = mask
         self._updated(ItemChangedType.MASK)
+
+    def getMasked(self):
+        """Retirieve the NaN-masked image
+        
+        :rtype: numpy.ndarray of dtype numpy.float32
+        """
+        if self._masked is None:
+            masked = numpy.array(self.data, dtype=numpy.float32, copy=True)
+            if self._mask is not None:
+                masked[numpy.where(self._mask)] = numpy.nan
+            self._masked = masked
+        return self._masked
 
     def getRgbaImageData(self, copy=True):
         """Get the displayed RGB(A) image

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -204,7 +204,6 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
 
         :param numpy.ndarray data:
         """
-        print("in Image.setMaskData")
         if mask is not None and self._data is not None:
             if mask.size and mask.shape != self._data.shape[:2]:
                 _logger.warning("Unconsistent shape between mask and data %s, %s", mask.shape, self._data.shape)
@@ -443,12 +442,10 @@ class ImageData(ImageBase, ColormapMixIn):
 
         :param numpy.ndarray data:
         """
-        print("in ImageData.setMaskData")
         super().setMaskData(mask, copy=copy)
         self._flushColormapCache()
 
     def getColormappedData(self, copy=True):
-        print("in ImageData.getColormappedData")
         data = super().getColormappedData(copy=copy)
         if data is not None:
             masked = numpy.array(data, dtype=numpy.float32, copy=not copy)  # one copy is enough!

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -383,24 +383,6 @@ class ImageData(ImageBase, ColormapMixIn):
         else:
             return numpy.array(self.__alpha, copy=copy)
 
-    def getColormappedData(self, copy=True):
-        """Returns the data used to compute the displayed colors
-
-        :param bool copy: True to get a copy,
-            False to get internal data (do not modify!).
-        :rtype: Union[None,numpy.ndarray]
-        """
-        data = ColormapMixIn.getColormappedData(self, copy=copy)
-        if data is None:
-            return None
-        else:
-            masked = numpy.array(data, dtype=numpy.float32, copy=True)
-            mask = self.getMaskData(copy=False)
-            if mask is not None:
-                print("In getColormappedData, masked pixels are ", mask.sum())
-                masked[numpy.where(mask)] = numpy.nan
-            return masked
-
     def setData(self, data, alternative=None, alpha=None, copy=True):
         """"Set the image data and optionally an alternative RGB(A) representation
 
@@ -414,7 +396,6 @@ class ImageData(ImageBase, ColormapMixIn):
         :param bool copy: True (Default) to get a copy,
                           False to use internal representation (do not modify!)
         """
-        print("ImageData.setData update image")
         data = numpy.array(data, copy=copy)
         assert data.ndim == 2
         if data.dtype.kind == 'b':

--- a/silx/gui/plot/items/image.py
+++ b/silx/gui/plot/items/image.py
@@ -205,11 +205,13 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
         :param numpy.ndarray data:
         """
         if mask is not None and self._data is not None:
-            if mask.shape != self._data.shape[:2]:
-                _logger.warning("Unconsistent shape between mask and data")
+            if mask.size and mask.shape != self._data.shape[:2]:
+                _logger.warning("Unconsistent shape between mask and data %s, %s", mask.shape, self._data.shape)
         self._masked = None
         self._mask = mask
-        self._updated(ItemChangedType.MASK)
+#       TODO: Why does this break tests ?
+#         if mask is not self._masked:
+#             self._updated(ItemChangedType.MASK)
 
     def getMasked(self):
         """Retirieve the NaN-masked image
@@ -217,7 +219,7 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
         :rtype: numpy.ndarray of dtype numpy.float32
         """
         if self._masked is None:
-            masked = numpy.array(self.data, dtype=numpy.float32, copy=True)
+            masked = numpy.array(self._data, dtype=numpy.float32, copy=True)
             if self._mask is not None:
                 masked[numpy.where(self._mask)] = numpy.nan
             self._masked = masked

--- a/silx/gui/plot/tools/profile/manager.py
+++ b/silx/gui/plot/tools/profile/manager.py
@@ -949,6 +949,7 @@ class ProfileManager(qt.QObject):
         """Handle item changes.
         """
         if changeType in (items.ItemChangedType.DATA,
+                          items.ItemChangedType.MASK,
                           items.ItemChangedType.POSITION,
                           items.ItemChangedType.SCALE):
             self.requestUpdateAllProfile()

--- a/silx/gui/plot/tools/profile/rois.py
+++ b/silx/gui/plot/tools/profile/rois.py
@@ -33,7 +33,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "27/11/2020"
+__date__ = "01/12/2020"
 
 import numpy
 import weakref
@@ -141,7 +141,7 @@ class _ImageProfileArea(items.Shape):
             rgba = item.getData(copy=False)
             currentData = rgba[..., 0]
         else:
-            currentData = item.getMasked()
+            currentData = item.getMaskedData()
 
         roi = self.getParentRoi()
         origin = item.getOrigin()
@@ -318,7 +318,7 @@ class _DefaultImageProfileRoiMixIn(core.ProfileRoiMixIn):
                 rgba = rgba.astype(numpy.float64)
             currentData = 0.21 * rgba[..., 0] + 0.72 * rgba[..., 1] + 0.07 * rgba[..., 2]
         else:
-            currentData = item.getMasked()
+            currentData = item.getMaskedData()
 
         yLabel = "%s" % str(method).capitalize()
         coords, profile, title, xLabel = createProfile2(currentData)

--- a/silx/gui/plot/tools/profile/rois.py
+++ b/silx/gui/plot/tools/profile/rois.py
@@ -33,7 +33,7 @@
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
-__date__ = "03/04/2020"
+__date__ = "27/11/2020"
 
 import numpy
 import weakref
@@ -141,7 +141,7 @@ class _ImageProfileArea(items.Shape):
             rgba = item.getData(copy=False)
             currentData = rgba[..., 0]
         else:
-            currentData = item.getData(copy=False)
+            currentData = item.getMasked()
 
         roi = self.getParentRoi()
         origin = item.getOrigin()
@@ -288,7 +288,7 @@ class _DefaultImageProfileRoiMixIn(core.ProfileRoiMixIn):
             roiStart, roiEnd = self.getEndPoints()
         else:
             assert False
-    
+
         return roiStart, roiEnd, lineProjectionMode
 
     def computeProfile(self, item):
@@ -318,7 +318,7 @@ class _DefaultImageProfileRoiMixIn(core.ProfileRoiMixIn):
                 rgba = rgba.astype(numpy.float64)
             currentData = 0.21 * rgba[..., 0] + 0.72 * rgba[..., 1] + 0.07 * rgba[..., 2]
         else:
-            currentData = item.getData(copy=False)
+            currentData = item.getMasked()
 
         yLabel = "%s" % str(method).capitalize()
         coords, profile, title, xLabel = createProfile2(currentData)
@@ -448,8 +448,8 @@ class ProfileImageDirectedLineROI(roi_items.LineROI,
             method=method)
 
         # Compute the line size
-        lineSize = numpy.sqrt((roiEnd[1] - roiStart[1])**2 +
-                              (roiEnd[0] - roiStart[0])**2)
+        lineSize = numpy.sqrt((roiEnd[1] - roiStart[1]) ** 2 +
+                              (roiEnd[0] - roiStart[0]) ** 2)
         coords = numpy.linspace(0, lineSize, len(profile),
                                 endpoint=True,
                                 dtype=numpy.float32)

--- a/silx/gui/plot/tools/profile/rois.py
+++ b/silx/gui/plot/tools/profile/rois.py
@@ -137,11 +137,7 @@ class _ImageProfileArea(items.Shape):
         if not isinstance(item, items.ImageBase):
             raise TypeError("Unexpected class %s" % type(item))
 
-        if isinstance(item, items.ImageRgba):
-            rgba = item.getData(copy=False)
-            currentData = rgba[..., 0]
-        else:
-            currentData = item.getMaskedData()
+        currentData = item.getValueData(copy=False)
 
         roi = self.getParentRoi()
         origin = item.getOrigin()
@@ -310,15 +306,7 @@ class _DefaultImageProfileRoiMixIn(core.ProfileRoiMixIn):
                 method=method)
             return coords, profile, profileName, xLabel
 
-        if isinstance(item, items.ImageRgba):
-            rgba = item.getData(copy=False)
-            is_uint8 = rgba.dtype.type == numpy.uint8
-            # luminosity
-            if is_uint8:
-                rgba = rgba.astype(numpy.float64)
-            currentData = 0.21 * rgba[..., 0] + 0.72 * rgba[..., 1] + 0.07 * rgba[..., 2]
-        else:
-            currentData = item.getMaskedData()
+        currentData = item.getValueData(copy=False)
 
         yLabel = "%s" % str(method).capitalize()
         coords, profile, title, xLabel = createProfile2(currentData)
@@ -427,7 +415,7 @@ class ProfileImageDirectedLineROI(roi_items.LineROI,
         scale = item.getScale()
         method = self.getProfileMethod()
         lineWidth = self.getProfileLineWidth()
-        currentData = item.getData(copy=False)
+        currentData = item.getValueData(copy=False)
 
         roiInfo = self._getRoiInfo()
         roiStart, roiEnd, _lineProjectionMode = roiInfo


### PR DESCRIPTION
Changelog: Associate a mask to the plotting of the image

- [X] Histogram
- [x] Colormap
- [x] Profile

closes #3263
closes #3124
closes #3285

This PR includes and superseeds PR #3289.
It adds:
- Support for data size change while mask is set.
- Support of all image items (i.e., complex, stack and RGBA images) by adding a `ImageBase.getValueData` method (If one has a better name I'll take it!) which returns a 2D array of data no matter of the kind of image and with mask applied.

TODO:
- [x] Proof-read mask tool
- [x] Tests