### PR TITLE
silx.gui: Added Pyside6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - name-suffix: "PyQt5 sdist"
+          - name-suffix: "PySide2 sdist"
             os: ubuntu-20.04
             python-version: 3.6
             BUILD_COMMAND: sdist
-            QT_BINDING: PyQt5
-            RUN_TESTS_OPTIONS: --qt-binding=PyQt5 --no-opengl
-          - name-suffix: "PySide2 wheel"
+            QT_BINDING: PySide2
+            RUN_TESTS_OPTIONS: --qt-binding=PySide2 --no-opengl
+          - name-suffix: "PyQt5 wheel"
             os: macos-latest
             python-version: 3.8
             BUILD_COMMAND: bdist_wheel
-            QT_BINDING: PySide2
-            RUN_TESTS_OPTIONS: --qt-binding=PySide2 --no-opencl
+            QT_BINDING: PyQt5
+            RUN_TESTS_OPTIONS: --qt-binding=PyQt5 --no-opencl
           - name-suffix: "No GUI wheel"
             os: windows-latest
             python-version: 3.9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,18 @@ jobs:
             BUILD_COMMAND: bdist_wheel
             QT_BINDING: PyQt5
             RUN_TESTS_OPTIONS: --qt-binding=PyQt5 --no-opencl
+          - name-suffix: "PySide6 wheel"
+            os: ubuntu-20.04
+            python-version: 3.7
+            BUILD_COMMAND: bdist_wheel
+            QT_BINDING: PySide6
+            RUN_TESTS_OPTIONS: --qt-binding=PySide6 --no-opengl
+          - name-suffix: "PySide6 wheel"
+            os: macos-latest
+            python-version: 3.9
+            BUILD_COMMAND: bdist_wheel
+            QT_BINDING: PySide6
+            RUN_TESTS_OPTIONS: --qt-binding=PySide6 --no-opencl
           - name-suffix: "No GUI wheel"
             os: windows-latest
             python-version: 3.9
@@ -98,6 +110,11 @@ jobs:
           if [ "${{ matrix.QT_BINDING }}" == "PySide2" ]; then
             pip install --pre pyside2;
           fi
+          if [ "${{ matrix.QT_BINDING }}" == "PySide6" ]; then
+            pip install --pre pyside6;
+            pip uninstall -y qtconsole; # No pyside6 support yet!
+          fi
+
 
       - name: Install pytest
         run: |

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -12,7 +12,7 @@ notifications:
   on_build_failure: false
   on_build_status_changed: true
 
-image: Visual Studio 2015
+image: Visual Studio 2019
 
 cache:
     - '%LOCALAPPDATA%\pip\Cache'
@@ -35,6 +35,12 @@ environment:
           QT_BINDING: "PySide2"
           WITH_GL_TEST: True
           PIP_OPTIONS: "-q"
+
+        # Python 3.7
+        - PYTHON_DIR: "C:\\Python37-x64"
+          QT_BINDING: "PySide6"
+          WITH_GL_TEST: True
+          PIP_OPTIONS: "-q --pre"
 
 branches:
     only:
@@ -87,6 +93,8 @@ before_test:
 
     # Install selected Qt binding
     - "pip install %PIP_OPTIONS% %QT_BINDING%"
+    # qtconsole does not support PySide6 yet
+    - IF %QT_BINDING%=="PySide6" pip uninstall -y qtconsole
 
     # Install pytest
     - "pip install %PIP_OPTIONS% pytest"

--- a/ci/info_platform.py
+++ b/ci/info_platform.py
@@ -78,5 +78,12 @@ try:
 except ImportError:
     pass
 
+try:
+    import PySide6.QtCore
+    have_qt_binding = True
+    print("Qt (from PySide6): %s" % PySide6.QtCore.qVersion())
+except ImportError:
+    pass
+
 if not have_qt_binding:
     print("No Qt binding")

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -7,15 +7,15 @@ programming language.
 
 This table summarizes the support matrix of silx:
 
