### PR TITLE
Fix missing data if there is a trailing space in the mca array

### DIFF
--- a/src/silx/io/specfile/src/sfmca.c
+++ b/src/silx/io/specfile/src/sfmca.c
@@ -298,6 +298,11 @@ SfGetMca( SpecFile *sf, long index, long number, double **retdata, int *error )
        val = PyMcaAtof(strval);
        data[vals] = val;
        vals++;
+     } else if (i>0) {
+         strval[i] = '\0';
+         val = PyMcaAtof(strval);
+         data[vals] = val;
+         vals++;
      }
 #ifndef _GNU_SOURCE
 #ifdef PYMCA_POSIX


### PR DESCRIPTION
Fixed the problem that the last data was not loaded if there was a non-numeric trailing character when loading mca data.

Please refer to https://github.com/silx-kit/silx/issues/3611#issue-1170627169.