### PR TITLE
ElideLabel: Fix API inherited from QLabel

### DIFF
--- a/src/silx/gui/widgets/ElidedLabel.py
+++ b/src/silx/gui/widgets/ElidedLabel.py
@@ -31,13 +31,13 @@ from silx.gui import qt
 
 
 class ElidedLabel(qt.QLabel):
-    """QLabel with an edile property.
+    """QLabel with an elide property.
 
-    By default if the text is too big, it is elided on the right.
+    By default if the text is too long, it is elided on the right.
 
     This mode can be changed with :func:`setElideMode`.
 
-    In case the text is elided, the full content is displayed as part of the
+    In this case the text is elided, the full content is displayed as part of the
     tool tip. This behavior can be disabled with :func:`setTextAsToolTip`.
     """
 
@@ -82,25 +82,33 @@ class ElidedLabel(qt.QLabel):
         else:
             qt.QLabel.setToolTip(self, self.__toolTip)
 
-    # Properties
+    # Inherited properties
+
+    def text(self):
+        """Returns the text defined by the user.
+
+        It can be different from the one really displayed, depending on the
+        `elideMode` defined for this widget.
+        """
+        return self.__text
 
     def setText(self, text):
         self.__text = text
         self.__updateText()
 
-    def getText(self):
-        return self.__text
+    def toolTip(self):
+        """Returns the tooltip defined by the user.
 
-    text = qt.Property(str, getText, setText)
+        It can be different from the one really displayed, if `textAsToolTip` was
+        set to true.
+        """
+        return self.__toolTip
 
     def setToolTip(self, toolTip):
         self.__toolTip = toolTip
         self.__updateToolTip()
 
-    def getToolTip(self):
-        return self.__toolTip
-
-    toolTip = qt.Property(str, getToolTip, setToolTip)
+    # New properties
 
     def setElideMode(self, elideMode):
         """Set the elide mode.

--- a/src/silx/gui/widgets/ElidedLabel.py
+++ b/src/silx/gui/widgets/ElidedLabel.py
@@ -117,7 +117,7 @@ class ElidedLabel(qt.QLabel):
         """
         return self.__elideMode
 
-    elideMode = qt.Property(qt.Qt.TextElideMode, getToolTip, setToolTip)
+    elideMode = qt.Property(qt.Qt.TextElideMode, getElideMode, setElideMode)
 
     def setTextAsToolTip(self, enabled):
         """Enable displaying text as part of the tooltip if it is elided.

--- a/src/silx/gui/widgets/ElidedLabel.py
+++ b/src/silx/gui/widgets/ElidedLabel.py
@@ -27,6 +27,7 @@
 __license__ = "MIT"
 __date__ = "07/12/2018"
 
+from ...utils.deprecation import deprecated
 from silx.gui import qt
 
 
@@ -92,6 +93,10 @@ class ElidedLabel(qt.QLabel):
         """
         return self.__text
 
+    @deprecated(replacement='text', since_version='1.1.0')
+    def getText(self):
+        return self.text()
+
     def setText(self, text):
         self.__text = text
         self.__updateText()
@@ -103,6 +108,10 @@ class ElidedLabel(qt.QLabel):
         set to true.
         """
         return self.__toolTip
+
+    @deprecated(replacement='toolTip', since_version='1.1.0')
+    def getToolTip(self):
+        return self.toolTip()
 
     def setToolTip(self, toolTip):
         self.__toolTip = toolTip

--- a/src/silx/gui/widgets/test/test_elidedlabel.py
+++ b/src/silx/gui/widgets/test/test_elidedlabel.py
@@ -44,6 +44,13 @@ class TestElidedLabel(testutils.TestCaseQt):
         del self.label
         self.qapp.processEvents()
 
+    def testQLabelApi(self):
+        """Test overrided API from QLabel"""
+        self.label.setText("a")
+        assert self.label.text() == "a"
+        self.label.setToolTip("b")
+        assert self.label.toolTip() == "b"
+
     def testElidedValue(self):
         """Test elided text"""
         raw = "mmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm"
@@ -95,3 +102,21 @@ class TestElidedLabel(testutils.TestCaseQt):
         displayedTooltip = qt.QLabel.toolTip(self.label)
         self.assertNotIn(raw1, displayedTooltip)
         self.assertIn(raw2, displayedTooltip)
+
+    def testTooltip(self):
+        """Test tooltip when elided"""
+        self.label.setToolTip("Fooo")
+        assert self.label.toolTip() == "Fooo"
+        displayedTooltip = qt.QLabel.toolTip(self.label)
+        assert displayedTooltip == "Fooo"
+
+    def testElidedTextAndTooltip(self):
+        """Test tooltip when elided"""
+        raw1 = "nnnnnnnnnnnnnnnnnnnnnnnnnnnnnnn"
+        self.label.setText(raw1)
+        self.label.setFixedWidth(30)
+        self.label.setToolTip("Fooo")
+        displayedTooltip = qt.QLabel.toolTip(self.label)
+        assert self.label.toolTip() == "Fooo"
+        assert "Fooo" in displayedTooltip
+        assert raw1 in displayedTooltip

--- a/src/silx/gui/widgets/test/test_elidedlabel.py
+++ b/src/silx/gui/widgets/test/test_elidedlabel.py
@@ -26,8 +26,6 @@
 __license__ = "MIT"
 __date__ = "08/06/2020"
 
-import unittest
-
 from silx.gui import qt
 from silx.gui.widgets.ElidedLabel import ElidedLabel
 from silx.gui.utils import testutils


### PR DESCRIPTION
This PR fixes the ElideLabel API inherited from QLabel.

For consistency and interoperability purpose.

Closes #3641

Changelog: 
- ElideLabel: Fix API inherited from QLabel