### PR TITLE
Support new h5py has a "locking" argument

### DIFF
--- a/src/silx/io/h5py_utils.py
+++ b/src/silx/io/h5py_utils.py
@@ -31,27 +31,115 @@ __license__ = "MIT"
 __date__ = "27/01/2020"
 
 
-import logging
 import os
+import sys
 import traceback
+import logging
 import h5py
 
 from .._version import calc_hexversion
 from ..utils import retry as retry_mod
+from silx.utils.deprecation import deprecated_warning
 
 _logger = logging.getLogger(__name__)
+
+IS_WINDOWS = sys.platform == "win32"
 
 H5PY_HEX_VERSION = calc_hexversion(*h5py.version.version_tuple[:3])
 HDF5_HEX_VERSION = calc_hexversion(*h5py.version.hdf5_version_tuple[:3])
 
 HDF5_SWMR_VERSION = calc_hexversion(*h5py.get_config().swmr_min_hdf5_version[:3])
-HDF5_TRACK_ORDER_VERSION = calc_hexversion(2, 9, 0)
-
 HAS_SWMR = HDF5_HEX_VERSION >= HDF5_SWMR_VERSION
-HAS_TRACK_ORDER = H5PY_HEX_VERSION >= HDF5_TRACK_ORDER_VERSION
+
+HAS_TRACK_ORDER = H5PY_HEX_VERSION >= calc_hexversion(2, 9, 0)
+
+if h5py.version.hdf5_version_tuple[:2] == (1, 10):
+    HDF5_HAS_LOCKING_ARGUMENT = HDF5_HEX_VERSION >= calc_hexversion(1, 10, 7)
+else:
+    HDF5_HAS_LOCKING_ARGUMENT = HDF5_HEX_VERSION >= calc_hexversion(1, 12, 1)
+H5PY_HAS_LOCKING_ARGUMENT = H5PY_HEX_VERSION >= calc_hexversion(3, 5, 0)
+HAS_LOCKING_ARGUMENT = HDF5_HAS_LOCKING_ARGUMENT & H5PY_HAS_LOCKING_ARGUMENT
+
+
+if HDF5_HEX_VERSION >= calc_hexversion(1, 12, 0):
+    LIBVER_LIST = ["v108", "v110", "v112"]
+elif HDF5_HEX_VERSION >= calc_hexversion(1, 10, 0):
+    LIBVER_LIST = ["v108", "v110"]
+else:
+    LIBVER_LIST = ["v108"]
+
+
+def _parse_libver_bound(libver_bound):
+    """
+    :param str libver_bound:
+    :returns str:
+    """
+    if libver_bound == "earliest":
+        return LIBVER_LIST[0]
+    elif libver_bound == "latest":
+        return LIBVER_LIST[-1]
+    else:
+        assert libver_bound in LIBVER_LIST
+        return libver_bound
+
+
+def _effective_hdf5_libver_bounds(libver):
+    """
+    :param None or str or tuple libver:
+    :returns tuple:
+    """
+    if libver is None:
+        return LIBVER_LIST[0], LIBVER_LIST[-1]
+    if isinstance(libver, str):
+        libver = _parse_libver_bound(libver)
+        return libver, LIBVER_LIST[-1]
+    assert len(libver) == 2
+    low = _parse_libver_bound(libver[0])
+    high = _parse_libver_bound(libver[1])
+    return low, high
+
+
+def _hdf5_file_locking(mode="r", locking=None, swmr=None, libver=None, **_):
+    """Concurrent access by disabling file locking is not supported
+    in these cases:
+
+        * mode != "r": causes file corruption
+        * SWMR: does not work
+        * libver > v108 and file already locked: does not work
+        * windows and HDF5_HAS_LOCKING_ARGUMENT and file already locked: does not work
+
+    :param str or None mode: read-only by default
+    :param bool or None locking: by default it is disabled for `mode='r'`
+                                 and `swmr=False` and enabled for all
+                                 other modes.
+    :param bool or None swmr: try both modes when `mode='r'` and `swmr=None`
+    :param None or str or tuple libver:
+    :returns bool:
+    """
+    if locking is None:
+        locking = bool(mode != "r" or swmr)
+    if not locking:
+        if mode != "r":
+            raise ValueError("Locking is mandatory for HDF5 writing")
+        if swmr:
+            raise ValueError("Locking is mandatory for HDF5 SWMR mode")
+        if IS_WINDOWS and HDF5_HAS_LOCKING_ARGUMENT:
+            _logger.warning(
+                "Non-locking readers will fail when a writer has already locked the HDF5 file (this restriction applies to libhdf5 >= 1.12.1 or libhdf5 >= 1.10.7 on Windows)"
+            )
+        low, _ = _effective_hdf5_libver_bounds(libver)
+        if low != "v108":
+            _logger.warning(
+                "Non-locking readers will fail when a writer has already locked the HDF5 file (this restriction applies to libver >= v110)"
+            )
+    return locking
 
 
 def _is_h5py_exception(e):
+    """
+    :param BaseException e:
+    :returns bool:
+    """
     for frame in traceback.walk_tb(e.__traceback__):
         if frame[0].f_locals.get("__package__", None) == "h5py":
             return True
