### PR TITLE
silx.gui.hdf5: Fixed issue with unsupported hdf5 entity (e.g. datatype)

### DIFF
--- a/src/silx/gui/hdf5/Hdf5Item.py
+++ b/src/silx/gui/hdf5/Hdf5Item.py
@@ -209,7 +209,7 @@ class Hdf5Item(Hdf5Node):
                 self.__isBroken = True
             else:
                 self.__obj = obj
-                if not self.isGroupObj():
+                if silx.io.utils.get_h5_class(obj) not in [silx.io.utils.H5Type.GROUP, silx.io.utils.H5Type.FILE]:
                     try:
                         # pre-fetch of the data
                         if obj.shape is None:


### PR DESCRIPTION
This PR fixes the infinite recursion in case of an unsupported hdf5 entity like a [`Datatype`](https://github.com/h5py/h5py/blob/master/h5py/_hl/datatype.py#L19).

It does not add support for `Datatype` though.

closes #3635