### PR TITLE
silx.gui.plot.PlotWidget: Added support of math syntax to text with OpenGL

### DIFF
--- a/src/silx/gui/_glutils/font.py
+++ b/src/silx/gui/_glutils/font.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -33,6 +33,7 @@ import logging
 import numpy
 
 from ..utils.image import convertQImageToArray
+from ..utils.matplotlib import rasterMathText
 from .. import qt
 
 _logger = logging.getLogger(__name__)
@@ -66,11 +67,7 @@ ULTRA_BLACK = 99
 """Thickest characters: Maximum font weight"""
 
 
-def rasterText(text, font,
-               size=-1,
-               weight=-1,
-               italic=False,
-               devicePixelRatio=1.0):
+def rasterTextQt(text, font, size=-1, weight=-1, italic=False, devicePixelRatio=1.0):
     """Raster text using Qt.
 
     It supports multiple lines.
@@ -154,3 +151,32 @@ def rasterText(text, font,
     array = array[min_row:row_cumsum.argmax() + 2, :]
 
     return array, metrics.ascent() - min_row
+
+
+def rasterText(text, font, size=-1, weight=-1, italic=False, devicePixelRatio=1.0):
+    """Raster text using Qt or matplotlib if there may be math syntax.
+
+    It supports multiple lines.
+
+    :param str text: The text to raster
+    :param font: Font name or QFont to use
+    :type font: str or :class:`QFont`
+    :param int size:
+        Font size in points
+        Used only if font is given as name.
+    :param int weight:
+        Font weight in [0, 99], see QFont.Weight.
+        Used only if font is given as name.
+    :param bool italic:
+        True for italic font (default: False).
+        Used only if font is given as name.
+    :param float devicePixelRatio:
+        The current ratio between device and device-independent pixel
+        (default: 1.0)
+    :return: Corresponding image in gray scale and baseline offset from top
+    :rtype: (HxW numpy.ndarray of uint8, int)
+    """
+    if text.count("$") >= 2:
+        return rasterMathText(text, font, size, weight, italic, devicePixelRatio)
+    else:
+        return rasterTextQt(text, font, size, weight, italic, devicePixelRatio)

--- a/src/silx/gui/_glutils/font.py
+++ b/src/silx/gui/_glutils/font.py
@@ -141,14 +141,14 @@ def rasterTextQt(text, font, size=-1, weight=-1, italic=False, devicePixelRatio=
     # RGB to R
     array = numpy.ascontiguousarray(array[:, :, 0])
 
-    # Remove leading and trailing empty columns but one on each side
-    column_cumsum = numpy.cumsum(numpy.sum(array, axis=0))
-    array = array[:, column_cumsum.argmin():column_cumsum.argmax() + 2]
-
-    # Remove leading and trailing empty rows but one on each side
-    row_cumsum = numpy.cumsum(numpy.sum(array, axis=1))
-    min_row = row_cumsum.argmin()
-    array = array[min_row:row_cumsum.argmax() + 2, :]
+    # Remove leading and trailing empty columns/rows but one on each side
+    filled_rows = numpy.nonzero(numpy.sum(array, axis=1))[0]
+    min_row = max(0, filled_rows[0] - 1)
+    filled_columns = numpy.nonzero(numpy.sum(array, axis=0))[0]
+    array = array[
+        min_row : filled_rows[-1] + 2,
+        max(0, filled_columns[0] - 1) : filled_columns[-1] + 2,
+    ]
 
     return array, metrics.ascent() - min_row
 

--- a/src/silx/gui/_glutils/font.py
+++ b/src/silx/gui/_glutils/font.py
@@ -92,7 +92,7 @@ def rasterTextQt(text, font, size=-1, weight=-1, italic=False, devicePixelRatio=
     """
     if not text:
         _logger.info("Trying to raster empty text, replaced by white space")
