### PR TITLE
Update for Python 3.11

### DIFF
--- a/src/silx/gui/utils/testutils.py
+++ b/src/silx/gui/utils/testutils.py
@@ -140,7 +140,7 @@ class TestCaseQt(unittest.TestCase):
 
     def _currentTestSucceeded(self):
         if hasattr(self, '_outcome'):
-            if hasattr(self._outcome, 'errors'):
+            if hasattr(self, '_feedErrorsToResult'):
                 # Python 3.4 - 3.10  (These two methods have no side effects)
                 result = self.defaultTestResult()
                 self._feedErrorsToResult(result, self._outcome.errors)

--- a/src/silx/gui/utils/testutils.py
+++ b/src/silx/gui/utils/testutils.py
@@ -141,9 +141,10 @@ class TestCaseQt(unittest.TestCase):
     def _currentTestSucceeded(self):
         if hasattr(self, '_outcome'):
             if hasattr(self, '_feedErrorsToResult'):
-                # Python 3.4 - 3.10  (These two methods have no side effects)
-                result = self.defaultTestResult()
-                self._feedErrorsToResult(result, self._outcome.errors)
+                # For Python 3.4 -3.10
+                result = self.defaultTestResult()  # these 2 methods have no side effects
+                if hasattr(self._outcome, 'errors'):
+                    self._feedErrorsToResult(result, self._outcome.errors)
             else:
                 # Python 3.11+
                 result = self._outcome.result

--- a/src/silx/gui/utils/testutils.py
+++ b/src/silx/gui/utils/testutils.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,7 @@
 
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
-__date__ = "05/10/2018"
+__date__ = "22/07/2022"
 
 
 import gc
@@ -140,10 +140,13 @@ class TestCaseQt(unittest.TestCase):
 
     def _currentTestSucceeded(self):
         if hasattr(self, '_outcome'):
-            # For Python >= 3.4
-            result = self.defaultTestResult()  # these 2 methods have no side effects
             if hasattr(self._outcome, 'errors'):
+                # Python 3.4 - 3.10  (These two methods have no side effects)
+                result = self.defaultTestResult()
                 self._feedErrorsToResult(result, self._outcome.errors)
+            else:
+                # Python 3.11+
+                result = self._outcome.result
         else:
             # For Python < 3.4
             result = getattr(self, '_outcomeForDoCleanups', self._resultForDoCleanups)


### PR DESCRIPTION
Reported (for PyMca) in https://github.com/vasole/pymca/issues/889

For the implemented solution see:

https://stackoverflow.com/questions/4414234/getting-pythons-unittest-results-in-a-teardown-method