### PR TITLE
silx.gui.plot3d: Added support for RGB colored points in internal scene graph. 

### DIFF
--- a/silx/gui/plot3d/scene/primitives.py
+++ b/silx/gui/plot3d/scene/primitives.py
@@ -1383,7 +1383,7 @@ class ColorPoints(_Points):
     """A set of points with an associated color and size."""
 
     _ATTR_INFO = _Points._ATTR_INFO.copy()
-    _ATTR_INFO.update({'value': {'dims': (1, 2), 'lastDim': (4,)}})
+    _ATTR_INFO.update({'value': {'dims': (1, 2), 'lastDim': (3, 4)}})
 
     def __init__(self, x, y, z, color=(1., 1., 1., 1.), size=1.,
                  indices=None):


### PR DESCRIPTION
This is only an internal fix, it is useful to define plot3d items that are not (yet?) available in silx.
