### PR TITLE
Build: `setup.py` cleanup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,27 +45,10 @@ logger = logging.getLogger("silx.setup")
 
 from distutils.command.clean import clean as Clean
 from distutils.command.build import build as _build
-try:
-    from setuptools import Command
-    from setuptools.command.sdist import sdist
-    try:
-        from Cython.Build import build_ext
-        logger.info("Use setuptools with cython")
-    except ImportError:
-        from setuptools.command.build_ext import build_ext
-        logger.info("Use setuptools, cython is missing")
-except ImportError:
-    try:
-        from numpy.distutils.core import Command
-    except ImportError:
-        from distutils.core import Command
-    from distutils.command.sdist import sdist
-    try:
-        from Cython.Build import build_ext
-        logger.info("Use distutils with cython")
-    except ImportError:
-        from distutils.command.build_ext import build_ext
-        logger.info("Use distutils, cython is missing")
+from setuptools import Command
+from setuptools.command.sdist import sdist
+from setuptools.command.build_ext import build_ext
+
 try:
     import sphinx
     import sphinx.util.console

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,14 @@ from setuptools.command.sdist import sdist
 from setuptools.command.build_ext import build_ext
 
 try:
+    import numpy
+    from numpy.distutils.misc_util import Configuration
+except ImportError:
+    raise ImportError(
+        "To install this package, you must install numpy first\n"
+        "(See https://pypi.org/project/numpy)")
+
+try:
     import sphinx
     import sphinx.util.console
     sphinx.util.console.color_terminal = lambda: False
@@ -408,18 +416,11 @@ else:
 # numpy.distutils Configuration #
 # ############################# #
 
-
 def configuration(parent_package='', top_path=None):
     """Recursive construction of package info to be used in setup().
 
     See http://docs.scipy.org/doc/numpy/reference/distutils.html#numpy.distutils.misc_util.Configuration
     """
-    try:
-        from numpy.distutils.misc_util import Configuration
-    except ImportError:
-        raise ImportError(
-            "To install this package, you must install numpy first\n"
-            "(See https://pypi.org/project/numpy)")
     config = Configuration(None, parent_package, top_path)
     config.set_options(
         ignore_setup_xxx_py=True,
@@ -575,7 +576,6 @@ class BuildExt(build_ext):
 
             ext.extra_compile_args.append('-fvisibility=hidden')
 
-            import numpy
             numpy_version = [int(i) for i in numpy.version.full_version.split(".", 2)[:2]]
             if numpy_version < [1, 16]:
                 ext.extra_compile_args.append(
@@ -771,8 +771,7 @@ def get_project_configuration():
     """Returns project arguments for setup"""
     # Use installed numpy version as minimal required version
     # This is useful for wheels to advertise the numpy version they were built with
-    from numpy.version import version as numpy_version
-    numpy_requested_version = ">=%s" % numpy_version
+    numpy_requested_version = ">=%s" % numpy.version.version
     logger.info("Install requires: numpy %s", numpy_requested_version)
 
     install_requires = [

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ logger = logging.getLogger("silx.setup")
 
 from distutils.command.clean import clean as Clean
 from distutils.command.build import build as _build
-from setuptools import Command
+from setuptools import Command, setup
 from setuptools.command.sdist import sdist
 from setuptools.command.build_ext import build_ext
 
@@ -896,22 +896,6 @@ def setup_package():
         '--help' in sys.argv[1:] or
         sys.argv[1] in ('--help-commands', 'egg_info', '--version',
                         'clean', '--name')))
-
-    if dry_run:
-        # DRY_RUN implies actions which do not require dependencies, like NumPy
-        try:
-            from setuptools import setup
-            logger.info("Use setuptools.setup")
-        except ImportError:
-            from distutils.core import setup
-            logger.info("Use distutils.core.setup")
-    else:
-        try:
-            from setuptools import setup
-        except ImportError:
-            from numpy.distutils.core import setup
-            logger.info("Use numpy.distutils.setup")
-
     setup_kwargs = get_project_configuration(dry_run)
     setup(**setup_kwargs)
 

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,6 @@ import platform
 import shutil
 import logging
 import glob
-# io import has to be here also to fix a bug on Debian 7 with python2.7
-# Without this, the system io module is not loaded from numpy.distutils.
-# The silx.io module seems to be loaded instead.
-import io
 
 logging.basicConfig(level=logging.INFO)
 
@@ -83,7 +79,7 @@ def get_readme():
     """Returns content of README.rst file"""
     dirname = os.path.dirname(os.path.abspath(__file__))
     filename = os.path.join(dirname, "README.rst")
-    with io.open(filename, "r", encoding="utf-8") as fp:
+    with open(filename, "r", encoding="utf-8") as fp:
         long_description = fp.read()
     return long_description
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ logger = logging.getLogger("silx.setup")
 
 from distutils.command.clean import clean as Clean
 from distutils.command.build import build as _build
-from setuptools import Command, setup
+from setuptools import Command
 from setuptools.command.sdist import sdist
 from setuptools.command.build_ext import build_ext
 
@@ -767,16 +767,13 @@ class sdist_debian(sdist):
 # ##### #
 
 
-def get_project_configuration(dry_run):
+def get_project_configuration():
     """Returns project arguments for setup"""
     # Use installed numpy version as minimal required version
     # This is useful for wheels to advertise the numpy version they were built with
-    if dry_run:
-        numpy_requested_version = ""
-    else:
-        from numpy.version import version as numpy_version
-        numpy_requested_version = ">=%s" % numpy_version
-        logger.info("Install requires: numpy %s", numpy_requested_version)
+    from numpy.version import version as numpy_version
+    numpy_requested_version = ">=%s" % numpy_version
+    logger.info("Install requires: numpy %s", numpy_requested_version)
 
     install_requires = [
         # for most of the computation
@@ -854,17 +851,7 @@ def get_project_configuration(dry_run):
         clean=CleanCommand,
         debian_src=sdist_debian)
 
-    if dry_run:
-        # DRY_RUN implies actions which do not require NumPy
-        #
-        # And they are required to succeed without Numpy for example when
-        # pip is used to install silx when Numpy is not yet present in
-        # the system.
-        setup_kwargs = {}
-    else:
-        config = configuration()
-        setup_kwargs = config.todict()
-
+    setup_kwargs = configuration().todict()
     setup_kwargs.update(name=PROJECT,
                         version=get_version(),
                         url="http://www.silx.org/",
@@ -884,21 +871,7 @@ def get_project_configuration(dry_run):
     return setup_kwargs
 
 
-def setup_package():
-    """Run setup(**kwargs)
-
-    Depending on the command, it either runs the complete setup which depends on numpy,
-    or a *dry run* setup with no dependency on numpy.
-    """
-
-    # Check if action requires build/install
-    dry_run = len(sys.argv) == 1 or (len(sys.argv) >= 2 and (
-        '--help' in sys.argv[1:] or
-        sys.argv[1] in ('--help-commands', 'egg_info', '--version',
-                        'clean', '--name')))
-    setup_kwargs = get_project_configuration(dry_run)
-    setup(**setup_kwargs)
-
-
 if __name__ == "__main__":
-    setup_package()
+    from setuptools import setup
+
+    setup(**get_project_configuration())


### PR DESCRIPTION
This PR removes some now useless code (IMO) from `setup.py`.

A lot of changes in `setuptools` are to be expected (including #3574), so silx's `setup.py` will have to be updated.

This PR is preparing this by doing some clean-up first:
- removes python2 compatibility code
- removes lazy imports and dry-run: nowadays with wheels/conda and  `pyproject.toml` the main ways of installing packages do not need this.