-+------------+--------------+---------------------+
-| System     | Python vers. | Qt and its bindings |
-+------------+--------------+---------------------+
-| `Windows`_ | 3.6-3.9      | PyQt5.6+, PySide2   |
-+------------+--------------+---------------------+
-| `MacOS`_   | 3.6-3.9      | PyQt5.6+, PySide2   |
-+------------+--------------+---------------------+
-| `Linux`_   | 3.6-3.9      | PyQt5.3+, PySide2   |
-+------------+--------------+---------------------+
++------------+--------------+----------------------------+
+| System     | Python vers. | Qt and its bindings        |
++------------+--------------+----------------------------+
+| `Windows`_ | 3.6-3.9      | PyQt5.6+, PySide2, PySide6 |
++------------+--------------+----------------------------+
+| `MacOS`_   | 3.6-3.9      | PyQt5.6+, PySide2, PySide6 |
++------------+--------------+----------------------------+
+| `Linux`_   | 3.6-3.9      | PyQt5.3+, PySide2, PySide6 |
++------------+--------------+----------------------------+
 
 For the description of *silx* dependencies, see the Dependencies_ section.
 
@@ -66,7 +66,8 @@ The mandatory dependencies are:
 The GUI widgets depend on the following extra packages:
 
 * A Qt binding: either `PyQt5 <https://riverbankcomputing.com/software/pyqt/intro>`_,
-  or `PySide2 <https://wiki.qt.io/Qt_for_Python>`_
+  `PySide2 <https://pypi.org/project/PySide2/>`_, or
+  `PySide6 <https://pypi.org/project/PySide6/>`_
 * `matplotlib <http://matplotlib.org/>`_
 * `PyOpenGL <http://pyopengl.sourceforge.net/>`_
 * `qt_console <https://pypi.org/project/qtconsole>`_

--- a/doc/source/modules/gui/plot/getting_started.rst
+++ b/doc/source/modules/gui/plot/getting_started.rst
@@ -20,7 +20,7 @@ For a complete description of the API, see :mod:`silx.gui.plot`.
 Use :mod:`silx.gui.plot` from (I)Python console
 -----------------------------------------------
 
-We recommend to use (I)Python >=3.5 and PyQt5.
+We recommend to use (I)Python >=3.6 and PyQt5.
 
 From a Python or IPython interpreter, the simplest way is to import the :mod:`silx.sx` module:
 
@@ -89,7 +89,7 @@ A Qt GUI script must have a QApplication initialised before creating widgets:
        [...]
        qapp.exec()
 
-Unless a Qt binding has already been loaded, :mod:`silx.gui.qt` uses one of the supported Qt bindings (PyQt5, PySide2).
+Unless a Qt binding has already been loaded, :mod:`silx.gui.qt` uses one of the supported Qt bindings (PyQt5, PySide2, PySide6).
 If you prefer to choose the Qt binding yourself, import it before importing
 a module from :mod:`silx.gui`:
 

--- a/doc/source/virtualenv.rst
+++ b/doc/source/virtualenv.rst
@@ -132,7 +132,7 @@ To test *silx*, open an interactive python console:
 
     python
 
-If you don't have PyQt5 or PySide2, run:
+If you don't have PyQt5, PySide2 or PySide6, run:
 
 .. code-block:: bash
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 --trusted-host www.silx.org
 --find-links http://www.silx.org/pub/wheelhouse/
---only-binary numpy,h5py,scipy,PySide2,PyQt5
+--only-binary numpy,h5py,scipy,PySide2,PyQt5,PySide6
 
 # Required dependencies (from setup.py setup_requires and install_requires)
 numpy >= 1.12
@@ -21,4 +21,4 @@ PyOpenGL                  # For silx.gui.plot3d
 python-dateutil           # For silx.gui.plot
 scipy                     # For silx.math.fit demo, silx.image.sift demo, silx.image.sift.test
 Pillow                    # For silx.opencl.image.test
-PyQt5  # or PySide2       # For silx.gui
+PyQt5  # PySide2, PySide6 # For silx.gui

--- a/run_tests.py
+++ b/run_tests.py
@@ -169,11 +169,11 @@ if __name__ == "__main__":  # Needed for multiprocessing support on Windows
     PROJECT_PATH = project_module.__path__[0]
 
     def normalize_option(option):
