### PR TITLE
`silx.utils.testutils`: Renamed `TestLogging` and `test_logging` to `LoggingValidator` and `validate_logging`

### DIFF
--- a/src/silx/app/test/test_convert.py
+++ b/src/silx/app/test/test_convert.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -108,7 +108,7 @@ class TestConvertCommand(unittest.TestCase):
             result = e.args[0]
         self.assertNotEqual(result, 0)
 
-    @testutils.test_logging(convert._logger.name, error=3)
+    @testutils.validate_logging(convert._logger.name, error=3)
     # one error log per missing file + one "Aborted" error log
     def testWrongFiles(self):
         result = convert.main(["convert", "foo.spec", "bar.edf"])

--- a/src/silx/gui/plot/tools/test/testProfile.py
+++ b/src/silx/gui/plot/tools/test/testProfile.py
@@ -369,7 +369,7 @@ class TestProfileToolBar(TestCaseQt, ParametricTestCase):
                             if not manager.hasPendingOperations():
                                 break
 
-    @testutils.test_logging(deprecation.depreclog.name, warning=4)
+    @testutils.validate_logging(deprecation.depreclog.name, warning=4)
     def testDiagonalProfile(self):
         """Test diagonal profile, without and with image"""
         # Use Plot backend widget to submit mouse events
@@ -446,7 +446,7 @@ class TestDeprecatedProfileToolBar(TestCaseQt):
 
         super(TestDeprecatedProfileToolBar, self).tearDown()
 
-    @testutils.test_logging(deprecation.depreclog.name, warning=2)
+    @testutils.validate_logging(deprecation.depreclog.name, warning=2)
     def testCustomProfileWindow(self):
         from silx.gui.plot import ProfileMainWindow
 
@@ -510,7 +510,7 @@ class TestProfile3DToolBar(TestCaseQt):
 
         super(TestProfile3DToolBar, self).tearDown()
 
-    @testutils.test_logging(deprecation.depreclog.name, warning=2)
+    @testutils.validate_logging(deprecation.depreclog.name, warning=2)
     def testMethodProfile2D(self):
         """Test that the profile can have a different method if we want to
         compute then in 1D or in 2D"""
@@ -539,7 +539,7 @@ class TestProfile3DToolBar(TestCaseQt):
         expected = numpy.array([[1, 4], [7, 10], [13, 16]])
         numpy.testing.assert_almost_equal(data, expected)
 
-    @testutils.test_logging(deprecation.depreclog.name, warning=2)
+    @testutils.validate_logging(deprecation.depreclog.name, warning=2)
     def testMethodSumLine(self):
         """Simple interaction test to make sure the sum is correctly computed
         """

--- a/src/silx/gui/plot/tools/test/testTools.py
+++ b/src/silx/gui/plot/tools/test/testTools.py
@@ -33,7 +33,7 @@ import functools
 import unittest
 import numpy
 
-from silx.utils.testutils import TestLogging as _TestLogging
+from silx.utils.testutils import LoggingValidator
 from silx.gui.utils.testutils import qWaitForWindowExposedAndActivate
 from silx.gui import qt
 from silx.gui.plot import PlotWindow
@@ -72,7 +72,7 @@ class TestPositionInfo(PlotWidgetTestCase):
         for index, name in enumerate(converterNames):
             self.assertEqual(converters[index][0], name)
 
-        with _TestLogging(tools.__name__, **kwargs):
+        with LoggingValidator(tools.__name__, **kwargs):
             # Move mouse to center
             center = self.plot.size() / 2
             self.mouseMove(self.plot, pos=(center.width(), center.height()))

--- a/src/silx/gui/widgets/test/test_threadpoolpushbutton.py
+++ b/src/silx/gui/widgets/test/test_threadpoolpushbutton.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +35,7 @@ from silx.gui import qt
 from silx.gui.utils.testutils import TestCaseQt
 from silx.gui.utils.testutils import SignalListener
 from silx.gui.widgets.ThreadPoolPushButton import ThreadPoolPushButton
-from silx.utils.testutils import TestLogging as _TestLogging
+from silx.utils.testutils import LoggingValidator
 
 
 class TestThreadPoolPushButton(TestCaseQt):
