### PR TITLE
silx.gui.plot.stats: Fixed warnings when all data is outside the selected stats region

### DIFF
--- a/src/silx/gui/plot/stats/stats.py
+++ b/src/silx/gui/plot/stats/stats.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -871,7 +871,7 @@ class StatCOM(StatBase):
 
         values = numpy.ma.array(context.values, mask=context.mask, dtype=numpy.float64)
         sum_ = numpy.sum(values)
-        if sum_ == 0.:
+        if sum_ == 0. or numpy.ma.is_masked(sum_):
             return (numpy.nan,) * len(context.axes)
 
         if context.isStructuredData():

--- a/src/silx/gui/plot/stats/statshandler.py
+++ b/src/silx/gui/plot/stats/statshandler.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -32,6 +32,9 @@ __date__ = "05/06/2018"
 
 
 import logging
+import numbers
+
+import numpy
 
 from silx.gui import qt
 from silx.gui.plot import stats as statsmdl
@@ -72,10 +75,13 @@ class StatFormatter(object):
         self.tabWidgetItemClass = qItemClass
 
     def format(self, val):
-        if self.formatter is None or val is None:
-            return str(val)
-        else:
+        if val is None or numpy.ma.is_masked(val):
+            return "--"
+
+        if self.formatter is not None and isinstance(val, numbers.Number):
             return self.formatter.format(val)
+
+        return str(val)
 
 
 class StatsHandler(object):


### PR DESCRIPTION
This PR fixes deprecation warnings in `StatFormatter` that occur when all the data of an item is outside the Stat computation region.
It also updates the display to show: `--` instead of `None` or `masked` (for numpy `MaskedConstant`).

The `StatCOM` also check for completely masked array to return `NaNs` in this case.

closes #3607