### PR TITLE
silx.gui.data.DataViewer: Added `selectionChanged` signal

### DIFF
--- a/src/silx/gui/data/DataViewer.py
+++ b/src/silx/gui/data/DataViewer.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -83,6 +83,14 @@ class DataViewer(qt.QFrame):
     dataChanged = qt.Signal()
     """Emitted when the data changes"""
 
+    selectionChanged = qt.Signal(object, object)
+    """Emitted when the data selection changes.
+
+    It provides:
+    - the slicing as a tuple of slice or None.
+    - the permutation as a tuple of int or None.
+    """
+
     currentAvailableViewsChanged = qt.Signal()
     """Emitted when the current available views (which support the current
     data) change"""
@@ -118,6 +126,7 @@ class DataViewer(qt.QFrame):
         self.__useAxisSelection = False
         self.__userSelectedView = None
         self.__hooks = None
+        self.__previousSelection = DataSelection(None, None, None, None)
 
         self.__views = []
         self.__index = {}
@@ -279,6 +288,13 @@ class DataViewer(qt.QFrame):
     def __setDataInView(self):
         self.__currentView.setData(self.__displayedData)
         self.__currentView.setDataSelection(self.__displayedSelection)
+        # Emit signal only when selection has changed
+        if (self.__previousSelection.slice != self.__displayedSelection.slice or
+            self.__previousSelection.permutation != self.__displayedSelection.permutation
+        ):
+            self.selectionChanged.emit(
+                self.__displayedSelection.slice, self.__displayedSelection.permutation)
+            self.__previousSelection = self.__displayedSelection
 
     def setDisplayedView(self, view):
         """Set the displayed view.

--- a/src/silx/gui/data/DataViewerFrame.py
+++ b/src/silx/gui/data/DataViewerFrame.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -60,6 +60,14 @@ class DataViewerFrame(qt.QWidget):
     dataChanged = qt.Signal()
     """Emitted when the data changes"""
 
+    selectionChanged = qt.Signal(object, object)
+    """Emitted when the data selection changes.
+
+    It provides:
+    - the slicing as a tuple of slice or None.
+    - the permutation as a tuple of int or None.
+    """
+
     def __init__(self, parent=None):
         """
         Constructor
@@ -104,6 +112,7 @@ class DataViewerFrame(qt.QWidget):
 
         self.__dataViewer.dataChanged.connect(self.__dataChanged)
         self.__dataViewer.displayedViewChanged.connect(self.__displayedViewChanged)
+        self.__dataViewer.selectionChanged.connect(self.__selectionChanged)
 
     def __dataChanged(self):
         """Called when the data is changed"""
@@ -112,6 +121,10 @@ class DataViewerFrame(qt.QWidget):
     def __displayedViewChanged(self, view):
         """Called when the displayed view changes"""
         self.displayedViewChanged.emit(view)
+
+    def __selectionChanged(self, slices, permutation):
+        """Called when the data selection has changed"""
+        self.selectionChanged.emit(slices, permutation)
 
     def setGlobalHooks(self, hooks):
         """Set a data view hooks for all the views

--- a/src/silx/gui/data/test/test_dataviewer.py
+++ b/src/silx/gui/data/test/test_dataviewer.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -192,18 +192,36 @@ class _TestAbstractDataViewer(TestCaseQt):
         listener.clear()
 
     def test_change_display_mode(self):
+        listener = SignalListener()
         data = numpy.arange(10 ** 4)
         data.shape = [10] * 4
         widget = self.create_widget()
+        widget.selectionChanged.connect(listener)
         widget.setData(data)
+
         widget.setDisplayMode(DataViews.PLOT1D_MODE)
         self.assertEqual(widget.displayedView().modeId(), DataViews.PLOT1D_MODE)
+        self.qWait(200)
+        assert listener.arguments() == [((0, 0, 0, slice(None)), None)]
+        listener.clear()
+
         widget.setDisplayMode(DataViews.IMAGE_MODE)
         self.assertEqual(widget.displayedView().modeId(), DataViews.IMAGE_MODE)
+        self.qWait(200)
+        assert listener.arguments() == [((0, 0, slice(None), slice(None)), None)]
+        listener.clear()
+
         widget.setDisplayMode(DataViews.RAW_MODE)
         self.assertEqual(widget.displayedView().modeId(), DataViews.RAW_MODE)
+        self.qWait(200)
+        # Changing from 2D to 2D view: Selection didn't changed
+        assert listener.callCount() == 0
+
         widget.setDisplayMode(DataViews.EMPTY_MODE)
         self.assertEqual(widget.displayedView().modeId(), DataViews.EMPTY_MODE)
+        self.qWait(200)
+        assert listener.arguments() == [(None, None)]
+        listener.clear()
 
     def test_create_default_views(self):
         widget = self.create_widget()


### PR DESCRIPTION
This PR adds a `selectionChanged` signal to `DataViewer` and `DataViewerFrame`.

This signal is triggered after the selection has changed. The selection change can be the result of:
- An update of the selection by the user.
- A change to a view which support different dimensionality (e.g., moving from image to curve view).
- A change of data with a different shape.

closes #3628