### PR TITLE
string conversion for key hdf5

### DIFF
--- a/src/silx/io/dictdump.py
+++ b/src/silx/io/dictdump.py
@@ -300,7 +300,7 @@ def dicttoh5(treedict, h5file, h5path='/',
 
         # Loop over all groups, links and datasets
         for key, value in _iter_treedict(attributes=False):
-            h5name = h5path + key
+            h5name = h5path + str(key)
             exists = h5name in h5f
 
             if value is None:


### PR DESCRIPTION



Changelog: string conversion for key hdf5 by casting the variable key to string in dicttoh5 function of dictdump.py file.
