### PR TITLE
Misc.: Fixed `run_test.py --qt-binding` option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,18 +21,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - name-suffix: "PyQt5 sdist"
+          - name-suffix: "PySide2 sdist"
             os: ubuntu-20.04
             python-version: 3.6
             BUILD_COMMAND: sdist
-            QT_BINDING: PyQt5
-            RUN_TESTS_OPTIONS: --qt-binding=PyQt5 --no-opengl
-          - name-suffix: "PySide2 wheel"
+            QT_BINDING: PySide2
+            RUN_TESTS_OPTIONS: --qt-binding=PySide2 --no-opengl
+          - name-suffix: "PyQt5 wheel"
             os: macos-latest
             python-version: 3.8
             BUILD_COMMAND: bdist_wheel
-            QT_BINDING: PySide2
-            RUN_TESTS_OPTIONS: --qt-binding=PySide2 --no-opencl
+            QT_BINDING: PyQt5
+            RUN_TESTS_OPTIONS: --qt-binding=PyQt5 --no-opencl
           - name-suffix: "No GUI wheel"
             os: windows-latest
             python-version: 3.9

--- a/run_tests.py
+++ b/run_tests.py
@@ -169,11 +169,11 @@ if __name__ == "__main__":  # Needed for multiprocessing support on Windows
     PROJECT_PATH = project_module.__path__[0]
 
     def normalize_option(option):
-        if option == "src/silx":
+        option_parts = option.split(os.path.sep)
+        if option_parts == ["src", "silx"]:
             return PROJECT_PATH
-        if option.startswith("src/silx/"):
-            path = option[9:]
-            return os.path.join(PROJECT_PATH, path)
+        if option_parts[:2] == ["src", "silx"]:
+            return os.path.join(PROJECT_PATH, *option_parts[2:])
         return option
 
     args = [normalize_option(p) for p in sys.argv[1:] if p != "--installed"]

--- a/src/silx/gui/dialog/test/test_colormapdialog.py
+++ b/src/silx/gui/dialog/test/test_colormapdialog.py
@@ -51,7 +51,7 @@ def colormap():
 
 
 @pytest.fixture
-def colormapDialog(qapp):
+def colormapDialog(qapp, qapp_utils):
     dialog = ColormapDialog.ColormapDialog()
     dialog.setAttribute(qt.Qt.WA_DeleteOnClose)
     yield weakref.proxy(dialog)

--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -43,6 +43,7 @@ from silx.gui import plot
 from silx.gui import icons
 from silx.gui.colors import Colormap
 from silx.gui.plot import tools
+from silx.utils.weakref import WeakMethodProxy
 
 _logger = logging.getLogger(__name__)
 
@@ -592,7 +593,7 @@ class CompareImages(qt.QMainWindow):
                 text='',
                 draggable=True,
                 color='blue',
-                constraint=self.__separatorConstraint)
+                constraint=WeakMethodProxy(self.__separatorConstraint))
         self.__vline = self.__plot._getMarker(legend)
 
         legend = VisualizationMode.HORIZONTAL_LINE.name
@@ -602,7 +603,7 @@ class CompareImages(qt.QMainWindow):
                 text='',
                 draggable=True,
                 color='blue',
-                constraint=self.__separatorConstraint)
+                constraint=WeakMethodProxy(self.__separatorConstraint))
         self.__hline = self.__plot._getMarker(legend)
 
         # default values

--- a/src/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/src/silx/gui/plot/test/testCurvesROIWidget.py
@@ -435,6 +435,8 @@ class TestRoiWidgetSignals(TestCaseQt):
 
         widget = self.plot.getWidgetHandle()
         widget.setFocus(qt.Qt.OtherFocusReason)
+        self.plot.raise_()
+        self.qapp.processEvents()
 
         # modify roi limits (from the gui)
         roi_marker_handler = self.curves_roi_widget.roiTable._markersHandler.getMarkerHandler(roi1.getID())

--- a/src/silx/gui/plot/test/testMaskToolsWidget.py
+++ b/src/silx/gui/plot/test/testMaskToolsWidget.py
@@ -129,12 +129,14 @@ class TestMaskToolsWidget(PlotWidgetTestCase, ParametricTestCase):
                 (x + offset, y - offset)]
 
         self.mouseMove(plot, pos=(0, 0))
-        self.mouseMove(plot, pos=star[0])
-        self.mousePress(plot, qt.Qt.LeftButton, pos=star[0])
-        for pos in star[1:]:
-            self.mouseMove(plot, pos=pos)
-        self.mouseRelease(
-            plot, qt.Qt.LeftButton, pos=star[-1])
+        for start, end in zip(star[:-1], star[1:]):
+           self.mouseMove(plot, pos=start)
+           self.mousePress(plot, qt.Qt.LeftButton, pos=start)
+           self.qapp.processEvents()
+           self.mouseMove(plot, pos=end)
+           self.qapp.processEvents()
+           self.mouseRelease(plot, qt.Qt.LeftButton, pos=end)
+           self.qapp.processEvents()
 
     def _isMaskItemSync(self):
         """Check if masks from item and tools are sync or not"""

