### PR TITLE
silx.io.h5py_utils: Fixed tests in CI environment

### DIFF
--- a/silx/io/test/test_h5py_utils.py
+++ b/silx/io/test/test_h5py_utils.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -107,7 +107,7 @@ def _top_level_names_test(txtfilename, *args, **kw):
             raise RetryError
         else:
             _cause_segfault()
-    return h5py_utils.top_level_names(*args, **kw)
+    return h5py_utils._top_level_names(*args, **kw)
 
 
 top_level_names_test = h5py_utils.retry_in_subprocess()(_top_level_names_test)

--- a/silx/io/test/test_h5py_utils.py
+++ b/silx/io/test/test_h5py_utils.py
@@ -363,11 +363,11 @@ class TestH5pyUtils(unittest.TestCase):
         filename = self._new_filename()
         txtfilename = os.path.join(self.test_dir, "counter.txt")
         nsleep = 3
-        retry_period = 0.01
 
         # just to make sure the test doesn't hang
         overhead = 10
 
+        retry_period = 2.
         kw = {
             "retry_timeout": nsleep * (retry_period + overhead),
             "retry_period": retry_period,
@@ -379,8 +379,9 @@ class TestH5pyUtils(unittest.TestCase):
         names = top_level_names_test(txtfilename, filename, **kw)
         self.assertEqual(names, ["check"])
 
+        retry_period = 0.01
         kw = {
-            "retry_timeout": nsleep * (retry_period * 0.9),
+            "retry_timeout": nsleep * retry_period * 0.01,
             "retry_period": retry_period,
             "include_only": None,
             "nsleep": nsleep,


### PR DESCRIPTION
closes #3420


With this, tests looks to pass where they seldom did: https://gitlab.esrf.fr/silx/bob/silx/-/pipelines/43129
I started a second run to check if it is still fine: https://gitlab.esrf.fr/silx/bob/silx/-/pipelines/43133