@@ -76,7 +164,7 @@ def _retry_h5py_error(e):
 
 
 def retry(**kw):
-    """Decorator for a method that needs to be executed until it not longer
+    r"""Decorator for a method that needs to be executed until it not longer
     fails on HDF5 IO. Mainly used for reading an HDF5 file that is being
     written.
 
@@ -87,7 +175,7 @@ def retry(**kw):
 
 
 def retry_contextmanager(**kw):
-    """Decorator to make a context manager from a method that needs to be
+    r"""Decorator to make a context manager from a method that needs to be
     entered until it not longer fails on HDF5 IO. Mainly used for reading
     an HDF5 file that is being written.
 
@@ -98,7 +186,7 @@ def retry_contextmanager(**kw):
 
 
 def retry_in_subprocess(**kw):
-    """Same as `retry` but it also retries segmentation faults.
+    r"""Same as `retry` but it also retries segmentation faults.
 
     On Window you cannot use this decorator with the "@" syntax:
 
@@ -130,15 +218,16 @@ def group_has_end_time(h5item):
 
 
 @retry_contextmanager()
-def open_item(filename, name, retry_invalid=False, validate=None):
-    """Yield an HDF5 dataset or group (retry until it can be instantiated).
+def open_item(filename, name, retry_invalid=False, validate=None, **open_options):
+    r"""Yield an HDF5 dataset or group (retry until it can be instantiated).
 
     :param str filename:
     :param bool retry_invalid: retry when item is missing or not valid
     :param callable or None validate:
+    :param \**open_options: see `File.__init__`
     :yields Dataset, Group or None:
     """
-    with File(filename) as h5file:
+    with File(filename, **open_options) as h5file:
         try:
             item = h5file[name]
         except KeyError as e:
@@ -158,14 +247,15 @@ def open_item(filename, name, retry_invalid=False, validate=None):
         yield item
 
 
-def _top_level_names(filename, include_only=group_has_end_time):
-    """Return all valid top-level HDF5 names.
+def _top_level_names(filename, include_only=group_has_end_time, **open_options):
+    r"""Return all valid top-level HDF5 names.
 
     :param str filename:
     :param callable or None include_only:
+    :param \**open_options: see `File.__init__`
     :returns list(str):
     """
-    with File(filename) as h5file:
+    with File(filename, **open_options) as h5file:
         try:
             if callable(include_only):
                 return [name for name in h5file["/"] if include_only(h5file[name])]
@@ -179,151 +269,270 @@ top_level_names = retry()(_top_level_names)
 safe_top_level_names = retry_in_subprocess()(_top_level_names)
 
 
-class File(h5py.File):
-    """Takes care of HDF5 file locking and SWMR mode without the need
-    to handle those explicitely.
+if HAS_LOCKING_ARGUMENT:
 
-    When using this class, you cannot open different files simultatiously
-    with different modes because the locking flag is an environment variable.
-    """
+    class File(h5py.File):
+        """Takes care of HDF5 file locking and SWMR mode without the need
+        to handle those explicitely.
 
-    _HDF5_FILE_LOCKING = None
-    _NOPEN = 0
-    _SWMR_LIBVER = "latest"
-
-    def __init__(
-        self,
-        filename,
-        mode=None,
-        enable_file_locking=None,
-        swmr=None,
-        libver=None,
-        **kwargs
-    ):
-        """The arguments `enable_file_locking` and `swmr` should not be
-        specified explicitly for normal use cases.
-
-        :param str filename:
-        :param str or None mode: read-only by default
-        :param bool or None enable_file_locking: by default it is disabled for `mode='r'`
-                                                 and `swmr=False` and enabled for all
-                                                 other modes.
-        :param bool or None swmr: try both modes when `mode='r'` and `swmr=None`
-        :param **kwargs: see `h5py.File.__init__`
+        When non-locking readers are not supported, opening an
+        HDF5 file without the explicit argument `locking=True` will
+        raise `ValueError`.
         """
-        # File locking behavior has changed in recent versions of libhdf5
-        hdf5_version = h5py.version.hdf5_version_tuple
-        if hdf5_version >= (1, 12, 1) or (
-                hdf5_version[:2] == (1, 10) and hdf5_version[2] >= 7):
-            _logger.critical(
-                "The version of libhdf5 ({}) used by h5py is not supported: "
-                "Do not expect file locking to work.".format(
-                    h5py.version.hdf5_version))
 
-        if mode is None:
-            mode = "r"
-        elif mode not in ("r", "w", "w-", "x", "a", "r+"):
-            raise ValueError("invalid mode {}".format(mode))
-        if not HAS_SWMR:
-            swmr = False
+        _SWMR_LIBVER = "latest"
 
-        if enable_file_locking is None:
-            enable_file_locking = bool(mode != "r" or swmr)
-        if self._NOPEN:
-            self._check_locking_env(enable_file_locking)
-        else:
-            self._set_locking_env(enable_file_locking)
+        def __init__(
+            self,
+            filename,
+            mode=None,
+            locking=None,
+            enable_file_locking=None,
+            swmr=None,
+            libver=None,
+            **kwargs,
+        ):
+            r"""The arguments `enable_file_locking` and `swmr` should not be
+            specified explicitly for normal use cases.
 
