### PR TITLE
silx.gui.plot.PlotWidget: Take errorbars into account for item bounds

### DIFF
--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1130,8 +1130,8 @@ class PlotWidget(qt.QMainWindow):
         :type xerror: A float, or a numpy.ndarray of float32.
                       If it is an array, it can either be a 1D array of
                       same length as the data or a 2D array with 2 rows
-                      of same length as the data: row 0 for positive errors,
-                      row 1 for negative errors.
+                      of same length as the data: row 0 for lower errors,
+                      row 1 for upper errors.
         :param yerror: Values with the uncertainties on the y values
         :type yerror: A float, or a numpy.ndarray of float32. See xerror.
         :param int z: Layer on which to draw the curve (default: 1)
@@ -1540,8 +1540,8 @@ class PlotWidget(qt.QMainWindow):
         :type xerror: A float, or a numpy.ndarray of float32.
                       If it is an array, it can either be a 1D array of
                       same length as the data or a 2D array with 2 rows
-                      of same length as the data: row 0 for positive errors,
-                      row 1 for negative errors.
+                      of same length as the data: row 0 for lower errors,
+                      row 1 for upper errors.
         :param yerror: Values with the uncertainties on the y values
         :type yerror: A float, or a numpy.ndarray of float32. See xerror.
         :param int z: Layer on which to draw the scatter (default: 1)

--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1600,8 +1600,8 @@ class PointsBase(DataItem, SymbolMixIn, AlphaMixIn):
         :type xerror: A float, or a numpy.ndarray of float32.
                       If it is an array, it can either be a 1D array of
                       same length as the data or a 2D array with 2 rows
-                      of same length as the data: row 0 for positive errors,
-                      row 1 for negative errors.
+                      of same length as the data: row 0 for lower errors,
+                      row 1 for upper errors.
         :param yerror: Values with the uncertainties on the y values.
         :type yerror: A float, or a numpy.ndarray of float32. See xerror.
         :param bool copy: True make a copy of the data (default),

--- a/src/silx/gui/plot/items/scatter.py
+++ b/src/silx/gui/plot/items/scatter.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -950,8 +950,8 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
         :type xerror: A float, or a numpy.ndarray of float32.
                       If it is an array, it can either be a 1D array of
                       same length as the data or a 2D array with 2 rows
-                      of same length as the data: row 0 for positive errors,
-                      row 1 for negative errors.
+                      of same length as the data: row 0 for lower errors,
+                      row 1 for upper errors.
         :param yerror: Values with the uncertainties on the y values
         :type yerror: A float, or a numpy.ndarray of float32. See xerror.
         :param alpha: Values with the transparency (between 0 and 1)

--- a/src/silx/gui/plot/test/testPlotWidget.py
+++ b/src/silx/gui/plot/test/testPlotWidget.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1650,6 +1650,26 @@ class TestPlotCurveLog(PlotWidgetTestCase, ParametricTestCase):
                                    color='green', linestyle="-", symbol='o')
 
                 self.qapp.processEvents()
+
+                if xError is None:
+                    dataMin, dataMax = numpy.min(self.xData), numpy.max(self.xData)
+                else:
+                    xMinusError = self.xData - numpy.atleast_2d(xError)[0]
+                    dataMin = numpy.min(xMinusError[xMinusError > 0])
+                    xPlusError = self.xData + numpy.atleast_2d(xError)[-1]
+                    dataMax = numpy.max(xPlusError[xPlusError > 0])
+                plotMin, plotMax = self.plot.getXAxis().getLimits()
+                assert numpy.allclose((dataMin, dataMax), (plotMin, plotMax))
+
+                if yError is None:
+                    dataMin, dataMax = numpy.min(self.yData), numpy.max(self.yData)
+                else:
+                    yMinusError = self.yData - numpy.atleast_2d(yError)[0]
+                    dataMin = numpy.min(yMinusError[yMinusError > 0])
+                    yPlusError = self.yData + numpy.atleast_2d(yError)[-1]
+                    dataMax = numpy.max(yPlusError[yPlusError > 0])
+                plotMin, plotMax = self.plot.getYAxis().getLimits()
+                assert numpy.allclose((dataMin, dataMax), (plotMin, plotMax))
 
                 self.plot.clear()
                 self.plot.resetZoom()


### PR DESCRIPTION
This PR:
- Fix the documentation of `xerror` and `yerror` to match the implementation regarding 2xN arrays
- Take error bars into accounts when computing the bounding box

closes #3606