### PR TITLE
Fixed running tests

### DIFF
--- a/src/silx/test/__init__.py
+++ b/src/silx/test/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -49,5 +49,5 @@ def run_tests(module: str='silx', verbosity: int=0, args=()):
         str(verbosity),
         '-o python_files=["test/test*.py","test/Test*.py"]',
         '-o python_classes=["Test"]',
-        '-o python_functions=["Test"]',
+        '-o python_functions=["test"]',
     ] + list(args))

--- a/src/silx/utils/test/test_external_resources.py
+++ b/src/silx/utils/test/test_external_resources.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -59,7 +59,7 @@ class TestExternalResources(unittest.TestCase):
             raise unittest.SkipTest("Network or silx website not available")
 
     def setUp(self):
-        self.resources = ExternalResources("toto", "http://www.silx.org/pub/silx/")
+        self.resources = ExternalResources("toto%d" % os.getpid(), "http://www.silx.org/pub/silx/")
 
     def tearDown(self):
         if self.resources.data_home:


### PR DESCRIPTION
This PR fixes small issues with running tests:
- A typo in selected test functions
- An issue when `resources` tests are run in parallel in multiple processes at the same time (Yes, I managed to get that!): The same folder was used by all concurrent processes