### PR TITLE
Misc: Disable OpenCL continuous integration tests on macos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,19 @@ jobs:
             python-version: 3.6
             BUILD_COMMAND: sdist
             QT_BINDING: PyQt5
+            RUN_TESTS_OPTIONS: --qt-binding=PyQt5
           - name-suffix: "PySide2 wheel"
             os: macos-latest
             python-version: 3.8
             BUILD_COMMAND: bdist_wheel
             QT_BINDING: PySide2
+            RUN_TESTS_OPTIONS: --qt-binding=PySide2 --no-opencl
           - name-suffix: "No GUI wheel"
             os: windows-latest
             python-version: 3.9
             BUILD_COMMAND: bdist_wheel
             QT_BINDING:
+            RUN_TESTS_OPTIONS: --no-gui
             # No GUI tests on Windows
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -115,9 +118,5 @@ jobs:
               Xorg -noreset +extension GLX +extension RANDR +extension RENDER -logfile ./99.log -config ./ci/travis-xorg.conf :99 &
               sleep 3
           fi
-          echo "QT_BINDING="${{ matrix.QT_BINDING }}
-          if [ -n "${{ matrix.QT_BINDING }}" ]; then
-            python run_tests.py --installed -v --qt-binding=${{ matrix.QT_BINDING }};
-          else
-            python run_tests.py --installed -v --no-gui;
-          fi
+          echo "RUN_TESTS_OPTIONS="${{ matrix.RUN_TESTS_OPTIONS }}
+          python run_tests.py --installed -v ${{ matrix.RUN_TESTS_OPTIONS }}


### PR DESCRIPTION
Makes CI tests pass on macos until #3456 is eventually fixed
