### PR TITLE
silx.io.spech5: Make SpecH5 resilient to malformed #G1 and #G3 header lines

### DIFF
--- a/src/silx/io/spech5.py
+++ b/src/silx/io/spech5.py
@@ -298,6 +298,7 @@ def _ub_matrix_in_scan(scan):
     try:
         ub_matrix = _parse_UB_matrix(header_line)
     except ValueError:
+        logger1.warning("Malformed G3 header line")
         return False
     return numpy.any(ub_matrix)
 
@@ -327,6 +328,7 @@ def _unit_cell_in_scan(scan):
     try:
         unit_cell = _parse_unit_cell(header_line)
     except ValueError:
+        logger1.warning("Malformed G1 header line")
         return False
     return numpy.any(unit_cell)
 

--- a/src/silx/io/test/test_spech5.py
+++ b/src/silx/io/test/test_spech5.py
@@ -865,11 +865,11 @@ class TestSpecH5SlashInLabels(unittest.TestCase):
 def testUnitCellUBMatrix(tmp_path):
     """Test unit cell (#G1) and UB matrix (#G3)"""
     file_path = tmp_path / "spec.dat"
-    file_path.write_text("""
+    file_path.write_bytes(bytes("""
 #S 1 OK
 #G1 0 1 2 3 4 5
 #G3 0 1 2 3 4 5 6 7 8
-""")
+""", encoding="ascii"))
     with SpecH5(str(file_path)) as spech5:
         assert numpy.array_equal(
             spech5["/1.1/sample/ub_matrix"],
@@ -885,11 +885,11 @@ def testUnitCellUBMatrix(tmp_path):
 def testMalformedUnitCellUBMatrix(tmp_path):
     """Test malformed unit cell (#G1) and UB matrix (#G3): 1 value"""
     file_path = tmp_path / "spec.dat"
-    file_path.write_text("""
+    file_path.write_bytes(bytes("""
 #S 1 all malformed=0
 #G1 0
 #G3 0
-""")
+""", encoding="ascii"))
     with SpecH5(str(file_path)) as spech5:
         assert "sample" not in spech5["1.1"]
 
@@ -897,11 +897,11 @@ def testMalformedUnitCellUBMatrix(tmp_path):
 def testMalformedUBMatrix(tmp_path):
     """Test malformed UB matrix (#G3): all zeros"""
     file_path = tmp_path / "spec.dat"
-    file_path.write_text("""
+    file_path.write_bytes(bytes("""
 #S 1 G3 all 0
 #G1 0 1 2 3 4 5
 #G3 0 0 0 0 0 0 0 0 0
-""")
+""", encoding="ascii"))
     with SpecH5(str(file_path)) as spech5:
         assert "ub_matrix" not in spech5["/1.1/sample"]
         assert numpy.array_equal(
@@ -915,11 +915,11 @@ def testMalformedUBMatrix(tmp_path):
 def testMalformedUnitCell(tmp_path):
     """Test malformed unit cell (#G1): missing values"""
     file_path = tmp_path / "spec.dat"
-    file_path.write_text("""
+    file_path.write_bytes(bytes("""
 #S 1 G1 malformed missing values
 #G1 0 1 2
 #G3 0 1 2 3 4 5 6 7 8
-""")
+""", encoding="ascii"))
     with SpecH5(str(file_path)) as spech5:
         assert "unit_cell" not in spech5["/1.1/sample"]
         assert "unit_cell_abc" not in spech5["/1.1/sample"]

--- a/src/silx/io/test/test_spech5.py
+++ b/src/silx/io/test/test_spech5.py
@@ -22,7 +22,7 @@
 #
 # ############################################################################*/
 """Tests for spech5"""
-from numpy import array_equal
+import numpy
 import os
 import io
 import sys
@@ -369,17 +369,17 @@ class TestSpecH5(unittest.TestCase):
                 u"#P1 4.74255 6.197579 2.238283")
 
     def testLinks(self):
