### PR TITLE
`silx.io.convert`: Added `write_to_h5` supporting HDF5 file as input 

### DIFF
--- a/src/silx/io/commonh5.py
+++ b/src/silx/io/commonh5.py
@@ -24,9 +24,6 @@
 """
 This module contains generic objects, emulating *h5py* groups, datasets and
 files. They are used in :mod:`spech5` and :mod:`fabioh5`.
-
-.. note:: This module has a dependency on the `h5py <http://www.h5py.org/>`_
-    library, which is not a mandatory dependency for `silx`.
 """
 import collections
 try:

--- a/src/silx/io/convert.py
+++ b/src/silx/io/convert.py
@@ -62,8 +62,8 @@ import h5py
 import numpy
 
 import silx.io
-from silx.io import is_dataset, is_group, is_softlink
-from silx.io import fabioh5
+from .utils import is_dataset, is_group, is_softlink, visitall
+from . import fabioh5
 
 
 _logger = logging.getLogger(__name__)
@@ -175,7 +175,8 @@ class Hdf5Writer(object):
         """
         # Recurse through all groups and datasets to add them to the HDF5
         self._h5f = h5f
-        infile.visititems(self.append_member_to_h5, visit_links=True)
+        for name, item in visitall(infile):
+            self.append_member_to_h5(name, item)
 
         # Handle the attributes of the root group
         root_grp = h5f[self.h5path]
@@ -249,6 +250,8 @@ class Hdf5Writer(object):
                 if self.overwrite_data or key not in grp.attrs:
                     grp.attrs.create(key,
                                      _attr_utf8(obj.attrs[key]))
+        else:
+            _logger.warning("Unsuppored entity, ignoring: %s", h5_name)
 
 
 def _is_commonh5_group(grp):

--- a/src/silx/io/convert.py
+++ b/src/silx/io/convert.py
@@ -222,9 +222,9 @@ class Hdf5Writer(object):
                 else:
                     # fancy arguments don't apply to small dataset
                     if obj.size < self.min_size:
-                        ds = self._h5f.create_dataset(h5_name, data=obj.value)
+                        ds = self._h5f.create_dataset(h5_name, data=obj[()])
                     else:
-                        ds = self._h5f.create_dataset(h5_name, data=obj.value,
+                        ds = self._h5f.create_dataset(h5_name, data=obj[()],
                                                       **self.create_dataset_args)
             else:
                 ds = self._h5f[h5_name]

--- a/src/silx/io/convert.py
+++ b/src/silx/io/convert.py
@@ -254,12 +254,6 @@ class Hdf5Writer(object):
             _logger.warning("Unsuppored entity, ignoring: %s", h5_name)
 
 
-def _is_commonh5_group(grp):
-    """Return True if grp is a commonh5 group.
-    (h5py.Group objects are not commonh5 groups)"""
-    return is_group(grp) and not isinstance(grp, h5py.Group)
-
-
 def write_to_h5(infile, h5file, h5path='/', mode="a",
                 overwrite_data=False, link_type="soft",
                 create_dataset_args=None, min_size=500):
@@ -298,23 +292,15 @@ def write_to_h5(infile, h5file, h5path='/', mode="a",
     # both infile and h5file can be either file handle or a file name: 4 cases
     if not isinstance(h5file, h5py.File) and not is_group(infile):
         with silx.io.open(infile) as h5pylike:
-            if not _is_commonh5_group(h5pylike):
-                raise IOError("Cannot convert HDF5 file %s to HDF5" % infile)
             with h5py.File(h5file, mode) as h5f:
                 writer.write(h5pylike, h5f)
     elif isinstance(h5file, h5py.File) and not is_group(infile):
         with silx.io.open(infile) as h5pylike:
-            if not _is_commonh5_group(h5pylike):
-                raise IOError("Cannot convert HDF5 file %s to HDF5" % infile)
             writer.write(h5pylike, h5file)
     elif is_group(infile) and not isinstance(h5file, h5py.File):
-        if not _is_commonh5_group(infile):
-            raise IOError("Cannot convert HDF5 file %s to HDF5" % infile.file.name)
         with h5py.File(h5file, mode) as h5f:
             writer.write(infile, h5f)
     else:
-        if not _is_commonh5_group(infile):
-            raise IOError("Cannot convert HDF5 file %s to HDF5" % infile.file.name)
         writer.write(infile, h5file)
 
 

--- a/src/silx/io/convert.py
+++ b/src/silx/io/convert.py
@@ -165,13 +165,16 @@ class Hdf5Writer(object):
         """List of *(link_path, target_path)* tuples."""
 
     def write(self, infile, h5f):
-        """Do the conversion from :attr:`sfh5` (Spec file) to *h5f* (HDF5)
+        """Copy `infile` content to `h5f` file under `h5path`.
 
         All the parameters needed for the conversion have been initialized
         in the constructor.
 
-        :param infile: :class:`SpecH5` object
-        :param h5f: :class:`h5py.File` instance
+        External links in `infile` are ignored.
+
+        :param Union[commonh5.Group,h5py.Group] infile:
+             File/Class from which to read the content to copy from.
+        :param h5py.File h5f: File where to write the copied content to
         """
         # Recurse through all groups and datasets to add them to the HDF5
         self._h5f = h5f
