### PR TITLE
silx.gui.PlotWindow: Fixed management of DockWidgets when showing/hiding the PlotWindow

### DIFF
--- a/src/silx/gui/console.py
+++ b/src/silx/gui/console.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -181,13 +181,6 @@ class IPythonDockWidget(qt.QDockWidget):
 
         if available_vars is not None:
             self.ipyconsole.pushVariables(available_vars)
-
-    def showEvent(self, event):
-        """Make sure this widget is raised when it is shown
-        (when it is first created as a tab in PlotWindow or when it is shown
-        again after hiding).
-        """
-        self.raise_()
 
 
 def main():

--- a/src/silx/gui/plot/CurvesROIWidget.py
+++ b/src/silx/gui/plot/CurvesROIWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1567,14 +1567,6 @@ class CurvesROIDockWidget(qt.QDockWidget):
         action = super(CurvesROIDockWidget, self).toggleViewAction()
         action.setIcon(icons.getQIcon('plot-roi'))
         return action
-
-    def showEvent(self, event):
-        """Make sure this widget is raised when it is shown
-        (when it is first created as a tab in PlotWindow or when it is shown
-        again after hiding).
-        """
-        self.raise_()
-        qt.QDockWidget.showEvent(self, event)
 
     @property
     def currentROI(self):

--- a/src/silx/gui/plot/LegendSelector.py
+++ b/src/silx/gui/plot/LegendSelector.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1030,10 +1030,3 @@ class LegendsDockWidget(qt.QDockWidget):
                 self.plot.sigContentChanged.disconnect(self.updateLegends)
                 self.plot.sigActiveCurveChanged.disconnect(self.updateLegends)
                 self._isConnected = False
-
-    def showEvent(self, event):
-        """Make sure this widget is raised when it is shown
-        (when it is first created as a tab in PlotWindow or when it is shown
-        again after hiding).
-        """
-        self.raise_()

--- a/src/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/src/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1273,10 +1273,3 @@ class BaseMaskToolsDockWidget(qt.QDockWidget):
             self.widget().setDirection(qt.QBoxLayout.LeftToRight)
             self.resize(self.widget().minimumSize())
             self.adjustSize()
-
-    def showEvent(self, event):
-        """Make sure this widget is raised when it is shown
-        (when it is first created as a tab in PlotWindow or when it is shown
-        again after hiding).
-        """
-        self.raise_()


### PR DESCRIPTION
This PR reworks the handling of the tools embedded in dock widgets in the `PlotWindow` to fix it when `PlotWindow` is displayed inside a tab and the visibility of the tab change.

- All opened tabbed dock widgets remain opened (it was not the case for the "Curves Stats" and the "Console" tabs)
- Dock widgets are only raised when it is shown due to a user action. Before the raised dock widget was changed when switch back and forth from a tab containing a `PlotWindow`.

attn @woutdenolf @vallsv 

closes #3629
