### PR TITLE
silx.gui: Prepare for Qt6 support

### DIFF
--- a/src/silx/app/view/Viewer.py
+++ b/src/silx/app/view/Viewer.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2020 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -601,12 +601,9 @@ class Viewer(qt.QMainWindow):
 
         # Plot backend
 
-        action = qt.QAction("Plot rendering backend", self)
-        action.setStatusTip("Select plot rendering backend")
-        self._plotBackendSelection = action
+        self._plotBackendMenu = qt.QMenu("Plot rendering backend", self)
+        self._plotBackendMenu.setStatusTip("Select plot rendering backend")
 
-        menu = qt.QMenu()
-        action.setMenu(menu)
         group = qt.QActionGroup(self)
         group.setExclusive(True)
 
@@ -615,7 +612,7 @@ class Viewer(qt.QMainWindow):
         action.setCheckable(True)
         action.triggered.connect(self.__forceMatplotlibBackend)
         group.addAction(action)
-        menu.addAction(action)
+        self._plotBackendMenu.addAction(action)
         self._usePlotWithMatplotlib = action
 
         action = qt.QAction("OpenGL", self)
@@ -623,17 +620,16 @@ class Viewer(qt.QMainWindow):
         action.setCheckable(True)
         action.triggered.connect(self.__forceOpenglBackend)
         group.addAction(action)
-        menu.addAction(action)
+        self._plotBackendMenu.addAction(action)
         self._usePlotWithOpengl = action
 
         # Plot image orientation
 
-        action = qt.QAction("Default plot image y-axis orientation", self)
-        action.setStatusTip("Select the default y-axis orientation used by plot displaying images")
-        self._plotImageOrientation = action
+        self._plotImageOrientationMenu = qt.QMenu(
+            "Default plot image y-axis orientation", self)
+        self._plotImageOrientationMenu.setStatusTip(
+            "Select the default y-axis orientation used by plot displaying images")
 
-        menu = qt.QMenu()
-        action.setMenu(menu)
         group = qt.QActionGroup(self)
         group.setExclusive(True)
 
@@ -643,7 +639,7 @@ class Viewer(qt.QMainWindow):
         action.setCheckable(True)
         action.triggered.connect(self.__forcePlotImageDownward)
         group.addAction(action)
-        menu.addAction(action)
+        self._plotImageOrientationMenu.addAction(action)
         self._useYAxisOrientationDownward = action
 
         action = qt.QAction("Upward, origin on bottom", self)
@@ -652,7 +648,7 @@ class Viewer(qt.QMainWindow):
         action.setCheckable(True)
         action.triggered.connect(self.__forcePlotImageUpward)
         group.addAction(action)
-        menu.addAction(action)
+        self._plotImageOrientationMenu.addAction(action)
         self._useYAxisOrientationUpward = action
 
         # Windows
@@ -700,9 +696,8 @@ class Viewer(qt.QMainWindow):
 
         # plot backend
 
-        action = self._plotBackendSelection
-        title = action.text().split(": ", 1)[0]
-        action.setText("%s: %s" % (title, silx.config.DEFAULT_PLOT_BACKEND))
+        title = self._plotBackendMenu.title().split(": ", 1)[0]
+        self._plotBackendMenu.setTitle("%s: %s" % (title, silx.config.DEFAULT_PLOT_BACKEND))
 
         action = self._usePlotWithMatplotlib
         action.setChecked(silx.config.DEFAULT_PLOT_BACKEND in ["matplotlib", "mpl"])
@@ -720,12 +715,11 @@ class Viewer(qt.QMainWindow):
 
         # plot orientation
 
-        action = self._plotImageOrientation
+        menu = self._plotImageOrientationMenu
         if silx.config.DEFAULT_PLOT_IMAGE_Y_AXIS_ORIENTATION == "downward":
-            action.setIcon(self._iconDownward)
+            menu.setIcon(self._iconDownward)
         else:
-            action.setIcon(self._iconUpward)
-        action.setIconVisibleInMenu(True)
+            menu.setIcon(self._iconUpward)
 
         action = self._useYAxisOrientationDownward
         action.setChecked(silx.config.DEFAULT_PLOT_IMAGE_Y_AXIS_ORIENTATION == "downward")
@@ -751,8 +745,8 @@ class Viewer(qt.QMainWindow):
         fileMenu.aboutToShow.connect(self.__updateFileMenu)
 
         optionMenu = self.menuBar().addMenu("&Options")
-        optionMenu.addAction(self._plotImageOrientation)
-        optionMenu.addAction(self._plotBackendSelection)
+        optionMenu.addMenu(self._plotImageOrientationMenu)
+        optionMenu.addMenu(self._plotBackendMenu)
         optionMenu.aboutToShow.connect(self.__updateOptionMenu)
 
         viewMenu = self.menuBar().addMenu("&Views")

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -132,8 +132,8 @@ def rgba(color, colorDict=None):
     if colorDict is None:
         colorDict = _COLORDICT
 