-        self.assertTrue(
-            array_equal(self.sfh5["/1.2/measurement/mca_0/data"],
-                        self.sfh5["/1.2/instrument/mca_0/data"])
+        self.assertTrue(numpy.array_equal(
+            self.sfh5["/1.2/measurement/mca_0/data"],
+            self.sfh5["/1.2/instrument/mca_0/data"])
         )
-        self.assertTrue(
-            array_equal(self.sfh5["/1.2/measurement/mca_0/info/data"],
-                        self.sfh5["/1.2/instrument/mca_0/data"])
+        self.assertTrue(numpy.array_equal(
+            self.sfh5["/1.2/measurement/mca_0/info/data"],
+            self.sfh5["/1.2/instrument/mca_0/data"])
         )
-        self.assertTrue(
-            array_equal(self.sfh5["/1.2/measurement/mca_0/info/channels"],
-                        self.sfh5["/1.2/instrument/mca_0/channels"])
+        self.assertTrue(numpy.array_equal(
+            self.sfh5["/1.2/measurement/mca_0/info/channels"],
+            self.sfh5["/1.2/instrument/mca_0/channels"])
         )
         self.assertEqual(self.sfh5["/1.2/measurement/mca_0/info/"].keys(),
                          self.sfh5["/1.2/instrument/mca_0/"].keys())
@@ -860,3 +860,70 @@ class TestSpecH5SlashInLabels(unittest.TestCase):
         # legitimate "%"
         self.assertIn("MRTSlit%UP",
                       self.sfh5["1.1/instrument/positioners"])
+
+
+def testUnitCellUBMatrix(tmp_path):
+    """Test unit cell (#G1) and UB matrix (#G3)"""
+    file_path = tmp_path / "spec.dat"
+    file_path.write_text("""
+#S 1 OK
+#G1 0 1 2 3 4 5
+#G3 0 1 2 3 4 5 6 7 8
+""")
+    with SpecH5(str(file_path)) as spech5:
+        assert numpy.array_equal(
+            spech5["/1.1/sample/ub_matrix"],
+            numpy.arange(9).reshape(1, 3, 3))
+        assert numpy.array_equal(
+            spech5["/1.1/sample/unit_cell"], [[0, 1, 2, 3, 4, 5]])
+        assert numpy.array_equal(
+            spech5["/1.1/sample/unit_cell_abc"], [0, 1, 2])
+        assert numpy.array_equal(
+            spech5["/1.1/sample/unit_cell_alphabetagamma"], [3, 4, 5])
+
+
+def testMalformedUnitCellUBMatrix(tmp_path):
+    """Test malformed unit cell (#G1) and UB matrix (#G3): 1 value"""
+    file_path = tmp_path / "spec.dat"
+    file_path.write_text("""
+#S 1 all malformed=0
+#G1 0
+#G3 0
+""")
+    with SpecH5(str(file_path)) as spech5:
+        assert "sample" not in spech5["1.1"]
+
+
+def testMalformedUBMatrix(tmp_path):
+    """Test malformed UB matrix (#G3): all zeros"""
+    file_path = tmp_path / "spec.dat"
+    file_path.write_text("""
+#S 1 G3 all 0
+#G1 0 1 2 3 4 5
+#G3 0 0 0 0 0 0 0 0 0
+""")
+    with SpecH5(str(file_path)) as spech5:
+        assert "ub_matrix" not in spech5["/1.1/sample"]
+        assert numpy.array_equal(
+            spech5["/1.1/sample/unit_cell"], [[0, 1, 2, 3, 4, 5]])
+        assert numpy.array_equal(
+            spech5["/1.1/sample/unit_cell_abc"], [0, 1, 2])
+        assert numpy.array_equal(
+            spech5["/1.1/sample/unit_cell_alphabetagamma"], [3, 4, 5])
+
+
+def testMalformedUnitCell(tmp_path):
+    """Test malformed unit cell (#G1): missing values"""
+    file_path = tmp_path / "spec.dat"
+    file_path.write_text("""
+#S 1 G1 malformed missing values
+#G1 0 1 2
+#G3 0 1 2 3 4 5 6 7 8
+""")
+    with SpecH5(str(file_path)) as spech5:
+        assert "unit_cell" not in spech5["/1.1/sample"]
+        assert "unit_cell_abc" not in spech5["/1.1/sample"]
+        assert "unit_cell_alphabetagamma" not in spech5["/1.1/sample"]
+        assert numpy.array_equal(
+            spech5["/1.1/sample/ub_matrix"],
+            numpy.arange(9).reshape(1, 3, 3))


### PR DESCRIPTION
This PR makes `SpecH5` resilient to `#G1` and `#G3` having less values than expected.

closes #3506