### PR TITLE
silx.gui.data: Do not keep aspect ratio in `NXdata` image views when axes `@units` are different

### DIFF
--- a/src/silx/gui/data/DataViews.py
+++ b/src/silx/gui/data/DataViews.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1759,6 +1759,8 @@ class _NXdataImageView(_NXdataBaseDataView):
         y_axis, x_axis = nxd.axes[img_slicing]
         y_label, x_label = nxd.axes_names[img_slicing]
         y_scale, x_scale = nxd.plot_style.axes_scale_types[img_slicing]
+        x_units = get_attr_as_unicode(x_axis, 'units') if x_axis else None
+        y_units = get_attr_as_unicode(y_axis, 'units') if y_axis else None
 
         self.getWidget().setImageData(
             [nxd.signal] + nxd.auxiliary_signals,
@@ -1766,7 +1768,9 @@ class _NXdataImageView(_NXdataBaseDataView):
             signals_names=[nxd.signal_name] + nxd.auxiliary_signals_names,
             xlabel=x_label, ylabel=y_label,
             title=nxd.title, isRgba=isRgba,
-            xscale=x_scale, yscale=y_scale)
+            xscale=x_scale, yscale=y_scale,
+            keep_ratio=(x_units == y_units),
+        )
 
     def getDataPriority(self, data, info):
         data = self.normalizeData(data)
@@ -1804,13 +1808,17 @@ class _NXdataComplexImageView(_NXdataBaseDataView):
         img_slicing = slice(-2, None)
         y_axis, x_axis = nxd.axes[img_slicing]
         y_label, x_label = nxd.axes_names[img_slicing]
+        x_units = get_attr_as_unicode(x_axis, 'units') if x_axis else None
+        y_units = get_attr_as_unicode(y_axis, 'units') if y_axis else None
 
         self.getWidget().setImageData(
             [nxd.signal] + nxd.auxiliary_signals,
             x_axis=x_axis, y_axis=y_axis,
             signals_names=[nxd.signal_name] + nxd.auxiliary_signals_names,
             xlabel=x_label, ylabel=y_label,
-            title=nxd.title)
+            title=nxd.title,
+            keep_ratio=(x_units == y_units),
+        )
 
     def axesNames(self, data, info):
         # disabled (used by default axis selector widget in Hdf5Viewer)

--- a/src/silx/gui/data/NXdataWidgets.py
+++ b/src/silx/gui/data/NXdataWidgets.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -412,7 +412,8 @@ class ArrayImagePlot(qt.QWidget):
                      signals_names=None,
                      xlabel=None, ylabel=None,
                      title=None, isRgba=False,
-                     xscale=None, yscale=None):
+                     xscale=None, yscale=None,
+                     keep_ratio: bool=True):
         """
 
         :param signals: list of n-D datasets, whose last 2 dimensions are used as the
@@ -430,6 +431,7 @@ class ArrayImagePlot(qt.QWidget):
         :param isRgba: True if data is a 3D RGBA image
         :param str xscale: Scale of X axis in (None, 'linear', 'log')
         :param str yscale: Scale of Y axis in (None, 'linear', 'log')
+        :param keep_ratio: Toggle plot keep aspect ratio
         """
         self._selector.selectionChanged.disconnect(self._updateImage)
         self._auxSigSlider.valueChanged.disconnect(self._sliderIdxChanged)
@@ -465,6 +467,7 @@ class ArrayImagePlot(qt.QWidget):
 
         self._axis_scales = xscale, yscale
         self._updateImage()
+        self._plot.setKeepDataAspectRatio(keep_ratio)
         self._plot.resetZoom()
 
         self._selector.selectionChanged.connect(self._updateImage)
@@ -629,7 +632,8 @@ class ArrayComplexImagePlot(qt.QWidget):
                      x_axis=None, y_axis=None,
                      signals_names=None,
                      xlabel=None, ylabel=None,
-                     title=None):
+                     title=None,
+                     keep_ratio: bool=True):
         """
 
         :param signals: list of n-D datasets, whose last 2 dimensions are used as the
@@ -644,6 +648,7 @@ class ArrayComplexImagePlot(qt.QWidget):
         :param xlabel: Label for X axis
         :param ylabel: Label for Y axis
         :param title: Graph title
+        :param keep_ratio: Toggle plot keep aspect ratio
         """
         self._selector.selectionChanged.disconnect(self._updateImage)
         self._auxSigSlider.valueChanged.disconnect(self._sliderIdxChanged)
@@ -673,6 +678,7 @@ class ArrayComplexImagePlot(qt.QWidget):
         self._auxSigSlider.setValue(0)
 
         self._updateImage()
+        self._plot.setKeepDataAspectRatio(keep_ratio)
         self._plot.getPlot().resetZoom()
 
         self._selector.selectionChanged.connect(self._updateImage)


### PR DESCRIPTION
This PR does not keep aspect ratio by default in the case the 2 axes of an image have different `@units` (either both are defined and different or only one is defined).
In all other cases, the aspect ratio is kept by default.
This is done for the image and complex image widgets, and not for the stack or 3D views.

closes #3626