### PR TITLE
silx view: Fixed settings when switching between PyQt5/PySide6

### DIFF
--- a/src/silx/app/view/ApplicationContext.py
+++ b/src/silx/app/view/ApplicationContext.py
@@ -74,8 +74,9 @@ class ApplicationContext(DataViewHooks):
         plotImageYAxisOrientation = settings.value("plot-image.y-axis-orientation", "")
         settings.endGroup()
 
-        if plotBackend != "":
-            silx.config.DEFAULT_PLOT_BACKEND = plotBackend
+        # Use matplotlib backend by default
+        silx.config.DEFAULT_PLOT_BACKEND = \
+            "opengl" if plotBackend == "opengl" else "matplotlib"
         if plotImageYAxisOrientation != "":
             silx.config.DEFAULT_PLOT_IMAGE_Y_AXIS_ORIENTATION = plotImageYAxisOrientation
 


### PR DESCRIPTION
When changing from PyQt5 to PySide6 (or the other way around), the settings are not correctly recovered and the backend is set to `None`... This PR ignores the value in this case.

Related to #3542
