### PR TITLE
Fix returned keepDataAspectRatioAction

### DIFF
--- a/src/silx/gui/plot/PlotWindow.py
+++ b/src/silx/gui/plot/PlotWindow.py
@@ -747,7 +747,7 @@ class PlotWindow(PlotWidget):
 
         :rtype: actions.PlotAction
         """
-        return self.keepDataAspectRatioButton
+        return self.keepDataAspectRatioAction
 
     def getYAxisInvertedButton(self):
         """Button to switch the Y axis orientation


### PR DESCRIPTION
This MR fixes probably a typo on the plot API.

Changelog: 
- Fix returned action from `getKeepDataAspectRatioAction`