### PR TITLE
silx.io.h5py_utils: Log a critical message for unsupported versions of libhdf5

### DIFF
--- a/ci/requirements-pinned.txt
+++ b/ci/requirements-pinned.txt
@@ -8,8 +8,3 @@ pybind11  # Required to build pyopencl
 # downloaded from https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyopencl
 # Anyway, we don't test OpenCL on appveyor
 pyopencl == 2020.3.1; sys_platform == 'win32'
-
-# There is a change of behaviour of libhdf5 regarding file locking
-# with libhdf5 1.12.1 included in h5py 3.4.0 wheels
-# See https://github.com/silx-kit/silx/issues/3523
-h5py==3.3.0; python_version >= '3.7'

--- a/src/silx/io/h5py_utils.py
+++ b/src/silx/io/h5py_utils.py
@@ -31,12 +31,15 @@ __license__ = "MIT"
 __date__ = "27/01/2020"
 
 
+import logging
 import os
 import traceback
 import h5py
 
 from .._version import calc_hexversion
 from ..utils import retry as retry_mod
+
+_logger = logging.getLogger(__name__)
 
 H5PY_HEX_VERSION = calc_hexversion(*h5py.version.version_tuple[:3])
 HDF5_HEX_VERSION = calc_hexversion(*h5py.version.hdf5_version_tuple[:3])
@@ -212,8 +215,9 @@ class File(h5py.File):
         hdf5_version = h5py.version.hdf5_version_tuple
         if hdf5_version >= (1, 12, 1) or (
                 hdf5_version[:2] == (1, 10) and hdf5_version[2] >= 7):
-            raise RuntimeError(
-                "The version of libhdf5 used by h5py ({}) is not supported.".format(
+            _logger.critical(
+                "The version of libhdf5 ({}) used by h5py is not supported: "
+                "Do not expect file locking to work.".format(
                     h5py.version.hdf5_version))
 
         if mode is None:

--- a/src/silx/io/h5py_utils.py
+++ b/src/silx/io/h5py_utils.py
@@ -208,6 +208,14 @@ class File(h5py.File):
         :param bool or None swmr: try both modes when `mode='r'` and `swmr=None`
         :param **kwargs: see `h5py.File.__init__`
         """
+        # File locking behavior has changed in recent versions of libhdf5
+        hdf5_version = h5py.version.hdf5_version_tuple
+        if hdf5_version >= (1, 12, 1) or (
+                hdf5_version[:2] == (1, 10) and hdf5_version[2] >= 7):
+            raise RuntimeError(
+                "The version of libhdf5 used by h5py ({}) is not supported.".format(
+                    h5py.version.hdf5_version))
+
         if mode is None:
             mode = "r"
         elif mode not in ("r", "w", "w-", "x", "a", "r+"):

--- a/src/silx/io/test/test_h5py_utils.py
+++ b/src/silx/io/test/test_h5py_utils.py
@@ -37,12 +37,14 @@ import tempfile
 import threading
 import multiprocessing
 from contextlib import contextmanager
+import h5py
+import pytest
 
 from .. import h5py_utils
 from ...utils.retry import RetryError, RetryTimeoutError
 
 IS_WINDOWS = sys.platform == "win32"
-
+HDF5_VERSION = h5py.version.hdf5_version_tuple
 
 def _subprocess_context_main(queue, contextmgr, *args, **kw):
     try:
@@ -124,7 +126,10 @@ def subtests(test):
 
     return wrapper
 
-
+@pytest.mark.skipif(
+    HDF5_VERSION >= (1, 12, 1) or (
+        HDF5_VERSION[:2] == (1, 10) and HDF5_VERSION[2] >= 7),
+    reason="Version of libhdf5 does not support changing HDF5_USE_FILE_LOCKING")
 class TestH5pyUtils(unittest.TestCase):
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()


### PR DESCRIPTION
This PR handles unsupported versions of libhdf5 regarding the change of behaviour of file locking by:
- skipping tests for unsupported versions.
- Logging a critical message in `h5py_utils.File` for unsupported versions of h5py.

It removes h5py version pin-pointing introduced in PR #3526

closes #3523