### PR TITLE
Backport of fix 'DataUrl.is_absolute' 

### DIFF
--- a/silx/io/url.py
+++ b/silx/io/url.py
@@ -344,6 +344,8 @@ class DataUrl(object):
         :rtype: bool
         """
         file_path = self.file_path()
+        if file_path is None:
+            return False
         if len(file_path) > 0:
             if file_path[0] == "/":
                 return True


### PR DESCRIPTION
backport of https://github.com/silx-kit/silx/pull/3437/commits/9bfc2f52d309647a3f9742b44ebc5b55a8686d90 on 0.15


