### PR TITLE
silx.gui.plot.PlotWidget: Fixed time axis with values outside of supported range ]0, 10000[ years

### DIFF
--- a/src/silx/gui/plot/_utils/test/test_dtime_ticklayout.py
+++ b/src/silx/gui/plot/_utils/test/test_dtime_ticklayout.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -32,6 +32,7 @@ __date__ = "06/04/2018"
 
 import datetime as dt
 import unittest
+import pytest
 
 
 from silx.gui.plot._utils.dtime_ticklayout import (
@@ -77,3 +78,17 @@ class TestTickLayout(unittest.TestCase):
                              numTicks, d2))
 
             value = value * 1.5 # let date period grow exponentially
+
+@pytest.mark.parametrize(
+    "dMin, dMax",
+    [
+        (dt.datetime(1, 1, 1), dt.datetime(400, 1, 1)),
+        (dt.datetime(4000, 1, 1), dt.datetime(9999, 1, 1)),
+        (dt.datetime(1, 1, 1), dt.datetime(9999, 12, 23)),
+    ],
+)
+def testCalcTicksOutOfBoundTicks(dMin, dMax):
+    """Test tick generation with values leading to out-of-bound ticks"""
+    ticks, _, unit = calcTicks(dMin, dMax, nTicks=5)
+    assert len(ticks) != 0
+    assert unit == DtUnit.YEARS

--- a/src/silx/gui/plot/_utils/test/test_dtime_ticklayout.py
+++ b/src/silx/gui/plot/_utils/test/test_dtime_ticklayout.py
@@ -31,53 +31,50 @@ __date__ = "06/04/2018"
 
 
 import datetime as dt
-import unittest
 import pytest
 
 
-from silx.gui.plot._utils.dtime_ticklayout import (
-    calcTicks, DtUnit, SECONDS_PER_YEAR)
+from silx.gui.plot._utils.dtime_ticklayout import calcTicks, DtUnit, SECONDS_PER_YEAR
 
 
-class TestTickLayout(unittest.TestCase):
-    """Test ticks layout algorithms"""
+def testSmallMonthlySpacing():
+    """Tests a range that did result in a spacing of less than 1 month.
+    It is impossible to add fractional month so the unit must be in days
+    """
+    from dateutil import parser
 
-    def testSmallMonthlySpacing(self):
-        """ Tests a range that did result in a spacing of less than 1 month.
-            It is impossible to add fractional month so the unit must be in days
-        """
-        from dateutil import parser
-        d1 = parser.parse("2017-01-03 13:15:06.000044")
-        d2 = parser.parse("2017-03-08 09:16:16.307584")
-        _ticks, _units, spacing = calcTicks(d1, d2, nTicks=4)
+    d1 = parser.parse("2017-01-03 13:15:06.000044")
+    d2 = parser.parse("2017-03-08 09:16:16.307584")
+    _ticks, _units, spacing = calcTicks(d1, d2, nTicks=4)
 
-        self.assertEqual(spacing, DtUnit.DAYS)
+    assert spacing == DtUnit.DAYS
 
 
-    def testNoCrash(self):
-        """ Creates many combinations of and number-of-ticks and end-dates;
-        tests that it doesn't give an exception and returns a reasonable number
-        of ticks.
-        """
-        d1 = dt.datetime(2017, 1, 3, 13, 15, 6, 44)
+def testNoCrash():
+    """Creates many combinations of and number-of-ticks and end-dates;
+    tests that it doesn't give an exception and returns a reasonable number
+    of ticks.
+    """
+    d1 = dt.datetime(2017, 1, 3, 13, 15, 6, 44)
 
-        value = 100e-6 # Start at 100 micro sec range.
+    value = 100e-6  # Start at 100 micro sec range.
 
-        while value <= 200 * SECONDS_PER_YEAR:
+    while value <= 200 * SECONDS_PER_YEAR:
 
-            d2 = d1 + dt.timedelta(microseconds=value*1e6) # end date range
+        d2 = d1 + dt.timedelta(microseconds=value * 1e6)  # end date range
 
-            for numTicks in range(2, 12):
-                ticks, _, _ = calcTicks(d1, d2, numTicks)
+        for numTicks in range(2, 12):
+            ticks, _, _ = calcTicks(d1, d2, numTicks)
 
-                margin = 2.5
-                self.assertTrue(
-                    numTicks/margin <= len(ticks) <= numTicks*margin,
-                    "Condition {} <= {} <= {} failed for # ticks={} and d2={}:"
-                     .format(numTicks/margin, len(ticks), numTicks * margin,
-                             numTicks, d2))
+            margin = 2.5
+            assert (
+                numTicks / margin <= len(ticks) <= numTicks * margin
+            ), "Condition {} <= {} <= {} failed for # ticks={} and d2={}:".format(
+                numTicks / margin, len(ticks), numTicks * margin, numTicks, d2
+            )
 
-            value = value * 1.5 # let date period grow exponentially
+        value = value * 1.5  # let date period grow exponentially
+
 
 @pytest.mark.parametrize(
     "dMin, dMax",

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -166,8 +166,13 @@ class NiceDateLocator(Locator):
             vmin, vmax = vmax, vmin
 
         # vmin and vmax should be timestamps (i.e. seconds since 1 Jan 1970)
-        dtMin = dt.datetime.fromtimestamp(vmin, tz=self.tz)
-        dtMax = dt.datetime.fromtimestamp(vmax, tz=self.tz)
+        try:
+            dtMin = dt.datetime.fromtimestamp(vmin, tz=self.tz)
+            dtMax = dt.datetime.fromtimestamp(vmax, tz=self.tz)
+        except ValueError:
+            _logger.warning("Data range cannot be displayed with time axis")
+            return []
+
         dtTicks, self._spacing, self._unit = \
             calcTicks(dtMin, dtMax, self.numTicks)
 

--- a/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2014-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -358,8 +358,12 @@ class PlotAxis(object):
                             yield ((xPixel, yPixel), dataPos, text)
                 else:
                     # Time series
-                    dtMin = dt.datetime.fromtimestamp(dataMin, tz=self.timeZone)
-                    dtMax = dt.datetime.fromtimestamp(dataMax, tz=self.timeZone)
+                    try:
+                        dtMin = dt.datetime.fromtimestamp(dataMin, tz=self.timeZone)
+                        dtMax = dt.datetime.fromtimestamp(dataMax, tz=self.timeZone)
+                    except ValueError:
+                        _logger.warning("Data range cannot be displayed with time axis")
+                        return  # Range is out of bound of the datetime
 
                     tickDateTimes, spacing, unit = calcTicksAdaptive(
                         dtMin, dtMax, nbPixels, tickDensity)


### PR DESCRIPTION
This PR fixes 2 issues causing exceptions related to time axis:
- When the initial range of the plot is out of the range supported by Python `datetime`. In this case, there is no tick and values displayed: no ideal, but definitely better than an exception.
- When the data range leads to "nice" ticks outside of the `datetime` range. In this case, those ticks are ignored, but others are still displayed.

closes  #3570
