### PR TITLE
silx.gui.qt: Deprecated `PySide2` support

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -7,15 +7,15 @@ programming language.
 
 This table summarizes the support matrix of silx:
 
-+------------+--------------+----------------------------+
-| System     | Python vers. | Qt and its bindings        |
-+------------+--------------+----------------------------+
-| `Windows`_ | 3.6-3.9      | PyQt5.6+, PySide2, PySide6 |
-+------------+--------------+----------------------------+
-| `MacOS`_   | 3.6-3.9      | PyQt5.6+, PySide2, PySide6 |
-+------------+--------------+----------------------------+
-| `Linux`_   | 3.6-3.9      | PyQt5.3+, PySide2, PySide6 |
-+------------+--------------+----------------------------+
++------------+--------------+---------------------+
+| System     | Python vers. | Qt and its bindings |
++------------+--------------+---------------------+
+| `Windows`_ | 3.6-3.9      | PyQt5.6+, PySide6   |
++------------+--------------+---------------------+
+| `MacOS`_   | 3.6-3.9      | PyQt5.6+, PySide6   |
++------------+--------------+---------------------+
+| `Linux`_   | 3.6-3.9      | PyQt5.3+, PySide6   |
++------------+--------------+---------------------+
 
 For the description of *silx* dependencies, see the Dependencies_ section.
 
@@ -65,8 +65,7 @@ The mandatory dependencies are:
 
 The GUI widgets depend on the following extra packages:
 
-* A Qt binding: either `PyQt5 <https://riverbankcomputing.com/software/pyqt/intro>`_,
-  `PySide2 <https://pypi.org/project/PySide2/>`_, or
+* A Qt binding: either `PyQt5 <https://riverbankcomputing.com/software/pyqt/intro>`_ or
   `PySide6 <https://pypi.org/project/PySide6/>`_
 * `matplotlib <http://matplotlib.org/>`_
 * `PyOpenGL <http://pyopengl.sourceforge.net/>`_

--- a/doc/source/modules/gui/plot/getting_started.rst
+++ b/doc/source/modules/gui/plot/getting_started.rst
@@ -89,7 +89,7 @@ A Qt GUI script must have a QApplication initialised before creating widgets:
        [...]
        qapp.exec()
 
-Unless a Qt binding has already been loaded, :mod:`silx.gui.qt` uses one of the supported Qt bindings (PyQt5, PySide2, PySide6).
+Unless a Qt binding has already been loaded, :mod:`silx.gui.qt` uses one of the supported Qt bindings (PyQt5, PySide6).
 If you prefer to choose the Qt binding yourself, import it before importing
 a module from :mod:`silx.gui`:
 

--- a/doc/source/virtualenv.rst
+++ b/doc/source/virtualenv.rst
@@ -132,7 +132,7 @@ To test *silx*, open an interactive python console:
 
     python
 
-If you don't have PyQt5, PySide2 or PySide6, run:
+If you don't have PyQt5 or PySide6, run:
 
 .. code-block:: bash
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ PyOpenGL                  # For silx.gui.plot3d
 python-dateutil           # For silx.gui.plot
 scipy                     # For silx.math.fit demo, silx.image.sift demo, silx.image.sift.test
 Pillow                    # For silx.opencl.image.test
-PyQt5  # PySide2, PySide6 # For silx.gui
+PyQt5  # PySide6          # For silx.gui

--- a/src/silx/gui/qt/__init__.py
+++ b/src/silx/gui/qt/__init__.py
@@ -25,11 +25,11 @@
 """Common wrapper over Python Qt bindings:
 
 - `PyQt5 <http://pyqt.sourceforge.net/Docs/PyQt5/>`_
-- `PySide2 <https://pypi.org/project/PySide2/>`_
 - `PySide6 <https://pypi.org/project/PySide6/>`_
+- `PySide2 <https://pypi.org/project/PySide2/>`_
 
 If a Qt binding is already loaded, it will use it, otherwise the different
-Qt bindings are tried in this order: PyQt5, PySide2, PySide6.
+Qt bindings are tried in this order: PyQt5, PySide6, PySide2.
 
 The name of the loaded Qt binding is stored in the BINDING variable.
 

--- a/src/silx/gui/qt/_qt.py
+++ b/src/silx/gui/qt/_qt.py
@@ -33,6 +33,7 @@ import logging
 import sys
 import traceback
 
+from silx.utils import deprecation
 
 _logger = logging.getLogger(__name__)
 
@@ -121,7 +122,12 @@ if BINDING == 'PyQt5':
 
 
 elif BINDING == 'PySide2':
-    _logger.debug('Using PySide2 bindings')
+    deprecation.deprecated_warning(
+        type_="Qt Binding",
+        name="PySide2",
+        replacement="PySide6",
+        since_version="1.1",
+    )
 
     import PySide2 as QtBinding  # noqa
 

--- a/src/silx/gui/qt/_qt.py
+++ b/src/silx/gui/qt/_qt.py
@@ -62,21 +62,21 @@ else:  # Then try Qt bindings
         if 'PyQt5' in sys.modules:
             del sys.modules["PyQt5"]
         try:
-            import PySide2.QtCore  # noqa
+            import PySide6.QtCore  # noqa
         except ImportError:
-            if 'PySide2' in sys.modules:
-                del sys.modules["PySide2"]
+            if 'PySide6' in sys.modules:
+                del sys.modules["PySide6"]
             try:
-                import PySide6.QtCore  # noqa
+                import PySide2.QtCore  # noqa
             except ImportError:
-                if 'PySide6' in sys.modules:
-                    del sys.modules["PySide6"]
+                if 'PySide2' in sys.modules:
+                    del sys.modules["PySide2"]
                 raise ImportError(
-                    'No Qt wrapper found. Install PyQt5, PySide2, PySide6.')
+                    'No Qt wrapper found. Install PyQt5 or PySide6.')
             else:
-                BINDING = 'PySide6'
+                BINDING = 'PySide2'
         else:
-            BINDING = 'PySide2'
+            BINDING = 'PySide6'
     else:
         BINDING = 'PyQt5'
 


### PR DESCRIPTION
This PR marks `PySide2` as deprecated but does not remove its support nor the tests.
It also tries to load `PySide6` before `PySide2` and removes reference to `PySide2` in the documentation (except for the `silx.gui.qt` module).

closes #3645