@@ -114,7 +114,7 @@ class TestThreadPoolPushButton(TestCaseQt):
         button.succeeded.connect(listener.partial(test="Unexpected success"))
         button.failed.connect(listener.partial(test="exception"))
         button.finished.connect(listener.partial(test="f"))
-        with _TestLogging('silx.gui.widgets.ThreadPoolPushButton', error=1):
+        with LoggingValidator('silx.gui.widgets.ThreadPoolPushButton', error=1):
             button.executeCallable()
             self.qapp.processEvents()
             time.sleep(0.1)

--- a/src/silx/io/test/test_dictdump.py
+++ b/src/silx/io/test/test_dictdump.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2020 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -37,7 +37,7 @@ from copy import deepcopy
 
 from collections import defaultdict
 
-from silx.utils.testutils import TestLogging as _TestLogging
+from silx.utils.testutils import LoggingValidator
 
 from ..configdict import ConfigDict
 from .. import dictdump
@@ -207,7 +207,7 @@ class TestDictToH5(H5DictTestCase):
         }
         with h5py.File(self.h5_fname, "w") as h5file:
             # This should not warn
-            with _TestLogging(dictdump_logger, warning=0):
+            with LoggingValidator(dictdump_logger, warning=0):
                 dictdump.dicttoh5(ddict, h5file, h5path="foo/bar")
 
     def testKeyOrder(self):
@@ -869,7 +869,7 @@ class TestNxToDict(H5DictTestCase):
         ddict = h5todict(self.h5_fname, path="/I/am/not/a/path", errors='ignore')
         self.assertFalse(ddict)
 
-        with _TestLogging(dictdump_logger, error=1):
+        with LoggingValidator(dictdump_logger, error=1):
             ddict = h5todict(self.h5_fname, path="/I/am/not/a/path", errors='log')
             self.assertFalse(ddict)
 
@@ -885,7 +885,7 @@ class TestNxToDict(H5DictTestCase):
         ddict = h5todict(self.h5_fname, path="/Mars", errors='ignore')
         self.assertFalse(ddict)
 
-        with _TestLogging(dictdump_logger, error=2):
+        with LoggingValidator(dictdump_logger, error=2):
             ddict = h5todict(self.h5_fname, path="/Mars", errors='log')
             self.assertFalse(ddict)
 

--- a/src/silx/io/test/test_specfile.py
+++ b/src/silx/io/test/test_specfile.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -376,7 +376,7 @@ class TestSpecFile(unittest.TestCase):
         self.assertEqual(self.scan25.mca.channels,
                          [])
 
-    @testutils.test_logging(specfile._logger.name, warning=1)
+    @testutils.validate_logging(specfile._logger.name, warning=1)
     def test_empty_scan(self):
         """Test reading a scan with no data points"""
         self.assertEqual(len(self.empty_scan.labels),

--- a/src/silx/io/test/test_spech5.py
+++ b/src/silx/io/test/test_spech5.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -569,7 +569,7 @@ class TestSpecH5(unittest.TestCase):
         with self.assertRaises(KeyError):
             self.sfh5["/1001.1/sample/unit_cell"]
 
-    @testutils.test_logging(spech5.logger1.name, warning=2)
+    @testutils.validate_logging(spech5.logger1.name, warning=2)
     def testOpenFileDescriptor(self):
         """Open a SpecH5 file from a file descriptor"""
         with io.open(self.sfh5.filename) as f:

--- a/src/silx/math/fit/test/test_fit.py
+++ b/src/silx/math/fit/test/test_fit.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2020 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -242,7 +242,7 @@ class Test_leastsq(unittest.TestCase):
                                                       fittedpar[i])
             self.assertTrue(test_condition, msg)
 
-    @testutils.test_logging(fitlogger.name, warning=2)
+    @testutils.validate_logging(fitlogger.name, warning=2)
     def testBadlyShapedData(self):
         parameters_actual = [10.5, 2, 1000.0, 20., 15]
         x = numpy.arange(10000.).reshape(1000, 10)
@@ -264,7 +264,7 @@ class Test_leastsq(unittest.TestCase):
                                                           fittedpar[i])
                 self.assertTrue(test_condition, msg)
 
