### PR TITLE
Returns the records together with the logging exception

### DIFF
--- a/silx/utils/test/test_testutils.py
+++ b/silx/utils/test/test_testutils.py
@@ -84,6 +84,15 @@ class TestTestLogging(unittest.TestCase):
             logger.error("aaa")
             self.assertIsNotNone(listener)
 
+    def testErrorMessage(self):
+        logger = logging.getLogger(__name__ + "testCanBreak")
+        listener = testutils.TestLogging(logger, error=1, warning=2)
+        with self.assertRaisesRegex(RuntimeError, "aaabbb"):
+            with listener:
+                logger.error("aaa")
+                logger.warning("aaabbb")
+                logger.error("aaa")
+
 
 def suite():
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase

--- a/silx/utils/testutils.py
+++ b/silx/utils/testutils.py
@@ -102,6 +102,17 @@ def parameterize(test_case_class, *args, **kwargs):
     return suite
 
 
+class LoggingRuntimeError(RuntimeError):
+    """Raised when the `TestLogging` fails"""
+
+    def __init__(self, msg, records):
+        super(LoggingRuntimeError, self).__init__(msg)
+        self.records = records
+
+    def __str__(self):
+        return super(LoggingRuntimeError, self).__str__() + " -> " + str(self.records)
+
+
 class TestLogging(logging.Handler):
     """Context checking the number of logging messages from a specified Logger.
 
@@ -220,8 +231,8 @@ class TestLogging(logging.Handler):
                 expected_count = expected_count_by_level[level]
                 message += "%d %s (got %d)" % (expected_count, logging.getLevelName(level), count)
 
-            raise RuntimeError(
-                'Expected %s' % message)
+            raise LoggingRuntimeError(
+                'Expected %s' % message, records=list(self.records))
 
     def emit(self, record):
         """Override :meth:`logging.Handler.emit`"""


### PR DESCRIPTION
On fails `TestLogging` returns no the logging records together with the exception.

<!--
You are encouraged to write a PR title that is meaningful by itself.
It will be used to auto-generate the complete changelog.

To highlight a change in the changelog, please add a line starting with `Changelog: ` in the PR description.
It will be used to generate the changelog's summary.

E.g., Changelog: Added new wonderful feature
-->


Changelog: 
- TestLogging returns now the logging records when there is mismatch