### PR TITLE
silx.gui.plot3d: Fixed `ImageRgba` alpha channel display

### DIFF
--- a/silx/gui/plot3d/scene/primitives.py
+++ b/silx/gui/plot3d/scene/primitives.py
@@ -2042,6 +2042,9 @@ class _Image(Geometry):
 
         vec4 color = imageColor(data, vTexCoords);
         color.a *= alpha;
+        if (color.a == 0.) { /* Discard fully transparent pixels */
+            discard;
+        }
 
         vec3 normal = vec3(0.0, 0.0, 1.0);
         gl_FragColor = $lightingCall(color, vPosition, normal);

--- a/silx/gui/plot3d/scene/primitives.py
+++ b/silx/gui/plot3d/scene/primitives.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -2041,7 +2041,7 @@ class _Image(Geometry):
         $scenePreCall(vCameraPosition);
 
         vec4 color = imageColor(data, vTexCoords);
-        color.a = alpha;
+        color.a *= alpha;
 
         vec3 normal = vec3(0.0, 0.0, 1.0);
         gl_FragColor = $lightingCall(color, vPosition, normal);


### PR DESCRIPTION
This PR fixes a typo on transparency composition.

closes #3413 