-        text = ' '  # Replace empty text by white space to produce an image
+        text = " "  # Replace empty text by white space to produce an image
 
     if not isinstance(font, qt.QFont):
         font = qt.QFont(font, size, weight, italic)
@@ -104,7 +104,8 @@ def rasterTextQt(text, font, size=-1, weight=-1, italic=False, devicePixelRatio=
     painter.setPen(qt.Qt.white)
     painter.setFont(font)
     bounds = painter.boundingRect(
-        qt.QRect(0, 0, 4096, 4096), qt.Qt.TextExpandTabs, text)
+        qt.QRect(0, 0, 4096, 4096), qt.Qt.TextExpandTabs, text
+    )
     painter.end()
 
     metrics = qt.QFontMetrics(font)
@@ -120,9 +121,9 @@ def rasterTextQt(text, font, size=-1, weight=-1, italic=False, devicePixelRatio=
     width = bounds.width() * devicePixelRatio + 2
     # align line size to 32 bits to ease conversion to numpy array
     width = 4 * ((width + 3) // 4)
-    image = qt.QImage(int(width),
-                      int(bounds.height() * devicePixelRatio + 2),
-                      qt.QImage.Format_RGB888)
+    image = qt.QImage(
+        int(width), int(bounds.height() * devicePixelRatio + 2), qt.QImage.Format_RGB888
+    )
     image.setDevicePixelRatio(devicePixelRatio)
 
     # TODO if Qt5 use Format_Grayscale8 instead

--- a/src/silx/gui/_glutils/font.py
+++ b/src/silx/gui/_glutils/font.py
@@ -32,9 +32,13 @@ __date__ = "13/10/2016"
 import logging
 import numpy
 
-from ..utils.image import convertQImageToArray
-from ..utils.matplotlib import rasterMathText
 from .. import qt
+from ..utils.image import convertQImageToArray
+
+try:
+    from ..utils.matplotlib import rasterMathText
+except ImportError:
+    rasterMathText = None
 
 _logger = logging.getLogger(__name__)
 
@@ -177,7 +181,7 @@ def rasterText(text, font, size=-1, weight=-1, italic=False, devicePixelRatio=1.
     :return: Corresponding image in gray scale and baseline offset from top
     :rtype: (HxW numpy.ndarray of uint8, int)
     """
-    if text.count("$") >= 2:
+    if rasterMathText is not None and text.count("$") >= 2:
         return rasterMathText(text, font, size, weight, italic, devicePixelRatio)
     else:
         return rasterTextQt(text, font, size, weight, italic, devicePixelRatio)

--- a/src/silx/gui/utils/matplotlib.py
+++ b/src/silx/gui/utils/matplotlib.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -38,10 +38,94 @@ __license__ = "MIT"
 __date__ = "02/05/2018"
 
 
+import io
 from pkg_resources import parse_version
 import matplotlib
+import numpy
 
 from .. import qt
+
+
+def rasterMathText(text, font, size=-1, weight=-1, italic=False, devicePixelRatio=1.0):
+    """Raster text using matplotlib supporting latex-like math syntax.
+
+    It supports multiple lines.
+
+    :param str text: The text to raster
+    :param font: Font name or QFont to use
+    :type font: str or :class:`QFont`
+    :param int size:
+        Font size in points
+        Used only if font is given as name.
+    :param int weight:
+        Font weight in [0, 99], see QFont.Weight.
+        Used only if font is given as name.
+    :param bool italic:
+        True for italic font (default: False).
+        Used only if font is given as name.
+    :param float devicePixelRatio:
+        The current ratio between device and device-independent pixel
+        (default: 1.0)
+    :return: Corresponding image in gray scale and baseline offset from top
+    :rtype: (HxW numpy.ndarray of uint8, int)
+    """
+    # Implementation adapted from:
+    # https://github.com/matplotlib/matplotlib/blob/d624571a19aec7c7d4a24123643288fc27db17e7/lib/matplotlib/mathtext.py#L264
+
+    # Lazy import to avoid imports before setting matplotlib's rcParams
+    from matplotlib.font_manager import FontProperties
+    from matplotlib.mathtext import MathTextParser
+    from matplotlib import figure
+
+    dpi = 96  # default
+    qapp = qt.QApplication.instance()
+    if qapp:
+        screen = qapp.primaryScreen()
+        if screen:
+            dpi = screen.logicalDotsPerInchY()
+
+    # Make sure dpi is even, it causes issues with array reshape otherwise
+    dpi = ((dpi * devicePixelRatio) // 2) * 2
+
+    stripped_text = text.strip("\n")
+
+    parser = MathTextParser("path")
+    width, height, depth, _, _ = parser.parse(stripped_text, dpi=dpi)
+    width *= 2
+    height *= 2 * (stripped_text.count("\n") + 1)
+
+    if not isinstance(font, qt.QFont):
+        font = qt.QFont(font, size, weight, italic)
+    prop = FontProperties(
+        family=font.family(),
+        style="italic" if font.italic() else "normal",
+        weight=10 * font.weight(),
+        size=font.pointSize(),
+    )
+
+    fig = figure.Figure(figsize=(width / dpi, height / dpi))
+    fig.text(0, depth / height, stripped_text, fontproperties=prop)
+    with io.BytesIO() as buffer:
+        fig.savefig(buffer, dpi=dpi, format="raw")
+        buffer.seek(0)
+        image = numpy.frombuffer(buffer.read(), dtype=numpy.uint8).reshape(
+            int(height), int(width), 4
+        )
+
+    # RGB to inverted R channel
+    array = 255 - image[:, :, 0]
+
+    # Remove leading and trailing empty columns/rows but one on each side
+    filled_rows = numpy.nonzero(numpy.sum(array, axis=1))[0]
+    filled_columns = numpy.nonzero(numpy.sum(array, axis=0))[0]
+    clipped_array = numpy.ascontiguousarray(
+        array[
+            max(0, filled_rows[0] - 1) : filled_rows[-1] + 2,
+            max(0, filled_columns[0] - 1) : filled_columns[-1] + 2,
+        ]
+    )
+
+    return clipped_array, image.shape[0] - 1  # baseline not available
 
 
 def _matplotlib_use(backend, force):

--- a/src/silx/gui/utils/matplotlib.py
+++ b/src/silx/gui/utils/matplotlib.py
@@ -131,18 +131,20 @@ def rasterMathText(text, font, size=-1, weight=-1, italic=False, devicePixelRati
 def _matplotlib_use(backend, force):
     """Wrapper of `matplotlib.use` to set-up backend.
 
-     It adds extra initialization for PySide2 with matplotlib < 2.2.
+    It adds extra initialization for PySide2 with matplotlib < 2.2.
     """
     # This is kept for compatibility with matplotlib < 2.2
-    if (parse_version(matplotlib.__version__) < parse_version('2.2') and
-            qt.BINDING == 'PySide2'):
-        matplotlib.rcParams['backend.qt5'] = 'PySide2'
+    if (
+        parse_version(matplotlib.__version__) < parse_version("2.2")
+        and qt.BINDING == "PySide2"
+    ):
+        matplotlib.rcParams["backend.qt5"] = "PySide2"
 
     matplotlib.use(backend, force=force)
 
 
-if qt.BINDING in ('PySide6', 'PyQt5', 'PySide2'):
-    _matplotlib_use('Qt5Agg', force=False)
+if qt.BINDING in ("PySide6", "PyQt5", "PySide2"):
+    _matplotlib_use("Qt5Agg", force=False)
     from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg  # noqa
 
 else:


### PR DESCRIPTION
This PR adds support for math syntax in plot texts (labels, title, etc...) with the OpenGL backend.
It does so by leveraging `matplotlib` parser (if present) to raster the text instead of using Qt.

It also fixes an issue in Qt raster which was producing larger image than necessary.

closes #845