### PR TITLE
Tests: Fixed warnings raised by the test themselves

### DIFF
--- a/src/silx/gui/widgets/test/test_threadpoolpushbutton.py
+++ b/src/silx/gui/widgets/test/test_threadpoolpushbutton.py
@@ -35,7 +35,7 @@ from silx.gui import qt
 from silx.gui.utils.testutils import TestCaseQt
 from silx.gui.utils.testutils import SignalListener
 from silx.gui.widgets.ThreadPoolPushButton import ThreadPoolPushButton
-from silx.utils.testutils import TestLogging
+from silx.utils.testutils import TestLogging as _TestLogging
 
 
 class TestThreadPoolPushButton(TestCaseQt):
@@ -114,7 +114,7 @@ class TestThreadPoolPushButton(TestCaseQt):
         button.succeeded.connect(listener.partial(test="Unexpected success"))
         button.failed.connect(listener.partial(test="exception"))
         button.finished.connect(listener.partial(test="f"))
-        with TestLogging('silx.gui.widgets.ThreadPoolPushButton', error=1):
+        with _TestLogging('silx.gui.widgets.ThreadPoolPushButton', error=1):
             button.executeCallable()
             self.qapp.processEvents()
             time.sleep(0.1)

--- a/src/silx/io/test/test_dictdump.py
+++ b/src/silx/io/test/test_dictdump.py
@@ -37,7 +37,7 @@ from copy import deepcopy
 
 from collections import defaultdict
 
-from silx.utils.testutils import TestLogging
+from silx.utils.testutils import TestLogging as _TestLogging
 
 from ..configdict import ConfigDict
 from .. import dictdump
@@ -207,7 +207,7 @@ class TestDictToH5(H5DictTestCase):
         }
         with h5py.File(self.h5_fname, "w") as h5file:
             # This should not warn
-            with TestLogging(dictdump_logger, warning=0):
+            with _TestLogging(dictdump_logger, warning=0):
                 dictdump.dicttoh5(ddict, h5file, h5path="foo/bar")
 
     def testKeyOrder(self):
@@ -869,7 +869,7 @@ class TestNxToDict(H5DictTestCase):
         ddict = h5todict(self.h5_fname, path="/I/am/not/a/path", errors='ignore')
         self.assertFalse(ddict)
 
-        with TestLogging(dictdump_logger, error=1):
+        with _TestLogging(dictdump_logger, error=1):
             ddict = h5todict(self.h5_fname, path="/I/am/not/a/path", errors='log')
             self.assertFalse(ddict)
 
@@ -885,7 +885,7 @@ class TestNxToDict(H5DictTestCase):
         ddict = h5todict(self.h5_fname, path="/Mars", errors='ignore')
         self.assertFalse(ddict)
 
-        with TestLogging(dictdump_logger, error=2):
+        with _TestLogging(dictdump_logger, error=2):
             ddict = h5todict(self.h5_fname, path="/Mars", errors='log')
             self.assertFalse(ddict)
 

--- a/src/silx/math/fit/test/test_fit.py
+++ b/src/silx/math/fit/test/test_fit.py
@@ -51,7 +51,8 @@ class Test_leastsq(unittest.TestCase):
         def myexp(x):
             # put a (bad) filter to avoid over/underflows
             # with no python looping
-            return numpy.exp(x*numpy.less(abs(x), 250)) - \
+            with numpy.errstate(invalid='ignore'):
+                return numpy.exp(x*numpy.less(abs(x), 250)) - \
                    1.0 * numpy.greater_equal(abs(x), 250)
 
         self.my_exp = myexp

--- a/src/silx/math/test/test_histogramnd_nominal.py
+++ b/src/silx/math/test/test_histogramnd_nominal.py
@@ -533,6 +533,7 @@ class _Test_Histogramnd_nominal(unittest.TestCase):
             def fill_histo(h, v, dim, op=None):
                 idx = [self.other_axes_index]*len(h.shape)
                 idx[dim] = slice(0, None)
+                idx = tuple(idx)
                 if op:
                     h[idx] = op(h[idx], v)
                 else:


### PR DESCRIPTION
This PR fixes warnings that are raised by the test code.

It should fix:
```
build_venv/lib/python3.9/site-packages/silx/utils/testutils.py:116
  /builds/9qviVUiL/0/silx/bob/silx/build_venv/lib/python3.9/site-packages/silx/utils/testutils.py:116: PytestCollectionWarning: cannot collect test class 'TestLogging' because it has a __init__ constructor (from: build_venv/lib/python3.9/site-packages/silx/gui/widgets/test/test_threadpoolpushbutton.py)
    class TestLogging(logging.Handler):
build_venv/lib/python3.9/site-packages/silx/utils/testutils.py:116
  /builds/9qviVUiL/0/silx/bob/silx/build_venv/lib/python3.9/site-packages/silx/utils/testutils.py:116: PytestCollectionWarning: cannot collect test class 'TestLogging' because it has a __init__ constructor (from: build_venv/lib/python3.9/site-packages/silx/io/test/test_dictdump.py)
    class TestLogging(logging.Handler):
  /builds/9qviVUiL/0/silx/bob/silx/build_venv/lib/python3.9/site-packages/silx/math/fit/test/test_fit.py:54: RuntimeWarning: invalid value encountered in multiply
    return numpy.exp(x*numpy.less(abs(x), 250)) - \
build_venv/lib/python3.9/site-packages/silx/math/test/test_histogramnd_nominal.py: 22 warnings
  /builds/9qviVUiL/0/silx/bob/silx/build_venv/lib/python3.9/site-packages/silx/math/test/test_histogramnd_nominal.py:539: FutureWarning: Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
    h[idx] = v
```