### PR TITLE
silx.math.histogram: Added support of uint16 weights for LUT histogram

### DIFF
--- a/src/silx/math/chistogramnd_lut.pyx
+++ b/src/silx/math/chistogramnd_lut.pyx
@@ -1,6 +1,6 @@
 # coding: utf-8
 # /*##########################################################################
-# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -44,6 +44,7 @@ ctypedef fused cumul_t:
     cnumpy.int64_t
 
 ctypedef fused weights_t:
+    cnumpy.uint16_t
     cnumpy.float64_t
     cnumpy.float32_t
     cnumpy.int32_t
@@ -108,7 +109,7 @@ def histogramnd_get_lut(sample,
         if histo_range.shape == (2,):
             pass
         elif histo_range.shape == (1, 2):
-            histo_range.reshape(-1)
+            histo_range = histo_range.reshape(-1)
         else:
             err_histo_range = True
     elif n_dims != 1 and histo_range.shape != (n_dims, 2):


### PR DESCRIPTION
This adds unit16 as a support type for weights and fixes a typo.

This would allow to remove a [duplicated implementation in xsocs](https://gitlab.esrf.fr/kmap/xsocs/-/blob/1f78899354a3693c7085cee0d4db49a0f37e65f1/xsocs/util/filt_utils/histogramnd_lut.pyx) (where the histogram lut was initially implemented).
