### PR TITLE
Doc: Removed link to no longer available document

### DIFF
--- a/src/silx/io/specfile.pyx
+++ b/src/silx/io/specfile.pyx
@@ -25,10 +25,6 @@
 This module is a cython binding to wrap the C SpecFile library, to access
 SpecFile data within a python program.
 
-Documentation for the original C library SpecFile can be found on the ESRF
-website:
-`The manual for the SpecFile Library <http://www.esrf.eu/files/live/sites/www/files/Instrumentation/software/beamline-control/BLISS/documentation/SpecFileManual.pdf>`_
-
 Examples
 ========
 


### PR DESCRIPTION
This PR remove ref to spec library documentation that is no longer publicly available.

closes #3433