### PR TITLE
silx view: Fixed refresh for content opened as `file.h5::/path`

### DIFF
--- a/src/silx/app/view/Viewer.py
+++ b/src/silx/app/view/Viewer.py
@@ -266,7 +266,6 @@ class Viewer(qt.QMainWindow):
             index = indexes.pop(0)
             if index.column() != 0:
                 continue
-            h5 = model.data(index, role=silx.gui.hdf5.Hdf5TreeModel.H5PY_OBJECT_ROLE)
             rootIndex = index
             # Reach the root of the tree
             while rootIndex.parent().isValid():
@@ -274,7 +273,8 @@ class Viewer(qt.QMainWindow):
             rootRow = rootIndex.row()
             relativePath = self.__getRelativePath(model, rootIndex, index)
             selectedItems.append((rootRow, relativePath))
-            h5files.add(h5.file)
+            h5 = model.data(rootIndex, role=silx.gui.hdf5.Hdf5TreeModel.H5PY_OBJECT_ROLE)
+            h5files.add(h5)
 
         if len(h5files) == 0:
             qt.QApplication.restoreOverrideCursor()
@@ -304,7 +304,7 @@ class Viewer(qt.QMainWindow):
         # FIXME: The architecture have to be reworked to support this feature.
         # model.synchronizeH5pyObject(h5)
 
-        filename = h5.filename
+        filename = f"{h5.file.filename}::{h5.name}"
         row = model.h5pyObjectRow(h5)
         index = self.__treeview.model().index(row, 0, qt.QModelIndex())
         paths = self.__getPathFromExpandedNodes(self.__treeview, index)

--- a/src/silx/app/view/Viewer.py
+++ b/src/silx/app/view/Viewer.py
@@ -31,6 +31,7 @@ import os
 import collections
 import logging
 import functools
+from typing import Optional
 
 import silx.io.nxdata
 from silx.gui import qt
@@ -274,15 +275,16 @@ class Viewer(qt.QMainWindow):
             relativePath = self.__getRelativePath(model, rootIndex, index)
             selectedItems.append((rootRow, relativePath))
             h5 = model.data(rootIndex, role=silx.gui.hdf5.Hdf5TreeModel.H5PY_OBJECT_ROLE)
-            h5files.add(h5)
+            item = model.data(rootIndex, role=silx.gui.hdf5.Hdf5TreeModel.H5PY_ITEM_ROLE)
+            h5files.add((h5, item._openedPath))
 
         if len(h5files) == 0:
             qt.QApplication.restoreOverrideCursor()
             return
 
         model = self.__treeview.findHdf5TreeModel()
-        for h5 in h5files:
-            self.__synchronizeH5pyObject(h5)
+        for h5, filename in h5files:
+            self.__synchronizeH5pyObject(h5, filename)
 
         model = self.__treeview.model()
         itemSelection = qt.QItemSelection()
@@ -297,14 +299,15 @@ class Viewer(qt.QMainWindow):
 
         qt.QApplication.restoreOverrideCursor()
 
-    def __synchronizeH5pyObject(self, h5):
+    def __synchronizeH5pyObject(self, h5, filename: Optional[str] = None):
         model = self.__treeview.findHdf5TreeModel()
         # This is buggy right now while h5py do not allow to close a file
         # while references are still used.
         # FIXME: The architecture have to be reworked to support this feature.
         # model.synchronizeH5pyObject(h5)
 
-        filename = f"{h5.file.filename}::{h5.name}"
+        if filename is None:
+            filename = f"{h5.file.filename}::{h5.name}"
         row = model.h5pyObjectRow(h5)
         index = self.__treeview.model().index(row, 0, qt.QModelIndex())
         paths = self.__getPathFromExpandedNodes(self.__treeview, index)

--- a/src/silx/app/view/Viewer.py
+++ b/src/silx/app/view/Viewer.py
@@ -262,7 +262,7 @@ class Viewer(qt.QMainWindow):
         indexes = selection.selectedIndexes()
         selectedItems = []
         model = self.__treeview.model()
