### PR TITLE
CI: Updated build with setuptools's embedded distutils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,7 @@ jobs:
           if [ ${{ runner.os }} == 'macOS' ]; then
               export MACOSX_DEPLOYMENT_TARGET=10.9;
           fi
+          export SETUPTOOLS_USE_DISTUTILS=local
           python setup.py ${{ matrix.BUILD_COMMAND }}
           ls dist
 
@@ -122,7 +123,9 @@ jobs:
           pip install pytest-xvfb
 
       - name: Install silx package
-        run: pip install --pre --find-links dist/ silx
+        run: |
+          export SETUPTOOLS_USE_DISTUTILS=local
+          pip install --pre --find-links dist/ silx
 
       - name: Print python info used for tests
         run: |


### PR DESCRIPTION
Trying to build with upcoming `setuptools` changes related to [PEP 632](https://www.python.org/dev/peps/pep-0632/) and checking `numpy.distutils` compatibility.
