### PR TITLE
silx.gui.plot: Added `getValueData` method to PlotWidget image items

### DIFF
--- a/silx/gui/plot/actions/histogram.py
+++ b/silx/gui/plot/actions/histogram.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -192,15 +192,7 @@ class PixelIntensitiesHistoAction(PlotToolAction):
             self._cleanUp()
             return
 
-        if isinstance(item, items.ImageBase):
-            array = item.getData(copy=False)
-            if array.ndim == 3:  # RGB(A) images
-                _logger.info('Converting current image from RGB(A) to grayscale\
-                    in order to compute the intensity distribution')
-                array = (array[:, :, 0] * 0.299 +
-                         array[:, :, 1] * 0.587 +
-                         array[:, :, 2] * 0.114)
-        elif isinstance(item, items.Scatter):
+        if isinstance(item, (items.ImageBase, items.Scatter)):
             array = item.getValueData(copy=False)
         else:
             assert(False)

--- a/silx/gui/plot/items/complex.py
+++ b/silx/gui/plot/items/complex.py
@@ -184,6 +184,8 @@ class ImageComplexData(ImageBase, ColormapMixIn, ComplexMixIn):
     def setComplexMode(self, mode):
         changed = super(ImageComplexData, self).setComplexMode(mode)
         if changed:
+            self._valueDataChanged()
+
             # Backward compatibility
             self._updated(ItemChangedType.VISUALIZATION_MODE)
 

--- a/silx/gui/plot/tools/profile/rois.py
+++ b/silx/gui/plot/tools/profile/rois.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -137,11 +137,7 @@ class _ImageProfileArea(items.Shape):
         if not isinstance(item, items.ImageBase):
             raise TypeError("Unexpected class %s" % type(item))
 
-        if isinstance(item, items.ImageRgba):
-            rgba = item.getData(copy=False)
-            currentData = rgba[..., 0]
-        else:
-            currentData = item.getData(copy=False)
+        currentData = item.getValueData(copy=False)
 
         roi = self.getParentRoi()
         origin = item.getOrigin()
@@ -310,15 +306,7 @@ class _DefaultImageProfileRoiMixIn(core.ProfileRoiMixIn):
                 method=method)
             return coords, profile, profileName, xLabel
 
-        if isinstance(item, items.ImageRgba):
-            rgba = item.getData(copy=False)
-            is_uint8 = rgba.dtype.type == numpy.uint8
-            # luminosity
-            if is_uint8:
-                rgba = rgba.astype(numpy.float64)
-            currentData = 0.21 * rgba[..., 0] + 0.72 * rgba[..., 1] + 0.07 * rgba[..., 2]
-        else:
-            currentData = item.getData(copy=False)
+        currentData = item.getValueData(copy=False)
 
         yLabel = "%s" % str(method).capitalize()
         coords, profile, title, xLabel = createProfile2(currentData)
@@ -427,7 +415,7 @@ class ProfileImageDirectedLineROI(roi_items.LineROI,
         scale = item.getScale()
         method = self.getProfileMethod()
         lineWidth = self.getProfileLineWidth()
-        currentData = item.getData(copy=False)
+        currentData = item.getValueData(copy=False)
 
         roiInfo = self._getRoiInfo()
         roiStart, roiEnd, _lineProjectionMode = roiInfo


### PR DESCRIPTION
This PR adds a `getValueData` method to all image items.
This method returns a 2D array of float (or int). It allows to simplify code requiring 2D data by avoiding handling RGBA to intensity conversion at multiple places.
It also paves the way to mask associated to an image, since it allows to return the masked array (with NaNs where masked) rather than having to do this at multiple places.


This PR is extracted from PR #3369 in order to split the changes in smaller chunks.