-        if option == "src/silx":
+        option_parts = option.split(os.path.sep)
+        if option_parts == ["src", "silx"]:
             return PROJECT_PATH
-        if option.startswith("src/silx/"):
-            path = option[9:]
-            return os.path.join(PROJECT_PATH, path)
+        if option_parts[:2] == ["src", "silx"]:
+            return os.path.join(PROJECT_PATH, *option_parts[2:])
         return option
 
     args = [normalize_option(p) for p in sys.argv[1:] if p != "--installed"]

--- a/src/silx/app/view/About.py
+++ b/src/silx/app/view/About.py
@@ -232,7 +232,10 @@ class About(qt.QDialog):
 
     def __updateSize(self):
         """Force the size to a QMessageBox like size."""
-        screenSize = qt.QApplication.desktop().availableGeometry(qt.QCursor.pos()).size()
+        if qt.BINDING in ("PySide2", "PyQt5"):
+            screenSize = qt.QApplication.desktop().availableGeometry(qt.QCursor.pos()).size()
+        else:  # Qt6
+            screenSize = qt.QApplication.instance().primaryScreen().availableGeometry().size()
         hardLimit = min(screenSize.width() - 480, 1000)
         if screenSize.width() <= 1024:
             hardLimit = screenSize.width()

--- a/src/silx/conftest.py
+++ b/src/silx/conftest.py
@@ -15,13 +15,16 @@ def _set_qt_binding(binding):
         elif binding == "pyside2":
             logger.info("Force using PySide2")
             import PySide2.QtCore  # noqa
+        elif binding == "pyside6":
+            logger.info("Force using PySide6")
+            import PySide6.QtCore  # noqa
         else:
             raise ValueError("Qt binding '%s' is unknown" % binding)
 
 
 def pytest_addoption(parser):
     parser.addoption("--qt-binding", type=str, default=None, dest="qt_binding",
-                     help="Force using a Qt binding: 'PyQt5', 'PySide2'")
+                     help="Force using a Qt binding: 'PyQt5', 'PySide2', 'PySide6'")
     parser.addoption("--no-gui", dest="gui", default=True,
                      action="store_false",
                      help="Disable the test of the graphical use interface")

--- a/src/silx/gui/dialog/AbstractDataFileDialog.py
+++ b/src/silx/gui/dialog/AbstractDataFileDialog.py
@@ -676,7 +676,7 @@ class AbstractDataFileDialog(qt.QDialog):
         self.__fileTypeCombo = FileTypeComboBox(self)
         self.__fileTypeCombo.setObjectName("fileTypeCombo")
         self.__fileTypeCombo.setDuplicatesEnabled(False)
-        self.__fileTypeCombo.setSizeAdjustPolicy(qt.QComboBox.AdjustToMinimumContentsLength)
+        self.__fileTypeCombo.setSizeAdjustPolicy(qt.QComboBox.AdjustToMinimumContentsLengthWithIcon)
         self.__fileTypeCombo.setSizePolicy(qt.QSizePolicy.Expanding, qt.QSizePolicy.Fixed)
         self.__fileTypeCombo.activated[int].connect(self.__filterSelected)
         self.__fileTypeCombo.setFabioUrlSupproted(self._isFabioFilesSupported())

--- a/src/silx/gui/dialog/test/test_colormapdialog.py
+++ b/src/silx/gui/dialog/test/test_colormapdialog.py
@@ -51,7 +51,7 @@ def colormap():
 
 
 @pytest.fixture
-def colormapDialog(qapp):
+def colormapDialog(qapp, qapp_utils):
     dialog = ColormapDialog.ColormapDialog()
     dialog.setAttribute(qt.Qt.WA_DeleteOnClose)
     yield weakref.proxy(dialog)

--- a/src/silx/gui/fit/FitWidget.py
+++ b/src/silx/gui/fit/FitWidget.py
@@ -208,8 +208,13 @@ class FitWidget(qt.QWidget):
                     self.fitconfig.get("WeightFlag", False))
             self.guiConfig.WeightCheckBox.stateChanged[int].connect(self.weightEvent)
 
