### PR TITLE
Build: Simplified `setup.py`

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -304,6 +304,10 @@ Advanced options can be set through the following environment variables:
    * - ``SPECFILE_USE_GNU_SOURCE``
      - Whether or not to use a cleaner locale independent implementation of :mod:`silx.io.specfile` by using `_GNU_SOURCE=1`
        (default: ``False``; POSIX operating system only).
+   * - ``SILX_FULL_INSTALL_REQUIRES``
+     - Set it to put all dependencies as ``install_requires`` (For packaging purpose).
+   * - ``SILX_INSTALL_REQUIRES_STRIP``
+     - Comma-separated list of package names to remove from ``install_requires`` (For packaging purpose).
 .. note:: Boolean options are passed as ``True`` or ``False``.
 
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -313,8 +313,13 @@ To build the documentation, using  `Sphinx <http://www.sphinx-doc.org/>`_:
 
 .. code-block:: bash 
 
-    python setup.py build build_doc
+    python setup.py build
+    PYTHONPATH=build/lib.<OS-ARCHITECTURE-PYTHONVER>/ sphinx-build doc/source/ build/html
 
+.. note::
+
+    To re-generate the example script screenshots, build the documentation with the
+    environment variable ``DIRECTIVE_SNAPSHOT_QT`` set to ``True``.
 
 Testing
 +++++++

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -301,7 +301,9 @@ Advanced options can be set through the following environment variables:
      - Whether or not to compile Cython code with OpenMP support (default: ``True`` except on macOS where it is ``False``)
    * - ``SILX_FORCE_CYTHON``
      - Whether or not to force re-generating the C/C++ source code from Cython files (default: ``False``).
-
+   * - ``SPECFILE_USE_GNU_SOURCE``
+     - Whether or not to use a cleaner locale independent implementation of :mod:`silx.io.specfile` by using `_GNU_SOURCE=1`
+       (default: ``False``; POSIX operating system only).
 .. note:: Boolean options are passed as ``True`` or ``False``.
 
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -289,13 +289,6 @@ To set the environment variables, type on the command line:
 Advanced build options
 ++++++++++++++++++++++
 
-In case you want more control over the build procedure, the build command is:
-
-.. code-block:: bash 
-
-    python setup.py build
-
-
 Advanced options can be set through the following environment variables:
 
 .. list-table::
@@ -312,19 +305,19 @@ Advanced options can be set through the following environment variables:
 .. note:: Boolean options are passed as ``True`` or ``False``.
 
 
-Package the build into a wheel and install it:
+Package the build into a wheel and install it (this requires to install the `build <https://pypa-build.readthedocs.io>`_ package):
 
 .. code-block:: bash 
 
-    python setup.py bdist_wheel
+    python -m build --wheel
     pip install dist/silx*.whl 
 
 To build the documentation, using  `Sphinx <http://www.sphinx-doc.org/>`_:
 
 .. code-block:: bash 
 
-    python setup.py build
-    PYTHONPATH=build/lib.<OS-ARCHITECTURE-PYTHONVER>/ sphinx-build doc/source/ build/html
+    pip install .  # Make sure to install the same version as the source
+    sphinx-build doc/source/ build/html
 
 .. note::
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -295,12 +295,22 @@ In case you want more control over the build procedure, the build command is:
 
     python setup.py build
 
-There are few advanced options to ``setup.py build``:
 
-* ``--no-cython``: Prevent Cython (even if installed) from re-generating the C source code.
-  Use the one provided by the development team.
-* ``--no-openmp``: Recompiles the Cython code without OpenMP support (default for MacOSX).
-* ``--openmp``: Recompiles the Cython code with OpenMP support (default for Windows and Linux).
+Advanced options can be set through the following environment variables:
+
+.. list-table::
+   :widths: 1 4
+   :header-rows: 1
+
+   * - Environment variable
+     - Description
+   * - ``SILX_WITH_OPENMP``
+     - Whether or not to compile Cython code with OpenMP support (default: ``True`` except on macOS where it is ``False``)
+   * - ``SILX_FORCE_CYTHON``
+     - Whether or not to force re-generating the C/C++ source code from Cython files (default: ``False``).
+
+.. note:: Boolean options are passed as ``True`` or ``False``.
+
 
 Package the build into a wheel and install it:
 

