### PR TITLE
Switch python version used for pyside2 test

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -24,14 +24,14 @@ environment:
         VENV_TEST_DIR: "venv_test"
 
     matrix:
-        # Python 3.8
-        - PYTHON_DIR: "C:\\Python38-x64"
+        # Python 3.6
+        - PYTHON_DIR: "C:\\Python36-x64"
           QT_BINDING: "PyQt5"
           WITH_GL_TEST: True
           PIP_OPTIONS: "-q --pre"
 
-        # Python 3.6
-        - PYTHON_DIR: "C:\\Python36-x64"
+        # Python 3.8
+        - PYTHON_DIR: "C:\\Python38-x64"
           QT_BINDING: "PySide2"
           WITH_GL_TEST: True
           PIP_OPTIONS: "-q"

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -84,6 +84,7 @@ before_test:
     # Create test virtualenv
     - "python -m venv --clear %VENV_TEST_DIR%"
     - "%VENV_TEST_DIR%\\Scripts\\activate.bat"
+    - "python -m pip install %PIP_OPTIONS% --upgrade pip"
 
     # First install any temporary pinned/additional requirements
     - pip install %PIP_OPTIONS% -r "ci\requirements-pinned.txt


### PR DESCRIPTION
`pywin32` v302 wheel for python3.6 on Windows seems to have an issue, this PR just exchange the version of python used for pyqt5/pyside2 tests.