### PR TITLE
Misc.: Fixed invalid value, deprecation and test warnings

### DIFF
--- a/src/silx/gui/_glutils/utils.py
+++ b/src/silx/gui/_glutils/utils.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -100,12 +100,14 @@ def segmentTrianglesIntersection(segment, triangles):
     intersect = numpy.where(intersect)[0]  # Indices of intersected triangles
 
     # Get barycentric coordinates
-    barycentric = subVolumes[intersect] / volume[intersect].reshape(-1, 1)
+    with numpy.errstate(invalid="ignore"):
+        barycentric = subVolumes[intersect] / volume[intersect].reshape(-1, 1)
     del subVolumes
 
     # Test segment/triangles intersection
     volAlpha = numpy.sum(t0s0CrossEdge01[intersect] * edge02[intersect], axis=1)
-    t = volAlpha / volume[intersect]  # segment parameter of intersected triangles
+    with numpy.errstate(invalid="ignore"):
+        t = volAlpha / volume[intersect]  # segment parameter of intersected triangles
     del t0s0CrossEdge01
     del edge02
     del volAlpha

--- a/src/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -987,10 +987,12 @@ class _ErrorBars(object):
 
             # Interleave vertices for xError
             endXError = 4 * nbDataPts
-            xCoords[0:endXError-3:4] = self._xData + xErrorPlus
+            with numpy.errstate(invalid="ignore"):
+                xCoords[0:endXError-3:4] = self._xData + xErrorPlus
             xCoords[1:endXError-2:4] = self._xData
             xCoords[2:endXError-1:4] = self._xData
-            xCoords[3:endXError:4] = self._xData - xErrorMinus
+            with numpy.errstate(invalid="ignore"):
+                xCoords[3:endXError:4] = self._xData - xErrorMinus
 
             yCoords[0:endXError-3:4] = self._yData
             yCoords[1:endXError-2:4] = self._yData
@@ -1013,10 +1015,12 @@ class _ErrorBars(object):
             xCoords[endXError+2::4] = self._xData
             xCoords[endXError+3::4] = self._xData
 
-            yCoords[endXError::4] = self._yData + yErrorPlus
+            with numpy.errstate(invalid="ignore"):
+                yCoords[endXError::4] = self._yData + yErrorPlus
             yCoords[endXError+1::4] = self._yData
             yCoords[endXError+2::4] = self._yData
-            yCoords[endXError+3::4] = self._yData - yErrorMinus
+            with numpy.errstate(invalid="ignore"):
+                yCoords[endXError+3::4] = self._yData - yErrorMinus
 
         return xCoords, yCoords
 
@@ -1143,8 +1147,9 @@ class GLPlotCurve2D(GLPlotItem):
         if xData.itemsize > 4 or yData.itemsize > 4:  # Use normalization
             # offset data, do not offset error as it is relative
             self.offset = self.xMin, self.yMin
-            self.xData = (xData - self.offset[0]).astype(numpy.float32)
-            self.yData = (yData - self.offset[1]).astype(numpy.float32)
+            with numpy.errstate(invalid="ignore"):
+                self.xData = (xData - self.offset[0]).astype(numpy.float32)
+                self.yData = (yData - self.offset[1]).astype(numpy.float32)
 
         else:  # float32
             self.offset = 0., 0.

--- a/src/silx/gui/plot/tools/test/testTools.py
+++ b/src/silx/gui/plot/tools/test/testTools.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -33,7 +33,7 @@ import functools
 import unittest
 import numpy
 
-from silx.utils.testutils import TestLogging
+from silx.utils.testutils import TestLogging as _TestLogging
 from silx.gui.utils.testutils import qWaitForWindowExposedAndActivate
 from silx.gui import qt
 from silx.gui.plot import PlotWindow
@@ -72,7 +72,7 @@ class TestPositionInfo(PlotWidgetTestCase):
         for index, name in enumerate(converterNames):
             self.assertEqual(converters[index][0], name)
 
-        with TestLogging(tools.__name__, **kwargs):
+        with _TestLogging(tools.__name__, **kwargs):
             # Move mouse to center
             center = self.plot.size() / 2
             self.mouseMove(self.plot, pos=(center.width(), center.height()))

--- a/src/silx/gui/plot3d/items/image.py
+++ b/src/silx/gui/plot3d/items/image.py
@@ -309,8 +309,8 @@ class HeightMapData(_HeightMap, ColormapMixIn):
 
         if data.shape != heightData.shape:  # data and height size miss-match
             # Colormapped data is interpolated (nearest-neighbour) to match the height field
