### PR TITLE
silx.gui.plot.PlotWidget: Fixed update of `Scatter` item binned statistics visualization

### DIFF
--- a/src/silx/gui/plot/items/scatter.py
+++ b/src/silx/gui/plot/items/scatter.py
@@ -954,7 +954,6 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
         self.__cacheHistogramInfo = None
 
         self._value = value
-        self._updateColormappedData()
 
         if alpha is not None:
             # Make sure alpha is an array of float in [0, 1]
@@ -971,3 +970,5 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
 
         # call self._updated + plot._invalidateDataRange()
         PointsBase.setData(self, x, y, xerror, yerror, copy)
+
+        self._updateColormappedData()

--- a/src/silx/gui/plot/test/testItem.py
+++ b/src/silx/gui/plot/test/testItem.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -205,8 +205,8 @@ class TestSigItemChangedSignal(PlotWidgetTestCase):
 
         self.assertEqual(listener.arguments(),
                          [(ItemChangedType.COLORMAP,),
-                          (ItemChangedType.COLORMAP,),
                           (ItemChangedType.DATA,),
+                          (ItemChangedType.COLORMAP,),
                           (ItemChangedType.VISUALIZATION_MODE,)])
 
     def testShapeChanged(self):

--- a/src/silx/gui/plot/test/testPlotWidget.py
+++ b/src/silx/gui/plot/test/testPlotWidget.py
@@ -712,7 +712,12 @@ class TestPlotScatter(PlotWidgetTestCase, ParametricTestCase):
 
         self.qapp.processEvents()
 
+        scatter.setData(*numpy.random.random(300).reshape(3, -1))
+        self.qapp.processEvents()
+
+        # Update data
         scatter.setData(*numpy.random.random(3000).reshape(3, -1))
+        self.qapp.processEvents()
 
         for reduction in ('count', 'sum', 'mean'):
             with self.subTest(reduction=reduction):


### PR DESCRIPTION
This PR fixes an issue when updating the data of a scatter plot while in `BINNED_STATISTIC` visualization mode.

closes  #3450