### PR TITLE
Fixed build by NOT using setuptools>=60.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,9 +82,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # Use latest setuptools using Python's distutils
       - name: Upgrade distribution modules
         run: |
-          python -m pip install --upgrade pip setuptools wheel
+          pip install --upgrade setuptools<60.0.0
+          python -m pip install --upgrade pip wheel
           pip install --upgrade --pre numpy cython
 
       - name: Print python info used for build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
       # Use latest setuptools using Python's distutils
       - name: Upgrade distribution modules
         run: |
-          pip install --upgrade setuptools<60.0.0
+          pip install --upgrade "setuptools<60.0.0"
           python -m pip install --upgrade pip wheel
           pip install --upgrade --pre numpy cython
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -64,6 +64,7 @@ build_script:
     - "%VENV_BUILD_DIR%\\Scripts\\activate.bat"
 
     # Install build dependencies
+    - "pip install %PIP_OPTIONS% --upgrade setuptools<60.0.0"
     - "pip install %PIP_OPTIONS% --upgrade wheel"
     - "pip install %PIP_OPTIONS% --upgrade numpy"
     - "pip install %PIP_OPTIONS% --upgrade cython"

--- a/ci/info_platform.py
+++ b/ci/info_platform.py
@@ -65,6 +65,7 @@ else:
 
 
 for binding_name in ("PyQt5", "PySide2", "PySide6"):
+    # Check Qt version in subprocess to avoid issues with importing multiple Qt bindins
     cmd = [
         sys.executable,
         "-c",

--- a/ci/info_platform.py
+++ b/ci/info_platform.py
@@ -6,9 +6,10 @@ __authors__ = ["Jérôme Kieffer"]
 __date__ = "09/09/2016"
 __license__ = "MIT"
 
-
 import sys
 import platform
+import subprocess
+
 
 print("Python %s bits" % (tuple.__itemsize__ * 8))
 print("       maxsize: %s\t maxunicode: %s" % (sys.maxsize, sys.maxunicode))
@@ -62,28 +63,16 @@ else:
             for d in p.devices:
                 print("    %s max_workgroup_size is %s" % (d, d.max_work_group_size))
 
-have_qt_binding = False
 
-try:
-    import PyQt5.QtCore
-    have_qt_binding = True
-    print("Qt (from PyQt5): %s" % PyQt5.QtCore.qVersion())
-except ImportError:
-    pass
-
-try:
-    import PySide2.QtCore
-    have_qt_binding = True
-    print("Qt (from PySide2): %s" % PySide2.QtCore.qVersion())
-except ImportError:
-    pass
-
-try:
-    import PySide6.QtCore
-    have_qt_binding = True
-    print("Qt (from PySide6): %s" % PySide6.QtCore.qVersion())
-except ImportError:
-    pass
-
-if not have_qt_binding:
-    print("No Qt binding")
+for binding_name in ("PyQt5", "PySide2", "PySide6"):
+    cmd = [
+        sys.executable,
+        "-c",
+        "import {0}.QtCore; print({0}.QtCore.qVersion())".format(binding_name),
+    ]
+    try:
+        version = subprocess.check_output(cmd, timeout=4).decode('ascii').rstrip("\n")
+    except subprocess.CalledProcessError:
+        print("{0}: Not available".format(binding_name))
+    else:
+        print("{0}: Qt version {1}".format(binding_name, version))

--- a/ci/requirements-pinned.txt
+++ b/ci/requirements-pinned.txt
@@ -8,3 +8,6 @@ pybind11  # Required to build pyopencl
 # downloaded from https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyopencl
 # Anyway, we don't test OpenCL on appveyor
 pyopencl == 2020.3.1; sys_platform == 'win32'
+
+# Until PySide6>=6.2.2 passed CI
+PySide6 == 6.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools",
+    "setuptools<60.0.0",
     "numpy>=1.12",
     "Cython>=0.21.1"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 
 # Required dependencies (from setup.py setup_requires and install_requires)
 numpy >= 1.12
-setuptools
+setuptools < 60.0.0
 Cython >= 0.21.1
 h5py
 fabio >= 0.9


### PR DESCRIPTION
This PR constraints `setuptools` to versions < 60.0.0 in `pyproject.toml`, `requirements.txt` and CI to avoid compatibility issues between recent `setuptools` version and `numpy.distutils`, due to `setuptools` now using it's own fork of `distutils` rather than the one from Python.

This is one step towards fixing CI:
- It also pin-point `PySide6` to version 6.2.1 in CI to avoid failures.
- It avoids `ci/info_platform.py` to import multiple Qt libs by running Qt checks in subprocesses.