@@ -259,8 +262,10 @@ def write_to_h5(infile, h5file, h5path='/', mode="a",
                 create_dataset_args=None, min_size=500):
     """Write content of a h5py-like object into a HDF5 file.
 
-    :param infile: Path of input file, or :class:`commonh5.File` object
-        or :class:`commonh5.Group` object.
+    Warning: External links in `infile` are ignored.
+
+    :param infile: Path of input file, :class:`commonh5.File`,
+        :class:`commonh5.Group`, :class:`h5py.File` or :class:`h5py.Group`
     :param h5file: Path of output HDF5 file or HDF5 file handle
         (`h5py.File` object)
     :param str h5path: Target path in HDF5 file in which scan groups are created.

--- a/src/silx/io/test/test_write_to_h5.py
+++ b/src/silx/io/test/test_write_to_h5.py
@@ -1,0 +1,115 @@
+# coding: utf-8
+# /*##########################################################################
+# Copyright (C) 2021 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+"""Test silx.io.convert.write_to_h5"""
+
+
+import h5py
+import numpy
+from silx.io import spech5
+
+from silx.io.convert import write_to_h5
+from silx.io.dictdump import h5todict
+from silx.io import commonh5
+from silx.io.spech5 import SpecH5
+
+
+def test_with_commonh5(tmp_path):
+    """Test write_to_h5 with commonh5 input"""
+    fobj = commonh5.File("filename.txt", mode="w")
+    group = fobj.create_group("group")
+    dataset = group.create_dataset("dataset", data=numpy.array(50))
+    group["soft_link"] = dataset # Create softlink
+
+    output_filepath = tmp_path / "output.h5"
+    write_to_h5(fobj, str(output_filepath))
+
+    assert h5todict(str(output_filepath)) == {
+        'group': {'dataset': numpy.array(50), 'soft_link': numpy.array(50)},
+    }
+    with h5py.File(output_filepath, mode="r") as h5file:
+        soft_link = h5file.get("/group/soft_link", getlink=True)
+        assert isinstance(soft_link, h5py.SoftLink)
+        assert soft_link.path == "/group/dataset"
+
+
+def test_with_hdf5(tmp_path):
+    """Test write_to_h5 with HDF5 file input"""
+    filepath = tmp_path / "base.h5"
+    with h5py.File(filepath, mode="w") as h5file:
+        h5file["group/dataset"] = 50
+        h5file["group/soft_link"] = h5py.SoftLink("/group/dataset")
+        h5file["group/external_link"] = h5py.ExternalLink("base.h5", "/group/dataset")
+
+    output_filepath = tmp_path / "output.h5"
+    write_to_h5(str(filepath), str(output_filepath))
+    assert h5todict(str(output_filepath)) == {
+        'group': {'dataset': 50, 'soft_link': 50},
+    }
+    with h5py.File(output_filepath, mode="r") as h5file:
+        soft_link = h5file.get("group/soft_link", getlink=True)
+        assert isinstance(soft_link, h5py.SoftLink)
+        assert soft_link.path == "/group/dataset"
+
+
+def test_with_spech5(tmp_path):
+    """Test write_to_h5 with SpecH5 input"""
+    filepath = tmp_path / "file.spec"
+    filepath.write_text(
+"""#F /tmp/sf.dat
+
+#S 1 cmd
+#L a  b
+1 2
+""")
+
+    output_filepath = tmp_path / "output.h5"
+    with spech5.SpecH5(str(filepath)) as spech5file:
+        write_to_h5(spech5file, str(output_filepath))
+    print(h5todict(str(output_filepath)))
+
+    def assert_equal(item1, item2):
+        if isinstance(item1, dict):
+            assert tuple(item1.keys()) == tuple(item2.keys())
+            for key in item1.keys():
+                assert_equal(item1[key], item2[key])
+        else:
+            numpy.array_equal(item1, item2)
+
+    assert_equal(h5todict(str(output_filepath)), {
+        '1.1': {
+            'instrument': {
+                'positioners': {},
+                'specfile': {
+                    'file_header': ['#F /tmp/sf.dat'],
+                    'scan_header': ['#S 1 cmd', '#L a  b'],
+                },
+            },
+            'measurement': {
+                'a': [1.],
+                'b': [2.],
+            },
+            'start_time': '',
+            'title': 'cmd',
+        },
+    })

--- a/src/silx/io/test/test_write_to_h5.py
+++ b/src/silx/io/test/test_write_to_h5.py
@@ -75,13 +75,16 @@ def test_with_hdf5(tmp_path):
 def test_with_spech5(tmp_path):
     """Test write_to_h5 with SpecH5 input"""
     filepath = tmp_path / "file.spec"
-    filepath.write_text(
+    filepath.write_bytes(
+        bytes(
 """#F /tmp/sf.dat
 
 #S 1 cmd
 #L a  b
 1 2