-            self.guiConfig.BkgComBox.activated[str].connect(self.bkgEvent)
-            self.guiConfig.FunComBox.activated[str].connect(self.funEvent)
+            if qt.BINDING in ('Pyside2', 'PyQt5'):
+                self.guiConfig.BkgComBox.activated[str].connect(self.bkgEvent)
+                self.guiConfig.FunComBox.activated[str].connect(self.funEvent)
+            else:  # Qt6
+                self.guiConfig.BkgComBox.textActivated.connect(self.bkgEvent)
+                self.guiConfig.FunComBox.textActivated.connect(self.funEvent)
+
             self._populateFunctions()
 
             layout.addWidget(self.guiConfig)

--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -43,6 +43,7 @@ from silx.gui import plot
 from silx.gui import icons
 from silx.gui.colors import Colormap
 from silx.gui.plot import tools
+from silx.utils.weakref import WeakMethodProxy
 
 _logger = logging.getLogger(__name__)
 
@@ -592,7 +593,7 @@ class CompareImages(qt.QMainWindow):
                 text='',
                 draggable=True,
                 color='blue',
-                constraint=self.__separatorConstraint)
+                constraint=WeakMethodProxy(self.__separatorConstraint))
         self.__vline = self.__plot._getMarker(legend)
 
         legend = VisualizationMode.HORIZONTAL_LINE.name
@@ -602,7 +603,7 @@ class CompareImages(qt.QMainWindow):
                 text='',
                 draggable=True,
                 color='blue',
-                constraint=self.__separatorConstraint)
+                constraint=WeakMethodProxy(self.__separatorConstraint))
         self.__hline = self.__plot._getMarker(legend)
 
         # default values

--- a/src/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/src/silx/gui/plot/test/testCurvesROIWidget.py
@@ -435,6 +435,8 @@ class TestRoiWidgetSignals(TestCaseQt):
 
         widget = self.plot.getWidgetHandle()
         widget.setFocus(qt.Qt.OtherFocusReason)
+        self.plot.raise_()
+        self.qapp.processEvents()
 
         # modify roi limits (from the gui)
         roi_marker_handler = self.curves_roi_widget.roiTable._markersHandler.getMarkerHandler(roi1.getID())

--- a/src/silx/gui/plot/test/testMaskToolsWidget.py
+++ b/src/silx/gui/plot/test/testMaskToolsWidget.py
@@ -129,12 +129,14 @@ class TestMaskToolsWidget(PlotWidgetTestCase, ParametricTestCase):
                 (x + offset, y - offset)]
 
         self.mouseMove(plot, pos=(0, 0))
-        self.mouseMove(plot, pos=star[0])
-        self.mousePress(plot, qt.Qt.LeftButton, pos=star[0])
-        for pos in star[1:]:
-            self.mouseMove(plot, pos=pos)
-        self.mouseRelease(
-            plot, qt.Qt.LeftButton, pos=star[-1])
+        for start, end in zip(star[:-1], star[1:]):
+           self.mouseMove(plot, pos=start)
+           self.mousePress(plot, qt.Qt.LeftButton, pos=start)
+           self.qapp.processEvents()
+           self.mouseMove(plot, pos=end)
+           self.qapp.processEvents()
+           self.mouseRelease(plot, qt.Qt.LeftButton, pos=end)
+           self.qapp.processEvents()
 
     def _isMaskItemSync(self):
         """Check if masks from item and tools are sync or not"""

--- a/src/silx/gui/plot/tools/profile/manager.py
+++ b/src/silx/gui/plot/tools/profile/manager.py
@@ -1039,9 +1039,12 @@ class ProfileManager(qt.QObject):
 
         window = self.getPlotWidget().window()
         winGeom = window.frameGeometry()
-        qapp = qt.QApplication.instance()
-        desktop = qapp.desktop()
-        screenGeom = desktop.availableGeometry(window)
+        if qt.BINDING in ("PySide2", "PyQt5"):
+            qapp = qt.QApplication.instance()
+            desktop = qapp.desktop()
+            screenGeom = desktop.availableGeometry(window)
+        else:  # Qt6 (and also Qt>=5.14)
+            screenGeom = window.screen().availableGeometry()
         spaceOnLeftSide = winGeom.left()
         spaceOnRightSide = screenGeom.width() - winGeom.right()
 

