### PR TITLE
silx.gui.plot.ImageView: Fixed issue with profile window size

### DIFF
--- a/src/silx/gui/plot/tools/profile/manager.py
+++ b/src/silx/gui/plot/tools/profile/manager.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -775,7 +775,8 @@ class ProfileManager(qt.QObject):
         window = self._disconnectProfileWindow(profileRoi)
         if window is not None:
             geometry = window.geometry()
-            self._previousWindowGeometry.append(geometry)
+            if not geometry.isEmpty():
+                self._previousWindowGeometry.append(geometry)
             self.clearProfileWindow(window)
         if profileRoi in self._rois:
             self._rois.remove(profileRoi)


### PR DESCRIPTION
This PR fixes an issue with `ImageView` profile window display.

To reproduce the issue: python bootstrap.py examples/imageview.py
Draw a horizontal line profile on the image and then draw a free line profile.

related to  #3454