-""")
+""",
+        encoding='ascii')
+    )
 
     output_filepath = tmp_path / "output.h5"
     with spech5.SpecH5(str(filepath)) as spech5file:

--- a/src/silx/io/utils.py
+++ b/src/silx/io/utils.py
@@ -791,7 +791,7 @@ def _visitall(item, path=''):
 
     for name, child_item in item.items():
         if isinstance(child_item, (h5py.Group, h5py.Dataset)):
-            link = child_item.get(name, getlink=True)
+            link = item.get(name, getlink=True)
         else:
             link = child_item
         child_path = '/'.join((path, name))

--- a/src/silx/io/utils.py
+++ b/src/silx/io/utils.py
@@ -780,6 +780,38 @@ def is_link(obj):
     return t in {H5Type.SOFT_LINK, H5Type.EXTERNAL_LINK}
 
 
+def _visitall(item, path=''):
+    """Helper function for func:`visitall`.
+
+    :param item: Item to visit
+    :param str path: Relative path of the item
+    """
+    if not is_group(item):
+        return
+
+    for name, child_item in item.items():
+        if isinstance(child_item, (h5py.Group, h5py.Dataset)):
+            link = child_item.get(name, getlink=True)
+        else:
+            link = child_item
+        child_path = '/'.join((path, name))
+
+        ret = link if link is not None and is_link(link) else child_item
+        yield child_path, ret
+        yield from _visitall(child_item, child_path)
+
+
+def visitall(item):
+    """Visit entity recursively including links.
+
+    It does not follow links.
+    This is a generator yielding (relative path, object) for visited items.
+
+    :param item: The item to visit.
+    """
+    yield from _visitall(item, '')
+
+
 def get_data(url):
     """Returns a numpy data from an URL.
 


### PR DESCRIPTION
This PR allows to provide a HDF5 file as input to `write_to_h5`.
This was not possible before because `commonh5.visititem` had a different API than it's `h5py` equivalent and was disabled as part of #1385.

To achieve this, this PR adds a `silx.io.utils.visitall` function that provides a visitor of all items including links that works for both `commonh5` and `h5py`. This function is used by `write_to_h5` implementation.

It also provides some basic tests.

Current limitation: External links in input file are ignored (with a warning).

closes #3468
