### PR TITLE
[fft] Use lazy init

### DIFF
--- a/src/silx/math/fft/__init__.py
+++ b/src/silx/math/fft/__init__.py
@@ -4,5 +4,3 @@
 __authors__ = ["P. Paleo"]
 __license__ = "MIT"
 __date__ = "12/12/2018"
-
-from .fft import FFT


### PR DESCRIPTION
This PR makes the `__init__`  of `silx.math.fft` lazy, in the sense that it does not import the files within.

The rationale is to avoid creating OpenCL contexts all over the place when importing modules not using it (like`silx.math.fft.fftw.FFTW`):
  -  `silx.math.fft.fft` does import the OpenCL stuff, as `fft.fft` is used to dispatch to the correct FFT class
  -  `silx.math.fft.fftw` should only import the relevant modules (pyfftw) and not create any OpenCL context.

Changelog: math.fft now does a lazy init
