### PR TITLE
silx.gui.plot: Fixed OpenGL issue with out-of-bouds axes limits

### DIFF
--- a/src/silx/gui/plot/_utils/__init__.py
+++ b/src/silx/gui/plot/_utils/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,7 @@ __date__ = "21/03/2017"
 import numpy
 
 from .panzoom import FLOAT32_SAFE_MIN, FLOAT32_MINPOS, FLOAT32_SAFE_MAX
-from .panzoom import applyZoomToPlot, applyPan
+from .panzoom import applyZoomToPlot, applyPan, checkAxisLimits
 
 
 def addMarginsToLimits(margins, isXLog, isYLog,
@@ -90,4 +90,3 @@ def addMarginsToLimits(margins, isXLog, isYLog,
         return xMin, xMax, yMin, yMax
     else:
         return xMin, xMax, yMin, yMax, y2Min, y2Max
-

--- a/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -44,7 +44,7 @@ from collections import namedtuple
 import numpy
 
 from ...._glutils import gl, Program
-from ..._utils import FLOAT32_SAFE_MIN, FLOAT32_MINPOS, FLOAT32_SAFE_MAX
+from ..._utils import checkAxisLimits, FLOAT32_MINPOS
 from .GLSupport import mat4Ortho
 from .GLText import Text2D, CENTER, BOTTOM, TOP, LEFT, RIGHT, ROTATE_270
 from ..._utils.ticklayout import niceNumbersAdaptative, niceNumbersForLog10
@@ -869,15 +869,6 @@ class GLPlotFrame2D(GLPlotFrame):
                                 self._dataRanges['y'],
                                 self._dataRanges['y2'])
 
-    @staticmethod
-    def _clipToSafeRange(min_, max_, isLog):
-        # Clip range if needed
-        minLimit = FLOAT32_MINPOS if isLog else FLOAT32_SAFE_MIN
-        min_ = numpy.clip(min_, minLimit, FLOAT32_SAFE_MAX)
-        max_ = numpy.clip(max_, minLimit, FLOAT32_SAFE_MAX)
-        assert min_ < max_
-        return min_, max_
-
     def setDataRanges(self, x=None, y=None, y2=None):
         """Set data range over each axes.
 
@@ -889,16 +880,16 @@ class GLPlotFrame2D(GLPlotFrame):
         :param y2: (min, max) data range over Y2 axis
         """
         if x is not None:
-            self._dataRanges['x'] = \
-                self._clipToSafeRange(x[0], x[1], self.xAxis.isLog)
+            self._dataRanges['x'] = checkAxisLimits(
+                x[0], x[1], self.xAxis.isLog, name='x')
 
         if y is not None:
-            self._dataRanges['y'] = \
-                self._clipToSafeRange(y[0], y[1], self.yAxis.isLog)
+            self._dataRanges['y'] = checkAxisLimits(
+                y[0], y[1], self.yAxis.isLog, name='y')
 
         if y2 is not None:
-            self._dataRanges['y2'] = \
-                self._clipToSafeRange(y2[0], y2[1], self.y2Axis.isLog)
+            self._dataRanges['y2'] = checkAxisLimits(
+                y2[0], y2[1], self.y2Axis.isLog, name='y2')
 
         self.xAxis.dataRange = self._dataRanges['x']
         self.yAxis.dataRange = self._dataRanges['y']

--- a/src/silx/gui/plot/items/axis.py
+++ b/src/silx/gui/plot/items/axis.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -34,8 +34,10 @@ import enum
 import logging
 
 import dateutil.tz
+import numpy
 
 from ... import qt
+from .. import _utils
 
 
 _logger = logging.getLogger(__name__)
@@ -141,26 +143,15 @@ class Axis(qt.QObject):
         self._getPlot()._notifyLimitsChanged(emitSignal=False)
 
     def _checkLimits(self, vmin, vmax):
-        """Makes sure axis range is not empty
+        """Makes sure axis range is not empty and within supported range.
 
         :param float vmin: Min axis value
         :param float vmax: Max axis value
         :return: (min, max) making sure min < max
         :rtype: 2-tuple of float
         """
-        if vmax < vmin:
-            _logger.debug('%s axis: max < min, inverting limits.', self._defaultLabel)
-            vmin, vmax = vmax, vmin
-        elif vmax == vmin:
-            _logger.debug('%s axis: max == min, expanding limits.', self._defaultLabel)
-            if vmin == 0.:
-                vmin, vmax = -0.1, 0.1
-            elif vmin < 0:
-                vmin, vmax = vmin * 1.1, vmin * 0.9
-            else:  # xmin > 0
-                vmin, vmax = vmin * 0.9, vmin * 1.1
-
-        return vmin, vmax
+        return _utils.checkAxisLimits(
+            vmin, vmax, isLog=self._isLogarithmic(), name=self._defaultLabel)
 
     def isInverted(self):
         """Return True if the axis is inverted (top to bottom for the y-axis),

--- a/src/silx/gui/plot/test/testPlotWidget.py
+++ b/src/silx/gui/plot/test/testPlotWidget.py
@@ -1559,6 +1559,23 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
                 axis._setLogarithmic(False)
                 self.plot.clear()
 
+    def testAxisLimitOverflow(self):
+        """Test setting limis beyond supported range"""
+        xaxis, yaxis = self.plot.getXAxis(), self.plot.getYAxis()
+        for scale in ("linear", "log"):
+            xaxis.setScale(scale)
+            yaxis.setScale(scale)
+            for limits in ((1e300, 1e308),
+                           (-1e308, 1e308),
+                           (1e-300, 2e-300)):
+                with self.subTest(scale=scale, limits=limits):
+                    xaxis.setLimits(*limits)
+                    self.qapp.processEvents()
+                    self.assertNotEqual(xaxis.getLimits(), limits)
+                    yaxis.setLimits(*limits)
+                    self.qapp.processEvents()
+                    self.assertNotEqual(yaxis.getLimits(), limits)
+
 
 class TestPlotCurveLog(PlotWidgetTestCase, ParametricTestCase):
     """Basic tests for addCurve with log scale axes"""


### PR DESCRIPTION
This PR removes an `assert` about axis limits in the `PlotWidget` OpenGL backend and replaces it with a change of the range in case of issue.
The code validating the limits range is the same as the `Axis` one and has been modified to ensure the limits are within the supported range even if the range is changed from the API or through `resetZoom` (which was not the case before).

It also adds some basic tests of out-of-bound limits.

closes #3501
