### PR TITLE
`silx.io.dictdump` extract update modes list to a constant global variable

### DIFF
--- a/src/silx/io/dictdump.py
+++ b/src/silx/io/dictdump.py
@@ -58,7 +58,6 @@ vlen_bytes = h5py.special_dtype(vlen=bytes)
 UPDATE_MODE_VALID_EXISTING_VALUES = ("add", "replace", "modify")
 
 
-
 def _prepare_hdf5_write_value(array_like):
     """Cast a python object into a numpy array in a HDF5 friendly format.
 


### PR DESCRIPTION
This allows users to properly create scripts on top of `silx` without needing to manually copy those constants.