-        h5files = set([])
+        h5files = []
         while len(indexes) > 0:
             index = indexes.pop(0)
             if index.column() != 0:
@@ -276,7 +276,7 @@ class Viewer(qt.QMainWindow):
             selectedItems.append((rootRow, relativePath))
             h5 = model.data(rootIndex, role=silx.gui.hdf5.Hdf5TreeModel.H5PY_OBJECT_ROLE)
             item = model.data(rootIndex, role=silx.gui.hdf5.Hdf5TreeModel.H5PY_ITEM_ROLE)
-            h5files.add((h5, item._openedPath))
+            h5files.append((h5, item._openedPath))
 
         if len(h5files) == 0:
             qt.QApplication.restoreOverrideCursor()

--- a/src/silx/gui/hdf5/Hdf5Item.py
+++ b/src/silx/gui/hdf5/Hdf5Item.py
@@ -30,6 +30,7 @@ __date__ = "17/01/2019"
 import logging
 import collections
 import enum
+from typing import Optional
 
 from .. import qt
 from .. import icons
@@ -61,10 +62,21 @@ class Hdf5Item(Hdf5Node):
     tree structure.
     """
 
-    def __init__(self, text, obj, parent, key=None, h5Class=None, linkClass=None, populateAll=False):
+    def __init__(
+        self,
+        text: Optional[str],
+        obj,
+        parent,
+        key=None,
+        h5Class=None,
+        linkClass=None,
+        populateAll=False,
+        openedPath: Optional[str] = None,
+    ):
         """
-        :param str text: text displayed
+        :param text: text displayed
         :param object obj: Pointer to a h5py-link object. See the `obj` attribute.
+        :param openedPath: The path with which the item was opened if any
         """
         self.__obj = obj
         self.__key = key
@@ -75,7 +87,7 @@ class Hdf5Item(Hdf5Node):
         self.__linkClass = linkClass
         self.__description = None
         self.__nx_class = None
-        Hdf5Node.__init__(self, parent, populateAll=populateAll)
+        Hdf5Node.__init__(self, parent, populateAll=populateAll, openedPath=openedPath)
 
     def _getCanonicalName(self):
         parent = self.parent

--- a/src/silx/gui/hdf5/Hdf5LoadingItem.py
+++ b/src/silx/gui/hdf5/Hdf5LoadingItem.py
@@ -26,6 +26,7 @@ __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "06/07/2018"
 
+from typing import Optional
 
 from .. import qt
 from .Hdf5Node import Hdf5Node
@@ -38,9 +39,15 @@ class Hdf5LoadingItem(Hdf5Node):
     At the end of the loading this item is replaced by the loaded one.
     """
 
-    def __init__(self, text, parent, animatedIcon):
+    def __init__(
+        self,
+        text,
+        parent,
+        animatedIcon,
+        openedPath: Optional[str] = None,
+    ):
         """Constructor"""
-        Hdf5Node.__init__(self, parent)
+        Hdf5Node.__init__(self, parent, openedPath=openedPath)
         self.__text = text
         self.__animatedIcon = animatedIcon
         self.__animatedIcon.register(self)

--- a/src/silx/gui/hdf5/Hdf5Node.py
+++ b/src/silx/gui/hdf5/Hdf5Node.py
@@ -27,6 +27,7 @@ __license__ = "MIT"
 __date__ = "24/07/2018"
 
 import weakref
+from typing import Optional
 
 
 class Hdf5Node(object):
@@ -35,16 +36,24 @@ class Hdf5Node(object):
     It provides link to the childs and to the parents, and a link to an
     external object.
     """
-    def __init__(self, parent=None, populateAll=False):
+    def __init__(
+        self,
+        parent=None,
+        populateAll=False,
+        openedPath: Optional[str]=None,
+    ):
         """
         Constructor
 
         :param Hdf5Node parent: Parent of the node, if exists, else None
         :param bool populateAll: If true, populate all the tree node. Else
             everything is lazy loaded.
