### PR TITLE
HDF5 table view bug for virtual datasets in the same file

### DIFF
--- a/src/silx/gui/data/Hdf5TableView.py
+++ b/src/silx/gui/data/Hdf5TableView.py
@@ -450,8 +450,9 @@ class Hdf5TableModel(HierarchicalTableView.HierarchicalTableModel):
                     return firstExtSource
 
                 if firstExtSource[0] == ".":
-                    firstExtSource.pop(0)
-                return os.path.join(os.path.dirname(filename), firstExtSource)
+                    return filename + firstExtSource[1:]
+                else:
+                    return os.path.join(os.path.dirname(filename), firstExtSource)
 
             self.__data.addHeaderRow(headerLabel="External sources")
             self.__data.addHeaderValueRow("Type", extType)


### PR DESCRIPTION
Closes #3571

![image](https://user-images.githubusercontent.com/7264703/144875587-ecd4792d-2add-4d55-80a8-17275c4eff4f.png)

The first virtual source is
```
/data/id21/inhouse/eduardo/out/fitted_EP_701_1_859_12158.h5::/2.1/blisspymca.1/results/parameters/Al_K
```

Alternatively this could also be

```
.::/2.1/blisspymca.1/results/parameters/Al_K
```

I prefer the first (absolute path) because it might not be clear that a "dot" refers to the current file and not to the current directory.
