### PR TITLE
silx.sx: Fixes compatibility with matplotlib>=3.6.0 and PySide6; Fixed continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,43 +23,43 @@ jobs:
         include:
           - name-suffix: "PySide2 sdist"
             os: ubuntu-20.04
-            python-version: 3.6
+            python-version: '3.6'
             BUILD_COMMAND: sdist
             QT_BINDING: PySide2
             RUN_TESTS_OPTIONS: --qt-binding=PySide2 --no-opengl --low-mem
           - name-suffix: "PyQt5 wheel"
             os: macos-latest
-            python-version: 3.8
+            python-version: '3.8'
             BUILD_COMMAND: bdist_wheel
             QT_BINDING: PyQt5
             RUN_TESTS_OPTIONS: --qt-binding=PyQt5 --no-opencl --low-mem
           - name-suffix: "PySide6 wheel"
             os: ubuntu-20.04
-            python-version: 3.7
+            python-version: '3.7'
             BUILD_COMMAND: bdist_wheel
             QT_BINDING: PySide6
             RUN_TESTS_OPTIONS: --qt-binding=PySide6 --no-opengl --low-mem
           - name-suffix: "PySide6 sdist"
             os: ubuntu-latest
-            python-version: 3.10.2
+            python-version: '3.10'
             BUILD_COMMAND: sdist
             QT_BINDING: PySide6
             RUN_TESTS_OPTIONS: --qt-binding=PySide6 --no-opencl --low-mem
           - name-suffix: "PyQt5 sdist"
             os: ubuntu-latest
-            python-version: 3.10.2
+            python-version: '3.7'
             BUILD_COMMAND: sdist
             QT_BINDING: PyQt5
             RUN_TESTS_OPTIONS: --qt-binding=PyQt5 --no-opencl --low-mem
           - name-suffix: "PySide6 wheel"
             os: macos-latest
-            python-version: 3.9
+            python-version: '3.9'
             BUILD_COMMAND: bdist_wheel
             QT_BINDING: PySide6
             RUN_TESTS_OPTIONS: --qt-binding=PySide6 --no-opencl --low-mem
           - name-suffix: "No GUI wheel"
             os: windows-latest
-            python-version: 3.9
+            python-version: '3.9'
             BUILD_COMMAND: bdist_wheel
             QT_BINDING:
             RUN_TESTS_OPTIONS: --no-gui --low-mem
@@ -90,7 +90,7 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -39,7 +39,7 @@ environment:
         # Python 3.7
         - PYTHON_DIR: "C:\\Python37-x64"
           QT_BINDING: "PySide6"
-          WITH_GL_TEST: True
+          WITH_GL_TEST: False  # OpenGL not working
           PIP_OPTIONS: "-q --pre"
 
 branches:

--- a/src/silx/gui/dialog/test/test_datafiledialog.py
+++ b/src/silx/gui/dialog/test/test_datafiledialog.py
@@ -89,7 +89,13 @@ def setUpModule():
 
 def tearDownModule():
     global _tmpDirectory
-    shutil.rmtree(_tmpDirectory)
+    for _ in range(10):
+        try:
+            shutil.rmtree(_tmpDirectory)
+        except PermissionError:  # Might fail on appveyor
+            testutils.TestCaseQt.qWait(500)
+        else:
+            break
     _tmpDirectory = None
 
 

--- a/src/silx/gui/dialog/test/test_imagefiledialog.py
+++ b/src/silx/gui/dialog/test/test_imagefiledialog.py
@@ -96,7 +96,13 @@ def setUpModule():
 
 def tearDownModule():
     global _tmpDirectory
-    shutil.rmtree(_tmpDirectory)
+    for _ in range(10):
+        try:
+            shutil.rmtree(_tmpDirectory)
+        except PermissionError:  # Might fail on appveyor
+            testutils.TestCaseQt.qWait(500)
+        else:
+            break
     _tmpDirectory = None
 
 

--- a/src/silx/gui/plot/CurvesROIWidget.py
+++ b/src/silx/gui/plot/CurvesROIWidget.py
@@ -175,8 +175,8 @@ class CurvesROIWidget(qt.QWidget):
         self._isConnected = False  # True if connected to plot signals
         self._isInit = False
 
-        # expose API
-        self.getROIListAndDict = self.roiTable.getROIListAndDict
+    def getROIListAndDict(self):
+        return self.roiTable.getROIListAndDict()
 
     def getPlotWidget(self):
         """Returns the associated PlotWidget or None

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1331,7 +1331,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
         self._synchronizeForegroundColors()
 
 
-class BackendMatplotlibQt(FigureCanvasQTAgg, BackendMatplotlib):
+class BackendMatplotlibQt(BackendMatplotlib, FigureCanvasQTAgg):
     """QWidget matplotlib backend using a QtAgg canvas.
 
     It adds fast overlay drawing and mouse event management.

--- a/src/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/src/silx/gui/plot/test/testCurvesROIWidget.py
@@ -348,6 +348,8 @@ class TestRoiWidgetSignals(TestCaseQt):
     """Test Signals emitted by the RoiWidgetSignals"""
 
     def setUp(self):
+        super().setUp()
+
         self.plot = Plot1D()
         x = range(20)
         y = range(20)
@@ -368,8 +370,15 @@ class TestRoiWidgetSignals(TestCaseQt):
         self.qWaitForWindowExposed(self.curves_roi_widget)
 
     def tearDown(self):
