### PR TITLE
Build: Simplified `setup.py`, removed support of `manylinux1`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -345,13 +345,9 @@ class Build(_build):
                 # Use it by default
                 use_openmp = True
 
-        if use_openmp:
-            if platform.system() == "Darwin":
-                # By default Xcode5 & XCode6 do not support OpenMP, Xcode4 is OK.
-                osx = tuple([int(i) for i in platform.mac_ver()[0].split(".")])
-                if osx >= (10, 8):
-                    logger.warning("OpenMP support ignored. Your platform does not support it.")
-                    use_openmp = False
+        if use_openmp and platform.system() == "Darwin":
+            logger.warning("OpenMP support ignored. Your platform does not support it.")
+            use_openmp = False
 
         # Remove attributes used by distutils parsing
         # use 'use_openmp' instead

--- a/setup.py
+++ b/setup.py
@@ -413,17 +413,6 @@ class BuildExt(build_ext):
             # Avoid empty arg
             ext.extra_link_args = [arg for arg in extra_link_args if arg]
 
-        elif self.compiler.compiler_type == 'unix':
-            # Avoids runtime symbol collision for manylinux1 platform
-            # See issue #1070
-            extern = 'extern "C" ' if ext.language == 'c++' else ''
-            return_type = 'PyObject*'
-
-            ext.extra_compile_args.append('-fvisibility=hidden')
-            ext.define_macros.append(
-                ('PyMODINIT_FUNC',
-                    '%s__attribute__((visibility("default"))) %s ' % (extern, return_type)))
-
     def is_debug_interpreter(self):
         """
         Returns true if the script is executed with a debug interpreter.


### PR DESCRIPTION
Merge PR #3651 first!

This PR:
- removes code for compatibility with macos 10.8 during the build.
- removes the patch of `PyMODINIT_FUNC` durign build for `manylinux1` support

closes #3652
