### PR TITLE
silx.gui.plot.ImageView: Fixed profile window, added `setProfileWindowBehavior` method

### DIFF
--- a/src/silx/gui/plot/ImageView.py
+++ b/src/silx/gui/plot/ImageView.py
@@ -420,8 +420,8 @@ class ImageView(PlotWindow):
 
         self._initWidgets(backend)
 
-        self.__profile = None
-        self.setProfileWindowBehavior(self.ProfileWindowBehavior.POPUP)
+        self.__profile = ProfileToolBar(plot=self)
+        self.addToolBar(self.__profile)
 
     def _initWidgets(self, backend):
         """Set-up layout and plots."""
@@ -846,7 +846,7 @@ class ImageViewMainWindow(ImageView):
         menu.addAction(actions.control.YAxisInvertedAction(self, self))
 
         self.__profileMenu = self.menuBar().addMenu('Profile')
-        self.__profileMenu.__updateProfileMenu()
+        self.__updateProfileMenu()
 
         # Connect to ImageView's signal
         self.valueChanged.connect(self._statusBarSlot)

--- a/src/silx/gui/plot/ImageView.py
+++ b/src/silx/gui/plot/ImageView.py
@@ -571,10 +571,10 @@ class ImageView(PlotWindow):
                 horizontalProfileWindow = None
                 verticalProfileWindow = None
 
