### PR TITLE
Fixes PySide6/Qt6 support

### DIFF
--- a/src/silx/gui/data/Hdf5TableView.py
+++ b/src/silx/gui/data/Hdf5TableView.py
@@ -214,9 +214,9 @@ class _CellFilterAvailableData(_CellData):
 
     def data(self, role=qt.Qt.DisplayRole):
         state = self._states[self.__availability]
-        if role == qt.Qt.TextColorRole:
+        if role == qt.Qt.ForegroundRole:
             return state[1]
-        elif role == qt.Qt.BackgroundColorRole:
+        elif role == qt.Qt.BackgroundRole:
             return state[2]
         else:
             return None

--- a/src/silx/gui/data/HexaTableView.py
+++ b/src/silx/gui/data/HexaTableView.py
@@ -160,7 +160,7 @@ class HexaTableModel(qt.QAbstractTableModel):
         elif role == qt.Qt.FontRole:
             return self.__font
 
-        elif role == qt.Qt.BackgroundColorRole:
+        elif role == qt.Qt.BackgroundRole:
             pos = (row << 4) + column
             if column != 0x10 and pos >= len(self.__connector):
                 return self.__palette.color(qt.QPalette.Disabled, qt.QPalette.Window)

--- a/src/silx/gui/plot/MaskToolsWidget.py
+++ b/src/silx/gui/plot/MaskToolsWidget.py
@@ -502,7 +502,7 @@ class MaskToolsWidget(BaseMaskToolsWidget):
             # Disconnect from previous image
             try:
                 previous.sigItemChanged.disconnect(self.__imageChanged)
-            except TypeError:
+            except (RuntimeError, TypeError):
                 pass  # TODO fixme should not happen
 
         # Set the image

--- a/src/silx/gui/plot/PlotWindow.py
+++ b/src/silx/gui/plot/PlotWindow.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -506,7 +506,7 @@ class PlotWindow(PlotWidget):
             self._dockWidgets.remove(dockwidget)
         super(PlotWindow, self).removeDockWidget(dockwidget)
 
