### PR TITLE
FFT: avoid creating opencl/cuda contexts when not needed

### DIFF
--- a/src/silx/math/fft/clfft.py
+++ b/src/silx/math/fft/clfft.py
@@ -74,7 +74,7 @@ class CLFFT(BaseFFT):
         if not(__have_clfft__) or not(__have_clfft__):
             raise ImportError("Please install pyopencl and gpyfft >= %s to use the OpenCL back-end" % __required_gpyfft_version__)
 
-        super(CLFFT, self).__init__(
+        super().__init__(
             shape=shape,
             dtype=dtype,
             template=template,

--- a/src/silx/math/fft/cufft.py
+++ b/src/silx/math/fft/cufft.py
@@ -61,7 +61,7 @@ class CUFFT(BaseFFT):
         if not(__have_cufft__) or not(__have_cufft__):
             raise ImportError("Please install pycuda and scikit-cuda to use the CUDA back-end")
 
-        super(CUFFT, self).__init__(
+        super().__init__(
             shape=shape,
             dtype=dtype,
             template=template,

--- a/src/silx/math/fft/fft.py
+++ b/src/silx/math/fft/fft.py
@@ -24,9 +24,7 @@
 #
 # ###########################################################################*/
 from .fftw import FFTW
-from .clfft import CLFFT
 from .npfft import NPFFT
-from .cufft import CUFFT
 
 
 def FFT(
@@ -71,20 +69,23 @@ def FFT(
     :param str backend:
         FFT Backend to use. Value can be "numpy", "fftw", "opencl", "cuda".
     """
-    backends = {
-        "numpy": NPFFT,
-        "np": NPFFT,
-        "fftw": FFTW,
-        "opencl": CLFFT,
-        "clfft": CLFFT,
-        "cuda": CUFFT,
-        "cufft": CUFFT,
-    }
-
+    backends = ["numpy", "fftw", "opencl", "cuda"]
     backend = backend.lower()
-    if backend not in backends:
+    if backend in ["numpy", "np"]:
+        fft_cls = NPFFT
+    elif backend == "fftw":
+        fft_cls = FFTW
+    elif backend in ["opencl", "clfft"]:
+        # Late import for creating context only if needed
+        from .clfft import CLFFT
+        fft_cls = CLFFT
+    elif backend in ["cuda", "cufft"]:
+        # Late import for creating context only if needed
+        from .cufft import CUFFT
+        fft_cls = CUFFT
+    else:
         raise ValueError("Unknown backend %s, available are %s" % (backend, backends))
-    F = backends[backend](
+    F = fft_cls(
         shape=shape,
         dtype=dtype,
         template=template,

--- a/src/silx/math/fft/fftw.py
+++ b/src/silx/math/fft/fftw.py
@@ -66,7 +66,7 @@ class FFTW(BaseFFT):
     ):
         if not(__have_fftw__):
             raise ImportError("Please install pyfftw >= %s to use the FFTW back-end" % __required_pyfftw_version__)
-        super(FFTW, self).__init__(
+        super().__init__(
             shape=shape,
             dtype=dtype,
             template=template,

--- a/src/silx/math/fft/npfft.py
+++ b/src/silx/math/fft/npfft.py
@@ -42,7 +42,7 @@ class NPFFT(BaseFFT):
         axes=None,
         normalize="rescale",
     ):
-        super(NPFFT, self).__init__(
+        super().__init__(
             shape=shape,
             dtype=dtype,
             template=template,

--- a/src/silx/math/fft/npfft.py
+++ b/src/silx/math/fft/npfft.py
@@ -59,7 +59,6 @@ class NPFFT(BaseFFT):
         if normalize != "ortho":
             self.normalize = None
         self.set_fft_functions()
-        #~ self.allocate_arrays() # not needed for this backend
         self.compute_plans()
 
 

--- a/src/silx/math/fft/npfft.py
+++ b/src/silx/math/fft/npfft.py
@@ -79,7 +79,7 @@ class NPFFT(BaseFFT):
 
 
     def _allocate(self, shape, dtype):
-        return np.zeros(self.queue, shape, dtype=dtype)
+        return np.zeros(shape, dtype=dtype)
 
 
     def compute_plans(self):


### PR DESCRIPTION
(see #3439 discussion)

This PR fixes opencl/cuda contexts being created unnecessarily.

Changelog: FFT: avoid creating opencl/cuda contexts when not needed