### PR TITLE
silx.gui: Renamed exec_ methods to exec for compatibility with Qt6

### DIFF
--- a/examples/compareImages.py
+++ b/examples/compareImages.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -208,4 +208,4 @@ if __name__ == "__main__":
         window.setFiles(options.files)
 
     window.setVisible(True)
-    app.exec_()
+    app.exec()

--- a/examples/exampleBaseline.py
+++ b/examples/exampleBaseline.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -157,7 +157,7 @@ def main(argv):
     plot_log = get_plot_log(backend=options.backend)
     plot_log.show()
 
-    qapp.exec_()
+    qapp.exec()
 
 
 if __name__ == '__main__':

--- a/examples/fileDialog.py
+++ b/examples/fileDialog.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -216,7 +216,7 @@ class DialogExample(qt.QMainWindow):
         dialog = self.createDialog()
 
         # Execute the dialog as modal
-        result = dialog.exec_()
+        result = dialog.exec()
         self.printResult(dialog, result)
 
     def openDialogStoredState(self):
@@ -226,7 +226,7 @@ class DialogExample(qt.QMainWindow):
             dialog.restoreState(self.__state[dialog.__class__])
 
         # Execute the dialog as modal
-        result = dialog.exec_()
+        result = dialog.exec()
         self.__state[dialog.__class__] = dialog.saveState()
         self.printResult(dialog, result)
 
@@ -237,7 +237,7 @@ class DialogExample(qt.QMainWindow):
         dialog.setDirectory(path)
 
         # Execute the dialog as modal
-        result = dialog.exec_()
+        result = dialog.exec()
         self.printResult(dialog, result)
 
     def openDialogAtComputer(self):
@@ -247,7 +247,7 @@ class DialogExample(qt.QMainWindow):
         dialog.setDirectory(path)
 
         # Execute the dialog as modal
-        result = dialog.exec_()
+        result = dialog.exec()
         self.printResult(dialog, result)
 
 
@@ -255,7 +255,7 @@ def main():
     app = qt.QApplication([])
     example = DialogExample()
     example.show()
-    app.exec_()
+    app.exec()
 
 
 if __name__ == "__main__":

--- a/examples/findContours.py
+++ b/examples/findContours.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -694,7 +694,7 @@ def main():
     window = FindContours()
     window.generateIsland()
     window.show()
-    result = app.exec_()
+    result = app.exec()
     # remove ending warnings relative to QTimer
     app.deleteLater()
     return result

--- a/examples/icons.py
+++ b/examples/icons.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -177,4 +177,4 @@ if __name__ == "__main__":
     app = qt.QApplication([])
     window = IconPreview()
     window.setVisible(True)
-    app.exec_()
+    app.exec()

--- a/examples/imageStack.py
+++ b/examples/imageStack.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -132,7 +132,7 @@ def main():
     urls = create_datasets(folder=dataset_folder)
     widget.setUrls(urls=urls)
     widget.show()
-    qapp.exec_()
+    qapp.exec()
     widget.close()
 
     shutil.rmtree(dataset_folder)

--- a/examples/periodicTable.py
+++ b/examples/periodicTable.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -77,5 +77,4 @@ w.addTab(pl, "PeriodicList")
 w.addTab(comboContainer, "PeriodicCombo")
 w.show()
 
-a.exec_()
-
+a.exec()

--- a/examples/plot3dContextMenu.py
+++ b/examples/plot3dContextMenu.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -86,7 +86,7 @@ class ScalarFieldViewWithContextMenu(ScalarFieldView):
         # The position received as argument is relative to Plot3DWidget
         # and needs to be converted.
         globalPosition = self.getPlot3DWidget().mapToGlobal(pos)
-        menu.exec_(globalPosition)
+        menu.exec(globalPosition)
 
 
 # Start Qt QApplication
@@ -109,4 +109,4 @@ window.setData(data)
 window.addIsosurface(0.2, '#FF0000FF')
 
 window.show()
-app.exec_()
+app.exec()

--- a/examples/plot3dSceneWindow.py
+++ b/examples/plot3dSceneWindow.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -200,4 +200,4 @@ window.show()
 sys.excepthook = qt.exceptionHandler
 
 # Run Qt event loop
-qapp.exec_()
+qapp.exec()

--- a/examples/plotClearAction.py
+++ b/examples/plotClearAction.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -72,4 +72,4 @@ if __name__ == '__main__':
     plot.addCurve((0, 1, 2, 3, 4), (0, 1, 1.5, 1, 0))  # Add a curve to the plot
 
     plot.show()  # Show the plot widget
-    app.exec_()  # Start Qt application
+    app.exec()  # Start Qt application

--- a/examples/plotCurveLegendWidget.py
+++ b/examples/plotCurveLegendWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -112,7 +112,7 @@ class MyCurveLegendsWidget(CurveLegendsWidget):
                            functools.partial(self._switchCurveVisibility, curve))
 
             globalPosition = self.mapToGlobal(pos)
-            menu.exec_(globalPosition)
+            menu.exec(globalPosition)
 
 
 # First create the QApplication
@@ -151,4 +151,4 @@ window.addDockWidget(qt.Qt.RightDockWidgetArea, dock)
 window.setAttribute(qt.Qt.WA_DeleteOnClose)
 window.show()
 
-app.exec_()
+app.exec()

--- a/examples/plotInteractiveImageROI.py
+++ b/examples/plotInteractiveImageROI.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2018-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -153,6 +153,6 @@ plot.addTabbedDockWidget(dock)
 
 # Show the widget and start the application
 plot.show()
-result = app.exec_()
+result = app.exec()
 app.deleteLater()
 sys.exit(result)

--- a/examples/plotLimits.py
+++ b/examples/plotLimits.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -90,4 +90,4 @@ if __name__ == "__main__":
     app = qt.QApplication([])
     window = ConstrainedViewPlot()
     window.setVisible(True)
-    app.exec_()
+    app.exec()

--- a/examples/plotStats.py
+++ b/examples/plotStats.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -161,7 +161,7 @@ def main(argv):
     plot.getStatsWidget().parent().setVisible(True)
 
     plot.show()
-    app.exec_()
+    app.exec()
     updateThread.stop()  # Stop updating the plot
 
 

--- a/examples/plotUpdateCurveFromThread.py
+++ b/examples/plotUpdateCurveFromThread.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -95,7 +95,7 @@ def main():
     updateThread = UpdateThread(plot1d)
     updateThread.start()  # Start updating the plot
 
-    app.exec_()
+    app.exec()
 
     updateThread.stop()  # Stop updating the plot
 

--- a/examples/printPreview.py
+++ b/examples/printPreview.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -96,4 +96,4 @@ pw3.show()
 pw3.addCurve(x, numpy.cos(x * 2 * numpy.pi / 1000))
 
 
-app.exec_()
+app.exec()

--- a/examples/shiftPlotAction.py
+++ b/examples/shiftPlotAction.py
@@ -2,7 +2,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -110,4 +110,4 @@ plotwin.addCurve(x, y1, legend="triangle shaped curve")
 plotwin.addCurve(x, y2, legend="oblique line")
 
 plotwin.show()
-app.exec_()
+app.exec()

--- a/examples/stackView.py
+++ b/examples/stackView.py
@@ -61,4 +61,4 @@ maskToolsWidget.setItemMaskUpdated(True)
 
 sv.show()
 
-app.exec_()
+app.exec()


### PR DESCRIPTION
This PR does more `exec_` to `exec` renaming that where missed in PR #3486