-    def __handleFirstDockWidgetShow(self, visible):
+    def _handleFirstDockWidgetShow(self, visible):
         """Handle QDockWidget.visibilityChanged
 
         It calls :meth:`addTabbedDockWidget` for the `sender` widget.
@@ -519,7 +519,7 @@ class PlotWindow(PlotWidget):
         if visible:
             dockWidget = self.sender()
             dockWidget.visibilityChanged.disconnect(
-                self.__handleFirstDockWidgetShow)
+                self._handleFirstDockWidgetShow)
             self.addTabbedDockWidget(dockWidget)
 
     def getColorBarWidget(self):
@@ -537,7 +537,7 @@ class PlotWindow(PlotWidget):
             self._legendsDockWidget = LegendsDockWidget(plot=self)
             self._legendsDockWidget.hide()
             self._legendsDockWidget.visibilityChanged.connect(
-                self.__handleFirstDockWidgetShow)
+                self._handleFirstDockWidgetShow)
         return self._legendsDockWidget
 
     def getCurvesRoiDockWidget(self):
@@ -548,7 +548,7 @@ class PlotWindow(PlotWidget):
                 plot=self, name='Regions Of Interest')
             self._curvesROIDockWidget.hide()
             self._curvesROIDockWidget.visibilityChanged.connect(
-                self.__handleFirstDockWidgetShow)
+                self._handleFirstDockWidgetShow)
         return self._curvesROIDockWidget
 
     def getCurvesRoiWidget(self):
@@ -569,7 +569,7 @@ class PlotWindow(PlotWidget):
                 plot=self, name='Mask')
             self._maskToolsDockWidget.hide()
             self._maskToolsDockWidget.visibilityChanged.connect(
-                self.__handleFirstDockWidgetShow)
+                self._handleFirstDockWidgetShow)
         return self._maskToolsDockWidget
 
     def getStatsWidget(self):
@@ -587,7 +587,7 @@ class PlotWindow(PlotWidget):
                 self.getStatsAction().setChecked)
             self._statsDockWidget.hide()
             self._statsDockWidget.visibilityChanged.connect(
-                self.__handleFirstDockWidgetShow)
+                self._handleFirstDockWidgetShow)
         return self._statsDockWidget.widget()
 
     # getters for actions

--- a/src/silx/gui/plot/actions/io.py
+++ b/src/silx/gui/plot/actions/io.py
@@ -744,7 +744,7 @@ class PrintAction(PlotAction):
         if not painter.begin(self.getPrinter()):
             return False
 
-        pageRect = self.getPrinter().pageRect()
+        pageRect = self.getPrinter().pageRect(qt.QPrinter.DevicePixel)
         xScale = pageRect.width() / widget.width()
         yScale = pageRect.height() / widget.height()
         scale = min(xScale, yScale)
@@ -776,8 +776,9 @@ class PrintAction(PlotAction):
         pixmap = qt.QPixmap()
         pixmap.loadFromData(pngData, 'png')
 
-        xScale = self.getPrinter().pageRect().width() / pixmap.width()
-        yScale = self.getPrinter().pageRect().height() / pixmap.height()
+        pageRect = self.getPrinter().pageRect(qt.QPrinter.DevicePixel)
+        xScale = pageRect.width() / pixmap.width()
+        yScale = pageRect.height() / pixmap.height()
         scale = min(xScale, yScale)
 
         # Draw pixmap with painter

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -277,7 +277,11 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
     def wheelEvent(self, event):
         delta = event.angleDelta().y()
         angleInDegrees = delta / 8.
-        self._plot.onMouseWheel(event.x(), event.y(), angleInDegrees)
+        if qt.BINDING == "PySide6":
+            x, y = event.position().x(), event.position().y()
+        else:
+            x, y = event.x(), event.y()
+        self._plot.onMouseWheel(x, y, angleInDegrees)
         event.accept()
 
     def leaveEvent(self, _):

--- a/src/silx/gui/plot/tools/profile/rois.py
+++ b/src/silx/gui/plot/tools/profile/rois.py
@@ -917,7 +917,7 @@ class _DefaultScatterProfileSliceRoiMixIn(core.ProfileRoiMixIn):
             axis = 0
         else:
             assert False
-        if position < bounds[0][axis] or position > bounds[1][axis]:
+        if bounds is None or position < bounds[0][axis] or position > bounds[1][axis]:
             # ROI outside of the scatter bound
             return None
 

--- a/src/silx/gui/plot3d/Plot3DWidget.py
+++ b/src/silx/gui/plot3d/Plot3DWidget.py
@@ -378,8 +378,12 @@ class Plot3DWidget(glu.OpenGLWidget):
         return convertArrayToQImage(image)
 
     def wheelEvent(self, event):
-        xpixel = event.x() * self.getDevicePixelRatio()
-        ypixel = event.y() * self.getDevicePixelRatio()
+        if qt.BINDING == "PySide6":
+            x, y = event.position().x(), event.position().y()
+        else:
+            x, y = event.x(), event.y()
+        xpixel = x * self.getDevicePixelRatio()
+        ypixel = y * self.getDevicePixelRatio()
         angle = event.angleDelta().y() / 8.
         event.accept()
 

--- a/src/silx/gui/plot3d/actions/io.py
+++ b/src/silx/gui/plot3d/actions/io.py
@@ -176,11 +176,12 @@ class PrintAction(Plot3DAction):
             if not painter.begin(printer):
                 return
 
-            if (printer.pageRect().width() < image.width() or
-                    printer.pageRect().height() < image.height()):
+            pageRect = printer.pageRect(qt.QPrinter.DevicePixel)
+            if (pageRect.width() < image.width() or
+                    pageRect.height() < image.height()):
                 # Downscale to page
-                xScale = printer.pageRect().width() / image.width()
-                yScale = printer.pageRect().height() / image.height()
+                xScale = pageRect.width() / image.width()
+                yScale = pageRect.height() / image.height()
                 scale = min(xScale, yScale)
             else:
                 scale = 1.

--- a/src/silx/gui/widgets/FloatEdit.py
+++ b/src/silx/gui/widgets/FloatEdit.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -61,5 +61,11 @@ class FloatEdit(qt.QLineEdit):
 
         :param float value: The value to set the QLineEdit to.
         """
-        text = self.validator().locale().toString(float(value))
+        locale = self.validator().locale()
+        if qt.BINDING == "PySide6":
+            # Fix for PySide6 not selecting the right method
+            text = locale.toString(float(value), 'g')
+        else:
+            text = locale.toString(float(value))
+
         self.setText(text)


### PR DESCRIPTION
~~Merge PR #3540 first!~~

This PR fixes a couple of Qt6/PySide6 compatibility issues spotted while testing `silx view`:
- Adapt to Qt6 API changes
- PySide6 bug workaround with private methods used as signals
- Avoid to raise exception with scatter profiles expecting a regular grid while a grid cannot be guessed.

related to #3432