### PR TITLE
Removed usage of `distutils`

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -13,12 +13,11 @@ __license__ = "MIT"
 __date__ = "30/09/2020"
 
 import argparse
-import distutils.util
 import logging
 import os
 import subprocess
 import sys
-import tempfile
+import sysconfig
 
 logging.basicConfig()
 logger = logging.getLogger("bootstrap")
@@ -26,23 +25,17 @@ logger = logging.getLogger("bootstrap")
 
 def is_debug_python():
     """Returns true if the Python interpreter is in debug mode."""
-    try:
-        import sysconfig
-    except ImportError:  # pragma nocover
-        # Python < 2.7
-        import distutils.sysconfig as sysconfig
-
     if sysconfig.get_config_var("Py_DEBUG"):
         return True
 
     return hasattr(sys, "gettotalrefcount")
 
 
-def _distutils_dir_name(dname="lib"):
+def _setuptools_dir_name(dname="lib"):
     """
-    Returns the name of a distutils build directory
+    Returns the name of a setuptools build directory
     """
-    platform = distutils.util.get_platform()
+    platform = sysconfig.get_platform()
     architecture = "%s.%s-%i.%i" % (dname, platform,
                                     sys.version_info[0], sys.version_info[1])
     if is_debug_python():
@@ -50,7 +43,7 @@ def _distutils_dir_name(dname="lib"):
     return architecture
 
 
-def _distutils_scripts_name():
+def _setuptools_scripts_name():
     """Return the name of the distrutils scripts sirectory"""
     f = "scripts-{version[0]}.{version[1]}"
     return f.format(version=sys.version_info)
@@ -251,7 +244,7 @@ def main(argv):
 
 if __name__ == "__main__":
     home = os.path.dirname(os.path.abspath(__file__))
-    LIBPATH = os.path.join(home, 'build', _distutils_dir_name('lib'))
+    LIBPATH = os.path.join(home, 'build', _setuptools_dir_name('lib'))
     cwd = os.getcwd()
     os.chdir(home)
     build = subprocess.Popen([sys.executable, "setup.py", "build"], shell=False)

--- a/ci/info_platform.py
+++ b/ci/info_platform.py
@@ -20,10 +20,7 @@ print("Platform: " + platform.platform())
 print("- Machine: " + platform.machine())
 print(" ")
 
-try:
-    from distutils.sysconfig import get_config_vars
-except ImportError:
-    from sysconfig import get_config_vars
+from sysconfig import get_config_vars
 print("Config: " + str(get_config_vars("CONFIG_ARGS")))
 print("")
 

--- a/run_tests.py
+++ b/run_tests.py
@@ -2,7 +2,7 @@
 # coding: utf8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -35,12 +35,12 @@ __authors__ = ["Jérôme Kieffer", "Thomas Vincent"]
 __date__ = "30/09/2020"
 __license__ = "MIT"
 
-import distutils.util
+import importlib
 import logging
 import os
 import subprocess
 import sys
-import importlib
+import sysconfig
 
 
 # Capture all default warnings
@@ -85,12 +85,6 @@ def get_project_name(root_dir):
 
 def is_debug_python():
     """Returns true if the Python interpreter is in debug mode."""
-    try:
-        import sysconfig
-    except ImportError:  # pragma nocover
-        # Python < 2.7
-        import distutils.sysconfig as sysconfig
-
     if sysconfig.get_config_var("Py_DEBUG"):
         return True
 
@@ -106,7 +100,7 @@ def build_project(name, root_dir):
     :param str root_dir: Root directory of the project
     :return: The path to the directory were build was performed
     """
-    platform = distutils.util.get_platform()
+    platform = sysconfig.get_platform()
     architecture = "lib.%s-%i.%i" % (platform,
                                      sys.version_info[0], sys.version_info[1])
     if is_debug_python():

--- a/src/silx/gui/dialog/AbstractDataFileDialog.py
+++ b/src/silx/gui/dialog/AbstractDataFileDialog.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -35,7 +35,6 @@ import sys
 import os
 import logging
 import functools
-from distutils.version import LooseVersion
 
 import numpy
 
@@ -149,13 +148,13 @@ class _SideBar(qt.QListView):
         :rtype: List[str]
         """
         urls = []
-        version = LooseVersion(qt.qVersion())
+        version = tuple(map(int, qt.qVersion().split('.')[:3]))
         feed_sidebar = True
 
         if not DEFAULT_SIDEBAR_URL:
             _logger.debug("Skip default sidebar URLs (from setted variable)")
             feed_sidebar = False
-        elif version < LooseVersion("5.11.2") and qt.BINDING == "PyQt5" and sys.platform in ["linux", "linux2"]:
+        elif version < (5, 11, 2) and qt.BINDING == "PyQt5" and sys.platform in ["linux", "linux2"]:
             # Avoid segfault on PyQt5 + gtk
             _logger.debug("Skip default sidebar URLs (avoid PyQt5 segfault)")
             feed_sidebar = False


### PR DESCRIPTION
This PR removes imports of `distutils` from `silx` library and from tool scripts (`bootstrap.py`, `run_tests.py`..)

closes #3656