-    @testutils.test_logging(fitlogger.name, warning=3)
+    @testutils.validate_logging(fitlogger.name, warning=3)
     def testDataWithNaN(self):
         parameters_actual = [10.5, 2, 1000.0, 20., 15]
         x = numpy.arange(10000.).reshape(1000, 10)

--- a/src/silx/utils/test/test_debug.py
+++ b/src/silx/utils/test/test_debug.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -62,24 +62,24 @@ class TestDebug(unittest.TestCase):
         test = _Foobar()
         test.b()
 
-    @testutils.test_logging(debug.debug_logger.name, warning=2)
+    @testutils.validate_logging(debug.debug_logger.name, warning=2)
     def testMethod(self):
         test = _Foobar()
         test.a()
 
-    @testutils.test_logging(debug.debug_logger.name, warning=4)
+    @testutils.validate_logging(debug.debug_logger.name, warning=4)
     def testInterleavedMethod(self):
         test = _Foobar()
         test.b()
 
-    @testutils.test_logging(debug.debug_logger.name, warning=2)
+    @testutils.validate_logging(debug.debug_logger.name, warning=2)
     def testNamedArgument(self):
         # Arguments arre still provided to the patched method
         test = _Foobar()
         result = test.named_args(10, 11)
         self.assertEqual(result, (11, 12))
 
-    @testutils.test_logging(debug.debug_logger.name, warning=2)
+    @testutils.validate_logging(debug.debug_logger.name, warning=2)
     def testRandomArguments(self):
         # Arguments arre still provided to the patched method
         test = _Foobar()

--- a/src/silx/utils/test/test_deprecation.py
+++ b/src/silx/utils/test/test_deprecation.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -87,10 +87,10 @@ class TestDeprecation(unittest.TestCase):
         deprecation.deprecated_warning(type_="t", name="n")
 
     def testBacktrace(self):
-        testLogging = testutils.TestLogging(deprecation.depreclog.name)
-        with testLogging:
+        loggingValidator = testutils.LoggingValidator(deprecation.depreclog.name)
+        with loggingValidator:
             self.deprecatedEveryTime()
-        message = testLogging.records[0].getMessage()
+        message = loggingValidator.records[0].getMessage()
         filename = __file__.replace(".pyc", ".py")
         self.assertTrue(filename in message)
         self.assertTrue("testBacktrace" in message)

--- a/src/silx/utils/test/test_deprecation.py
+++ b/src/silx/utils/test/test_deprecation.py
@@ -53,22 +53,22 @@ class TestDeprecation(unittest.TestCase):
     def deprecatedEveryTime(self):
         pass
 
-    @testutils.test_logging(deprecation.depreclog.name, warning=1)
+    @testutils.validate_logging(deprecation.depreclog.name, warning=1)
     def testAnnotationWithoutParam(self):
         self.deprecatedWithoutParam()
 
-    @testutils.test_logging(deprecation.depreclog.name, warning=1)
+    @testutils.validate_logging(deprecation.depreclog.name, warning=1)
     def testAnnotationWithParams(self):
         self.deprecatedWithParams()
 
-    @testutils.test_logging(deprecation.depreclog.name, warning=3)
+    @testutils.validate_logging(deprecation.depreclog.name, warning=3)
     def testLoggedEveryTime(self):
         """Logged everytime cause it is 3 different locations"""
         self.deprecatedOnlyOnce()
         self.deprecatedOnlyOnce()
         self.deprecatedOnlyOnce()
 
-    @testutils.test_logging(deprecation.depreclog.name, warning=1)
+    @testutils.validate_logging(deprecation.depreclog.name, warning=1)
     def testLoggedSingleTime(self):
         def log():
             self.deprecatedOnlyOnce()
@@ -76,13 +76,13 @@ class TestDeprecation(unittest.TestCase):
         log()
         log()
 
-    @testutils.test_logging(deprecation.depreclog.name, warning=3)
+    @testutils.validate_logging(deprecation.depreclog.name, warning=3)
     def testLoggedEveryTime2(self):
         self.deprecatedEveryTime()
         self.deprecatedEveryTime()
         self.deprecatedEveryTime()
 
-    @testutils.test_logging(deprecation.depreclog.name, warning=1)
+    @testutils.validate_logging(deprecation.depreclog.name, warning=1)
     def testWarning(self):
         deprecation.deprecated_warning(type_="t", name="n")
 