--- a/doc/source/modules/io/commonh5.rst
+++ b/doc/source/modules/io/commonh5.rst
@@ -1,0 +1,28 @@
+. currentmodule:: silx.io
+
+:mod:`commonh5`: Helpers for writing h5py-like API
+--------------------------------------------------
+
+.. automodule:: silx.io.commonh5
+
+Classes
++++++++
+
+.. autoclass:: Node
+   :members:
+
+.. autoclass:: File
+   :show-inheritance:
+   :members:
+
+.. autoclass:: Group
+    :show-inheritance:
+    :undoc-members:
+    :members: name, basename, file, attrs, h5py_class, parent,
+        get, keys, values, items, visit, visititems
+    :special-members: __getitem__, __len__, __contains__, __iter__
+    :exclude-members: add_node
+
+.. autoclass:: Dataset
+   :show-inheritance:
+   :members:

--- a/doc/source/modules/io/fioh5.rst
+++ b/doc/source/modules/io/fioh5.rst
@@ -24,12 +24,4 @@ Classes
 
 .. autoclass:: FioFile
 
-.. autoclass:: silx.io.commonh5.Group
-    :show-inheritance:
-    :undoc-members:
-    :members: name, basename, file, attrs, h5py_class, parent,
-        get, keys, values, items, visit, visititems
-    :special-members: __getitem__, __len__, __contains__, __iter__
-    :exclude-members: add_node
-
 .. autofunction:: is_fiofile

--- a/doc/source/modules/io/index.rst
+++ b/doc/source/modules/io/index.rst
@@ -7,7 +7,8 @@
 
 .. toctree::
    :maxdepth: 1
-   
+
+   commonh5.rst
    configdict.rst
    convert.rst
    dictdump.rst

--- a/doc/source/modules/io/spech5.rst
+++ b/doc/source/modules/io/spech5.rst
@@ -26,14 +26,6 @@ Classes
 .. autoclass:: SpecH5Group
     :show-inheritance:
 
-.. autoclass:: silx.io.commonh5.Group
-    :show-inheritance:
-    :undoc-members:
-    :members: name, basename, file, attrs, h5py_class, parent,
-        get, keys, values, items, visit, visititems
-    :special-members: __getitem__, __len__, __contains__, __iter__
-    :exclude-members: add_node
-
 .. autoclass:: SpecH5Dataset
     :show-inheritance:
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,8 @@
 # List of silx development dependencies
-# Those ARE NOT required for installation, at runtime or to build from source (except for the doc)
+# Those ARE NOT required for installation or at runtime
 
 -r requirements.txt
+build             # To build the project
 wheel             # To build wheels
 Sphinx            # To build the documentation in doc/
 pillow            # For loading images in documentation generation

--- a/setup.py
+++ b/setup.py
@@ -112,29 +112,6 @@ classifiers = ["Development Status :: 5 - Production/Stable",
                "Topic :: Software Development :: Libraries :: Python Modules",
                ]
 
-########
-# Test #
-########
-
-
-class PyTest(Command):
-    """Command to start tests running the script: run_tests.py"""
-    user_options = []
-
-    description = "Execute the unittests"
-
-    def initialize_options(self):
-        pass
-
-    def finalize_options(self):
-        pass
-
-    def run(self):
-        import subprocess
-        errno = subprocess.call([sys.executable, 'run_tests.py'])
-        if errno != 0:
-            raise SystemExit(errno)
-
 # ################### #
 # build_doc command   #
 # ################### #