-        if swmr and libver is None:
-            libver = self._SWMR_LIBVER
+            :param str filename:
+            :param str or None mode: read-only by default
+            :param bool or None locking: by default it is disabled for `mode='r'`
+                                         and `swmr=False` and enabled for all
+                                         other modes.
+            :param bool or None enable_file_locking: deprecated
+            :param bool or None swmr: try both modes when `mode='r'` and `swmr=None`
+            :param None or str or tuple libver:
+            :param \**kwargs: see `h5py.File.__init__`
+            """
+            if mode is None:
+                mode = "r"
+            elif mode not in ("r", "w", "w-", "x", "a", "r+"):
+                raise ValueError("invalid mode {}".format(mode))
+            if not HAS_SWMR:
+                swmr = False
+            if swmr and libver is None:
+                libver = self._SWMR_LIBVER
 
-        if HAS_TRACK_ORDER:
-            kwargs.setdefault("track_order", True)
-        try:
-            super().__init__(filename, mode=mode, swmr=swmr, libver=libver, **kwargs)
-        except OSError as e:
-            #   wlock   wSWMR   rlock   rSWMR   OSError: Unable to open file (...)
-            # 1 TRUE    FALSE   FALSE   FALSE   -
-            # 2 TRUE    FALSE   FALSE   TRUE    -
-            # 3 TRUE    FALSE   TRUE    FALSE   unable to lock file, errno = 11, error message = 'Resource temporarily unavailable'
-            # 4 TRUE    FALSE   TRUE    TRUE    unable to lock file, errno = 11, error message = 'Resource temporarily unavailable'
-            # 5 TRUE    TRUE    FALSE   FALSE   file is already open for write (may use <h5clear file> to clear file consistency flags)
-            # 6 TRUE    TRUE    FALSE   TRUE    -
-            # 7 TRUE    TRUE    TRUE    FALSE   file is already open for write (may use <h5clear file> to clear file consistency flags)
-            # 8 TRUE    TRUE    TRUE    TRUE    -
-            if (
-                mode == "r"
-                and swmr is None
-                and "file is already open for write" in str(e)
-            ):
-                # Try reading in SWMR mode (situation 5 and 7)
-                swmr = True
-                if libver is None:
-                    libver = self._SWMR_LIBVER
+            if enable_file_locking is not None:
+                deprecated_warning(
+                    type_="argument",
+                    name="enable_file_locking",
+                    replacement="locking",
+                    since_version="1.0",
+                )
+                if locking is None:
+                    locking = enable_file_locking
+            locking = _hdf5_file_locking(
+                mode=mode, locking=locking, swmr=swmr, libver=libver
+            )
+            kwargs.setdefault("locking", locking)
+
+            if HAS_TRACK_ORDER:
+                kwargs.setdefault("track_order", True)
+            try:
                 super().__init__(
                     filename, mode=mode, swmr=swmr, libver=libver, **kwargs
                 )
+            except OSError as e:
+                #   wlock   wSWMR   rlock   rSWMR   OSError: Unable to open file (...)
+                # 1 TRUE    FALSE   FALSE   FALSE   -
+                # 2 TRUE    FALSE   FALSE   TRUE    -
+                # 3 TRUE    FALSE   TRUE    FALSE   unable to lock file, errno = 11, error message = 'Resource temporarily unavailable'
+                # 4 TRUE    FALSE   TRUE    TRUE    unable to lock file, errno = 11, error message = 'Resource temporarily unavailable'
+                # 5 TRUE    TRUE    FALSE   FALSE   file is already open for write (may use <h5clear file> to clear file consistency flags)
+                # 6 TRUE    TRUE    FALSE   TRUE    -
+                # 7 TRUE    TRUE    TRUE    FALSE   file is already open for write (may use <h5clear file> to clear file consistency flags)
+                # 8 TRUE    TRUE    TRUE    TRUE    -
+                if (
+                    mode == "r"
+                    and swmr is None
+                    and "file is already open for write" in str(e)
+                ):
+                    # Try reading in SWMR mode (situation 5 and 7)
+                    swmr = True
+                    if libver is None:
+                        libver = self._SWMR_LIBVER
+                    super().__init__(
+                        filename, mode=mode, swmr=swmr, libver=libver, **kwargs
+                    )
+                else:
+                    raise
             else:
-                raise
-        else:
-            self._add_nopen(1)
+                try:
+                    if mode != "r" and swmr:
+                        # Try setting writer in SWMR mode
+                        self.swmr_mode = True
+                except Exception:
+                    self.close()
+                    raise
+
+
+else:
+
+    class File(h5py.File):
+        """Takes care of HDF5 file locking and SWMR mode without the need
+        to handle those explicitely.
+
+        When non-locking readers are not supported, opening an
+        HDF5 file without the explicit argument `locking=True` will
+        raise `ValueError`.
+
+        When using this class, you cannot open different files simultatiously
+        with different modes because the locking flag is an environment variable.
+        """
+
+        _HDF5_FILE_LOCKING = None
+        _NOPEN = 0
+        _SWMR_LIBVER = "latest"
+
+        def __init__(
+            self,
+            filename,
+            mode=None,
+            locking=None,
+            enable_file_locking=None,
+            swmr=None,
+            libver=None,
+            **kwargs,
+        ):
+            r"""The arguments `enable_file_locking` and `swmr` should not be
+            specified explicitly for normal use cases.
+
+            :param str filename:
+            :param str or None mode: read-only by default
+            :param bool or None locking: by default it is disabled for `mode='r'`
+                                         and `swmr=False` and enabled for all
+                                         other modes.
+            :param bool or None enable_file_locking: deprecated
+            :param bool or None swmr: try both modes when `mode='r'` and `swmr=None`
+            :param None or str or tuple libver:
+            :param \**kwargs: see `h5py.File.__init__`
+            """
+            # File locking behavior has changed in recent versions of libhdf5
+            if HDF5_HAS_LOCKING_ARGUMENT:
+                _logger.critical(
+                    "The version of libhdf5 ({}) used by h5py is not supported: "
+                    "Do not expect file locking to work.".format(
+                        h5py.version.hdf5_version
+                    )
+                )
+
+            if mode is None:
+                mode = "r"
+            elif mode not in ("r", "w", "w-", "x", "a", "r+"):
+                raise ValueError("invalid mode {}".format(mode))
+            if not HAS_SWMR:
+                swmr = False
+            if swmr and libver is None:
+                libver = self._SWMR_LIBVER
+
+            if enable_file_locking is not None:
+                deprecated_warning(
+                    type_="argument",
+                    name="enable_file_locking",
+                    replacement="locking",
+                    since_version="1.0",
+                )
+                if locking is None:
+                    locking = enable_file_locking
+            locking = _hdf5_file_locking(
+                mode=mode, locking=locking, swmr=swmr, libver=libver
+            )
+            if self._NOPEN:
+                self._check_locking_env(locking)
+            else:
+                self._set_locking_env(locking)
+
+            if HAS_TRACK_ORDER:
+                kwargs.setdefault("track_order", True)
             try:
-                if mode != "r" and swmr:
-                    # Try setting writer in SWMR mode
-                    self.swmr_mode = True
-            except Exception:
-                self.close()
-                raise
+                super().__init__(
+                    filename, mode=mode, swmr=swmr, libver=libver, **kwargs
+                )
+            except OSError as e:
+                #   wlock   wSWMR   rlock   rSWMR   OSError: Unable to open file (...)
+                # 1 TRUE    FALSE   FALSE   FALSE   -
+                # 2 TRUE    FALSE   FALSE   TRUE    -
+                # 3 TRUE    FALSE   TRUE    FALSE   unable to lock file, errno = 11, error message = 'Resource temporarily unavailable'
+                # 4 TRUE    FALSE   TRUE    TRUE    unable to lock file, errno = 11, error message = 'Resource temporarily unavailable'
+                # 5 TRUE    TRUE    FALSE   FALSE   file is already open for write (may use <h5clear file> to clear file consistency flags)
+                # 6 TRUE    TRUE    FALSE   TRUE    -
+                # 7 TRUE    TRUE    TRUE    FALSE   file is already open for write (may use <h5clear file> to clear file consistency flags)
+                # 8 TRUE    TRUE    TRUE    TRUE    -
+                if (
+                    mode == "r"
+                    and swmr is None
+                    and "file is already open for write" in str(e)
+                ):
+                    # Try reading in SWMR mode (situation 5 and 7)
+                    swmr = True
+                    if libver is None:
+                        libver = self._SWMR_LIBVER
+                    super().__init__(
+                        filename, mode=mode, swmr=swmr, libver=libver, **kwargs
+                    )
+                else:
+                    raise
+            else:
+                self._add_nopen(1)
+                try:
+                    if mode != "r" and swmr:
+                        # Try setting writer in SWMR mode
+                        self.swmr_mode = True
+                except Exception:
+                    self.close()
+                    raise
 
-    @classmethod
-    def _add_nopen(cls, v):
-        cls._NOPEN = max(cls._NOPEN + v, 0)
+        @classmethod
+        def _add_nopen(cls, v):
+            cls._NOPEN = max(cls._NOPEN + v, 0)
 
-    def close(self):
-        super().close()
-        self._add_nopen(-1)
-        if not self._NOPEN:
-            self._restore_locking_env()
+        def close(self):
+            super().close()
+            self._add_nopen(-1)
+            if not self._NOPEN:
+                self._restore_locking_env()
 
-    def _set_locking_env(self, enable):
-        self._backup_locking_env()
-        if enable:
-            os.environ["HDF5_USE_FILE_LOCKING"] = "TRUE"
-        elif enable is None:
-            try:
-                del os.environ["HDF5_USE_FILE_LOCKING"]
-            except KeyError:
-                pass
-        else:
-            os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
-
-    def _get_locking_env(self):
-        v = os.environ.get("HDF5_USE_FILE_LOCKING")
-        if v == "TRUE":
-            return True
-        elif v is None:
-            return None
-        else:
-            return False
-
-    def _check_locking_env(self, enable):
-        if enable != self._get_locking_env():
+        def _set_locking_env(self, enable):
+            self._backup_locking_env()
             if enable:
-                raise RuntimeError(
-                    "Close all HDF5 files before enabling HDF5 file locking"
-                )
+                os.environ["HDF5_USE_FILE_LOCKING"] = "TRUE"
+            elif enable is None:
+                try:
+                    del os.environ["HDF5_USE_FILE_LOCKING"]
+                except KeyError:
+                    pass
             else:
-                raise RuntimeError(
-                    "Close all HDF5 files before disabling HDF5 file locking"
-                )
+                os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
 
-    def _backup_locking_env(self):
-        v = os.environ.get("HDF5_USE_FILE_LOCKING")
-        if v is None:
+        def _get_locking_env(self):
+            v = os.environ.get("HDF5_USE_FILE_LOCKING")
+            if v == "TRUE":
+                return True
+            elif v is None:
+                return None
+            else:
+                return False
+
+        def _check_locking_env(self, enable):
+            if enable != self._get_locking_env():
+                if enable:
+                    raise RuntimeError(
+                        "Close all HDF5 files before enabling HDF5 file locking"
+                    )
+                else:
+                    raise RuntimeError(
+                        "Close all HDF5 files before disabling HDF5 file locking"
+                    )
+
+        def _backup_locking_env(self):
+            v = os.environ.get("HDF5_USE_FILE_LOCKING")
+            if v is None:
+                self._HDF5_FILE_LOCKING = None
+            else:
+                self._HDF5_FILE_LOCKING = v == "TRUE"
+
+        def _restore_locking_env(self):
+            self._set_locking_env(self._HDF5_FILE_LOCKING)
             self._HDF5_FILE_LOCKING = None
-        else:
-            self._HDF5_FILE_LOCKING = v == "TRUE"
-
-    def _restore_locking_env(self):
-        self._set_locking_env(self._HDF5_FILE_LOCKING)
-        self._HDF5_FILE_LOCKING = None

--- a/src/silx/io/h5py_utils.py
+++ b/src/silx/io/h5py_utils.py
@@ -341,7 +341,7 @@ class File(h5py.File):
         libver=None,
         **kwargs,
     ):
-        r"""The arguments `enable_file_locking` and `swmr` should not be
+        r"""The arguments `locking` and `swmr` should not be
         specified explicitly for normal use cases.
 
         :param str filename:

--- a/src/silx/io/h5py_utils.py
+++ b/src/silx/io/h5py_utils.py
@@ -102,11 +102,11 @@ def _hdf5_file_locking(mode="r", locking=None, swmr=None, libver=None, **_):
         if swmr:
             raise ValueError("Locking is mandatory for HDF5 SWMR mode")
         if IS_WINDOWS and HDF5_HAS_LOCKING_ARGUMENT:
-            _logger.warning(
+            _logger.debug(
                 "Non-locking readers will fail when a writer has already locked the HDF5 file (this restriction applies to libhdf5 >= 1.12.1 or libhdf5 >= 1.10.7 on Windows)"
             )
         if not _libver_low_bound_is_v108(libver):
-            _logger.warning(
+            _logger.debug(
                 "Non-locking readers will fail when a writer has already locked the HDF5 file (this restriction applies to libver >= v110)"
             )
     return locking

--- a/src/silx/io/h5py_utils.py
+++ b/src/silx/io/h5py_utils.py
@@ -378,7 +378,7 @@ else:
         HDF5 file without the explicit argument `locking=True` will
         raise `ValueError`.
 
-        When using this class, you cannot open different files simultatiously
+        When using this class, you cannot open different files simultaneously
         with different modes because the locking flag is an environment variable.
         """
 

