### PR TITLE
[DOC] Correct documentation concerning the interpretation attribute.

### DIFF
--- a/doc/source/Tutorials/writing_NXdata.rst
+++ b/doc/source/Tutorials/writing_NXdata.rst
@@ -154,8 +154,7 @@ a *frame number*.
 
 .. note::
 
-   This additional attribute is not mentionned in the official NXdata
-   specification.
+   This attribute is documented in the official NeXus `description <https://manual.nexusformat.org/nxdl_desc.html>`_
 
 
 Writing NXdata with h5py


### PR DESCRIPTION
The interpretation attribute is duly documented by NeXus. It never was a silx thing.