### PR TITLE
silx.gui.plot: Removed error logs for scatter triangle visualisation with aligned points

### DIFF
--- a/src/silx/gui/plot/_utils/delaunay.py
+++ b/src/silx/gui/plot/_utils/delaunay.py
@@ -55,8 +55,7 @@ def delaunay(x, y):
     try:
         delaunay = _Delaunay(points)
     except (RuntimeError, ValueError):
-        _logger.error("Delaunay tesselation failed: %s",
-                      sys.exc_info()[1])
+        _logger.debug("Delaunay tesselation failed: %s", sys.exc_info()[1])
         delaunay = None
 
     return delaunay


### PR DESCRIPTION
This PR removes the error message displayed when `delaunay` fails when displaying a scatter plot as a mesh.

It changes `delaunay` error log from error to debug level (returns None in case of error anyway)

closes #3608
