### PR TITLE
Supports RGB and RGBA in ImageView

### DIFF
--- a/src/silx/gui/plot/ImageView.py
+++ b/src/silx/gui/plot/ImageView.py
@@ -756,7 +756,7 @@ class ImageView(PlotWindow):
 
         data = numpy.array(image, order='C', copy=copy)
         assert data.size != 0
-        assert data.ndim in (2, 3)
+        assert data.ndim == 2 or (data.ndim == 3 and data.shape[2] in (3, 4))
 
         self.addImage(data,
                       legend=self._imageLegend,

--- a/src/silx/gui/plot/ImageView.py
+++ b/src/silx/gui/plot/ImageView.py
@@ -825,7 +825,7 @@ class ImageViewMainWindow(ImageView):
         try:
             if isinstance(value, numpy.ndarray):
                 if len(value) == 4:
-                    return "RGBA: %i %i %i %i" % (value[0], value[1], value[2], value[3])
+                    return "RGBA: %.3g, %.3g, %.3g, %.3g" % (value[0], value[1], value[2], value[3])
                 elif len(value) == 3:
                     return "RGB: %i %i %i" % (value[0], value[1], value[2])
             else:

--- a/src/silx/gui/plot/ImageView.py
+++ b/src/silx/gui/plot/ImageView.py
@@ -857,7 +857,7 @@ class ImageViewMainWindow(ImageView):
     @docstring(ImageView)
     def setImage(self, image, *args, **kwargs):
         if hasattr(image, 'dtype') and hasattr(image, 'shape'):
-            assert image.ndim in (2, 3)
+            assert image.ndim == 2 or (image.ndim == 3 and image.shape[2] in (3, 4))
             height, width = image.shape[0:2]
             self._dataInfo = 'Data: %dx%d (%s)' % (width, height,
                                                    str(image.dtype))

--- a/src/silx/gui/plot/ImageView.py
+++ b/src/silx/gui/plot/ImageView.py
@@ -827,7 +827,7 @@ class ImageViewMainWindow(ImageView):
                 if len(value) == 4:
                     return "RGBA: %.3g, %.3g, %.3g, %.3g" % (value[0], value[1], value[2], value[3])
                 elif len(value) == 3:
-                    return "RGB: %i %i %i" % (value[0], value[1], value[2])
+                    return "RGB: %.3g, %.3g, %.3g" % (value[0], value[1], value[2])
             else:
                 return "Value: %g" % value
         except Exception:

--- a/src/silx/gui/plot/test/testImageView.py
+++ b/src/silx/gui/plot/test/testImageView.py
@@ -148,6 +148,24 @@ class TestImageView(TestCaseQt):
             ImageView.ProfileWindowBehavior.POPUP,
         )
 
+    def testRGBImage(self):
+        """Test setImage"""
+        image = numpy.arange(100 * 3, dtype=numpy.uint8).reshape(10, 10, 3)
+
+        self.plot.setImage(image, reset=True)
+        self.qWait(100)
+        self.assertEqual(self.plot.getXAxis().getLimits(), (0, 10))
+        self.assertEqual(self.plot.getYAxis().getLimits(), (0, 10))
+
+    def testRGBAImage(self):
+        """Test setImage"""
+        image = numpy.arange(100 * 4, dtype=numpy.uint8).reshape(10, 10, 4)
+
+        self.plot.setImage(image, reset=True)
+        self.qWait(100)
+        self.assertEqual(self.plot.getXAxis().getLimits(), (0, 10))
+        self.assertEqual(self.plot.getYAxis().getLimits(), (0, 10))
+
 
 def suite():
     test_suite = unittest.TestSuite()


### PR DESCRIPTION
This PR release constraints on `setImage` to allow to set RGB and RGBA images.

Few other places were fixed, like statusbar display, but not much.

Changelog: 
- Added support of RGB and RGBA images to ImageView