--- a/src/silx/utils/test/test_number.py
+++ b/src/silx/utils/test/test_number.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -154,7 +154,7 @@ class TestConversionTypes(testutils.ParametricTestCase):
             self.skipTest("numpy > 1.10.4 expected")
         # value does not fit even in a 128 bits mantissa
         value = "1.0340282366920938463463374607431768211456"
-        func = testutils.test_logging(number._logger.name, warning=1)
+        func = testutils.validate_logging(number._logger.name, warning=1)
         func = func(number.min_numerical_convertible_type)
         dtype = func(value)
         self.assertIn(dtype, (numpy.longdouble, ))

--- a/src/silx/utils/test/test_testutils.py
+++ b/src/silx/utils/test/test_testutils.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -34,26 +34,26 @@ import logging
 from .. import testutils
 
 
-class TestTestLogging(unittest.TestCase):
-    """Tests for TestLogging."""
+class TestLoggingValidator(unittest.TestCase):
+    """Tests for LoggingValidator"""
 
     def testRight(self):
         logger = logging.getLogger(__name__ + "testRight")
-        listener = testutils.TestLogging(logger, error=1)
+        listener = testutils.LoggingValidator(logger, error=1)
         with listener:
             logger.error("expected")
             logger.info("ignored")
 
     def testCustomLevel(self):
         logger = logging.getLogger(__name__ + "testCustomLevel")
-        listener = testutils.TestLogging(logger, error=1)
+        listener = testutils.LoggingValidator(logger, error=1)
         with listener:
             logger.error("expected")
             logger.log(666, "custom level have to be ignored")
 
     def testWrong(self):
         logger = logging.getLogger(__name__ + "testWrong")
-        listener = testutils.TestLogging(logger, error=1)
+        listener = testutils.LoggingValidator(logger, error=1)
         with self.assertRaises(RuntimeError):
             with listener:
                 logger.error("expected")
@@ -61,14 +61,14 @@ class TestTestLogging(unittest.TestCase):
 
     def testManyErrors(self):
         logger = logging.getLogger(__name__ + "testManyErrors")
-        listener = testutils.TestLogging(logger, error=1, warning=2)
+        listener = testutils.LoggingValidator(logger, error=1, warning=2)
         with self.assertRaises(RuntimeError):
             with listener:
                 pass
 
     def testCanBeChecked(self):
         logger = logging.getLogger(__name__ + "testCanBreak")
-        listener = testutils.TestLogging(logger, error=1, warning=2)
+        listener = testutils.LoggingValidator(logger, error=1, warning=2)
         with self.assertRaises(RuntimeError):
             with listener:
                 logger.error("aaa")
@@ -80,13 +80,13 @@ class TestTestLogging(unittest.TestCase):
 
     def testWithAs(self):
         logger = logging.getLogger(__name__ + "testCanBreak")
-        with testutils.TestLogging(logger) as listener:
+        with testutils.LoggingValidator(logger) as listener:
             logger.error("aaa")
             self.assertIsNotNone(listener)
 
     def testErrorMessage(self):
         logger = logging.getLogger(__name__ + "testCanBreak")
-        listener = testutils.TestLogging(logger, error=1, warning=2)
+        listener = testutils.LoggingValidator(logger, error=1, warning=2)
         with self.assertRaisesRegex(RuntimeError, "aaabbb"):
             with listener:
                 logger.error("aaa")

--- a/src/silx/utils/testutils.py
+++ b/src/silx/utils/testutils.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,7 @@
 
 - :class:`ParametricTestCase` provides a :meth:`TestCase.subTest` replacement
   for Python < 3.4
-- :class:`TestLogging` with context or the :func:`test_logging` decorator
+- :class:`LoggingValidator` with context or the :func:`test_logging` decorator
   enables testing the number of logging messages of different levels.
 """
 
@@ -103,7 +103,7 @@ def parameterize(test_case_class, *args, **kwargs):
 
 
 class LoggingRuntimeError(RuntimeError):
-    """Raised when the `TestLogging` fails"""
+    """Raised when the `LoggingValidator` fails"""
 
     def __init__(self, msg, records):
         super(LoggingRuntimeError, self).__init__(msg)
@@ -113,14 +113,14 @@ class LoggingRuntimeError(RuntimeError):
         return super(LoggingRuntimeError, self).__str__() + " -> " + str(self.records)
 
 
-class TestLogging(logging.Handler):
+class LoggingValidator(logging.Handler):
     """Context checking the number of logging messages from a specified Logger.
 
     It disables propagation of logging message while running.
 
     This is meant to be used as a with statement, for example:
 
