### PR TITLE
silx.gui.plot.PlotWidget: Fixed OpenGL backend memory leak

### DIFF
--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -990,7 +990,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                                item.getYAxis() == 'right')
                 self._plotFrame.isY2Axis = next(y2AxisItems, None) is not None
 
-            self._glGarbageCollector.append(item)
+            if item.isInitialized():
+                self._glGarbageCollector.append(item)
 
         elif isinstance(item, (_MarkerItem, _ShapeItem)):
             pass  # No-op

--- a/src/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -235,11 +235,14 @@ class _Fill2D(object):
 
     def discard(self):
         """Release VBOs"""
-        if self._xFillVboData is not None:
+        if self.isInitialized():
             self._xFillVboData.vbo.discard()
 
         self._xFillVboData = None
         self._yFillVboData = None
+
+    def isInitialized(self):
+        return self._xFillVboData is not None
 
 
 # line ########################################################################
@@ -1061,12 +1064,15 @@ class _ErrorBars(object):
 
     def discard(self):
         """Release VBOs"""
-        if self._attribs is not None:
+        if self.isInitialized():
             self._lines.xVboData, self._lines.yVboData = None, None
             self._xErrPoints.xVboData, self._xErrPoints.yVboData = None, None
             self._yErrPoints.xVboData, self._yErrPoints.yVboData = None, None
             self._attribs[0].vbo.discard()
             self._attribs = None
+
+    def isInitialized(self):
+        return self._attribs is not None
 
 
 # curves ######################################################################
@@ -1271,6 +1277,11 @@ class GLPlotCurve2D(GLPlotItem):
         self._errorBars.discard()
         if self.fill is not None:
             self.fill.discard()
+
+    def isInitialized(self):
+        return (self.xVboData is not None or
+                self._errorBars.isInitialized() or
+                (self.fill is not None and self.fill.isInitialized()))
 
     def pick(self, xPickMin, yPickMin, xPickMax, yPickMax):
         """Perform picking on the curve according to its rendering.

--- a/src/silx/gui/plot/backends/glutils/GLPlotImage.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotImage.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -285,6 +285,10 @@ class GLPlotColormap(_GLPlotData2D):
             self._texture.discard()
             self._texture = None
         self._textureIsDirty = False
+
+    def isInitialized(self):
+        return (self._cmap_texture is not None or
+                self._texture is not None)
 
     @property
     def cmapRange(self):
@@ -622,10 +626,13 @@ class GLPlotRGBAImage(_GLPlotData2D):
         return self._alpha
 
     def discard(self):
-        if self._texture is not None:
+        if self.isInitialized():
             self._texture.discard()
             self._texture = None
         self._textureIsDirty = False
+
+    def isInitialized(self):
+        return self._texture is not None
 
     def updateData(self, data):
         assert data.dtype in self._SUPPORTED_DTYPES

--- a/src/silx/gui/plot/backends/glutils/GLPlotItem.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotItem.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2020 European Synchrotron Radiation Facility
+# Copyright (c) 2020-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -92,3 +92,8 @@ class GLPlotItem:
     def discard(self):
         """Discards OpenGL resources this item has created."""
         pass
+
+    def isInitialized(self) -> bool:
+        """Returns True if resources where initialized and requires `discard`.
+        """
+        return True

--- a/src/silx/gui/plot/backends/glutils/GLPlotTriangles.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotTriangles.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2019-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2019-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -144,11 +144,14 @@ class GLPlotTriangles(GLPlotItem):
 
     def discard(self):
         """Release resources on the GPU"""
-        if self.__vbos is not None:
+        if self.isInitialized():
             self.__vbos[0].vbo.discard()
             self.__vbos = None
             self.__indicesVbo.discard()
             self.__indicesVbo = None
+
+    def isInitialized(self):
+        return self.__vbos is not None
 
     def prepare(self):
         """Allocate resources on the GPU"""


### PR DESCRIPTION
This PR ports changes made in `0.14` and `0.15` regarding a memory leak in the `PlotWidget` OpenGL backend under specific circumstances. 
While PR #3449 also fixes this issue in a completely different way, the change made here will not hurt: "ceinture et bretelles".

closes #3443