+        :param openedPath:
+            The url or filename the node was created from, None if not directly created
         """
         self.__child = None
         self.__parent = None
+        self.__openedPath = openedPath
         if parent is not None:
             self.__parent = weakref.ref(parent)
         if populateAll:
@@ -57,6 +66,11 @@ class Hdf5Node(object):
             return "root"
         else:
             return "%s/?" % (parent._getCanonicalName())
+
+    @property
+    def _openedPath(self) -> Optional[str]:
+        """url or filename the node was created from, None if not directly created"""
+        return self.__openedPath
 
     @property
     def parent(self):

--- a/src/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/src/silx/gui/hdf5/Hdf5TreeModel.py
@@ -29,6 +29,7 @@ __date__ = "12/03/2019"
 
 import os
 import logging
+from typing import Optional
 import functools
 from .. import qt
 from .. import icons
@@ -97,7 +98,13 @@ class LoadingItemRunnable(qt.QRunnable):
         :rtpye: Hdf5Node
         """
         text = _createRootLabel(h5obj)
-        item = Hdf5Item(text=text, obj=h5obj, parent=oldItem.parent, populateAll=True)
+        item = Hdf5Item(
+            text=text,
+            obj=h5obj,
+            parent=oldItem.parent,
+            populateAll=True,
+            openedPath=oldItem._openedPath,
+        )
         return item
 
     def run(self):
@@ -607,7 +614,13 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
             else:
                 index += 1
 
-    def insertH5pyObject(self, h5pyObject, text=None, row=-1):
+    def insertH5pyObject(
+        self,
+        h5pyObject,
+        text: Optional[str] = None,
+        row: int = -1,
+        filename: Optional[str] = None,
+    ):
         """Append an HDF5 object from h5py to the tree.
 
         :param h5pyObject: File handle/descriptor for a :class:`h5py.File`
@@ -617,7 +630,15 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
             text = _createRootLabel(h5pyObject)
         if row == -1:
             row = self.__root.childCount()
-        self.insertNode(row, Hdf5Item(text=text, obj=h5pyObject, parent=self.__root))
+        self.insertNode(
+            row,
+            Hdf5Item(
+                text=text,
+                obj=h5pyObject,
+                parent=self.__root,
+                openedPath=filename,
+            )
+        )
 
     def hasPendingOperations(self):
         return len(self.__runnerSet) > 0
@@ -629,7 +650,12 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         # create temporary item
         if synchronizingNode is None:
             text = os.path.basename(filename)
-            item = Hdf5LoadingItem(text=text, parent=self.__root, animatedIcon=self.__animatedIcon)
+            item = Hdf5LoadingItem(
+                text=text,
+                parent=self.__root,
+                animatedIcon=self.__animatedIcon,
+                openedPath=filename,
+            )
             self.insertNode(row, item)
         else:
             item = synchronizingNode
@@ -654,7 +680,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
             if self.__ownFiles:
                 self.__openedFiles.append(h5file)
             self.sigH5pyObjectLoaded.emit(h5file)
-            self.insertH5pyObject(h5file, row=row)
+            self.insertH5pyObject(h5file, row=row, filename=filename)
         except IOError:
             _logger.debug("File '%s' can't be read.", filename, exc_info=True)
             raise

--- a/src/silx/io/utils.py
+++ b/src/silx/io/utils.py
@@ -539,6 +539,7 @@ class _MainNode(Proxy):
 
     def __init__(self, h5_node, h5_file):
         super(_MainNode, self).__init__(h5_node)
+        self.__node = h5_node
         self.__file = h5_file
         self.__class = get_h5_class(h5_node)
 


### PR DESCRIPTION
This PR fixes the refresh of selected files for files which where opened with a subpath (e.g., `file.h5::/entry/data`)


closes #3616