-    >>> with TestLogging(logger, error=2, warning=0):
+    >>> with LoggingValidator(logger, error=2, warning=0):
     >>>     pass  # Run tests here expecting 2 ERROR and no WARNING from logger
     ...
 
@@ -164,7 +164,7 @@ class TestLogging(logging.Handler):
         self._expected_count = sum([v for k, v in self.expected_count_by_level.items() if v is not None])
         """Amount of any logging expected"""
 
-        super(TestLogging, self).__init__()
+        super(LoggingValidator, self).__init__()
 
     def __enter__(self):
         """Context (i.e., with) support"""
@@ -270,8 +270,8 @@ def test_logging(logger=None, critical=None, error=None,
                        Default: Do not check.
     """
     def decorator(func):
-        test_context = TestLogging(logger, critical, error,
-                                   warning, info, debug, notset)
+        test_context = LoggingValidator(
+            logger, critical, error, warning, info, debug, notset)
 
         @functools.wraps(func)
         def wrapper(*args, **kwargs):

--- a/src/silx/utils/testutils.py
+++ b/src/silx/utils/testutils.py
@@ -40,6 +40,8 @@ import functools
 import logging
 import sys
 import unittest
+from . import deprecation
+
 
 _logger = logging.getLogger(__name__)
 
@@ -239,7 +241,6 @@ class LoggingValidator(logging.Handler):
         self.records.append(record)
 
 
-
 def validate_logging(logger=None, critical=None, error=None,
                      warning=None, info=None, debug=None, notset=None):
     """Decorator checking number of logging messages.
@@ -281,6 +282,22 @@ def validate_logging(logger=None, critical=None, error=None,
             return result
         return wrapper
     return decorator
+
+
+# Backward compatibility
+class TestLogging(LoggingValidator):
+    def __init__(self, *args, **kwargs):
+        deprecation.deprecated_warning(
+            "Class",
+            "TestLogging",
+            since_version="1.0.0",
+            replacement="LoggingValidator")
+        super().__init__(*args, **kwargs)
+
+
+@deprecation.deprecated(since_version="1.0.0", replacement="validate_logging")
+def test_logging(*args, **kwargs):
+    return validate_logging(*args, **kwargs)
 
 
 # Simulate missing library context

--- a/src/silx/utils/testutils.py
+++ b/src/silx/utils/testutils.py
@@ -26,8 +26,8 @@
 
 - :class:`ParametricTestCase` provides a :meth:`TestCase.subTest` replacement
   for Python < 3.4
-- :class:`LoggingValidator` with context or the :func:`test_logging` decorator
-  enables testing the number of logging messages of different levels.
+- :class:`LoggingValidator` with context or the :func:`validate_logging`
+  decorator enables testing the number of logging messages of different levels.
 """
 
 __authors__ = ["T. Vincent"]
@@ -239,8 +239,9 @@ class LoggingValidator(logging.Handler):
         self.records.append(record)
 
 
-def test_logging(logger=None, critical=None, error=None,
-                 warning=None, info=None, debug=None, notset=None):
+
+def validate_logging(logger=None, critical=None, error=None,
+                     warning=None, info=None, debug=None, notset=None):
     """Decorator checking number of logging messages.
 
     Propagation of logging messages is disabled by this decorator.
@@ -249,7 +250,7 @@ def test_logging(logger=None, critical=None, error=None,
     a RuntimeError.
 
     >>> class Test(unittest.TestCase):
-    ...     @test_logging('module_logger_name', error=2, warning=0)
+    ...     @validate_logging('module_logger_name', error=2, warning=0)
     ...     def test(self):
     ...         pass  # Test expecting 2 ERROR and 0 WARNING messages
 


### PR DESCRIPTION
This renaming is to avoid pytest test gathering possible issue with functions/classes that starts with `test`/`Test` but are not tests.

It follows https://github.com/silx-kit/silx/pull/3515#issuecomment-889282524