### PR TITLE
silx.gui.plot: Fixed histogram picking, Enabled `PositionInfo` snapping to histogram

### DIFF
--- a/silx/gui/plot/actions/histogram.py
+++ b/silx/gui/plot/actions/histogram.py
@@ -122,6 +122,8 @@ class HistogramWidget(qt.QWidget):
         self.__plot.setDataMargins(0.1, 0.1, 0.1, 0.1)
         self.__plot.getXAxis().setLabel("Value")
         self.__plot.getYAxis().setLabel("Count")
+        posInfo = self.__plot.getPositionInfoWidget()
+        posInfo.setSnappingMode(posInfo.SNAPPING_CURVE)
 
         # Stats display
         statsWidget = qt.QWidget(self)

--- a/silx/gui/plot/tools/PositionInfo.py
+++ b/silx/gui/plot/tools/PositionInfo.py
@@ -227,7 +227,7 @@ class PositionInfo(qt.QWidget):
                 if snappingMode & self.SNAPPING_SCATTER:
                     kinds.append(items.Scatter)
                 selectedItems = [item for item in plot.getItems()
-                                 if isinstance(item, kinds) and item.isVisible()]
+                                 if isinstance(item, tuple(kinds)) and item.isVisible()]
 
             # Compute distance threshold
             if qt.BINDING in ('PyQt5', 'PySide2'):

--- a/silx/gui/plot/tools/PositionInfo.py
+++ b/silx/gui/plot/tools/PositionInfo.py
@@ -254,16 +254,12 @@ class PositionInfo(qt.QWidget):
                 if isinstance(item, items.Histogram):
                     result = item.pick(xPixel, yPixel)
                     if result is not None:  # Histogram picked
+                        index = result.getIndices()[0]
                         edges = item.getBinEdgesData(copy=False)
-                        value = item.getValueData(copy=False)
-
-                        # TODO fix picking bug with fill index = result.getIndices()[0]
-                        index = numpy.searchsorted(edges, (x,), side='left')[0] - 1
-                        index = numpy.clip(index, 0, len(value) - 1)
 
                         # Snap to bin center and value
                         xData = 0.5 * (edges[index] + edges[index + 1])
-                        yData = value[index]
+                        yData = item.getValueData(copy=False)[index]
 
                         # Update label style sheet
                         styleSheet = "color: rgb(0, 0, 0);"


### PR DESCRIPTION
This PR:
- Fixes histogram picking and returned indices
- Enables snapping to histogram items in the PositionInfo widget

There is still an issue with the OpenGL backend where the filled part is not taken into account for picking.
