### PR TITLE
silx view: Enabled plot grid by default for curve plots

### DIFF
--- a/src/silx/gui/data/DataViews.py
+++ b/src/silx/gui/data/DataViews.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -876,7 +876,9 @@ class _Plot1dView(DataView):
 
     def createWidget(self, parent):
         from silx.gui import plot
-        return plot.Plot1D(parent=parent)
+        widget = plot.Plot1D(parent=parent)
+        widget.setGraphGrid(True)
+        return widget
 
     def clear(self):
         self.getWidget().clear()

--- a/src/silx/gui/data/NXdataWidgets.py
+++ b/src/silx/gui/data/NXdataWidgets.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 # /*##########################################################################
 #
-# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -76,6 +76,7 @@ class ArrayCurvePlot(qt.QWidget):
         self.__values = None
 
         self._plot = Plot1D(self)
+        self._plot.setGraphGrid(True)
 
         self._selector = NumpyAxesSelector(self)
         self._selector.setNamedAxesSelectorVisibility(False)


### PR DESCRIPTION
This PR activates the plot grid by default when plotting curves and `NXdata` view displaying curves and (x, y) scatters. It is activated neither for (x, y, value) scatters nor for images.
 
closes #3355
