### PR TITLE
silx.gui.plot.PlotWidget: Fixed rendering; Doc: Updated sample code.

### DIFF
--- a/examples/stackView.py
+++ b/examples/stackView.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -47,12 +47,18 @@ dim2_calib = (-5., 15. / 120.)
 
 # sv = StackView()
 sv = StackViewMainWindow()
-sv.setColormap("jet", autoscale=True)
 sv.setStack(mystack,
             calibrations=[dim0_calib, dim1_calib, dim2_calib])
 sv.setLabels(["dim0: -10 to 10 (200 samples)",
               "dim1: -10 to 5 (150 samples)",
               "dim2: -5 to 10 (120 samples)"])
+sv.setColormap("jet")
+sv.scaleColormapRangeToStack()
+
+# Enable use of mask in other tools: colormap autoscale, histogram, profile
+maskToolsWidget = sv.getPlotWidget().getMaskToolsDockWidget().widget()
+maskToolsWidget.setItemMaskUpdated(True)
+
 sv.show()
 
 app.exec_()

--- a/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -288,11 +288,17 @@ class _TextWithOffset(Text):
             yoffset = 0
 
         trans = self.get_transform()
-        invtrans = self.get_transform().inverted()
-
         x = super(_TextWithOffset, self).convert_xunits(self._x)
         y = super(_TextWithOffset, self).convert_xunits(self._y)
         pos = x, y
+
+        try:
+            invtrans = trans.inverted()
+        except numpy.linalg.LinAlgError:
+            # Cannot inverse transform, fallback: pos without offset
+            self.__cache = None
+            return pos
+
         proj = trans.transform_point(pos)
         proj = proj + numpy.array((xoffset, yoffset))
         pos = invtrans.transform_point(proj)


### PR DESCRIPTION
This PR does 2 things:
- Enables usage of image mask in tools (histogram, colormap autscale and profiles) in `examples/stackView.py`.
- Fixes a bug in text rendering in the matplotlib backend when the widget as a width of 0.

To reproduce the bug, use the `examples/stackView.py` from this PR, create a horizontal profile and then open the mask tools.
This leads to:
```
Traceback (most recent call last):
  File "silx/gui/plot/backends/BackendBase.py", line 343, in postRedisplay
    plot.replot()
  File "silx/gui/plot/PlotWidget.py", line 3137, in replot
    self._backend.replot()
  File "silx/gui/plot/backends/BackendMatplotlib.py", line 1517, in replot
    self.draw()
  File "silx/gui/plot/backends/BackendMatplotlib.py", line 1501, in draw
    self._drawOverlays()
  File "silx/gui/plot/backends/BackendMatplotlib.py", line 1014, in _drawOverlays
    axes.draw_artist(item._backendRenderer)
  File "matplotlib/axes/_base.py", line 2762, in draw_artist
    a.draw(self.figure._cachedRenderer)
  File "silx/gui/plot/backends/BackendMatplotlib.py", line 339, in draw
    self.text.draw(*args, **kwargs)
  File "silx/gui/plot/backends/BackendMatplotlib.py", line 268, in draw
    return Text.draw(self, renderer)
  File "matplotlib/artist.py", line 41, in draw_wrapper
    return draw(artist, renderer, *args, **kwargs)
  File "matplotlib/text.py", line 681, in draw
    bbox, info, descent = textobj._get_layout(renderer)
  File "matplotlib/text.py", line 274, in _get_layout
    key = self.get_prop_tup(renderer=renderer)
  File "matplotlib/text.py", line 842, in get_prop_tup
    x, y = self.get_unitless_position()
  File "matplotlib/text.py", line 824, in get_unitless_position
    x = float(self.convert_xunits(self._x))
  File "silx/gui/plot/backends/BackendMatplotlib.py", line 307, in convert_xunits
    return self.__get_xy()[0]
  File silx/gui/plot/backends/BackendMatplotlib.py", line 300, in __get_xy
    invtrans = trans.inverted()
  File "matplotlib/transforms.py", line 2377, in inverted
    self._b.inverted(), self._a.inverted())
  File "matplotlib/transforms.py", line 2377, in inverted
    self._b.inverted(), self._a.inverted())
  File "matplotlib/transforms.py", line 1822, in inverted
    self._inverted = Affine2D(inv(mtx), shorthand_name=shorthand_name)
  File "<__array_function__ internals>", line 6, in inv
  File "numpy/linalg/linalg.py", line 546, in inv
    ainv = _umath_linalg.inv(a, signature=signature, extobj=extobj)
  File "numpy/linalg/linalg.py", line 88, in _raise_linalgerror_singular
    raise LinAlgError("Singular matrix")
numpy.linalg.LinAlgError: Singular matrix

```
