### PR TITLE
Misc: Fixed development scripts compatibility with `setuptools`

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -254,7 +254,10 @@ if __name__ == "__main__":
     LIBPATH = os.path.join(home, 'build', _distutils_dir_name('lib'))
     cwd = os.getcwd()
     os.chdir(home)
-    build = subprocess.Popen([sys.executable, "setup.py", "build"], shell=False)
+    build = subprocess.Popen(
+        [sys.executable, "setup.py", "build", "--build-lib", LIBPATH],
+        shell=False,
+    )
     build_rc = build.wait()
     if not os.path.exists(LIBPATH):
         logger.warning("`lib` directory does not exist, trying common Python3 lib")

--- a/run_tests.py
+++ b/run_tests.py
@@ -2,7 +2,7 @@
 # coding: utf8
 # /*##########################################################################
 #
-# Copyright (c) 2015-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -121,8 +121,10 @@ def build_project(name, root_dir):
         home = os.path.join(root_dir, "build", architecture)
 
     logger.warning("Building %s to %s", name, home)
-    p = subprocess.Popen([sys.executable, "setup.py", "build"],
-                         shell=False, cwd=root_dir)
+    cmd = [sys.executable, "setup.py", "build"]
+    if home:
+        cmd += ["--build-lib", home]
+    p = subprocess.Popen(cmd, shell=False, cwd=root_dir)
     logger.debug("subprocess ended with rc= %s", p.wait())
 
     if os.path.isdir(home):


### PR DESCRIPTION
This PR fixes `bootstrap.py` and `run_tests.py` no longer working with latest versions of `setuptools` since the build path has changed from e.g., `build/lib.linux-x86_64-3.7` to `build/lib.linux-x86_64-cpython-37`...
As a result, the path added to `sys.path`/`PYTHONPATH` was no longer the right one.

This PR fixes it by forcing the `--build-lib` directory to the previous one (e.g., `build/lib.linux-x86_64-3.7`) so the scripts know where it is.

closes #3676