--- a/src/silx/gui/plot3d/tools/PositionInfoWidget.py
+++ b/src/silx/gui/plot3d/tools/PositionInfoWidget.py
@@ -102,7 +102,13 @@ class PositionInfoWidget(qt.QWidget):
         widget = qt.QLabel('-')
         widget.setAlignment(qt.Qt.AlignLeft | qt.Qt.AlignVCenter)
         widget.setTextInteractionFlags(qt.Qt.TextSelectableByMouse)
-        widget.setMinimumWidth(widget.fontMetrics().width('#######'))
+
+        metrics = widget.fontMetrics()
+        if qt.BINDING in ('PySide2', 'PyQt5'):
+            width = metrics.width("#######")
+        else:  # Qt6
+            width = metrics.horizontalAdvance("#######")
+        widget.setMinimumWidth(width)
         subLayout.addWidget(widget)
 
         subLayout.addStretch(1)

--- a/src/silx/gui/qt/__init__.py
+++ b/src/silx/gui/qt/__init__.py
@@ -25,10 +25,11 @@
 """Common wrapper over Python Qt bindings:
 
 - `PyQt5 <http://pyqt.sourceforge.net/Docs/PyQt5/>`_
-- `PySide2 <https://wiki.qt.io/Qt_for_Python>`_
+- `PySide2 <https://pypi.org/project/PySide2/>`_
+- `PySide6 <https://pypi.org/project/PySide6/>`_
 
 If a Qt binding is already loaded, it will use it, otherwise the different
-Qt bindings are tried in this order: PyQt5, PySide2.
+Qt bindings are tried in this order: PyQt5, PySide2, PySide6.
 
 The name of the loaded Qt binding is stored in the BINDING variable.
 
@@ -47,4 +48,7 @@ see `qtpy <https://pypi.org/project/QtPy/>`_.
 """
 
 from ._qt import *  # noqa
+if BINDING in ('PySide2', 'PySide6'):
+    # Import loadUi wrapper
+    from ._pyside_dynamic import loadUi # noqa
 from ._utils import *  # noqa

--- a/src/silx/gui/qt/_pyside_dynamic.py
+++ b/src/silx/gui/qt/_pyside_dynamic.py
@@ -38,9 +38,18 @@
 
 import logging
 
-from PySide2.QtCore import QMetaObject, Property, Qt
-from PySide2.QtWidgets import QFrame
-from PySide2.QtUiTools import QUiLoader
+from ._qt import BINDING
+if BINDING == 'PySide2':
+    from PySide2.QtCore import QMetaObject, Property, Qt
+    from PySide2.QtWidgets import QFrame
+    from PySide2.QtUiTools import QUiLoader
+elif BINDING == 'PySide6':
+    from PySide6.QtCore import QMetaObject, Property, Qt
+    from PySide6.QtWidgets import QFrame
+    from PySide6.QtUiTools import QUiLoader
+else:
+    raise RuntimeError("Unsupported Qt binding: %s", BINDING)
+
 
 _logger = logging.getLogger(__name__)
 

--- a/src/silx/gui/qt/_qt.py
+++ b/src/silx/gui/qt/_qt.py
@@ -146,9 +146,6 @@ elif BINDING == 'PySide2':
     else:
         HAS_SVG = True
 
-    # Import loadUi wrapper for PySide2
-    from ._pyside_dynamic import loadUi  # noqa
-
     pyqtSignal = Signal
 
     # Qt6 compatibility:
@@ -204,9 +201,6 @@ elif BINDING == 'PySide6':
         HAS_SVG = False
     else:
         HAS_SVG = True
-
-    # Import loadUi wrapper for PySide6
-    from ._pyside_dynamic import loadUi  # noqa
 
     pyqtSignal = Signal
 

--- a/src/silx/gui/qt/_qt.py
+++ b/src/silx/gui/qt/_qt.py
@@ -146,34 +146,37 @@ elif BINDING == 'PySide2':
 
     pyqtSignal = Signal
 