-        self.plot = None
-        self.curves_roi_widget = None
+        self.plot.setAttribute(qt.Qt.WA_DeleteOnClose)
+        self.plot.close()
+        del self.plot
+
+        self.curves_roi_widget.setAttribute(qt.Qt.WA_DeleteOnClose)
+        self.curves_roi_widget.close()
+        del self.curves_roi_widget
+
+        super().tearDown()
 
     def testSigROISignalAddRmRois(self):
         """Test SigROISignal when adding and removing ROIS"""

--- a/src/silx/gui/plot3d/test/testGL.py
+++ b/src/silx/gui/plot3d/test/testGL.py
@@ -29,7 +29,7 @@ __date__ = "10/08/2017"
 
 
 import logging
-import unittest
+import pytest
 
 from silx.gui._glutils import gl, OpenGLWidget
 from silx.gui.utils.testutils import TestCaseQt
@@ -39,6 +39,7 @@ from silx.gui import qt
 _logger = logging.getLogger(__name__)
 
 
+@pytest.mark.usefixtures("use_opengl")
 class TestOpenGL(TestCaseQt):
     """Tests of OpenGL widget."""
 

--- a/src/silx/gui/plot3d/test/testScalarFieldView.py
+++ b/src/silx/gui/plot3d/test/testScalarFieldView.py
@@ -29,7 +29,7 @@ __date__ = "17/01/2018"
 
 
 import logging
-import unittest
+import pytest
 
 import numpy
 
@@ -44,6 +44,7 @@ from silx.gui.plot3d.SFViewParamTree import TreeView
 _logger = logging.getLogger(__name__)
 
 
+@pytest.mark.usefixtures("use_opengl")
 class TestScalarFieldView(TestCaseQt, ParametricTestCase):
     """Tests of ScalarFieldView widget."""
 

--- a/src/silx/gui/plot3d/test/testSceneWidget.py
+++ b/src/silx/gui/plot3d/test/testSceneWidget.py
@@ -28,7 +28,7 @@ __license__ = "MIT"
 __date__ = "06/03/2019"
 
 
-import unittest
+import pytest
 
 import numpy
 
@@ -39,6 +39,7 @@ from silx.gui import qt
 from silx.gui.plot3d.SceneWidget import SceneWidget
 
 
+@pytest.mark.usefixtures("use_opengl")
 class TestSceneWidget(TestCaseQt, ParametricTestCase):
     """Tests SceneWidget picking feature"""
 

--- a/src/silx/gui/plot3d/test/testSceneWidgetPicking.py
+++ b/src/silx/gui/plot3d/test/testSceneWidgetPicking.py
@@ -28,7 +28,7 @@ __license__ = "MIT"
 __date__ = "03/10/2018"
 
 
-import unittest
+import pytest
 
 import numpy
 
@@ -39,6 +39,7 @@ from silx.gui import qt
 from silx.gui.plot3d.SceneWidget import SceneWidget, items
 
 
+@pytest.mark.usefixtures("use_opengl")
 class TestSceneWidgetPicking(TestCaseQt, ParametricTestCase):
     """Tests SceneWidget picking feature"""
 

--- a/src/silx/gui/plot3d/test/testSceneWindow.py
+++ b/src/silx/gui/plot3d/test/testSceneWindow.py
@@ -28,7 +28,7 @@ __license__ = "MIT"
 __date__ = "22/03/2019"
 
 
-import unittest
+import pytest
 
 import numpy
 
@@ -39,6 +39,8 @@ from silx.gui import qt
 from silx.gui.plot3d.SceneWindow import SceneWindow
 from silx.gui.plot3d.items import HeightMapData, HeightMapRGBA
 
+
+@pytest.mark.usefixtures("use_opengl")
 class TestSceneWindow(TestCaseQt, ParametricTestCase):
     """Tests SceneWidget picking feature"""
 

--- a/src/silx/gui/plot3d/test/testStatsWidget.py
+++ b/src/silx/gui/plot3d/test/testStatsWidget.py
@@ -28,7 +28,7 @@ __license__ = "MIT"
 __date__ = "25/01/2019"
 
 
-import unittest
+import pytest
 
 import numpy
 
@@ -43,6 +43,7 @@ from silx.gui.plot3d.ScalarFieldView import ScalarFieldView
 from silx.gui.plot3d.SceneWidget import SceneWidget, items
 
 
+@pytest.mark.usefixtures("use_opengl")
 class TestSceneWidget(TestCaseQt, ParametricTestCase):
     """Tests StatsWidget combined with SceneWidget"""
 

--- a/src/silx/gui/utils/testutils.py
+++ b/src/silx/gui/utils/testutils.py
@@ -159,10 +159,10 @@ class TestCaseQt(unittest.TestCase):
 
     def _checkForUnreleasedWidgets(self):
         """Test fixture checking that no more widgets exists."""
-        gc.collect()
-
         if self.__previousWidgets is None:
             return  # Do not test for leaking widgets with PySide2
+
+        gc.collect()
 
         widgets = [widget for widget in self.qapp.allWidgets()
                    if (widget not in self.__previousWidgets and

--- a/src/silx/sx/__init__.py
+++ b/src/silx/sx/__init__.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -88,7 +88,7 @@ def enable_gui():
 
     global qt, _qapp
 
-    if _IS_NOTEBOOK:
+    if _get_ipython is not None and _get_ipython() is not None:
         _get_ipython().enable_pylab(gui='qt', import_all=False)
 
     from silx.gui import qt


### PR DESCRIPTION
This PR fixes compatibility with the upcoming matplotlib version 3.6.0 and the display of `silx.sx` widgets which requires to enable matplotib (here through pylab) with matplotlib >=3.5.2 which uses PySide6 by default.

Tested on Linux with matplotlib v3.0 to v3.6.

It also updates tests and CI config to fix failing tests.