### PR TITLE
Add silx-view.gif to documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,9 @@
 silx toolkit
 ============
 
+.. |silxView| image:: http://www.silx.org/doc/silx/img/silx-view-v1-0.gif
+   :height: 480px
+
 The purpose of the *silx* project is to provide a collection of Python packages to support the
 development of data assessment, reduction and analysis applications at synchrotron
 radiation facilities.
@@ -29,7 +32,11 @@ The current version features:
 * a set of applications:
 
   * a unified viewer (*silx view filename*) for HDF5, SPEC and image file formats
+  
+    |silxView|
+
   * a unified converter to HDF5 format (*silx convert filename*)
+
 
 Installation
 ------------

--- a/doc/source/applications/view.rst
+++ b/doc/source/applications/view.rst
@@ -1,6 +1,10 @@
+.. _silx view:
 
 silx view
 =========
+
+.. figure:: http://www.silx.org/doc/silx/img/silx-view-v1-0.gif
+   :align: center
 
 Purpose
 -------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -32,7 +32,9 @@ The current version (v\ |version|) caters for:
 * a set of applications:
 
     * a unified viewer (:ref:`silx view` *filename*) for HDF5, SPEC and image file formats
+
       |silxView|
+
     * a unified converter to HDF5 format (*silx convert filename*)
 
    

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,6 +1,9 @@
 silx |version|
 ==============
 
+.. |silxView| image:: http://www.silx.org/doc/silx/img/silx-view-v1-0.gif
+   :height: 80px
+
 The silx project aims to provide a collection of Python packages to support the
 development of data assessment, reduction and analysis at synchrotron radiation
 facilities.
@@ -28,9 +31,11 @@ The current version (v\ |version|) caters for:
 
 * a set of applications:
 
-  * a unified viewer (*silx view filename*) for HDF5, SPEC and image file formats
-  * a unified converter to HDF5 format (*silx convert filename*)
+    * a unified viewer (:ref:`silx view` *filename*) for HDF5, SPEC and image file formats
+      |silxView|
+    * a unified converter to HDF5 format (*silx convert filename*)
 
+   
 
 .. toctree::
    :hidden:


### PR DESCRIPTION
# TODO
- [x] add it as a 'small' image in index.html
- [x] add it larget in the silx view doc index page
- [x] add a link on the README.rst (should be active once in master only)

# Notes
I am not a big fan of the layout but with rst hard to do something more 'fancy'.

# Extra information

## screenshot of the generated documentation:
![Screenshot from 2021-11-19 14-05-01](https://user-images.githubusercontent.com/12907796/142627963-072172ab-dfd3-4515-8bf4-226254d681ac.png)
![Screenshot from 2021-11-19 14-04-47](https://user-images.githubusercontent.com/12907796/142627969-184086a2-bcb1-456c-8766-f1e4aa1364e5.png)

## raw videos

if needs to be reused at one point

https://user-images.githubusercontent.com/12907796/142628021-b554f620-ede9-438f-85c0-34953d7345d7.mp4

