### PR TITLE
silx.gui.utils.glutils: Enhanced `isOpenGLAvailable` function: avoid blinking icon in the app bar on linux

### DIFF
--- a/silx/gui/utils/glutils/__init__.py
+++ b/silx/gui/utils/glutils/__init__.py
@@ -183,7 +183,7 @@ if __name__ == "__main__":
 
     app = qt.QApplication([])
     window = qt.QMainWindow(flags=
-        qt.Qt.Window |
+        qt.Qt.Popup |
         qt.Qt.FramelessWindowHint |
         qt.Qt.NoDropShadowWindowHint |
         qt.Qt.WindowStaysOnTopHint)


### PR DESCRIPTION
Changing the WindowFlags allows to avoid the blinking icon in the app bar at least on debian10.
It does not prevent it on macos.

closes #3339