### PR TITLE
silx.gui: clean-up Qt4 support code

### DIFF
--- a/src/silx/app/view/CustomNxdataWidget.py
+++ b/src/silx/app/view/CustomNxdataWidget.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -791,14 +791,10 @@ class CustomNxdataWidget(qt.QTreeView):
         self.__model.rowsAboutToBeInserted.connect(self.__rowsAboutToBeInserted)
 
         header = self.header()
-        if qt.qVersion() < "5.0":
-            setResizeMode = header.setResizeMode
-        else:
-            setResizeMode = header.setSectionResizeMode
-        setResizeMode(0, qt.QHeaderView.ResizeToContents)
-        setResizeMode(1, qt.QHeaderView.Stretch)
-        setResizeMode(2, qt.QHeaderView.ResizeToContents)
-        setResizeMode(3, qt.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(0, qt.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(1, qt.QHeaderView.Stretch)
+        header.setSectionResizeMode(2, qt.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(3, qt.QHeaderView.ResizeToContents)
 
         self.setSelectionMode(qt.QAbstractItemView.SingleSelection)
         self.setDropIndicatorShown(True)

--- a/src/silx/app/view/CustomNxdataWidget.py
+++ b/src/silx/app/view/CustomNxdataWidget.py
@@ -806,11 +806,10 @@ class CustomNxdataWidget(qt.QTreeView):
         self.customContextMenuRequested[qt.QPoint].connect(self.__executeContextMenu)
 
     def __rowsAboutToBeInserted(self, parentIndex, start, end):
-        if qt.qVersion()[0:2] == "5.":
-            # FIXME: workaround for https://github.com/silx-kit/silx/issues/1919
-            # Uses of ResizeToContents looks to break nice update of cells with Qt5
-            # This patch make the view blinking
-            self.repaint()
+        # FIXME: workaround for https://github.com/silx-kit/silx/issues/1919
+        # Uses of ResizeToContents looks to break nice update of cells with Qt5
+        # This patch make the view blinking
+        self.repaint()
 
     def __rowsAboutToBeRemoved(self, parentIndex, start, end):
         """Called when an item was removed from the model."""
@@ -824,11 +823,10 @@ class CustomNxdataWidget(qt.QTreeView):
         for item in items:
             self.sigNxdataItemRemoved.emit(item)
 
-        if qt.qVersion()[0:2] == "5.":
-            # FIXME: workaround for https://github.com/silx-kit/silx/issues/1919
-            # Uses of ResizeToContents looks to break nice update of cells with Qt5
-            # This patch make the view blinking
-            self.repaint()
+        # FIXME: workaround for https://github.com/silx-kit/silx/issues/1919
+        # Uses of ResizeToContents looks to break nice update of cells with Qt5
+        # This patch make the view blinking
+        self.repaint()
 
     def __nxdataUpdate(self, index):
         """Called when a virtual NXdata was updated from the model."""

--- a/src/silx/gui/_glutils/font.py
+++ b/src/silx/gui/_glutils/font.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -97,11 +97,6 @@ def rasterText(text, font,
         _logger.info("Trying to raster empty text, replaced by white space")
         text = ' '  # Replace empty text by white space to produce an image
 
-    if (devicePixelRatio != 1.0 and
-            not hasattr(qt.QImage, 'setDevicePixelRatio')):  # Qt 4
-        _logger.error('devicePixelRatio not supported')
-        devicePixelRatio = 1.0
-
     if not isinstance(font, qt.QFont):
         font = qt.QFont(font, size, weight, italic)
 
@@ -131,9 +126,7 @@ def rasterText(text, font,
     image = qt.QImage(int(width),
                       int(bounds.height() * devicePixelRatio + 2),
                       qt.QImage.Format_RGB888)
-    if (devicePixelRatio != 1.0 and
-            hasattr(image, 'setDevicePixelRatio')):  # Qt 5
-        image.setDevicePixelRatio(devicePixelRatio)
+    image.setDevicePixelRatio(devicePixelRatio)
 
     # TODO if Qt5 use Format_Grayscale8 instead
     image.fill(0)

--- a/src/silx/gui/data/ArrayTableModel.py
+++ b/src/silx/gui/data/ArrayTableModel.py
@@ -342,10 +342,7 @@ class ArrayTableModel(qt.QAbstractTableModel):
             dimensions, to view frames parallel to the last two axes.
         :param bool editable: Flag to enable editing data. Default *False*.
         """
-        if qt.qVersion() > "4.6":
-            self.beginResetModel()
-        else:
-            self.reset()
+        self.beginResetModel()
 
         if data is None:
             # empty array
@@ -386,8 +383,7 @@ class ArrayTableModel(qt.QAbstractTableModel):
         self._perspective = tuple(perspective) if perspective is not None else\
             tuple(range(0, len(self._array.shape) - 2))
 
-        if qt.qVersion() > "4.6":
-            self.endResetModel()
+        self.endResetModel()
 
     def setArrayColors(self, bgcolors=None, fgcolors=None):
         """Set the colors for all table cells by passing an array
@@ -485,10 +481,7 @@ class ArrayTableModel(qt.QAbstractTableModel):
             # index is ignored
             return
 
-        if qt.qVersion() > "4.6":
-            self.beginResetModel()
-        else:
-            self.reset()
+        self.beginResetModel()
 
         if len(shape) == 3:
             len_ = shape[self._perspective[0]]
@@ -508,8 +501,7 @@ class ArrayTableModel(qt.QAbstractTableModel):
                                      "not in range 0-%d" % (shape[i_] - 1))
             self._index = index
 
-        if qt.qVersion() > "4.6":
-            self.endResetModel()
+        self.endResetModel()
 
     def setFormatter(self, formatter):
         """Set the formatter object to be used to display data from the model
@@ -519,8 +511,7 @@ class ArrayTableModel(qt.QAbstractTableModel):
         if formatter is self._formatter:
             return
 
-        if qt.qVersion() > "4.6":
-            self.beginResetModel()
+        self.beginResetModel()
 
         if self._formatter is not None:
             self._formatter.formatChanged.disconnect(self.__formatChanged)
@@ -529,10 +520,7 @@ class ArrayTableModel(qt.QAbstractTableModel):
         if self._formatter is not None:
             self._formatter.formatChanged.connect(self.__formatChanged)
 
-        if qt.qVersion() > "4.6":
-            self.endResetModel()
-        else:
-            self.reset()
+        self.endResetModel()
 
     def getFormatter(self):
         """Returns the text formatter used.
@@ -597,18 +585,14 @@ class ArrayTableModel(qt.QAbstractTableModel):
                     " for %d-D array " % n_dimensions +
                     "with shape " + str(self._array.shape))
 
-        if qt.qVersion() > "4.6":
-            self.beginResetModel()
-        else:
-            self.reset()
+        self.beginResetModel()
 
         self._perspective = perspective
 
         # reset index
         self._index = [0 for _i in range(n_dimensions - 2)]
 
-        if qt.qVersion() > "4.6":
-            self.endResetModel()
+        self.endResetModel()
 
     def setFrameAxes(self, row_axis, col_axis):
         """Set the perspective by specifying the two axes parallel to the frame
@@ -643,17 +627,13 @@ class ArrayTableModel(qt.QAbstractTableModel):
                     " for %d-D array " % n_dimensions +
                     "with shape " + str(self._array.shape))
 
-        if qt.qVersion() > "4.6":
-            self.beginResetModel()
-        else:
-            self.reset()
+        self.beginResetModel()
 
         self._perspective = perspective
         # reset index
         self._index = [0 for _i in range(n_dimensions - 2)]
 
-        if qt.qVersion() > "4.6":
-            self.endResetModel()
+        self.endResetModel()
 
 
 if __name__ == "__main__":

--- a/src/silx/gui/data/Hdf5TableView.py
+++ b/src/silx/gui/data/Hdf5TableView.py
@@ -306,8 +306,7 @@ class Hdf5TableModel(HierarchicalTableView.HierarchicalTableModel):
             `silx.gui.hdf5.H5Node` which is needed to display some local path
             information.
         """
-        if qt.qVersion() > "4.6":
-            self.beginResetModel()
+        self.beginResetModel()
 
         if h5pyObject is None or self.isSupportedObject(h5pyObject):
             self.__obj = h5pyObject
@@ -315,10 +314,7 @@ class Hdf5TableModel(HierarchicalTableView.HierarchicalTableModel):
             _logger.warning("Object class %s unsupported. Object ignored.", type(h5pyObject))
         self.__initProperties()
 
-        if qt.qVersion() > "4.6":
-            self.endResetModel()
-        else:
-            self.reset()
+        self.endResetModel()
 
     def __formatHdf5Type(self, dataset):
         """Format the HDF5 type"""
@@ -544,8 +540,7 @@ class Hdf5TableModel(HierarchicalTableView.HierarchicalTableModel):
 
         self.__hdf5Formatter.setTextFormatter(formatter)
 
-        if qt.qVersion() > "4.6":
-            self.beginResetModel()
+        self.beginResetModel()
 
         if self.__formatter is not None:
             self.__formatter.formatChanged.disconnect(self.__formatChanged)
@@ -554,10 +549,7 @@ class Hdf5TableModel(HierarchicalTableView.HierarchicalTableModel):
         if self.__formatter is not None:
             self.__formatter.formatChanged.connect(self.__formatChanged)
 
-        if qt.qVersion() > "4.6":
-            self.endResetModel()
-        else:
-            self.reset()
+        self.endResetModel()
 
     def getFormatter(self):
         """Returns the text formatter used.

--- a/src/silx/gui/data/Hdf5TableView.py
+++ b/src/silx/gui/data/Hdf5TableView.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -627,15 +627,11 @@ class Hdf5TableView(HierarchicalTableView.HierarchicalTableView):
 
         model.setObject(data)
         header = self.horizontalHeader()
-        if qt.qVersion() < "5.0":
-            setResizeMode = header.setResizeMode
-        else:
-            setResizeMode = header.setSectionResizeMode
-        setResizeMode(0, qt.QHeaderView.Fixed)
-        setResizeMode(1, qt.QHeaderView.ResizeToContents)
-        setResizeMode(2, qt.QHeaderView.Stretch)
-        setResizeMode(3, qt.QHeaderView.ResizeToContents)
-        setResizeMode(4, qt.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(0, qt.QHeaderView.Fixed)
+        header.setSectionResizeMode(1, qt.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(2, qt.QHeaderView.Stretch)
+        header.setSectionResizeMode(3, qt.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(4, qt.QHeaderView.ResizeToContents)
         header.setStretchLastSection(False)
 
         for row in range(model.rowCount()):

--- a/src/silx/gui/data/HexaTableView.py
+++ b/src/silx/gui/data/HexaTableView.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -274,13 +274,8 @@ class HexaTableView(qt.QTableView):
     def __fixHeader(self):
         """Update the view according to the state of the auto-resize"""
         header = self.horizontalHeader()
-        if qt.qVersion() < "5.0":
-            setResizeMode = header.setResizeMode
-        else:
-            setResizeMode = header.setSectionResizeMode
-
         header.setDefaultSectionSize(30)
         header.setStretchLastSection(True)
         for i in range(0x10):
-            setResizeMode(i, qt.QHeaderView.Fixed)
-        setResizeMode(0x10, qt.QHeaderView.Stretch)
+            header.setSectionResizeMode(i, qt.QHeaderView.Fixed)
+        header.setSectionResizeMode(0x10, qt.QHeaderView.Stretch)

--- a/src/silx/gui/data/HexaTableView.py
+++ b/src/silx/gui/data/HexaTableView.py
@@ -112,9 +112,9 @@ class HexaTableModel(qt.QAbstractTableModel):
         self.__connector = None
         self.setArrayData(data)
 
-        if hasattr(qt.QFontDatabase, "systemFont"):
+        if hasattr(qt.QFontDatabase, "systemFont"):  # Qt >= 5.2
             self.__font = qt.QFontDatabase.systemFont(qt.QFontDatabase.FixedFont)
-        else:
+        else:  # Qt < 5.2
             self.__font = qt.QFont("Monospace")
             self.__font.setStyleHint(qt.QFont.TypeWriter)
         self.__palette = qt.QPalette()

--- a/src/silx/gui/data/HexaTableView.py
+++ b/src/silx/gui/data/HexaTableView.py
@@ -217,8 +217,7 @@ class HexaTableModel(qt.QAbstractTableModel):
 
         :param data: A numpy object or a dataset.
         """
-        if qt.qVersion() > "4.6":
-            self.beginResetModel()
+        self.beginResetModel()
 
         self.__connector = None
         self.__data = data
@@ -229,10 +228,7 @@ class HexaTableModel(qt.QAbstractTableModel):
                 data = data[()]
             self.__connector = _VoidConnector(data)
 
-        if qt.qVersion() > "4.6":
-            self.endResetModel()
-        else:
-            self.reset()
+        self.endResetModel()
 
     def arrayData(self):
         """Returns the internal data.

--- a/src/silx/gui/data/RecordTableView.py
+++ b/src/silx/gui/data/RecordTableView.py
@@ -296,8 +296,7 @@ class RecordTableModel(qt.QAbstractTableModel):
             converted to a numpy array using ``numpy.array(data)`` (e.g.
             a nested sequence).
         """
-        if qt.qVersion() > "4.6":
-            self.beginResetModel()
+        self.beginResetModel()
 
         self.__data = data
         if isinstance(data, numpy.ndarray):
@@ -323,10 +322,7 @@ class RecordTableModel(qt.QAbstractTableModel):
             else:
                 self.__fields = None
 
-        if qt.qVersion() > "4.6":
-            self.endResetModel()
-        else:
-            self.reset()
+        self.endResetModel()
 
     def arrayData(self):
         """Returns the internal data.
@@ -343,8 +339,7 @@ class RecordTableModel(qt.QAbstractTableModel):
         if formatter is self.__formatter:
             return
 
-        if qt.qVersion() > "4.6":
-            self.beginResetModel()
+        self.beginResetModel()
 
         if self.__formatter is not None:
             self.__formatter.formatChanged.disconnect(self.__formatChanged)
@@ -356,10 +351,7 @@ class RecordTableModel(qt.QAbstractTableModel):
         if self.__formatter is not None:
             self.__formatter.formatChanged.connect(self.__formatChanged)
 
-        if qt.qVersion() > "4.6":
-            self.endResetModel()
-        else:
-            self.reset()
+        self.endResetModel()
 
     def getFormatter(self):
         """Returns the text formatter used.

--- a/src/silx/gui/dialog/AbstractDataFileDialog.py
+++ b/src/silx/gui/dialog/AbstractDataFileDialog.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -155,10 +155,6 @@ class _SideBar(qt.QListView):
 
         if not DEFAULT_SIDEBAR_URL:
             _logger.debug("Skip default sidebar URLs (from setted variable)")
-            feed_sidebar = False
-        elif version.version[0] == 4 and sys.platform in ["win32"]:
-            # Avoid locking the GUI 5min in case of use of network driver
-            _logger.debug("Skip default sidebar URLs (avoid lock when using network drivers)")
             feed_sidebar = False
         elif version < LooseVersion("5.11.2") and qt.BINDING == "PyQt5" and sys.platform in ["linux", "linux2"]:
             # Avoid segfault on PyQt5 + gtk
@@ -565,18 +561,12 @@ class AbstractDataFileDialog(qt.QDialog):
         self.__h5 = None
         self.__fabio = None
 
-        if qt.qVersion() < "5.0":
-            # On Qt4 it is needed to provide a safe file system model
-            _logger.debug("Uses SafeFileSystemModel")
-            from .SafeFileSystemModel import SafeFileSystemModel
-            self.__fileModel = SafeFileSystemModel(self)
-        else:
-            # On Qt5 a safe icon provider is still needed to avoid freeze
-            _logger.debug("Uses default QFileSystemModel with a SafeFileIconProvider")
-            self.__fileModel = qt.QFileSystemModel(self)
-            from .SafeFileIconProvider import SafeFileIconProvider
-            iconProvider = SafeFileIconProvider()
-            self.__fileModel.setIconProvider(iconProvider)
+        # On Qt5 a safe icon provider is still needed to avoid freeze
+        _logger.debug("Uses default QFileSystemModel with a SafeFileIconProvider")
+        self.__fileModel = qt.QFileSystemModel(self)
+        from .SafeFileIconProvider import SafeFileIconProvider
+        iconProvider = SafeFileIconProvider()
+        self.__fileModel.setIconProvider(iconProvider)
 
         # The common file dialog filter only on Mac OS X
         self.__fileModel.setNameFilterDisables(sys.platform == "darwin")

--- a/src/silx/gui/fit/FitWidget.py
+++ b/src/silx/gui/fit/FitWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -53,7 +53,6 @@ from .FitConfig import getFitConfigDialog
 from .BackgroundWidget import getBgDialog, BackgroundDialog
 from ...utils.deprecation import deprecated
 
-QTVERSION = qt.qVersion()
 DEBUG = 0
 _logger = logging.getLogger(__name__)
 

--- a/src/silx/gui/fit/FitWidgets.py
+++ b/src/silx/gui/fit/FitWidgets.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2004-2016 European Synchrotron Radiation Facility
+# Copyright (C) 2004-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,6 @@ from collections import OrderedDict
 from silx.gui import qt
 from silx.gui.fit.Parameters import Parameters
 
-QTVERSION = qt.qVersion()
 
 __authors__ = ["V.A. Sole", "P. Knobel"]
 __license__ = "MIT"
@@ -406,10 +405,7 @@ class ParametersTab(qt.QTabWidget):
         ncols = table.columnCount()
         for l in range(ncols):
             text += ('<td align="left" bgcolor="%s"><b>' % hcolor)
-            if QTVERSION < '4.0.0':
-                text += (str(table.horizontalHeader().label(l)))
-            else:
-                text += (str(table.horizontalHeaderItem(l).text()))
+            text += str(table.horizontalHeaderItem(l).text())
             text += "</b></td>"
         text += "</tr>"
         nrows = table.rowCount()

--- a/src/silx/gui/hdf5/Hdf5HeaderView.py
+++ b/src/silx/gui/hdf5/Hdf5HeaderView.py
@@ -31,8 +31,6 @@ __date__ = "16/06/2017"
 from .. import qt
 from .Hdf5TreeModel import Hdf5TreeModel
 
-QTVERSION = qt.qVersion()
-
 
 class Hdf5HeaderView(qt.QHeaderView):
     """
@@ -53,12 +51,8 @@ class Hdf5HeaderView(qt.QHeaderView):
         self.customContextMenuRequested.connect(self.__createContextMenu)
 
         # default initialization done by QTreeView for it's own header
-        if QTVERSION < "5.0":
-            self.setClickable(True)
-            self.setMovable(True)
-        else:
-            self.setSectionsClickable(True)
-            self.setSectionsMovable(True)
+        self.setSectionsClickable(True)
+        self.setSectionsMovable(True)
         self.setDefaultAlignment(qt.Qt.AlignLeft | qt.Qt.AlignVCenter)
         self.setStretchLastSection(True)
 

--- a/src/silx/gui/hdf5/Hdf5HeaderView.py
+++ b/src/silx/gui/hdf5/Hdf5HeaderView.py
@@ -62,7 +62,7 @@ class Hdf5HeaderView(qt.QHeaderView):
     def setModel(self, model):
         """Override model to configure view when a model is expected
 
-        `qt.QHeaderView.setResizeMode` expect already existing columns
+        `qt.QHeaderView.setSectionResizeMode` expect already existing columns
         to work.
 
         :param model qt.QAbstractItemModel: A model

--- a/src/silx/gui/hdf5/Hdf5HeaderView.py
+++ b/src/silx/gui/hdf5/Hdf5HeaderView.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -78,27 +78,22 @@ class Hdf5HeaderView(qt.QHeaderView):
 
     def __updateAutoResize(self):
         """Update the view according to the state of the auto-resize"""
-        if QTVERSION < "5.0":
-            setResizeMode = self.setResizeMode
-        else:
-            setResizeMode = self.setSectionResizeMode
-
         if self.__auto_resize:
-            setResizeMode(Hdf5TreeModel.NAME_COLUMN, qt.QHeaderView.ResizeToContents)
-            setResizeMode(Hdf5TreeModel.TYPE_COLUMN, qt.QHeaderView.ResizeToContents)
-            setResizeMode(Hdf5TreeModel.SHAPE_COLUMN, qt.QHeaderView.ResizeToContents)
-            setResizeMode(Hdf5TreeModel.VALUE_COLUMN, qt.QHeaderView.Interactive)
-            setResizeMode(Hdf5TreeModel.DESCRIPTION_COLUMN, qt.QHeaderView.Interactive)
-            setResizeMode(Hdf5TreeModel.NODE_COLUMN, qt.QHeaderView.ResizeToContents)
-            setResizeMode(Hdf5TreeModel.LINK_COLUMN, qt.QHeaderView.ResizeToContents)
+            self.setSectionResizeMode(Hdf5TreeModel.NAME_COLUMN, qt.QHeaderView.ResizeToContents)
+            self.setSectionResizeMode(Hdf5TreeModel.TYPE_COLUMN, qt.QHeaderView.ResizeToContents)
+            self.setSectionResizeMode(Hdf5TreeModel.SHAPE_COLUMN, qt.QHeaderView.ResizeToContents)
+            self.setSectionResizeMode(Hdf5TreeModel.VALUE_COLUMN, qt.QHeaderView.Interactive)
+            self.setSectionResizeMode(Hdf5TreeModel.DESCRIPTION_COLUMN, qt.QHeaderView.Interactive)
+            self.setSectionResizeMode(Hdf5TreeModel.NODE_COLUMN, qt.QHeaderView.ResizeToContents)
+            self.setSectionResizeMode(Hdf5TreeModel.LINK_COLUMN, qt.QHeaderView.ResizeToContents)
         else:
-            setResizeMode(Hdf5TreeModel.NAME_COLUMN, qt.QHeaderView.Interactive)
-            setResizeMode(Hdf5TreeModel.TYPE_COLUMN, qt.QHeaderView.Interactive)
-            setResizeMode(Hdf5TreeModel.SHAPE_COLUMN, qt.QHeaderView.Interactive)
-            setResizeMode(Hdf5TreeModel.VALUE_COLUMN, qt.QHeaderView.Interactive)
-            setResizeMode(Hdf5TreeModel.DESCRIPTION_COLUMN, qt.QHeaderView.Interactive)
-            setResizeMode(Hdf5TreeModel.NODE_COLUMN, qt.QHeaderView.Interactive)
-            setResizeMode(Hdf5TreeModel.LINK_COLUMN, qt.QHeaderView.Interactive)
+            self.setSectionResizeMode(Hdf5TreeModel.NAME_COLUMN, qt.QHeaderView.Interactive)
+            self.setSectionResizeMode(Hdf5TreeModel.TYPE_COLUMN, qt.QHeaderView.Interactive)
+            self.setSectionResizeMode(Hdf5TreeModel.SHAPE_COLUMN, qt.QHeaderView.Interactive)
+            self.setSectionResizeMode(Hdf5TreeModel.VALUE_COLUMN, qt.QHeaderView.Interactive)
+            self.setSectionResizeMode(Hdf5TreeModel.DESCRIPTION_COLUMN, qt.QHeaderView.Interactive)
+            self.setSectionResizeMode(Hdf5TreeModel.NODE_COLUMN, qt.QHeaderView.Interactive)
+            self.setSectionResizeMode(Hdf5TreeModel.LINK_COLUMN, qt.QHeaderView.Interactive)
 
     def setAutoResizeColumns(self, autoResize):
         """Enable/disable auto-resize. When auto-resized, the header take care

--- a/src/silx/gui/hdf5/Hdf5TreeView.py
+++ b/src/silx/gui/hdf5/Hdf5TreeView.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -265,7 +265,5 @@ class Hdf5TreeView(qt.QTreeView):
         """
         super(Hdf5TreeView, self).mousePressEvent(event)
         if event.button() != qt.Qt.LeftButton:
-            # Qt5 only sends itemClicked on left button mouse click
-            if qt.qVersion() > "5":
-                qindex = self.indexAt(event.pos())
-                self.clicked.emit(qindex)
+            qindex = self.indexAt(event.pos())
+            self.clicked.emit(qindex)

--- a/src/silx/gui/plot/CurvesROIWidget.py
+++ b/src/silx/gui/plot/CurvesROIWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -528,10 +528,7 @@ class ROITable(TableWidget):
         self.setRowCount(0)
         self.setHorizontalHeaderLabels(self.COLUMNS)
         header = self.horizontalHeader()
-        if hasattr(header, 'setSectionResizeMode'):  # Qt5
-            header.setSectionResizeMode(qt.QHeaderView.ResizeToContents)
-        else:  # Qt4
-            header.setResizeMode(qt.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(qt.QHeaderView.ResizeToContents)
         self.sortByColumn(0, qt.Qt.AscendingOrder)
         self.hideColumn(self.COLUMNS_INDEX['ID'])
 

--- a/src/silx/gui/plot/ROIStatsWidget.py
+++ b/src/silx/gui/plot/ROIStatsWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -377,10 +377,7 @@ class _StatsROITable(_StatsWidgetBase, TableWidget):
             self.setHorizontalHeaderItem(3 + index, headerItem)
 
         horizontalHeader = self.horizontalHeader()
-        if hasattr(horizontalHeader, 'setSectionResizeMode'):  # Qt5
-            horizontalHeader.setSectionResizeMode(qt.QHeaderView.ResizeToContents)
-        else:  # Qt4
-            horizontalHeader.setResizeMode(qt.QHeaderView.ResizeToContents)
+        horizontalHeader.setSectionResizeMode(qt.QHeaderView.ResizeToContents)
 
         self._updateItemObserve()
 

--- a/src/silx/gui/plot/StatsWidget.py
+++ b/src/silx/gui/plot/StatsWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -627,10 +627,7 @@ class StatsTable(_StatsWidgetBase, TableWidget):
             self.setHorizontalHeaderItem(2 + index, headerItem)
 
         horizontalHeader = self.horizontalHeader()
-        if hasattr(horizontalHeader, 'setSectionResizeMode'):  # Qt5
-            horizontalHeader.setSectionResizeMode(qt.QHeaderView.ResizeToContents)
-        else:  # Qt4
-            horizontalHeader.setResizeMode(qt.QHeaderView.ResizeToContents)
+        horizontalHeader.setSectionResizeMode(qt.QHeaderView.ResizeToContents)
 
         self._updateItemObserve()
 

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -275,10 +275,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         event.accept()
 
     def wheelEvent(self, event):
-        if hasattr(event, 'angleDelta'):  # Qt 5
-            delta = event.angleDelta().y()
-        else:  # Qt 4 support
-            delta = event.delta()
+        delta = event.angleDelta().y()
         angleInDegrees = delta / 8.
         self._plot.onMouseWheel(event.x(), event.y(), angleInDegrees)
         event.accept()

--- a/src/silx/gui/plot/tools/roi.py
+++ b/src/silx/gui/plot/tools/roi.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1258,16 +1258,12 @@ class RegionOfInterestTableWidget(qt.QTableWidget):
 
         horizontalHeader = self.horizontalHeader()
         horizontalHeader.setDefaultAlignment(qt.Qt.AlignLeft)
-        if hasattr(horizontalHeader, 'setResizeMode'):  # Qt 4
-            setSectionResizeMode = horizontalHeader.setResizeMode
-        else:  # Qt5
-            setSectionResizeMode = horizontalHeader.setSectionResizeMode
 
-        setSectionResizeMode(0, qt.QHeaderView.Interactive)
-        setSectionResizeMode(1, qt.QHeaderView.ResizeToContents)
-        setSectionResizeMode(2, qt.QHeaderView.ResizeToContents)
-        setSectionResizeMode(3, qt.QHeaderView.Stretch)
-        setSectionResizeMode(4, qt.QHeaderView.ResizeToContents)
+        horizontalHeader.setSectionResizeMode(0, qt.QHeaderView.Interactive)
+        horizontalHeader.setSectionResizeMode(1, qt.QHeaderView.ResizeToContents)
+        horizontalHeader.setSectionResizeMode(2, qt.QHeaderView.ResizeToContents)
+        horizontalHeader.setSectionResizeMode(3, qt.QHeaderView.Stretch)
+        horizontalHeader.setSectionResizeMode(4, qt.QHeaderView.ResizeToContents)
 
         verticalHeader = self.verticalHeader()
         verticalHeader.setVisible(False)

--- a/src/silx/gui/plot3d/ParamTreeView.py
+++ b/src/silx/gui/plot3d/ParamTreeView.py
@@ -376,14 +376,11 @@ class ParameterTreeDelegate(qt.QStyledItemDelegate):
                     userProperty = metaObject.userProperty()
                     if userProperty.isValid() and userProperty.hasNotifySignal():
                         notifySignal = userProperty.notifySignal()
-                        if hasattr(notifySignal, 'signature'):  # Qt4
-                            signature = notifySignal.signature()
+                        signature = notifySignal.methodSignature()
+                        if qt.BINDING == 'PySide2':
+                            signature = signature.data()
                         else:
-                            signature = notifySignal.methodSignature()
-                            if qt.BINDING == 'PySide2':
-                                signature = signature.data()
-                            else:
-                                signature = bytes(signature)
+                            signature = bytes(signature)
 
                         if hasattr(signature, 'decode'):  # For PySide with python3
                             signature = signature.decode('ascii')

--- a/src/silx/gui/plot3d/ParamTreeView.py
+++ b/src/silx/gui/plot3d/ParamTreeView.py
@@ -433,10 +433,7 @@ class ParamTreeView(qt.QTreeView):
 
         header = self.header()
         header.setMinimumSectionSize(128)  # For colormap pixmaps
-        if hasattr(header, 'setSectionResizeMode'):  # Qt5
-            header.setSectionResizeMode(qt.QHeaderView.ResizeToContents)
-        else:  # Qt4
-            header.setResizeMode(qt.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(qt.QHeaderView.ResizeToContents)
 
         delegate = ParameterTreeDelegate()
         self.setItemDelegate(delegate)

--- a/src/silx/gui/plot3d/Plot3DWidget.py
+++ b/src/silx/gui/plot3d/Plot3DWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -380,10 +380,7 @@ class Plot3DWidget(glu.OpenGLWidget):
     def wheelEvent(self, event):
         xpixel = event.x() * self.getDevicePixelRatio()
         ypixel = event.y() * self.getDevicePixelRatio()
-        if hasattr(event, 'delta'):  # Qt4
-            angle = event.delta() / 8.
-        else:  # Qt5
-            angle = event.angleDelta().y() / 8.
+        angle = event.angleDelta().y() / 8.
         event.accept()
 
         if self.eventHandler is not None and angle != 0 and self.isValid():

--- a/src/silx/gui/plot3d/SFViewParamTree.py
+++ b/src/silx/gui/plot3d/SFViewParamTree.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1605,10 +1605,7 @@ class TreeView(qt.QTreeView):
         self.setIconSize(qt.QSize(16, 16))
 
         header = self.header()
-        if hasattr(header, 'setSectionResizeMode'):  # Qt5
-            header.setSectionResizeMode(qt.QHeaderView.ResizeToContents)
-        else:  # Qt4
-            header.setResizeMode(qt.QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(qt.QHeaderView.ResizeToContents)
 
         delegate = ItemDelegate()
         self.setItemDelegate(delegate)

--- a/src/silx/gui/utils/testutils.py
+++ b/src/silx/gui/utils/testutils.py
@@ -394,14 +394,8 @@ class TestCaseQt(unittest.TestCase):
         filename = "Screenshot_%s.png" % self.id()
         filename = os.path.join(basedir, filename)
 
-        if not hasattr(self.qapp, "primaryScreen"):
-            # Qt4
-            winId = qt.QApplication.desktop().winId()
-            pixmap = qt.QPixmap.grabWindow(winId)
-        else:
-            # Qt5
-            screen = self.qapp.primaryScreen()
-            pixmap = screen.grabWindow(0)
+        screen = self.qapp.primaryScreen()
+        pixmap = screen.grabWindow(0)
         pixmap.save(filename)
         _logger.log(level, "Screenshot saved at %s", filename)
 

--- a/src/silx/gui/widgets/PrintPreview.py
+++ b/src/silx/gui/widgets/PrintPreview.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -229,11 +229,7 @@ class PrintPreviewDialog(qt.QDialog):
             comment = ' ' * 88
         if commentPosition is None:
             commentPosition = "CENTER"
-        if qt.qVersion() < "5.0":
-            rectItem = qt.QGraphicsRectItem(self.page, self.scene)
-        else:
-            rectItem = qt.QGraphicsRectItem(self.page)
-
+        rectItem = qt.QGraphicsRectItem(self.page)
         rectItem.setRect(qt.QRectF(1, 1,
                                    pixmap.width(), pixmap.height()))
 
@@ -250,28 +246,19 @@ class PrintPreviewDialog(qt.QDialog):
         rectItemResizeRect = _GraphicsResizeRectItem(rectItem, self.scene)
         rectItemResizeRect.setZValue(2)
 
-        if qt.qVersion() < "5.0":
-            pixmapItem = qt.QGraphicsPixmapItem(rectItem, self.scene)
-        else:
-            pixmapItem = qt.QGraphicsPixmapItem(rectItem)
+        pixmapItem = qt.QGraphicsPixmapItem(rectItem)
         pixmapItem.setPixmap(pixmap)
         pixmapItem.setZValue(0)
 
         # I add the title
-        if qt.qVersion() < "5.0":
-            textItem = qt.QGraphicsTextItem(title, rectItem, self.scene)
-        else:
-            textItem = qt.QGraphicsTextItem(title, rectItem)
+        textItem = qt.QGraphicsTextItem(title, rectItem)
         textItem.setTextInteractionFlags(qt.Qt.TextEditorInteraction)
         offset = 0.5 * textItem.boundingRect().width()
         textItem.moveBy(0.5 * pixmap.width() - offset, -20)
         textItem.setZValue(2)
 
         # I add the comment
-        if qt.qVersion() < "5.0":
-            commentItem = qt.QGraphicsTextItem(comment, rectItem, self.scene)
-        else:
-            commentItem = qt.QGraphicsTextItem(comment, rectItem)
+        commentItem = qt.QGraphicsTextItem(comment, rectItem)
         commentItem.setTextInteractionFlags(qt.Qt.TextEditorInteraction)
         offset = 0.5 * commentItem.boundingRect().width()
         if commentPosition.upper() == "LEFT":
@@ -341,10 +328,7 @@ class PrintPreviewDialog(qt.QDialog):
 
         # Comment / legend
         dummyComment = 80 * "1"
-        if qt.qVersion() < '5.0':
-            commentItem = qt.QGraphicsTextItem(dummyComment, svgItem, self.scene)
-        else:
-            commentItem = qt.QGraphicsTextItem(dummyComment, svgItem)
+        commentItem = qt.QGraphicsTextItem(dummyComment, svgItem)
         commentItem.setTextInteractionFlags(qt.Qt.TextEditorInteraction)
         # we scale the text to have the legend  box have the same width as the graph
         scaleCalculationRect = qt.QRectF(commentItem.boundingRect())
@@ -354,10 +338,7 @@ class PrintPreviewDialog(qt.QDialog):
         commentItem.setZValue(1)
 
         commentItem.setFlag(qt.QGraphicsItem.ItemIsMovable, True)
-        if qt.qVersion() < "5.0":
-            commentItem.scale(scale, scale)
-        else:
-            commentItem.setScale(scale)
+        commentItem.setScale(scale)
 
         # align
         if commentPosition.upper() == "CENTER":
@@ -382,10 +363,7 @@ class PrintPreviewDialog(qt.QDialog):
                            svgItem.boundingRect().y() + svgItem.boundingRect().height())
 
         # Title
-        if qt.qVersion() < '5.0':
-            textItem = qt.QGraphicsTextItem(title, svgItem, self.scene)
-        else:
-            textItem = qt.QGraphicsTextItem(title, svgItem)
+        textItem = qt.QGraphicsTextItem(title, svgItem)
         textItem.setTextInteractionFlags(qt.Qt.TextEditorInteraction)
         textItem.setZValue(1)
         textItem.setFlag(qt.QGraphicsItem.ItemIsMovable, True)
@@ -394,10 +372,7 @@ class PrintPreviewDialog(qt.QDialog):
         textItem.moveBy(svgItem.boundingRect().x() +
                         0.5 * svgItem.boundingRect().width() - title_offset * scale,
                         svgItem.boundingRect().y())
-        if qt.qVersion() < "5.0":
-            textItem.scale(scale, scale)
-        else:
-            textItem.setScale(scale)
+        textItem.setScale(scale)
 
     def setup(self):
         """Open a print dialog to ensure the :attr:`printer` is set.
@@ -567,10 +542,7 @@ class _GraphicsSvgRectItem(qt.QGraphicsRectItem):
 class _GraphicsResizeRectItem(qt.QGraphicsRectItem):
     """Resizable QGraphicsRectItem."""
     def __init__(self, parent=None, scene=None, keepratio=True):
-        if qt.qVersion() < '5.0':
-            qt.QGraphicsRectItem.__init__(self, parent, scene)
-        else:
-            qt.QGraphicsRectItem.__init__(self, parent)
+        qt.QGraphicsRectItem.__init__(self, parent)
         rect = parent.boundingRect()
         x = rect.x()
         y = rect.y()
@@ -627,10 +599,7 @@ class _GraphicsResizeRectItem(qt.QGraphicsRectItem):
         self._w = rect.width()
         self._h = rect.height()
         self._ratio = self._w / self._h
-        if qt.qVersion() < "5.0":
-            self._newRect = qt.QGraphicsRectItem(parent, scene)
-        else:
-            self._newRect = qt.QGraphicsRectItem(parent)
+        self._newRect = qt.QGraphicsRectItem(parent)
         self._newRect.setRect(qt.QRectF(self._x,
                                         self._y,
                                         self._w,
@@ -669,20 +638,17 @@ class _GraphicsResizeRectItem(qt.QGraphicsRectItem):
         parent = self.parentItem()
 
         # deduce scale from rectangle
-        if (qt.qVersion() < "5.0") or self.keepRatio:
+        if self.keepRatio:
             scalex = self._newRect.rect().width() / self._w
             scaley = scalex
         else:
             scalex = self._newRect.rect().width() / self._w
             scaley = self._newRect.rect().height() / self._h
 
-        if qt.qVersion() < "5.0":
-            parent.scale(scalex, scaley)
-        else:
-            # apply the scale to the previous transformation matrix
-            previousTransform = parent.transform()
-            parent.setTransform(
-                    previousTransform.scale(scalex, scaley))
+        # apply the scale to the previous transformation matrix
+        previousTransform = parent.transform()
+        parent.setTransform(
+                previousTransform.scale(scalex, scaley))
 
         self.scene().removeItem(self._newRect)
         self._newRect = None

--- a/src/silx/gui/widgets/UrlSelectionTable.py
+++ b/src/silx/gui/widgets/UrlSelectionTable.py
@@ -65,11 +65,8 @@ class UrlSelectionTable(TableWidget):
         self.setColumnCount(len(self.COLUMS_INDEX))
         self.setHorizontalHeaderLabels(list(self.COLUMS_INDEX.keys()))
         self.verticalHeader().hide()
-        if hasattr(self.horizontalHeader(), 'setSectionResizeMode'):  # Qt5
-            self.horizontalHeader().setSectionResizeMode(0,
-                                                         qt.QHeaderView.Stretch)
-        else:  # Qt4
-            self.horizontalHeader().setResizeMode(0, qt.QHeaderView.Stretch)
+        self.horizontalHeader().setSectionResizeMode(0,
+                                                     qt.QHeaderView.Stretch)
 
         self.setSortingEnabled(True)
         self._checkBoxes = {}

--- a/src/silx/gui/widgets/test/test_hierarchicaltableview.py
+++ b/src/silx/gui/widgets/test/test_hierarchicaltableview.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -46,10 +46,7 @@ class TableModel(HierarchicalTableView.HierarchicalTableModel):
         return 3
 
     def setData1(self):
-        if qt.qVersion() > "4.6":
-            self.beginResetModel()
-        else:
-            self.reset()
+        self.beginResetModel()
 
         content = {}
         content[0, 0] = ("title", True, (1, 3))
@@ -58,8 +55,8 @@ class TableModel(HierarchicalTableView.HierarchicalTableModel):
         content[1, 2] = ("c", False, (1, 1))
         content[2, 2] = ("d", False, (1, 1))
         self.__content = content
-        if qt.qVersion() > "4.6":
-            self.endResetModel()
+
+        self.endResetModel()
 
     def data(self, index, role=qt.Qt.DisplayRole):
         if not index.isValid():


### PR DESCRIPTION
This PR cleans-up Qt4 support that is related to using `qt.qVersion()` and `setSectionResizeMode`.
It is mostly (but not only) related to `QHeaderView.setSectionResizeMode`  and `beginResetModel`/`endResetModel`.

Related to #3432