### PR TITLE
silx.gui.plot.PlotWidget: Enhanced control of repaint

### DIFF
--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -3128,14 +3128,22 @@ class PlotWidget(qt.QMainWindow):
         if self._autoreplot and self._getDirtyPlot():
             self._backend.postRedisplay()
 
-    def replot(self):
-        """Redraw the plot immediately."""
+    @contextmanager
+    def _paintContext(self):
+        """This context MUST surround backend rendering.
+
+        It is in charge of performing required PlotWidget operations
+        """
         for item in self._contentToUpdate:
             item._update(self._backend)
 
         self._contentToUpdate = []
-        self._backend.replot()
+        yield
         self._dirty = False  # reset dirty flag
+
+    def replot(self):
+        """Request to draw the plot."""
+        self._backend.replot()
 
     def _forceResetZoom(self, dataMargins=None):
         """Reset the plot limits to the bounds of the data and redraw the plot.

--- a/src/silx/gui/plot/backends/BackendBase.py
+++ b/src/silx/gui/plot/backends/BackendBase.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -328,23 +328,13 @@ class BackendBase(object):
         return None
 
     def postRedisplay(self):
-        """Trigger a :meth:`Plot.replot`.
-
-        Default implementation triggers a synchronous replot if plot is dirty.
-        This method should be overridden by the embedding widget in order to
-        provide an asynchronous call to replot in order to optimize the number
-        replot operations.
-        """
-        # This method can be deferred and it might happen that plot has been
-        # destroyed in between, especially with unittests
-
-        plot = self._plotRef()
-        if plot is not None and plot._getDirtyPlot():
-            plot.replot()
+        """Trigger backend update and repaint."""
+        self.replot()
 
     def replot(self):
         """Redraw the plot."""
-        pass
+        with self._plot._paintContext():
+            pass
 
     def saveGraph(self, fileName, fileFormat, dpi):
         """Save the graph to a file (or a StringIO)

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1362,7 +1362,9 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
     def __deferredReplot(self):
         # Since this is deferred, makes sure it is still needed
         plot = self._plotRef()
-        if plot is not None and plot._getDirtyPlot():
+        if (plot is not None and
+                plot._getDirtyPlot() and
+                plot.getBackend() is self):
             self.replot()
 
     def _getDevicePixelRatio(self) -> float:


### PR DESCRIPTION
This PR reworks the management of PlotWidget backend updates.
Behavior of the matplotlib backend should be the same, but the OpenGL backend now has one indirection less and this should avoids issues such as #3443


closes #3443