-    if hasattr(color, 'getRgbF'):  # QColor support
-        color = color.getRgbF()
+    if hasattr(color, 'getRgb'):  # QColor support
+        color = color.getRgb()
 
     values = numpy.asarray(color).ravel()
 

--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -98,10 +98,10 @@ class CompareImagesToolBar(qt.QToolBar):
         self.__compareWidget = None
 
         menu = qt.QMenu(self)
-        self.__visualizationAction = qt.QAction(self)
-        self.__visualizationAction.setMenu(menu)
-        self.__visualizationAction.setCheckable(False)
-        self.addAction(self.__visualizationAction)
+        self.__visualizationToolButton = qt.QToolButton(self)
+        self.__visualizationToolButton.setMenu(menu)
+        self.__visualizationToolButton.setPopupMode(qt.QToolButton.InstantPopup)
+        self.addWidget(self.__visualizationToolButton)
         self.__visualizationGroup = qt.QActionGroup(self)
         self.__visualizationGroup.setExclusive(True)
         self.__visualizationGroup.triggered.connect(self.__visualizationModeChanged)
@@ -177,10 +177,10 @@ class CompareImagesToolBar(qt.QToolBar):
         self.__visualizationGroup.addAction(action)
 
         menu = qt.QMenu(self)
-        self.__alignmentAction = qt.QAction(self)
-        self.__alignmentAction.setMenu(menu)
-        self.__alignmentAction.setIconVisibleInMenu(True)
-        self.addAction(self.__alignmentAction)
+        self.__alignmentToolButton = qt.QToolButton(self)
+        self.__alignmentToolButton.setMenu(menu)
+        self.__alignmentToolButton.setPopupMode(qt.QToolButton.InstantPopup)
+        self.addWidget(self.__alignmentToolButton)
         self.__alignmentGroup = qt.QActionGroup(self)
         self.__alignmentGroup.setExclusive(True)
         self.__alignmentGroup.triggered.connect(self.__alignmentModeChanged)
@@ -320,13 +320,13 @@ class CompareImagesToolBar(qt.QToolBar):
         """
         selectedAction = self.__visualizationGroup.checkedAction()
         if selectedAction is not None:
-            self.__visualizationAction.setText(selectedAction.text())
-            self.__visualizationAction.setIcon(selectedAction.icon())
-            self.__visualizationAction.setToolTip(selectedAction.toolTip())
+            self.__visualizationToolButton.setText(selectedAction.text())
+            self.__visualizationToolButton.setIcon(selectedAction.icon())
+            self.__visualizationToolButton.setToolTip(selectedAction.toolTip())
         else:
-            self.__visualizationAction.setText("")
-            self.__visualizationAction.setIcon(qt.QIcon())
-            self.__visualizationAction.setToolTip("")
+            self.__visualizationToolButton.setText("")
+            self.__visualizationToolButton.setIcon(qt.QIcon())
+            self.__visualizationToolButton.setToolTip("")
 
     def __alignmentModeChanged(self, selectedAction):
         """Called when user requesting changes of the alignment mode.
@@ -342,13 +342,13 @@ class CompareImagesToolBar(qt.QToolBar):
         """
         selectedAction = self.__alignmentGroup.checkedAction()
         if selectedAction is not None:
-            self.__alignmentAction.setText(selectedAction.text())
-            self.__alignmentAction.setIcon(selectedAction.icon())
-            self.__alignmentAction.setToolTip(selectedAction.toolTip())
+            self.__alignmentToolButton.setText(selectedAction.text())
+            self.__alignmentToolButton.setIcon(selectedAction.icon())
+            self.__alignmentToolButton.setToolTip(selectedAction.toolTip())
         else:
-            self.__alignmentAction.setText("")
-            self.__alignmentAction.setIcon(qt.QIcon())
-            self.__alignmentAction.setToolTip("")
+            self.__alignmentToolButton.setText("")
+            self.__alignmentToolButton.setIcon(qt.QIcon())
+            self.__alignmentToolButton.setToolTip("")
 
     def __keypointVisibilityChanged(self):
         """Called when action managing keypoints visibility changes"""


### PR DESCRIPTION
This PR prepares for Qt6 support by changing implementation for obsolete/inconsistent features that does not require Qt6 specific code:

- `QAction.setMenu` is obsolete in Qt6, so when it is used, `QAction` needs to be replaced with `QMenu` or `QToolButton`.
- `QColor.getRgbF` is not exactly consistent across Qt5 and Qt6 (precision, rounding change?), so use `QColor.getRgb` instead

Related to #3432
