### PR TITLE
silx.gui: Minor bug fixes

### DIFF
--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -666,6 +666,7 @@ class _ColormapHistogram(qt.QWidget):
         else:
             norm = colormap.getNormalization()
             normColormap = colormap.copy()
+            normColormap.setEditable(True)
             normColormap.setVRange(0, 255)
             normColormap.setNormalization(Colormap.LINEAR)
             if norm == Colormap.LINEAR:

--- a/src/silx/gui/fit/FitWidget.py
+++ b/src/silx/gui/fit/FitWidget.py
@@ -208,7 +208,7 @@ class FitWidget(qt.QWidget):
                     self.fitconfig.get("WeightFlag", False))
             self.guiConfig.WeightCheckBox.stateChanged[int].connect(self.weightEvent)
 
-            if qt.BINDING in ('Pyside2', 'PyQt5'):
+            if qt.BINDING in ('PySide2', 'PyQt5'):
                 self.guiConfig.BkgComBox.activated[str].connect(self.bkgEvent)
                 self.guiConfig.FunComBox.activated[str].connect(self.funEvent)
             else:  # Qt6

--- a/src/silx/gui/plot/tools/test/testTools.py
+++ b/src/silx/gui/plot/tools/test/testTools.py
@@ -72,6 +72,7 @@ class TestPositionInfo(PlotWidgetTestCase):
         for index, name in enumerate(converterNames):
             self.assertEqual(converters[index][0], name)
 
+        self.qapp.processEvents()
         with LoggingValidator(tools.__name__, **kwargs):
             # Move mouse to center
             center = self.plot.size() / 2


### PR DESCRIPTION
- silx.gui.fit: Typo affecting PySide2<5.14 since later versions provide `QComboBox.textActivated`
- silx.gui.dialog.ColormapDialog: Fixed bug with non editable colormaps (close #3524)
- silx.gui.plot.tools.test: Fixed test with PySide2