### PR TITLE
silx.io.nxdata: removed support of `NXcanSAS` signal `@uncertainties`

### DIFF
--- a/src/silx/io/nxdata/parse.py
+++ b/src/silx/io/nxdata/parse.py
@@ -725,12 +725,8 @@ class NXdata(object):
             "errors",
             # Not Nexus (VARIABLE_errors is only for axes), but supported anyway
             self.signal_dataset_name + "_errors",
-            # From NXcanSAS application definition @uncertainties
-            get_attr_as_unicode(self.group[self.signal_dataset_name], "uncertainties"),
         ]
         for name in dataset_names:
-            if name is None:
-                continue
             entity = self.group.get(name)
             if entity is not None and is_dataset(entity):
                 return entity


### PR DESCRIPTION
As discussed in PR #3657, this removes the support of `@uncertainties` on the signal as described in the `NXcanSAS` application definition, and instead stick to `NXdata` `<signal>_errors`.

Related to #3657