-else:
-    raise ImportError('No Qt wrapper found. Install PyQt5, PySide2')
-
-
-if BINDING in ('PyQt5', 'PySide2'):  # Qt6 compatibility
+    # Qt6 compatibility:
+    # with PySide2 `exec` method has a special behavior
     class _ExecMixIn:
         """Mix-in class providind `exec` compatibility"""
         def exec(self, *args, **kwargs):
-            self.exec_(*args, **kwargs)
+            return super().exec_(*args, **kwargs)
 
     # QtWidgets
-    class QApplication(QApplication, _ExecMixIn): pass
-    class QColorDialog(QColorDialog, _ExecMixIn): pass
-    class QDialog(QDialog, _ExecMixIn): pass
-    class QErrorMessage(QErrorMessage, _ExecMixIn): pass
-    class QFileDialog(QFileDialog, _ExecMixIn): pass
-    class QFontDialog(QFontDialog, _ExecMixIn): pass
-    class QInputDialog(QInputDialog, _ExecMixIn): pass
-    class QMenu(QMenu, _ExecMixIn): pass
-    class QMessageBox(QMessageBox, _ExecMixIn): pass
-    class QProgressDialog(QProgressDialog, _ExecMixIn): pass
+    class QApplication(_ExecMixIn, QApplication): pass
+    class QColorDialog(_ExecMixIn, QColorDialog): pass
+    class QDialog(_ExecMixIn, QDialog): pass
+    class QErrorMessage(_ExecMixIn, QErrorMessage): pass
+    class QFileDialog(_ExecMixIn, QFileDialog): pass
+    class QFontDialog(_ExecMixIn, QFontDialog): pass
+    class QInputDialog(_ExecMixIn, QInputDialog): pass
+    class QMenu(_ExecMixIn, QMenu): pass
+    class QMessageBox(_ExecMixIn, QMessageBox): pass
+    class QProgressDialog(_ExecMixIn, QProgressDialog): pass
     #QtCore
-    class QCoreApplication(QCoreApplication, _ExecMixIn): pass
-    class QEventLoop(QEventLoop, _ExecMixIn): pass
+    class QCoreApplication(_ExecMixIn, QCoreApplication): pass
+    class QEventLoop(_ExecMixIn, QEventLoop): pass
     if hasattr(QTextStreamManipulator, "exec_"):
         # exec_ only wrapped in PySide2 and NOT in PyQt5
-        class QTextStreamManipulator(QTextStreamManipulator, _ExecMixIn): pass
-    class QThread(QThread, _ExecMixIn): pass
+        class QTextStreamManipulator(_ExecMixIn, QTextStreamManipulator): pass
+    class QThread(_ExecMixIn, QThread): pass
+
+
+
+
+else:
+    raise ImportError('No Qt wrapper found. Install PyQt5, PySide2')
 
 
 # provide a exception handler but not implement it by default

--- a/src/silx/gui/qt/inspect.py
+++ b/src/silx/gui/qt/inspect.py
@@ -66,6 +66,8 @@ elif qt.BINDING == 'PySide2':
         from shiboken2 import createdByPython  # noqa
         from shiboken2 import ownedByPython  # noqa
 
+elif qt.BINDING == 'PySide6':
+    from shiboken6 import isValid, createdByPython, ownedByPython  # noqa
 
 else:
     raise ImportError("Unsupported Qt binding %s" % qt.BINDING)

--- a/src/silx/gui/test/test_icons.py
+++ b/src/silx/gui/test/test_icons.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,6 @@ __license__ = "MIT"
 __date__ = "06/09/2017"
 
 
-import gc
 import unittest
 import weakref
 import tempfile
@@ -109,7 +108,6 @@ class TestIcons(TestCaseQt):
         icon = icons.getQIcon("crop")
         icon_ref = weakref.ref(icon)
         del icon
-        gc.collect()
         self.assertIsNone(icon_ref())
 
 

--- a/src/silx/gui/test/test_qt.py
+++ b/src/silx/gui/test/test_qt.py
@@ -186,7 +186,7 @@ class TestQtInspect(unittest.TestCase):
         self.assertFalse(qt_inspect.isValid(obj))
 
 
