### PR TITLE
silx.gui.plot: Fixed `ArcROI.setGeometry`

### DIFF
--- a/src/silx/gui/plot/items/_arc_roi.py
+++ b/src/silx/gui/plot/items/_arc_roi.py
@@ -29,6 +29,7 @@ __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "28/06/2018"
 
+import logging
 import numpy
 
 from ... import utils
@@ -38,6 +39,9 @@ from ....utils.proxy import docstring
 from ._roi_base import HandleBasedROI
 from ._roi_base import InteractionModeMixIn
 from ._roi_base import RoiInteractionMode
+
+
+logger = logging.getLogger(__name__)
 
 
 class _ArcGeometry:
@@ -779,7 +783,9 @@ class ArcROI(HandleBasedROI, items.LineMixIn, InteractionModeMixIn):
             If `startAngle` is smaller than `endAngle` the rotation is clockwise,
             else the rotation is anticlockwise.
         """
-        assert innerRadius <= outerRadius
+        if innerRadius > outerRadius:
+            logger.error("inner radius larger than outer radius")
+            innerRadius, outerRadius = outerRadius, innerRadius
         assert numpy.abs(startAngle - endAngle) <= 2 * numpy.pi
         center = numpy.array(center)
         radius = (innerRadius + outerRadius) * 0.5

--- a/src/silx/gui/plot/items/_arc_roi.py
+++ b/src/silx/gui/plot/items/_arc_roi.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -786,7 +786,6 @@ class ArcROI(HandleBasedROI, items.LineMixIn, InteractionModeMixIn):
         if innerRadius > outerRadius:
             logger.error("inner radius larger than outer radius")
             innerRadius, outerRadius = outerRadius, innerRadius
-        assert numpy.abs(startAngle - endAngle) <= 2 * numpy.pi
         center = numpy.array(center)
         radius = (innerRadius + outerRadius) * 0.5
         weight = outerRadius - innerRadius


### PR DESCRIPTION
This PR removes `assert` from `ArcROI.setGeometry`.
From what I tested, it works fine, you can create `ArcROI` with any angle range.

Only issue is that if angle range is >2π, then when you start interacting with the ROI, the arc area jumps, which is not really nice.

closes #3489
