### PR TITLE
dicttoh5 overwrite behavior

### DIFF
--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -206,13 +206,14 @@ def dicttoh5(treedict, h5file, h5path='/',
     :param create_dataset_args: Dictionary of args you want to pass to
         ``h5f.create_dataset``. This allows you to specify filters and
         compression parameters. Don't specify ``name`` and ``data``.
-    :param existing: can be 'add' (default), 'update' or 'overwrite'.
-        add: Existing HDF5 items are untouched. Nodes from the dict tree are
+    :param existing: Can be ``add`` (default), ``update`` or ``overwrite``.
+
+        * ``add``: Existing HDF5 items are untouched. Nodes from the dict tree are
             added to the HDF5 tree when the existing HDF5 tree allows it.
-        update: Existing HDF5 items may be updated or deleted explicitly
+        * ``update``: Existing HDF5 items may be updated or deleted explicitly
             by assigning them to `None`. The dict tree will be a subtree
             of the HDF5 tree.
-        overwrite: Existing HDF5 items may be overwritten or deleted.
+        * ``overwrite``: Existing HDF5 items may be overwritten or deleted.
             The HDF5 tree will be exactly the dict tree, except for already
             existing top-level items that were not deleted explicitly by
             assigning them to `None`.

--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -246,8 +246,8 @@ def dicttoh5(treedict, h5file, h5path='/',
 
     if overwrite_data is not None:
         reason = (
-            '`overwrite_data=True` becomes `existing="update"` and '
-            '`overwrite_data=False` becomes `existing="add"`'
+            "`overwrite_data=True` becomes `existing='update'` and "
+            "`overwrite_data=False` becomes `existing='add'`"
         )
         deprecated_warning(
             type_="argument",
@@ -283,7 +283,7 @@ def dicttoh5(treedict, h5file, h5path='/',
             if isinstance(key, tuple) == attributes:
                 yield key, value
 
-    change_allowed = existing in ["overwrite", "update"]
+    change_allowed = existing in ("overwrite", "update")
 
     with _SafeH5FileWrite(h5file, mode=mode) as h5f:
         # Create the root of the tree

--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -254,7 +254,7 @@ def dicttoh5(treedict, h5file, h5path='/',
             name="overwrite_data",
             reason=reason,
             replacement="existing",
-            since_version="x.y.z",
+            since_version="0.15",
         )
 
     if existing is None:

--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -382,7 +382,7 @@ def dicttoh5(treedict, h5file, h5path='/',
                 if exists and not change_allowed:
                     continue
                 data = _prepare_hdf5_write_value(value)
-                h5a[attr_name] = value
+                h5a[attr_name] = data
 
 
 def _has_nx_class(treedict, key=""):

--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -714,7 +714,7 @@ def dicttonx(treedict, h5file, h5path="/", add_nx_class=None, **kw):
     dicttoh5(nxtreedict, h5file, h5path=h5path, **kw)
 
 
-def nxtodict(h5file, **kw):
+def nxtodict(h5file, include_attributes=True, **kw):
     """Read a HDF5 file and return a nested dictionary with the complete file
     structure and all data.
 
@@ -723,7 +723,7 @@ def nxtodict(h5file, **kw):
 
     The named parameters are passed to h5todict.
     """
-    nxtreedict = h5todict(h5file, **kw)
+    nxtreedict = h5todict(h5file, include_attributes=include_attributes, **kw)
     return h5_to_nexus_dict(nxtreedict)
 
 

--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -263,10 +263,11 @@ def dicttoh5(treedict, h5file, h5path='/',
         else:
             existing = "add"
     else:
-        if existing not in ["add", "overwrite", "update"]:
+        valid_existing_values = ("add", "overwrite", "update")
+        if existing not in valid_existing_values:
             raise ValueError((
-                'Argument "existing" can only have values '
-                '"add", "overwrite" and "update"'
+                "Argument 'existing' can only have values: {}"
+                "".format(valid_existing_values)
             ))
         if overwrite_data is not None:
             logger.warning("The argument `overwrite_data` is ignored")

--- a/silx/io/dictdump.py
+++ b/silx/io/dictdump.py
@@ -708,7 +708,7 @@ def dicttonx(treedict, h5file, h5path="/", add_nx_class=None, **kw):
     h5file, h5path = _normalize_h5_path(h5file, h5path)
     parents = tuple(p for p in h5path.split("/") if p)
     if add_nx_class is None:
-        add_nx_class = kw.get("existing") in [None, "add"]
+        add_nx_class = kw.get("existing", None) in (None, "add")
     nxtreedict = nexus_to_h5_dict(
         treedict, parents=parents, add_nx_class=add_nx_class
     )

--- a/silx/io/test/test_dictdump.py
+++ b/silx/io/test/test_dictdump.py
@@ -333,12 +333,12 @@ class TestDictToH5(H5DictTestCase):
                 mode="w",
             )
 
-        def append_file(existing):
+        def append_file(update_mode):
             dicttoh5(
                 wtreedict,
                 h5file=self.h5_fname,
                 mode="a",
-                existing=existing
+                update_mode=update_mode
             )
 
         def assert_file():
@@ -360,8 +360,8 @@ class TestDictToH5(H5DictTestCase):
                 pprint(rtreedict)
                 raise
 
-        def assert_append(existing):
-            append_file(existing)
+        def assert_append(update_mode):
+            append_file(update_mode)
             assert_file()
 
         # Test wrong arguments
@@ -370,7 +370,7 @@ class TestDictToH5(H5DictTestCase):
                 otreedict,
                 h5file=self.h5_fname,
                 mode="w",
-                existing="wrong-value"
+                update_mode="wrong-value"
             )
 
         # No writing
@@ -383,16 +383,16 @@ class TestDictToH5(H5DictTestCase):
 
         reset_file()
         etreedict = deepcopy(otreedict)
-        for existing in [None, "add", "update", "overwrite"]:
-            assert_append(existing)
+        for update_mode in [None, "add", "modify", "replace"]:
+            assert_append(update_mode)
 
         # Write empty dictionary
         wtreedict = dict()
 
         reset_file()
         etreedict = deepcopy(otreedict)
-        for existing in [None, "add", "update", "overwrite"]:
-            assert_append(existing)
+        for update_mode in [None, "add", "modify", "replace"]:
+            assert_append(update_mode)
 
         # Modified dataset
         wtreedict = dict()
@@ -403,18 +403,18 @@ class TestDictToH5(H5DictTestCase):
 
         reset_file()
         etreedict = deepcopy(otreedict)
-        for existing in [None, "add"]:
-            assert_append(existing)
+        for update_mode in [None, "add"]:
+            assert_append(update_mode)
 
         etreedict["group2"]["subgroup2"]["dset2"] = [10, 20]
-        assert_append("update")
+        assert_append("modify")
 
         etreedict["group2"] = dict()
         del etreedict[("group2", "attr1")]
         etreedict["group2"]["subgroup2"] = dict()
         etreedict["group2"]["subgroup2"]["dset1"] = {"dset3": [10, 20]}
         etreedict["group2"]["subgroup2"]["dset2"] = [10, 20]
-        assert_append("overwrite")
+        assert_append("replace")
 
         # Modified group
         wtreedict = dict()
@@ -423,13 +423,13 @@ class TestDictToH5(H5DictTestCase):
 
         reset_file()
         etreedict = deepcopy(otreedict)
-        for existing in [None, "add", "update"]:
-            assert_append(existing)
+        for update_mode in [None, "add", "modify"]:
+            assert_append(update_mode)
 
         etreedict["group2"] = dict()
         del etreedict[("group2", "attr1")]
         etreedict["group2"]["subgroup2"] = [0, 1]
-        assert_append("overwrite")
+        assert_append("replace")
 
         # Modified attribute
         wtreedict = dict()
@@ -439,18 +439,18 @@ class TestDictToH5(H5DictTestCase):
 
         reset_file()
         etreedict = deepcopy(otreedict)
-        for existing in [None, "add"]:
-            assert_append(existing)
+        for update_mode in [None, "add"]:
+            assert_append(update_mode)
 
         etreedict["group2"]["subgroup2"][("dset1", "attr1")] = "modified"
-        assert_append("update")
+        assert_append("modify")
 
         etreedict["group2"] = dict()
         del etreedict[("group2", "attr1")]
         etreedict["group2"]["subgroup2"] = dict()
         etreedict["group2"]["subgroup2"]["dset1"] = dict()
         etreedict["group2"]["subgroup2"]["dset1"][("", "attr1")] = "modified"
-        assert_append("overwrite")
+        assert_append("replace")
 
         # Delete group
         wtreedict = dict()
@@ -459,16 +459,16 @@ class TestDictToH5(H5DictTestCase):
 
         reset_file()
         etreedict = deepcopy(otreedict)
-        for existing in [None, "add"]:
-            assert_append(existing)
+        for update_mode in [None, "add"]:
+            assert_append(update_mode)
 
         del etreedict["group2"]["subgroup2"]
         del etreedict["group2"][("subgroup2", "attr1")]
-        assert_append("update")
+        assert_append("modify")
 
         etreedict["group2"] = dict()
         del etreedict[("group2", "attr1")]
-        assert_append("overwrite")
+        assert_append("replace")
 
         # Delete dataset
         wtreedict = dict()
@@ -478,18 +478,18 @@ class TestDictToH5(H5DictTestCase):
 
         reset_file()
         etreedict = deepcopy(otreedict)
-        for existing in [None, "add"]:
-            assert_append(existing)
+        for update_mode in [None, "add"]:
+            assert_append(update_mode)
 
         del etreedict["group2"]["subgroup2"]["dset2"]
         del etreedict["group2"]["subgroup2"][("dset2", "attr1")]
         del etreedict["group2"]["subgroup2"][("dset2", "attr2")]
-        assert_append("update")
+        assert_append("modify")
 
         etreedict["group2"] = dict()
         del etreedict[("group2", "attr1")]
         etreedict["group2"]["subgroup2"] = dict()
-        assert_append("overwrite")
+        assert_append("replace")
 
         # Delete attribute
         wtreedict = dict()
@@ -499,17 +499,17 @@ class TestDictToH5(H5DictTestCase):
 
         reset_file()
         etreedict = deepcopy(otreedict)
-        for existing in [None, "add"]:
-            assert_append(existing)
+        for update_mode in [None, "add"]:
+            assert_append(update_mode)
 
         del etreedict["group2"]["subgroup2"][("dset2", "attr1")]
-        assert_append("update")
+        assert_append("modify")
 
         etreedict["group2"] = dict()
         del etreedict[("group2", "attr1")]
         etreedict["group2"]["subgroup2"] = dict()
         etreedict["group2"]["subgroup2"]["dset2"] = dict()
-        assert_append("overwrite")
+        assert_append("replace")
 
 
 class TestH5ToDict(H5DictTestCase):
@@ -731,13 +731,13 @@ class TestDictToNx(H5DictTestCase):
         }
         etreedict = {entry_name: esubtree}
 
-        def append_file(existing, add_nx_class):
+        def append_file(update_mode, add_nx_class):
             dictdump.dicttonx(
                 wtreedict,
                 h5file=self.h5_fname,
                 mode="a",
                 h5path=entry_name,
-                existing=existing,
+                update_mode=update_mode,
                 add_nx_class=add_nx_class
             )
 
@@ -760,8 +760,8 @@ class TestDictToNx(H5DictTestCase):
                 pprint(rtreedict)
                 raise
 
-        def assert_append(existing, add_nx_class=None):
-            append_file(existing, add_nx_class=add_nx_class)
+        def assert_append(update_mode, add_nx_class=None):
+            append_file(update_mode, add_nx_class=add_nx_class)
             assert_file()
 
         # First to an empty file
@@ -781,14 +781,14 @@ class TestDictToNx(H5DictTestCase):
         # Add update existing attributes and datasets
         esubtree["group2"]["@attr2"] = "attr3"
         esubtree["group2"]["dataset4"] = 9
-        assert_append("update")
+        assert_append("modify")
 
         # Do not add missing NX_class by default when updating
         wtreedict["group2"]["@NX_class"] = "NXprocess"
         esubtree["group2"]["@NX_class"] = "NXprocess"
-        assert_append("update")
+        assert_append("modify")
         del wtreedict["group2"]["@NX_class"]
-        assert_append("update")
+        assert_append("modify")
 
         # Overwrite existing groups/datasets/attributes
         esubtree["group1"].pop("a")
@@ -797,7 +797,7 @@ class TestDictToNx(H5DictTestCase):
         esubtree["group2"]["dataset4"] = 9
         del esubtree["group2"]["dataset4@units"]
         esubtree["group3"] = {"@NX_class": "NXcollection"}
-        assert_append("overwrite", add_nx_class=True)
+        assert_append("replace", add_nx_class=True)
 
 
 class TestNxToDict(H5DictTestCase):


### PR DESCRIPTION
Closes #3226 

Add missing features so the Bliss Nexus writer can use `dicttonx` from `silx`.

- `dicttoh5` has a new `existing` argument to specify overwrite behavior: 
   * **add**: Existing HDF5 items are untouched. Nodes from the dict tree are added to the HDF5 tree when the existing HDF5 tree allows it.
   * **update**: Existing HDF5 items may be updated or deleted explicitly by assigning them to `None`. The dict tree will be a subtree of the HDF5 tree.
   * **overwrite**: Existing HDF5 items may be overwritten or deleted. The HDF5 tree will be exactly the dict tree, except for already existing top-level items that were not deleted explicitly by assigning them to `None`.

- A `None` value in the dict of `dicttoh5` will never create anything (previously it was creating an empty HDF5 group). When `existing == "overwrite"` or `existing == "update"` a `None` will delete the associated key from the HDF5 file if it exists.

- The `overwrite_data` argument of `dicttoh5` is deprecated.
  * `True` is approx. equivalent to `existing="update"`
  * `False` is equivalent to `existing="add"`

- `dicttonx`: by default add missing "NX_class" attributes of groups when `existing in [None, "add"]`

- `dicttoh5`/`h5todict`: accept a `Group` or `Dataset` as HDF5 root (before it was only `str` and `File`)

- `nxtodict`: now includes attributes by default (as opposed to `h5todict`). Attributes are essential for the Nexus format.

Remark: The `h5file` argument should now be called `h5root` but this would break the API (it seems some calls use `dicttoh5(treedict, h5file=...)`).