@@ -824,7 +801,6 @@ def get_project_configuration():
 
     cmdclass = dict(
         build=Build,
-        test=PyTest,
         build_screenshots=BuildDocAndGenerateScreenshotCommand,
         build_doc=BuildDocCommand,
         test_doc=TestDocCommand,

--- a/setup.py
+++ b/setup.py
@@ -634,24 +634,14 @@ def get_project_configuration():
 
     def silx_io_specfile_define_macros():
         # Locale and platform management
-        SPECFILE_USE_GNU_SOURCE = os.getenv("SPECFILE_USE_GNU_SOURCE")
-        if SPECFILE_USE_GNU_SOURCE is None:
-            SPECFILE_USE_GNU_SOURCE = 0
-            if sys.platform.lower().startswith("linux"):
-                warn = ("silx.io.specfile WARNING:",
-                        "A cleaner locale independent implementation",
-                        "may be achieved setting SPECFILE_USE_GNU_SOURCE to 1")
-                print(os.linesep.join(warn))
-        else:
-            SPECFILE_USE_GNU_SOURCE = int(SPECFILE_USE_GNU_SOURCE)
-
         if sys.platform == "win32":
             return [('WIN32', None), ('SPECFILE_POSIX', None)]
         elif os.name.lower().startswith('posix'):
             # the best choice is to have _GNU_SOURCE defined
             # as a compilation flag because that allows the
             # use of strtod_l
-            if SPECFILE_USE_GNU_SOURCE:
+            use_gnu_source = os.environ.get("SPECFILE_USE_GNU_SOURCE", "False")
+            if use_gnu_source in ("True", "1"):  # 1 was the initially supported value
                 return [('_GNU_SOURCE', 1)]
             return [('SPECFILE_POSIX', None)]
         else:

--- a/setup.py
+++ b/setup.py
@@ -836,33 +836,32 @@ def get_project_configuration():
             )
         )
 
-    setup_kwargs = dict(
-        ext_modules=ext_modules,
+    return dict(
+        name=PROJECT,
+        version=get_version(),
+        url="http://www.silx.org/",
+        author="data analysis unit",
+        author_email="silx@esrf.fr",
+        classifiers=classifiers,
+        description="Software library for X-ray data analysis",
+        long_description=get_readme(),
+        install_requires=install_requires,
+        extras_require=extras_require,
+        python_requires='>=3.5',
+        cmdclass=cmdclass,
+        zip_safe=False,
+        entry_points=entry_points,
         packages=find_packages(where='src', include=['silx*']) + ['silx.examples'],
         package_dir={
             "": "src",
-            "silx.examples": "examples"},
+            "silx.examples": "examples",
+        },
+        ext_modules=ext_modules,
+        package_data=package_data,
         data_files=[
             ('silx/third_party/_local/scipy_spatial/qhull', ['src/silx/third_party/_local/scipy_spatial/qhull/COPYING.txt'])
-        ]
+        ],
     )
-    setup_kwargs.update(name=PROJECT,
-                        version=get_version(),
-                        url="http://www.silx.org/",
-                        author="data analysis unit",
-                        author_email="silx@esrf.fr",
-                        classifiers=classifiers,
-                        description="Software library for X-ray data analysis",
-                        long_description=get_readme(),
-                        install_requires=install_requires,
-                        extras_require=extras_require,
-                        cmdclass=cmdclass,
-                        package_data=package_data,
-                        zip_safe=False,
-                        entry_points=entry_points,
-                        python_requires='>=3.5',
-                        )
-    return setup_kwargs
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -30,15 +30,12 @@ __license__ = "MIT"
 import sys
 import os
 import platform
-import shutil
 import logging
-import glob
 
 logging.basicConfig(level=logging.INFO)
 
 logger = logging.getLogger("silx.setup")
 