--- a/src/silx/gui/qt/_qt.py
+++ b/src/silx/gui/qt/_qt.py
@@ -146,34 +146,37 @@ elif BINDING == 'PySide2':
 
     pyqtSignal = Signal
 
-else:
-    raise ImportError('No Qt wrapper found. Install PyQt5, PySide2')
-
-
-if BINDING in ('PyQt5', 'PySide2'):  # Qt6 compatibility
+    # Qt6 compatibility:
+    # with PySide2 `exec` method has a special behavior
     class _ExecMixIn:
         """Mix-in class providind `exec` compatibility"""
         def exec(self, *args, **kwargs):
-            self.exec_(*args, **kwargs)
+            return super().exec_(*args, **kwargs)
 
     # QtWidgets
-    class QApplication(QApplication, _ExecMixIn): pass
-    class QColorDialog(QColorDialog, _ExecMixIn): pass
-    class QDialog(QDialog, _ExecMixIn): pass
-    class QErrorMessage(QErrorMessage, _ExecMixIn): pass
-    class QFileDialog(QFileDialog, _ExecMixIn): pass
-    class QFontDialog(QFontDialog, _ExecMixIn): pass
-    class QInputDialog(QInputDialog, _ExecMixIn): pass
-    class QMenu(QMenu, _ExecMixIn): pass
-    class QMessageBox(QMessageBox, _ExecMixIn): pass
-    class QProgressDialog(QProgressDialog, _ExecMixIn): pass
+    class QApplication(_ExecMixIn, QApplication): pass
+    class QColorDialog(_ExecMixIn, QColorDialog): pass
+    class QDialog(_ExecMixIn, QDialog): pass
+    class QErrorMessage(_ExecMixIn, QErrorMessage): pass
+    class QFileDialog(_ExecMixIn, QFileDialog): pass
+    class QFontDialog(_ExecMixIn, QFontDialog): pass
+    class QInputDialog(_ExecMixIn, QInputDialog): pass
+    class QMenu(_ExecMixIn, QMenu): pass
+    class QMessageBox(_ExecMixIn, QMessageBox): pass
+    class QProgressDialog(_ExecMixIn, QProgressDialog): pass
     #QtCore
-    class QCoreApplication(QCoreApplication, _ExecMixIn): pass
-    class QEventLoop(QEventLoop, _ExecMixIn): pass
+    class QCoreApplication(_ExecMixIn, QCoreApplication): pass
+    class QEventLoop(_ExecMixIn, QEventLoop): pass
     if hasattr(QTextStreamManipulator, "exec_"):
         # exec_ only wrapped in PySide2 and NOT in PyQt5
-        class QTextStreamManipulator(QTextStreamManipulator, _ExecMixIn): pass
-    class QThread(QThread, _ExecMixIn): pass
+        class QTextStreamManipulator(_ExecMixIn, QTextStreamManipulator): pass
+    class QThread(_ExecMixIn, QThread): pass
+
+
+
+
+else:
+    raise ImportError('No Qt wrapper found. Install PyQt5, PySide2')
 
 
 # provide a exception handler but not implement it by default

--- a/src/silx/gui/test/test_icons.py
+++ b/src/silx/gui/test/test_icons.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,6 @@ __license__ = "MIT"
 __date__ = "06/09/2017"
 
 
-import gc
 import unittest
 import weakref
 import tempfile
@@ -109,7 +108,6 @@ class TestIcons(TestCaseQt):
         icon = icons.getQIcon("crop")
         icon_ref = weakref.ref(icon)
         del icon
-        gc.collect()
         self.assertIsNone(icon_ref())
 
 

--- a/src/silx/gui/test/test_qt.py
+++ b/src/silx/gui/test/test_qt.py
@@ -186,7 +186,7 @@ class TestQtInspect(unittest.TestCase):
         self.assertFalse(qt_inspect.isValid(obj))
 
 
-@pytest.mark.skipif(qt.BINDING not in ("PyQt5", "PySide"),
+@pytest.mark.skipif(qt.BINDING not in ("PyQt5", "PySide2"),
                     reason="PyQt5/PySide2 only test")
 def test_exec_():
     """Test the exec_ is still useable with Qt5 bindings"""

--- a/src/silx/gui/utils/testutils.py
+++ b/src/silx/gui/utils/testutils.py
@@ -150,15 +150,15 @@ class TestCaseQt(unittest.TestCase):
 
     def _checkForUnreleasedWidgets(self):
         """Test fixture checking that no more widgets exists."""
+        if qt.BINDING == 'PySide2':
+            return  # Do not test for leaking widgets with PySide2
+
         gc.collect()
 
         widgets = [widget for widget in self.qapp.allWidgets()
                    if (widget not in self.__previousWidgets and
                        _inspect.createdByPython(widget))]
         del self.__previousWidgets
-
-        if qt.BINDING == 'PySide2':
-            return  # Do not test for leaking widgets with PySide2
 
         allowedLeakingWidgets = self.allowedLeakingWidgets
         self.allowedLeakingWidgets = 0


### PR DESCRIPTION
This PR makes sure the chosen Qt binding is loaded by importing it as early as possible, else this can cause issues if multipe Qt bindings are available.
