### PR TITLE
silx view: Improved wildcard support in filename and data path

### DIFF
--- a/src/silx/app/view/main.py
+++ b/src/silx/app/view/main.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2021 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -116,6 +116,7 @@ def mainQt(options):
 
     import silx
     import silx.utils.files
+    from silx.io.url import DataUrl
     from silx.gui import qt
     # Make sure matplotlib is configured
     # Needed for Debian 8: compatibility between Qt4/Qt5 and old matplotlib
@@ -152,13 +153,23 @@ def mainQt(options):
         # It have to be done after the settings (after the Viewer creation)
         silx.config.DEFAULT_PLOT_BACKEND = "opengl"
 
-    # NOTE: under Windows, cmd does not convert `*.tif` into existing files
-    options.files = silx.utils.files.expand_filenames(options.files)
-
+    urls = []
     for filename in options.files:
+        url = DataUrl(filename)
+
+        for file_path in silx.utils.files.expand_filenames([url.file_path()]):
+            urls.append(
+                DataUrl(
+                    file_path=file_path,
+                    data_path=url.data_path(),
+                    data_slice=url.data_slice(), scheme=url.scheme(),
+                )
+            )
+
+    for url in urls:
         # TODO: Would be nice to add a process widget and a cancel button
         try:
-            window.appendFile(filename)
+            window.appendFile(url.path())
         except IOError as e:
             _logger.error(e.args[0])
             _logger.debug("Backtrace", exc_info=True)

--- a/src/silx/app/view/main.py
+++ b/src/silx/app/view/main.py
@@ -75,6 +75,7 @@ def createParser():
 
 def filesArgToUrls(filenames: Iterable[str]) -> Generator[object, None, None]:
     """Expand filenames and HDF5 data path in files input argument"""
+    # Imports here so they are performed after setting HDF5_USE_FILE_LOCKING and logging level
     import silx.io
     from silx.io.utils import match
     from silx.io.url import DataUrl
@@ -84,7 +85,7 @@ def filesArgToUrls(filenames: Iterable[str]) -> Generator[object, None, None]:
         url = DataUrl(filename)
 
         for file_path in sorted(silx.utils.files.expand_filenames([url.file_path()])):
-            if glob.has_magic(url.data_path()):
+            if url.data_path() is not None and glob.has_magic(url.data_path()):
                 try:
                     with silx.io.open(file_path) as f:
                         data_paths = list(match(f, url.data_path()))

--- a/src/silx/io/test/test_utils.py
+++ b/src/silx/io/test/test_utils.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2019 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +30,6 @@ import re
 import shutil
 import tempfile
 import unittest
-import sys
 
 from .. import utils
 from ..._version import calc_hexversion
@@ -39,6 +38,7 @@ import silx.io.url
 import h5py
 from ..utils import h5ls
 from silx.io import commonh5
+
 
 import fabio
 
@@ -921,3 +921,33 @@ def test_visitall_commonh5():
     soft_link = visited_items["/group/soft_link"]
     assert isinstance(soft_link, commonh5.SoftLink)
     assert soft_link.path == "/group/dataset"
+
+
+def test_match_hdf5(tmp_path):
+    """Test match function with HDF5 file"""
+    with h5py.File(tmp_path / "test_match.h5", "w") as h5f:
+        h5f.create_group("entry_0000/group")
+        h5f["entry_0000/data"] = 0
+        h5f.create_group("entry_0001/group")
+        h5f["entry_0001/data"] = 1
+        h5f.create_group("entry_0002")
+        h5f["entry_0003"] = 3
+
+        result = list(utils.match(h5f, "/entry_*/*"))
+
+        assert sorted(result) == ['entry_0000/data', 'entry_0000/group', 'entry_0001/data', 'entry_0001/group']
+
+
+def test_match_commonh5():
+    """Test match function with commonh5 objects"""
+    with commonh5.File("filename.file", mode="w") as fobj:
+        fobj.create_group("entry_0000/group")
+        fobj["entry_0000/data"] = 0
+        fobj.create_group("entry_0001/group")
+        fobj["entry_0001/data"] = 1
+        fobj.create_group("entry_0002")
+        fobj["entry_0003"] = 3
+
+        result = list(utils.match(fobj, "/entry_*/*"))
+
+        assert sorted(result) == ['entry_0000/data', 'entry_0000/group', 'entry_0001/data', 'entry_0001/group']

--- a/src/silx/io/utils.py
+++ b/src/silx/io/utils.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2021 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -28,11 +28,13 @@ __license__ = "MIT"
 __date__ = "03/12/2020"
 
 import enum
+import fnmatch
 import os.path
 import sys
 import time
 import logging
 import collections
+from typing import Generator
 import urllib.parse
 
 import numpy
@@ -821,6 +823,24 @@ def visitall(item):
     :param item: The item to visit.
     """
     yield from _visitall(item, '')
+
+
+
+def match(group, path_pattern: str) -> Generator[str, None, None]:
+    """Generator of paths inside given h5py-like `group` matching `path_pattern`"""
+    if not is_group(group):
+        raise ValueError(f"Not a h5py-like group: {group}")
+
+    path_parts = path_pattern.strip("/").split("/", 1)
+    for matching_path in fnmatch.filter(group.keys(), path_parts[0]):
+        if len(path_parts) == 1:  # No more sub-path, stop recursion
+            yield matching_path
+            continue
+
+        entity = group.get(matching_path)
+        if is_group(entity):
+            for matching_subpath in match(entity, path_parts[1]):
+                yield f"{matching_path}/{matching_subpath}"
 
 
 def get_data(url):


### PR DESCRIPTION
This PR adds "*" support for `silx view` `files` argument for filename even when a data path is provided and for data path. Some examples of supported syntax:
`myfiles_*.h5::/data`, `myfiles_*.h5::/entry_*/data`, `myfile.h5::/entry_*/data/*`

It also adds a `silx.io.utils.match` function to find data path matching a pattern in a file.

It is similar to PR #3615 and borrows some of the approach.

closes  #3577