-from distutils.command.clean import clean as Clean
 try:  # setuptools >=62.4.0
     from setuptools.command.build import build as _build
 except ImportError:
@@ -475,70 +472,6 @@ class BuildExt(build_ext):
             self.patch_extension(ext)
         build_ext.build_extensions(self)
 
-################################################################################
-# Clean command
-################################################################################
-
-
-class CleanCommand(Clean):
-    description = "Remove build artifacts from the source tree"
-
-    def expand(self, path_list):
-        """Expand a list of path using glob magic.
-
-        :param list[str] path_list: A list of path which may contains magic
-        :rtype: list[str]
-        :returns: A list of path without magic
-        """
-        path_list2 = []
-        for path in path_list:
-            if glob.has_magic(path):
-                iterator = glob.iglob(path)
-                path_list2.extend(iterator)
-            else:
-                path_list2.append(path)
-        return path_list2
-
-    def find(self, path_list):
-        """Find a file pattern if directories.
-
-        Could be done using "**/*.c" but it is only supported in Python 3.5.
-
-        :param list[str] path_list: A list of path which may contains magic
-        :rtype: list[str]
-        :returns: A list of path without magic
-        """
-        import fnmatch
-        path_list2 = []
-        for pattern in path_list:
-            for root, _, filenames in os.walk('.'):
-                for filename in fnmatch.filter(filenames, pattern):
-                    path_list2.append(os.path.join(root, filename))
-        return path_list2
-
-    def run(self):
-        Clean.run(self)
-
-        cython_files = self.find(["*.pyx"])
-        cythonized_files = [path.replace(".pyx", ".c") for path in cython_files]
-        cythonized_files += [path.replace(".pyx", ".cpp") for path in cython_files]
-
-        # really remove the directories
-        # and not only if they are empty
-        to_remove = [self.build_base]
-        to_remove = self.expand(to_remove)
-        to_remove += cythonized_files
-
-        if not self.dry_run:
-            for path in to_remove:
-                try:
-                    if os.path.isdir(path):
-                        shutil.rmtree(path)
-                    else:
-                        os.remove(path)
-                    logger.info("removing '%s'", path)
-                except OSError:
-                    pass
 
 ################################################################################
 # Debian source tree
@@ -691,7 +624,6 @@ def get_project_configuration():
         build=Build,
         build_ext=BuildExt,
         build_man=BuildMan,
-        clean=CleanCommand,
         debian_src=sdist_debian)
 
     def silx_io_specfile_define_macros():

--- a/setup.py
+++ b/setup.py
@@ -640,9 +640,7 @@ def get_project_configuration():
             if sys.platform.lower().startswith("linux"):
                 warn = ("silx.io.specfile WARNING:",
                         "A cleaner locale independent implementation",
-                        "may be achieved setting SPECFILE_USE_GNU_SOURCE to 1",
-                        "For instance running this script as:",
-                        "SPECFILE_USE_GNU_SOURCE=1 python setup.py build")
+                        "may be achieved setting SPECFILE_USE_GNU_SOURCE to 1")
                 print(os.linesep.join(warn))
         else:
             SPECFILE_USE_GNU_SOURCE = int(SPECFILE_USE_GNU_SOURCE)

--- a/setup.py
+++ b/setup.py
@@ -285,11 +285,11 @@ class Build(_build):
 
     user_options = [
         ('no-openmp', None,
-         "do not use OpenMP for compiled extension modules"),
+         "DEPRECATED: Instead, set the environment variable SILX_WITH_OPENMP to False"),
         ('openmp', None,
-         "use OpenMP for the compiled extension modules"),
+         "DEPRECATED: Instead, set the environment variable SILX_WITH_OPENMP to True"),
         ('force-cython', None,
-         "recompile all Cython extension modules"),
+         "DEPRECATED: Instead, set the environment variable SILX_FORCE_CYTHON to True"),
     ]
     user_options.extend(_build.user_options)
 
