### PR TITLE
silx.gui.plot.PlotWidget: Fixed matplotlib backend replot failure under specific conditions

### DIFF
--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -64,6 +64,7 @@ from . import BackendBase
 from .. import items
 from .._utils import FLOAT32_MINPOS
 from .._utils.dtime_ticklayout import calcTicks, bestFormatString, timestamp
+from ...qt import inspect as qt_inspect
 
 _PATCH_LINESTYLE = {
     "-": 'solid',
@@ -1516,6 +1517,10 @@ class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
         self._drawOverlays()
 
     def replot(self):
+        if not qt_inspect.isValid(self):
+            _logger.info("replot requested but widget no longer exists")
+            return
+
         with self._plot._paintContext():
             BackendMatplotlib._replot(self)
 


### PR DESCRIPTION
This PR adds a test in `replot` method to make sure the underlying matplotlib backend is valid before reploting.
This can occur because of the async execution of `replot` through `__deferredReplot`.

@vallsv let me know whether it fixes your issue or not?

closes #3589