-            self.__profile.getProfileManager().setSpecializedProfileWindow(
+            manager.setSpecializedProfileWindow(
                 rois.ProfileImageHorizontalLineROI, horizontalProfileWindow
             )
-            self.__profile.getProfileManager().setSpecializedProfileWindow(
+            manager.setSpecializedProfileWindow(
                 rois.ProfileImageVerticalLineROI, verticalProfileWindow
             )
             self.__profileWindowBehavior = behavior

--- a/src/silx/gui/plot/ImageView.py
+++ b/src/silx/gui/plot/ImageView.py
@@ -420,8 +420,8 @@ class ImageView(PlotWindow):
 
         self._initWidgets(backend)
 
-        self.__profile = ProfileToolBar(plot=self)
-        self.addToolBar(self.__profile)
+        self.__profile = None
+        self.setProfileWindowBehavior('popup')
 
     def _initWidgets(self, backend):
         """Set-up layout and plots."""
@@ -818,6 +818,7 @@ class ImageViewMainWindow(ImageView):
     """
     def __init__(self, parent=None, backend=None):
         self._dataInfo = None
+        self.__profileMenu = None
         super(ImageViewMainWindow, self).__init__(parent, backend)
         self.setWindowFlags(qt.Qt.Window)
 
@@ -853,6 +854,9 @@ class ImageViewMainWindow(ImageView):
 
     def __updateProfileMenu(self):
         """Update actions available in 'Profile' menu"""
+        if self.__profileMenu is None:
+            return  # Skip during ImageView.__init__
+
         profile = self.getProfileToolBar()
         self.__profileMenu.clear()
         self.__profileMenu.addAction(profile.hLineAction)

--- a/src/silx/gui/plot/ImageView.py
+++ b/src/silx/gui/plot/ImageView.py
@@ -61,6 +61,7 @@ from ..colors import cursorColorForColormap
 from .tools import LimitsToolBar
 from .Profile import ProfileToolBar
 from ...utils.proxy import docstring
+from ...utils.deprecation import deprecated
 from ...utils.enum import Enum
 from .tools.RadarView import RadarView
 from .utils.axis import SyncAxes
@@ -633,8 +634,9 @@ class ImageView(PlotWindow):
         return weakref.proxy(self.__profile)
 
     @property
+    @deprecated(replacement="getProfileToolBar()")
     def profile(self):
-        return self.__profile
+        return self.getProfileToolBar()
 
     def getHistogram(self, axis):
         """Return the histogram and corresponding row or column extent.

--- a/src/silx/gui/plot/test/testImageView.py
+++ b/src/silx/gui/plot/test/testImageView.py
@@ -35,7 +35,7 @@ import numpy
 from silx.gui import qt
 from silx.gui.utils.testutils import TestCaseQt
 
-from silx.gui.plot.ImageView import ImageView, ProfileWindowBehavior
+from silx.gui.plot.ImageView import ImageView
 from silx.gui.colors import Colormap
 
 
@@ -128,24 +128,24 @@ class TestImageView(TestCaseQt):
         """Test change of profile window display behavior"""
         self.assertIs(
             self.plot.getProfileWindowBehavior(),
-            ProfileWindowBehavior.POPUP,
+            ImageView.ProfileWindowBehavior.POPUP,
         )
 
         self.plot.setProfileWindowBehavior('embedded')
         self.assertIs(
             self.plot.getProfileWindowBehavior(),
-            ProfileWindowBehavior.EMBEDDED,
+            ImageView.ProfileWindowBehavior.EMBEDDED,
         )
 
         image = numpy.arange(100).reshape(10, 10)
         self.plot.setImage(image)
 
         self.plot.setProfileWindowBehavior(
-            ProfileWindowBehavior.POPUP
+            ImageView.ProfileWindowBehavior.POPUP
         )
         self.assertIs(
             self.plot.getProfileWindowBehavior(),
-            ProfileWindowBehavior.POPUP,
+            ImageView.ProfileWindowBehavior.POPUP,
         )
 
 

--- a/src/silx/gui/plot/test/testImageView.py
+++ b/src/silx/gui/plot/test/testImageView.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +35,7 @@ import numpy
 from silx.gui import qt
 from silx.gui.utils.testutils import TestCaseQt
 
-from silx.gui.plot import ImageView
+from silx.gui.plot.ImageView import ImageView, ProfileWindowBehavior
 from silx.gui.colors import Colormap
 
 
@@ -128,24 +128,24 @@ class TestImageView(TestCaseQt):
         """Test change of profile window display behavior"""
         self.assertIs(
             self.plot.getProfileWindowBehavior(),
-            ImageView.ProfileWindowBehavior.POPUP,
+            ProfileWindowBehavior.POPUP,
         )
 
         self.plot.setProfileWindowBehavior('embedded')
         self.assertIs(
             self.plot.getProfileWindowBehavior(),
-            ImageView.ProfileWindowBehavior.EMBEDDED,
+            ProfileWindowBehavior.EMBEDDED,
         )
 
         image = numpy.arange(100).reshape(10, 10)
         self.plot.setImage(image)
 
         self.plot.setProfileWindowBehavior(
-            ImageView.ProfileWindowBehavior.POPUP
+            ProfileWindowBehavior.POPUP
         )
         self.assertIs(
             self.plot.getProfileWindowBehavior(),
-            ImageView.ProfileWindowBehavior.POPUP,
+            ProfileWindowBehavior.POPUP,
         )
 
 

--- a/src/silx/gui/plot/test/testImageView.py
+++ b/src/silx/gui/plot/test/testImageView.py
@@ -124,6 +124,30 @@ class TestImageView(TestCaseQt):
         self.plot.setColormap(cmap)
         self.assertIs(self.plot.getColormap(), cmap)
 
+    def testSetProfileWindowBehavior(self):
+        """Test change of profile window display behavior"""
+        self.assertIs(
+            self.plot.getProfileWindowBehavior(),
+            ImageView.ProfileWindowBehavior.POPUP,
+        )
+
+        self.plot.setProfileWindowBehavior('embedded')
+        self.assertIs(
+            self.plot.getProfileWindowBehavior(),
+            ImageView.ProfileWindowBehavior.EMBEDDED,
+        )
+
+        image = numpy.arange(100).reshape(10, 10)
+        self.plot.setImage(image)
+
+        self.plot.setProfileWindowBehavior(
+            ImageView.ProfileWindowBehavior.POPUP
+        )
+        self.assertIs(
+            self.plot.getProfileWindowBehavior(),
+            ImageView.ProfileWindowBehavior.POPUP,
+        )
+
 
 def suite():
     test_suite = unittest.TestSuite()


### PR DESCRIPTION
This PR:
- restores previous behavior for displaying profile windows (i.e., pop-up)
- adds `ImageView.get|setProfileWindowBehavior` method to change it to embed horizontal, vertical and cross profiles on the side widgets.
- adds `ImageView.getProfileToolBar` and deprecates `ImageView.profile` attribute.

closes  #3454