@@ -304,8 +304,14 @@ class Build(_build):
 
     def finalize_options(self):
         _build.finalize_options(self)
+        if self.no_openmp is not None:
+            logger.warning("--no-openmp is deprecated: Instead, set the environment variable SILX_WITH_OPENMP to False")
+        if self.openmp is not None:
+            logger.warning("--openmp is deprecated: Instead, set the environment variable SILX_WITH_OPENMP to True")
+        if self.force_cython is not None:
+            logger.warning("--force-cython is deprecated: Instead, set the environment variable SILX_FORCE_CYTHON to True")
         if not self.force_cython:
-            self.force_cython = self._parse_env_as_bool("FORCE_CYTHON") is True
+            self.force_cython = self._parse_env_as_bool("SILX_FORCE_CYTHON") is True
         self.finalize_openmp_options()
 
     def _parse_env_as_bool(self, key):
@@ -332,7 +338,7 @@ class Build(_build):
         elif self.no_openmp:
             use_openmp = False
         else:
-            env_with_openmp = self._parse_env_as_bool("WITH_OPENMP")
+            env_with_openmp = self._parse_env_as_bool("SILX_WITH_OPENMP")
             if env_with_openmp is not None:
                 use_openmp = env_with_openmp
             else:


### PR DESCRIPTION
Merge PR #3649 first!

This PR cleans-up/removes features from `setup.py` since:
> running python setup.py directly as a script is considered deprecated. This also means that users should avoid running commands directly via python setup.py \<command>.

https://setuptools.pypa.io/en/latest/deprecated/commands.html

We can look at packages such as [invoke](https://www.pyinvoke.org/) for this.

This PR:
* Removes `setup.py` commands:
  - Remove `python setup.py test` (https://github.com/silx-kit/silx/commit/84b3d7047ccb74f1a7bca1e62258a63209181695): There is `run_test.py` for it.
  - Remove `python setup.py build_doc` &cie and document how to call sphinx directly (https://github.com/silx-kit/silx/commit/ea1d920da1964075886c75c1b5e0419872a39f7b): [Sphinx setuptools integration is deprecated](https://www.sphinx-doc.org/en/master/usage/advanced/setuptools.html).
  - Remove `python setup.py clean` override (https://github.com/silx-kit/silx/commit/c9db62e9f2ff09d1fbdd4fd6bdf512b83caeb9da): There is no equivalent for that, but it allows to get rid of the last `distutils` import.
* Prepares for not calling `setup.py build` directly:
  - Deprecate `python setup.py build` arguments (``--no-openmp``, ``--openmp``, ``--force-cython``) and document the env. var. that provides the same feature (https://github.com/silx-kit/silx/commit/e5ee93adcf04f369cf523df507db4bac3262cfda and https://github.com/silx-kit/silx/commit/d080eafc1a7b1b7b42fc471b7f88a561b6297a04). I renamed the env. var. with a `SILX_` prefix while at it.
  - Rework and document `SPECFILE_USE_GNU_SOURCE` (https://github.com/silx-kit/silx/commit/ba22270b8ccb596ae9869ec54d969cf2b5897c1e).
  - Document `SILX_FULL_INSTALL_REQUIRES` and `SILX_INSTALL_REQUIRES_STRIP` env. var. (https://github.com/silx-kit/silx/commit/6ae33008c7bbe348757e7e7d819e09170eea8dd6)

* Misc:
  - Fixed documentation by de duplicating the doc of `silx.io.commonh5.Group` (https://github.com/silx-kit/silx/commit/75324d254156b2965e8913d62766951abc52c96a)
  - Simplify setup kwargs (https://github.com/silx-kit/silx/commit/c02fec2558ffd6352ed244a64cebdf2cd3d0f711)

With this PR, `setup.py` no longer rely on `distutils`.
2 `setup.py` commands remains (`build_man` and `debian_src`) which are related to Linux packaging.


closes #3574