--- a/src/silx/io/test/test_h5py_utils.py
+++ b/src/silx/io/test/test_h5py_utils.py
@@ -223,12 +223,16 @@ class TestH5pyUtils(unittest.TestCase):
         self.assertEqual(orig, os.environ.get("HDF5_USE_FILE_LOCKING"))
 
     @property
+    def _libver_low_bound_is_v108(self):
+        libver = self._subtest_options.get("libver")
+        return h5py_utils._libver_low_bound_is_v108(libver)
+
+    @property
     def _nonlocking_reader_before_writer(self):
         """A non-locking reader must open the file before it is locked by a writer"""
         if IS_WINDOWS and h5py_utils.HDF5_HAS_LOCKING_ARGUMENT:
             return True
-        libver = self._subtest_options.get("libver")
-        if not h5py_utils._libver_low_bound_is_v108(libver):
+        if not self._libver_low_bound_is_v108:
             return True
         return False
 
@@ -255,7 +259,7 @@ class TestH5pyUtils(unittest.TestCase):
         locked_exception = OSError
 
         # File locked by a writer
-        unexpected_access = old_hdf5_on_windows and self._libbound_low == "v108"
+        unexpected_access = old_hdf5_on_windows and self._libver_low_bound_is_v108
         for wmode in ["w", "a"]:
             with self._open_context_subprocess(filename, mode=wmode):
                 # Access by a second non-locking reader

