### PR TITLE
silx.gui.plot: Enhanced `PositionInfo` information labels layout

### DIFF
--- a/silx/gui/plot/tools/PositionInfo.py
+++ b/silx/gui/plot/tools/PositionInfo.py
@@ -44,17 +44,17 @@ import numpy
 from ....utils.deprecation import deprecated
 from ... import qt
 from .. import items
+from ...widgets.ElidedLabel import ElidedLabel
 
 
 _logger = logging.getLogger(__name__)
 
 
-class _PositionInfoLabel(qt.QLabel):
+class _PositionInfoLabel(ElidedLabel):
     """QLabel with a default size larger than what is displayed."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.setText('------')
         self.setTextInteractionFlags(qt.Qt.TextSelectableByMouse)
 
     def sizeHint(self):

--- a/silx/gui/plot/tools/PositionInfo.py
+++ b/silx/gui/plot/tools/PositionInfo.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -47,6 +47,20 @@ from .. import items
 
 
 _logger = logging.getLogger(__name__)
+
+
+class _PositionInfoLabel(qt.QLabel):
+    """QLabel with a default size larger than what is displayed."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.setText('------')
+        self.setTextInteractionFlags(qt.Qt.TextSelectableByMouse)
+
+    def sizeHint(self):
+        hint = super().sizeHint()
+        width = self.fontMetrics().boundingRect('##############').width()
+        return qt.QSize(max(hint.width(), width), hint.height())
 
 
 # PositionInfo ################################################################
@@ -117,11 +131,8 @@ class PositionInfo(qt.QWidget):
         for name, func in converters:
             layout.addWidget(qt.QLabel('<b>' + name + ':</b>'))
 
-            contentWidget = qt.QLabel()
+            contentWidget = _PositionInfoLabel(self)
             contentWidget.setText('------')
-            contentWidget.setTextInteractionFlags(qt.Qt.TextSelectableByMouse)
-            contentWidget.setFixedWidth(
-                contentWidget.fontMetrics().boundingRect('##############').width())
             layout.addWidget(contentWidget)
             self._fields.append((contentWidget, name, func))
 


### PR DESCRIPTION
This PR allows `PositionInfo` field to be smaller... yet keep their default size, this makes `Plot2D` default size the same, but it can be shrinked down by removing space between the fields.

To me, it is another way to close #2997

Default and min:
![Plot2D](https://user-images.githubusercontent.com/9449698/109677153-aede5e00-7b79-11eb-8188-7a3de12cc170.png)
