### PR TITLE
silx.gui.plot.actions.histogram: Added controls to change histogram nbins and range

### DIFF
--- a/examples/plotUpdateImageFromThread.py
+++ b/examples/plotUpdateImageFromThread.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -116,6 +116,7 @@ def main():
 
     # Create a Plot2D, set its limits and display it
     plot2d = Plot2D()
+    plot2d.getIntensityHistogramAction().setVisible(True)
     plot2d.setLimits(0, Nx, 0, Ny)
     plot2d.getDefaultColormap().setVRange(0., 1.5)
     plot2d.show()

--- a/src/silx/gui/plot/actions/histogram.py
+++ b/src/silx/gui/plot/actions/histogram.py
@@ -262,7 +262,7 @@ class HistogramWidget(qt.QWidget):
         if nbins is None:
             nbins = self.__nbinsLineEdit.getValue()
         if range_ is None:
-            range_ = self.__rangeSlider.getRange()
+            range_ = self.__rangeSlider.getValues()
 
         hist = self.getHistogram(copy=False)
         if hist is not None:

--- a/src/silx/gui/plot/actions/histogram.py
+++ b/src/silx/gui/plot/actions/histogram.py
@@ -385,9 +385,13 @@ class HistogramWidget(qt.QWidget):
         # Set slider range: do not keep the range value, but the relative pos.
         previousPositions = self.__rangeSlider.getPositions()
         if xmin == xmax:  # Enlarge range is none
-            range_ = sorted((xmin * .99, xmin * 1.01))
+            if xmin == 0:
+                range_ = -0.01, 0.01
+            else:
+                range_ = sorted((xmin * .99, xmin * 1.01))
         else:
             range_ = xmin, xmax
+
         self.__rangeSlider.setRange(*range_)
         self.__rangeSlider.setPositions(*previousPositions)
 

--- a/src/silx/gui/plot/actions/histogram.py
+++ b/src/silx/gui/plot/actions/histogram.py
@@ -384,7 +384,11 @@ class HistogramWidget(qt.QWidget):
         self.__nbinsLineEdit.setDefaultValue(guessed_nbins, extend_range=True)
         # Set slider range: do not keep the range value, but the relative pos.
         previousPositions = self.__rangeSlider.getPositions()
-        self.__rangeSlider.setRange(xmin, xmax)
+        if xmin == xmax:  # Enlarge range is none
+            range_ = sorted((xmin * .99, xmin * 1.01))
+        else:
+            range_ = xmin, xmax
+        self.__rangeSlider.setRange(*range_)
         self.__rangeSlider.setPositions(*previousPositions)
 
         histogram = Histogramnd(

--- a/src/silx/gui/widgets/RangeSlider.py
+++ b/src/silx/gui/widgets/RangeSlider.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -287,8 +287,12 @@ class RangeSlider(qt.QWidget):
         Slider positions remains unchanged and slider values are modified.
 
         :param float minimum:
+        :raises ValueError:
         """
         minimum = float(minimum)
+        if minimum == self.getMaximum():
+            raise ValueError("min and max must be different")
+
         if minimum != self.getMinimum():
             if minimum > self.getMaximum():
                 self.__maxValue = minimum
@@ -309,8 +313,12 @@ class RangeSlider(qt.QWidget):
         Slider positions remains unchanged and slider values are modified.
 
         :param float maximum:
+        :raises ValueError:
         """
         maximum = float(maximum)
+        if maximum == self.getMinimum():
+            raise ValueError("min and max must be different")
+
         if maximum != self.getMaximum():
             if maximum < self.getMinimum():
                 self.__minValue = maximum
@@ -332,8 +340,11 @@ class RangeSlider(qt.QWidget):
 
         :param float minimum:
         :param float maximum:
+        :raises ValueError:
         """
         minimum, maximum = float(minimum), float(maximum)
+        if minimum == maximum:
+            raise ValueError("min and max must be different")
         if minimum != self.getMinimum() or maximum != self.getMaximum():
             self.__minValue = minimum
             self.__maxValue = max(maximum, minimum)


### PR DESCRIPTION
This PR adds 2 widgets to set the number of bins and the range of the histogram in the plot from the histogram action.

The number of bins is guessed by default (and displayed as placeholder text) and when the user inputs it, it is kept when data is updated (e.g., browsing a stack of image in silx view). To fallback to bin number guessing, the user has to delete the input text.
Updates are done on "Enter".

The absolute range is NOT persisted when changing data, instead the "relative range" is persisted (i.e., the histogram bounds in the data are changed but the positions of the thumb on the range slider are not).
I see it hard to keep the absolute range since it can fall outside of the data range when changing data.
At the same time, it might be useful to keep some similar range from one image to the next in a stack.


![Screenshot from 2021-07-29 14-11-35](https://user-images.githubusercontent.com/9449698/127509513-57a8d10f-70f7-4925-ae5d-b4069bc3a91a.png)

closes #3216