-            data = data[numpy.floor(y * data.shape[0] / height).astype(numpy.int),
-                        numpy.floor(x * data.shape[1] / height).astype(numpy.int)]
+            data = data[numpy.floor(y * data.shape[0] / height).astype(numpy.int32),
+                        numpy.floor(x * data.shape[1] / height).astype(numpy.int32)]
 
         x = numpy.ravel(x)
         y = numpy.ravel(y)
@@ -383,8 +383,8 @@ class HeightMapRGBA(_HeightMap):
 
         if rgba.shape[:2] != heightData.shape:  # image and height size miss-match
             # RGBA data is interpolated (nearest-neighbour) to match the height field
-            rgba = rgba[numpy.floor(y * rgba.shape[0] / height).astype(numpy.int),
-                        numpy.floor(x * rgba.shape[1] / height).astype(numpy.int)]
+            rgba = rgba[numpy.floor(y * rgba.shape[0] / height).astype(numpy.int32),
+                        numpy.floor(x * rgba.shape[1] / height).astype(numpy.int32)]
 
         x = numpy.ravel(x)
         y = numpy.ravel(y)


### PR DESCRIPTION
Fixes the following warnings raised in CI on Windows when running the tests:
```
venv_test\lib\site-packages\silx\utils\testutils.py:116
  C:\projects\silx-7wjwv\venv_test\lib\site-packages\silx\utils\testutils.py:116: PytestCollectionWarning: cannot collect test class 'TestLogging' because it has a __init__ constructor (from: gui/plot/tools/test/testTools.py)
    class TestLogging(logging.Handler):

gui/plot/test/testPlotWidget.py::TestPlotCurve_Gl::testPlotCurveInfinite
  C:\projects\silx-7wjwv\venv_test\lib\site-packages\silx\gui\plot\backends\glutils\GLPlotCurve.py:1147: RuntimeWarning: invalid value encountered in subtract
    self.yData = (yData - self.offset[1]).astype(numpy.float32)

gui/plot/test/testPlotWidget.py::TestPlotCurveLog_Gl::testPlotCurveErrorLogXY
  C:\projects\silx-7wjwv\venv_test\lib\site-packages\silx\gui\plot\backends\glutils\GLPlotCurve.py:993: RuntimeWarning: invalid value encountered in subtract
    xCoords[3:endXError:4] = self._xData - xErrorMinus

gui/plot/test/testPlotWidget.py::TestPlotCurveLog_Gl::testPlotCurveErrorLogXY
  C:\projects\silx-7wjwv\venv_test\lib\site-packages\silx\gui\plot\backends\glutils\GLPlotCurve.py:1019: RuntimeWarning: invalid value encountered in subtract
    yCoords[endXError+3::4] = self._yData - yErrorMinus

gui/plot3d/test/testSceneWidgetPicking.py::TestSceneWidgetPicking::testPickMeshWithIndices
  C:\projects\silx-7wjwv\venv_test\lib\site-packages\silx\gui\_glutils\utils.py:103: RuntimeWarning: invalid value encountered in true_divide
    barycentric = subVolumes[intersect] / volume[intersect].reshape(-1, 1)

gui/plot3d/test/testSceneWidgetPicking.py::TestSceneWidgetPicking::testPickMeshWithIndices
  C:\projects\silx-7wjwv\venv_test\lib\site-packages\silx\gui\_glutils\utils.py:108: RuntimeWarning: invalid value encountered in true_divide
    t = volAlpha / volume[intersect]  # segment parameter of intersected triangles

gui/plot3d/test/testSceneWindow.py::TestSceneWindow::testHeightMap
  C:\projects\silx-7wjwv\venv_test\lib\site-packages\silx\gui\plot3d\items\image.py:312: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    data = data[numpy.floor(y * data.shape[0] / height).astype(numpy.int),

gui/plot3d/test/testSceneWindow.py::TestSceneWindow::testHeightMap
  C:\projects\silx-7wjwv\venv_test\lib\site-packages\silx\gui\plot3d\items\image.py:313: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    numpy.floor(x * data.shape[1] / height).astype(numpy.int)]

gui/plot3d/test/testSceneWindow.py::TestSceneWindow::testHeightMap
  C:\projects\silx-7wjwv\venv_test\lib\site-packages\silx\gui\plot3d\items\image.py:386: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    rgba = rgba[numpy.floor(y * rgba.shape[0] / height).astype(numpy.int),

gui/plot3d/test/testSceneWindow.py::TestSceneWindow::testHeightMap
  C:\projects\silx-7wjwv\venv_test\lib\site-packages\silx\gui\plot3d\items\image.py:387: DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
    numpy.floor(x * rgba.shape[1] / height).astype(numpy.int)]

```