-@pytest.mark.skipif(qt.BINDING not in ("PyQt5", "PySide"),
+@pytest.mark.skipif(qt.BINDING not in ("PyQt5", "PySide2"),
                     reason="PyQt5/PySide2 only test")
 def test_exec_():
     """Test the exec_ is still useable with Qt5 bindings"""

--- a/src/silx/gui/utils/glutils/__init__.py
+++ b/src/silx/gui/utils/glutils/__init__.py
@@ -124,7 +124,7 @@ def isOpenGLAvailable(version=(2, 1), runtimeCheck=True):
                 if not qt.HAS_OPENGL:
                     error = '%s.QtOpenGL not available' % qt.BINDING
 
-                elif qt.QApplication.instance() and not qt.QGLFormat.hasOpenGL():
+                elif qt.BINDING in ('PySide2', 'PyQt5') and qt.QApplication.instance() and not qt.QGLFormat.hasOpenGL():
                     # qt.QGLFormat.hasOpenGL MUST be called with a QApplication created
                     # so this is only checked if the QApplication is already created
                     error = 'Qt reports OpenGL not available'

--- a/src/silx/gui/utils/image.py
+++ b/src/silx/gui/utils/image.py
@@ -118,7 +118,7 @@ def convertQImageToArray(image):
     ptr = image.bits()
     if qt.BINDING == 'PyQt5':
         ptr.setsize(image.byteCount())
-    elif qt.BINDING == 'PySide2':
+    elif qt.BINDING in ('PySide2', 'PySide6'):
         ptr = ptr.tobytes()
     else:
         raise RuntimeError("Unsupported Qt binding: %s" % qt.BINDING)

--- a/src/silx/gui/utils/matplotlib.py
+++ b/src/silx/gui/utils/matplotlib.py
@@ -57,7 +57,7 @@ def _matplotlib_use(backend, force):
     matplotlib.use(backend, force=force)
 
 
-if qt.BINDING in ('PyQt5', 'PySide2'):
+if qt.BINDING in ('PySide6', 'PyQt5', 'PySide2'):
     _matplotlib_use('Qt5Agg', force=False)
     from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg  # noqa
 

--- a/src/silx/gui/utils/testutils.py
+++ b/src/silx/gui/utils/testutils.py
@@ -150,15 +150,15 @@ class TestCaseQt(unittest.TestCase):
 
     def _checkForUnreleasedWidgets(self):
         """Test fixture checking that no more widgets exists."""
+        if qt.BINDING == 'PySide2':
+            return  # Do not test for leaking widgets with PySide2
+
         gc.collect()
 
         widgets = [widget for widget in self.qapp.allWidgets()
                    if (widget not in self.__previousWidgets and
                        _inspect.createdByPython(widget))]
         del self.__previousWidgets
-
-        if qt.BINDING == 'PySide2':
-            return  # Do not test for leaking widgets with PySide2
 
         allowedLeakingWidgets = self.allowedLeakingWidgets
         self.allowedLeakingWidgets = 0

--- a/src/silx/gui/utils/testutils.py
+++ b/src/silx/gui/utils/testutils.py
@@ -47,6 +47,8 @@ if qt.BINDING == 'PySide2':
     from PySide2.QtTest import QTest
 elif qt.BINDING == 'PyQt5':
     from PyQt5.QtTest import QTest
+elif qt.BINDING == 'PySide6':
+    from PySide6.QtTest import QTest
 else:
     raise ImportError('Unsupported Qt bindings')
 

--- a/src/silx/gui/utils/testutils.py
+++ b/src/silx/gui/utils/testutils.py
@@ -484,7 +484,12 @@ def getQToolButtonFromAction(action):
     :param QAction action: The QAction from which to get QToolButton.
     :return: A QToolButton associated to action or None.
     """
-    for widget in action.associatedWidgets():
+    if qt.BINDING == "PySide6":
+        widgets = action.associatedObjects()
+    else:
+        widgets = action.associatedWidgets()
+
+    for widget in widgets:
         if isinstance(widget, qt.QToolButton):
             return widget
     return None

--- a/src/silx/gui/utils/testutils.py
+++ b/src/silx/gui/utils/testutils.py
@@ -314,14 +314,14 @@ class TestCaseQt(unittest.TestCase):
         if ms is None:
             ms = cls.DEFAULT_TIMEOUT_WAIT
 
-        if qt.BINDING =='PySide2':
+        if qt.BINDING in ('PySide2', 'PySide6'):
             # PySide2 has no qWait, provide a replacement
             timeout = int(ms)
             endTimeMS = int(time.time() * 1000) + timeout
             qapp = qt.QApplication.instance()
             while timeout > 0:
                 qapp.processEvents(qt.QEventLoop.AllEvents,
-                                   maxtime=timeout)
+                                   timeout)
                 timeout = endTimeMS - int(time.time() * 1000)
         else:
             QTest.qWait(int(ms) + cls.TIMEOUT_WAIT)

--- a/src/silx/gui/utils/testutils.py
+++ b/src/silx/gui/utils/testutils.py
@@ -132,7 +132,7 @@ class TestCaseQt(unittest.TestCase):
     def setUp(self):
         """Get the list of existing widgets."""
         self.allowedLeakingWidgets = 0
-        if qt.BINDING == 'PySide2':
+        if qt.BINDING in ('PySide2', 'PySide6'):
             self.__previousWidgets = None
         else:
             self.__previousWidgets = self.qapp.allWidgets()

--- a/src/silx/gui/utils/testutils.py
+++ b/src/silx/gui/utils/testutils.py
@@ -178,6 +178,8 @@ class TestCaseQt(unittest.TestCase):
                 "Test ended with widgets alive: %s" % str(widgets))
 
     def tearDown(self):
+        self.qapp.processEvents()
+
         if len(self.__class__._exceptions) > 0:
             messages = "\n".join(self.__class__._exceptions)
             raise AssertionError("Exception occured in Qt thread:\n" + messages)

--- a/src/silx/gui/utils/testutils.py
+++ b/src/silx/gui/utils/testutils.py
@@ -491,7 +491,7 @@ def getQToolButtonFromAction(action):
 
 
 def findChildren(parent, kind, name=None):
-    if qt.BINDING == "PySide2" and name is not None:
+    if qt.BINDING in ("PySide2", "PySide6") and name is not None:
         result = []
         for obj in parent.findChildren(kind):
             if obj.objectName() == name:

--- a/src/silx/gui/widgets/ElidedLabel.py
+++ b/src/silx/gui/widgets/ElidedLabel.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -62,7 +62,10 @@ class ElidedLabel(qt.QLabel):
 
     def __updateMinimumSize(self):
         metrics = self.fontMetrics()
-        width = metrics.width("...")
+        if qt.BINDING in ('PySide2', 'PyQt5'):
+            width = metrics.width("...")
+        else:  # Qt6
+            width = metrics.horizontalAdvance("...")
         self.setMinimumWidth(width)
 
     def __updateText(self):

--- a/src/silx/gui/widgets/WaitingPushButton.py
+++ b/src/silx/gui/widgets/WaitingPushButton.py
@@ -106,7 +106,8 @@ class WaitingPushButton(qt.QPushButton):
 
         contentSize = qt.QSize(w, h)
         sizeHint = self.style().sizeFromContents(qt.QStyle.CT_PushButton, opt, contentSize, self)
-        sizeHint = sizeHint.expandedTo(qt.QApplication.globalStrut())
+        if qt.BINDING in ('PySide2', 'PyQt5'):  # Qt6: globalStrut not available
+            sizeHint = sizeHint.expandedTo(qt.QApplication.globalStrut())
         return sizeHint
 
     def setDisabledWhenWaiting(self, isDisabled):


### PR DESCRIPTION
This PR intend to provide support for `PySide6` in silx.

It relies on ~~PR https://github.com/matplotlib/matplotlib/pull/19255~~ matplotlib >= 3.5.0b1
and would need `qtpy`to support it (see https://github.com/spyder-ide/qtpy/pull/225) which is a dependency of `qtconsole`
Related to #3432