### PR TITLE
silx.gui.plot: Fixed profile tool issue when closing profile window after attaced PlotWidget

### DIFF
--- a/silx/gui/plot/tools/profile/core.py
+++ b/silx/gui/plot/tools/profile/core.py
@@ -167,7 +167,10 @@ class ProfileRoiMixIn:
     def __profileWindowAboutToClose(self):
         profileManager = self.getProfileManager()
         roiManager = profileManager.getRoiManager()
-        roiManager.removeRoi(self)
+        try:
+            roiManager.removeRoi(self)
+        except ValueError:
+            pass
 
     def computeProfile(self, item):
         """


### PR DESCRIPTION
This occurs sometimes in `silx view` with the profile tool, when one draws a profile and change the displayed dataset or the visualization, the profile window remains open with the last profile, but when closing it it raises an exception:
```
ERROR:silx.gui.qt._qt:<class 'ValueError'> RegionOfInterest does not belong to this instance   File "silx/gui/plot/tools/profile/core.py", line 170, in __profileWindowAboutToClose
    roiManager.removeRoi(self)
  File "silx/gui/plot/tools/roi.py", line 748, in removeRoi
    'RegionOfInterest does not belong to this instance')
```

Not an elegant fix, but it does the job.