--- a/src/silx/io/test/test_h5py_utils.py
+++ b/src/silx/io/test/test_h5py_utils.py
@@ -33,24 +33,23 @@ import os
 import sys
 import time
 import shutil
+import logging
 import tempfile
-import threading
 import multiprocessing
 from contextlib import contextmanager
-import h5py
-import pytest
 
 from .. import h5py_utils
 from ...utils.retry import RetryError, RetryTimeoutError
 
 IS_WINDOWS = sys.platform == "win32"
-HDF5_VERSION = h5py.version.hdf5_version_tuple
+logger = logging.getLogger()
+
 
 def _subprocess_context_main(queue, contextmgr, *args, **kw):
     try:
         with contextmgr(*args, **kw):
             queue.put(None)
-            threading.Event().wait()
+            queue.get()
     except Exception:
         queue.put(None)
         raise
@@ -58,6 +57,7 @@ def _subprocess_context_main(queue, contextmgr, *args, **kw):
 
 @contextmanager
 def _subprocess_context(contextmgr, *args, **kw):
+    print("\nSTART", os.getpid())
     timeout = kw.pop("timeout", 10)
     queue = multiprocessing.Queue(maxsize=1)
     p = multiprocessing.Process(
@@ -68,20 +68,25 @@ def _subprocess_context(contextmgr, *args, **kw):
         queue.get(timeout=timeout)
         yield
     finally:
-        try:
-            p.kill()
-        except AttributeError:
-            p.terminate()
+        queue.put(None)
         p.join(timeout)
+        print(" EXIT", os.getpid())
 
 
 @contextmanager
 def _open_context(filename, **kw):
-    with h5py_utils.File(filename, **kw) as f:
-        if kw.get("mode") == "w":
-            f["check"] = True
-            f.flush()
-        yield f
+    try:
+        print(os.getpid(), "OPEN", filename, kw)
+        with h5py_utils.File(filename, **kw) as f:
+            if kw.get("mode") == "w":
+                f["check"] = True
+                f.flush()
+            yield f
+    except Exception:
+        print(" ", os.getpid(), "FAILED", filename, kw)
+        raise
+    else:
+        print(" ", os.getpid(), "CLOSED", filename, kw)
 
 
 def _cause_segfault():
@@ -120,16 +125,15 @@ top_level_names_test = h5py_utils.retry_in_subprocess()(_top_level_names_test)
 
 def subtests(test):
     def wrapper(self):
-        for _ in self._subtests():
-            with self.subTest(**self._subtest_options):
+        for subtest_options in self._subtests():
+            print("\n====SUB TEST===\n")
+            print(f"sub test options: {subtest_options}")
+            with self.subTest(str(subtest_options)):
                 test(self)
 
     return wrapper
 
-@pytest.mark.skipif(
-    HDF5_VERSION >= (1, 12, 1) or (
-        HDF5_VERSION[:2] == (1, 10) and HDF5_VERSION[2] >= 7),
-    reason="Version of libhdf5 does not support changing HDF5_USE_FILE_LOCKING")
+
 class TestH5pyUtils(unittest.TestCase):
     def setUp(self):
         self.test_dir = tempfile.mkdtemp()
@@ -140,14 +144,10 @@ class TestH5pyUtils(unittest.TestCase):
     def _subtests(self):
         self._subtest_options = {"mode": "w"}
         self.filename_generator = self._filenames()
-        yield
+        yield self._subtest_options
         self._subtest_options = {"mode": "w", "libver": "latest"}
         self.filename_generator = self._filenames()
         yield
-
-    @property
-    def _liber_allows_concurrent_access(self):
-        return self._subtest_options.get("libver") in [None, "earliest", "v18"]
 
     def _filenames(self):
         i = 1
@@ -163,15 +163,14 @@ class TestH5pyUtils(unittest.TestCase):
 
     @contextmanager
     def _open_context(self, filename, **kwargs):
-        kw = self._subtest_options
+        kw = dict(self._subtest_options)
         kw.update(kwargs)
         with _open_context(filename, **kw) as f:
-
             yield f
 
     @contextmanager
     def _open_context_subprocess(self, filename, **kwargs):
-        kw = self._subtest_options
+        kw = dict(self._subtest_options)
         kw.update(kwargs)
         with _subprocess_context(_open_context, filename, **kw):
             yield
@@ -186,85 +185,142 @@ class TestH5pyUtils(unittest.TestCase):
 
     @subtests
     def test_modes_single_process(self):
+        """Test concurrent access to the different files from the same process"""
+        # When using HDF5_USE_FILE_LOCKING, open files with and without
+        # locking should raise an exception. HDF5_USE_FILE_LOCKING should
+        # be reset when all files are closed.
+
         orig = os.environ.get("HDF5_USE_FILE_LOCKING")
         filename1 = self._new_filename()
         self.assertEqual(orig, os.environ.get("HDF5_USE_FILE_LOCKING"))
         filename2 = self._new_filename()
         self.assertEqual(orig, os.environ.get("HDF5_USE_FILE_LOCKING"))
+
         with self._open_context(filename1, mode="r"):
-            with self._open_context(filename2, mode="r"):
-                pass
-            for mode in ["w", "a"]:
-                with self.assertRaises(RuntimeError):
+            locking1 = False
+            for mode in ["r", "w", "a"]:
+                locking2 = mode != "r"
+                raise_condition = not h5py_utils.HAS_LOCKING_ARGUMENT
+                raise_condition &= locking1 != locking2
+                with self.assertRaisesIf(raise_condition, RuntimeError):
                     with self._open_context(filename2, mode=mode):
                         pass
-        self.assertEqual(orig, os.environ.get("HDF5_USE_FILE_LOCKING"))
-        with self._open_context(filename1, mode="a"):
-            for mode in ["w", "a"]:
-                with self._open_context(filename2, mode=mode):
-                    pass
-            with self.assertRaises(RuntimeError):
-                with self._open_context(filename2, mode="r"):
-                    pass
+        self._validate_hdf5_data(filename1)
+        self._validate_hdf5_data(filename2)
         self.assertEqual(orig, os.environ.get("HDF5_USE_FILE_LOCKING"))
 
+        with self._open_context(filename1, mode="a"):
+            locking1 = True
+            for mode in ["r", "w", "a"]:
+                locking2 = mode != "r"
+                raise_condition = not h5py_utils.HAS_LOCKING_ARGUMENT
+                raise_condition &= locking1 != locking2
+                with self.assertRaisesIf(raise_condition, RuntimeError):
+                    with self._open_context(filename2, mode=mode):
+                        pass
+        self._validate_hdf5_data(filename1)
+        self._validate_hdf5_data(filename2)
+        self.assertEqual(orig, os.environ.get("HDF5_USE_FILE_LOCKING"))
+
+    @property
+    def _libbound_low(self):
+        libver = self._subtest_options.get("libver")
+        low, _ = h5py_utils._effective_hdf5_libver_bounds(libver)
+        return low
+
+    @property
+    def _nonlocking_reader_before_writer(self):
+        """A non-locking reader must open the file before it is locked by a writer"""
+        if IS_WINDOWS and h5py_utils.HDF5_HAS_LOCKING_ARGUMENT:
+            return True
+        if self._libbound_low != "v108":
+            return True
+        return False
+
+    @contextmanager
+    def assertRaisesIf(self, condition, *args, **kw):
+        if condition:
+            with self.assertRaises(*args, **kw):
+                yield
+        else:
+            yield
+
+    @unittest.skipIf(
+        h5py_utils.HDF5_HAS_LOCKING_ARGUMENT != h5py_utils.H5PY_HAS_LOCKING_ARGUMENT,
+        "Versions of libhdf5 and h5py use incompatible file locking behaviour",
+    )
     @subtests
     def test_modes_multi_process(self):
-        if not self._liber_allows_concurrent_access:
-            # A concurrent reader with HDF5_USE_FILE_LOCKING=FALSE is
-            # no longer works with HDF5 >=1.10 (you get an exception
-            # when trying to open the file)
-            return
+        """Test concurrent access to the same file from different processes"""
         filename = self._new_filename()
 
-        # File open by truncating writer
-        with self._open_context_subprocess(filename, mode="w"):
-            with self._open_context(filename, mode="r") as f:
-                self._assert_hdf5_data(f)
-            if IS_WINDOWS:
-                with self._open_context(filename, mode="a") as f:
-                    self._assert_hdf5_data(f)
-            else:
-                with self.assertRaises(OSError):
+        nonlocking_reader_before_writer = self._nonlocking_reader_before_writer
+        writer_before_nonlocking_reader_exception = OSError
+        old_hdf5_on_windows = IS_WINDOWS and not h5py_utils.HDF5_HAS_LOCKING_ARGUMENT
+        locked_exception = OSError
+
+        # File locked by a writer
+        unexpected_access = old_hdf5_on_windows and self._libbound_low == "v108"
+        for wmode in ["w", "a"]:
+            with self._open_context_subprocess(filename, mode=wmode):
+                # Access by a second non-locking reader
+                with self.assertRaisesIf(
+                    nonlocking_reader_before_writer,
+                    writer_before_nonlocking_reader_exception,
+                ):
+                    with self._open_context(filename, mode="r") as f:
+                        self._assert_hdf5_data(f)
+                # No access by a second locking reader
+                if unexpected_access:
+                    logger.warning("unexpected concurrent access by a locking reader")
+                with self.assertRaisesIf(not unexpected_access, locked_exception):
+                    with self._open_context(filename, mode="r", locking=True) as f:
+                        self._assert_hdf5_data(f)
+                # No access by a second writer
+                if unexpected_access:
+                    logger.warning("unexpected concurrent access by a writer")
+                with self.assertRaisesIf(not unexpected_access, locked_exception):
                     with self._open_context(filename, mode="a") as f:
-                        pass
+                        self._assert_hdf5_data(f)
+                # Check for file corruption
+                if not nonlocking_reader_before_writer:
+                    self._validate_hdf5_data(filename)
             self._validate_hdf5_data(filename)
 
-        # File open by appending writer
-        with self._open_context_subprocess(filename, mode="a"):
+        # File locked by a reader
+        unexpected_access = old_hdf5_on_windows
+        with _subprocess_context(_open_context, filename, mode="r", locking=True):
+            # Access by a non-locking reader
             with self._open_context(filename, mode="r") as f:
                 self._assert_hdf5_data(f)
-            if IS_WINDOWS:
+            # Access by a locking reader
+            with self._open_context(filename, mode="r", locking=True) as f:
+                self._assert_hdf5_data(f)
+            # No access by a second writer
+            if unexpected_access:
+                logger.warning("unexpected concurrent access by a writer")
+            raise_condition = not unexpected_access
+            with self.assertRaisesIf(raise_condition, locked_exception):
                 with self._open_context(filename, mode="a") as f:
                     self._assert_hdf5_data(f)
-            else:
-                with self.assertRaises(OSError):
-                    with self._open_context(filename, mode="a") as f:
-                        pass
+            # Check for file corruption
             self._validate_hdf5_data(filename)
+        self._validate_hdf5_data(filename)
 
-        # File open by reader
+        # File open by a non-locking reader
         with self._open_context_subprocess(filename, mode="r"):
+            # Access by a second non-locking reader
             with self._open_context(filename, mode="r") as f:
                 self._assert_hdf5_data(f)
+            # Access by a second locking reader
+            with self._open_context(filename, mode="r", locking=True) as f:
+                self._assert_hdf5_data(f)
+            # Access by a second writer
             with self._open_context(filename, mode="a") as f:
-                pass
-            self._validate_hdf5_data(filename)
-
-        # File open by locking reader
-        with _subprocess_context(
-            _open_context, filename, mode="r", enable_file_locking=True
-        ):
-            with self._open_context(filename, mode="r") as f:
                 self._assert_hdf5_data(f)
-            if IS_WINDOWS:
-                with self._open_context(filename, mode="a") as f:
-                    self._assert_hdf5_data(f)
-            else:
-                with self.assertRaises(OSError):
-                    with self._open_context(filename, mode="a") as f:
-                        pass
+            # Check for file corruption
             self._validate_hdf5_data(filename)
+        self._validate_hdf5_data(filename)
 
     @subtests
     @unittest.skipIf(not h5py_utils.HAS_SWMR, "SWMR not supported")
@@ -327,7 +383,11 @@ class TestH5pyUtils(unittest.TestCase):
                 raise RetryError
 
         with h5py_utils.open_item(
-            filename, "/check", validate=validate, retry_timeout=1, retry_invalid=True
+            filename,
+            "/check",
+            validate=validate,
+            retry_timeout=1,
+            retry_invalid=True,
         ) as item:
             self.assertTrue(item[()])
 

--- a/src/silx/io/test/test_h5py_utils.py
+++ b/src/silx/io/test/test_h5py_utils.py
@@ -223,17 +223,12 @@ class TestH5pyUtils(unittest.TestCase):
         self.assertEqual(orig, os.environ.get("HDF5_USE_FILE_LOCKING"))
 
     @property
-    def _libbound_low(self):
-        libver = self._subtest_options.get("libver")
-        low, _ = h5py_utils._effective_hdf5_libver_bounds(libver)
-        return low
-
-    @property
     def _nonlocking_reader_before_writer(self):
         """A non-locking reader must open the file before it is locked by a writer"""
         if IS_WINDOWS and h5py_utils.HDF5_HAS_LOCKING_ARGUMENT:
             return True
-        if self._libbound_low != "v108":
+        libver = self._subtest_options.get("libver")
+        if not h5py_utils._libver_low_bound_is_v108(libver):
             return True
         return False
 


### PR DESCRIPTION
Closes #3541

I tested  `src/silx/io/test/test_h5py_utils.py` against different h5py/libhdf5 on Ubuntu

```
h5py: 2.8.0, hdf5: 1.10.4
h5py: 2.9.0, hdf5: 1.10.4
h5py: 2.10.0, hdf5: 1.10.4
h5py: 2.10.0, hdf5: 1.10.6 CONDA
h5py: 3.1.0, hdf5: 1.12.0
h5py: 3.2.0, hdf5: 1.12.0
h5py: 3.3.0, hdf5: 1.12.0
h5py: 3.3.0, hdf5: 1.10.6 CONDA
h5py: 3.4.0, hdf5: 1.12.1 REMARK
h5py: 3.5.0, hdf5: 1.12.1
```

and on Windows

```
h5py: 2.10.0, hdf5: 1.10.5
h5py: 3.1.0, hdf5: 1.12.0
h5py: 3.2.0, hdf5: 1.12.0
h5py: 3.3.0, hdf5: 1.12.0
h5py: 3.4.0, hdf5: 1.12.1 REMARK
h5py: 3.5.0, hdf5: 1.12.1
```

No manual tests done on Mac.

REMARK: skips `test_modes_multi_process` due to  "Versions of libhdf5 and h5py use incompatible file locking behavior"
