### PR TITLE
Retry for generator functions

### DIFF
--- a/doc/source/Tutorials/io.rst
+++ b/doc/source/Tutorials/io.rst
@@ -338,13 +338,13 @@ An equivalent decorator exists for context managers
         with silx.io.h5py_utils.File(filename) as h5file:
             yield h5file[name]["measurement"]
 
-and for iterators
+Generator functions need to have a `start_index` parameter
 
 .. code-block:: python
 
     import silx.io.h5py_utils
 
-    @silx.io.h5py_utils.retry_iterator()
+    @silx.io.h5py_utils.retry()
     def iter_measurement(filename, names, start_index=0):
         """The method will be iterated again if any HDF5
         IO fails, possibly with a different start index.

--- a/doc/source/Tutorials/io.rst
+++ b/doc/source/Tutorials/io.rst
@@ -324,6 +324,34 @@ For example to process all top-level groups of an HDF5 file:
 Note that the method with the `retry` decorator has to be idempotent
 as it can be executed several times for one call.
 
+An equivalent decorator exists for context managers
+
+.. code-block:: python
+
+    import silx.io.h5py_utils
+
+    @silx.io.h5py_utils.retry_contextmanager()
+    def measurement_context(filename, name):
+        """The method will be entered again if
+        any HDF5 IO fails.
+        """
+        with silx.io.h5py_utils.File(filename) as h5file:
+            yield h5file[name]["measurement"]
+
+and for iterators
+
+.. code-block:: python
+
+    import silx.io.h5py_utils
+
+    @silx.io.h5py_utils.retry_iterator()
+    def iter_measurement(filename, names, start_index=0):
+        """The method will be iterated again if any HDF5
+        IO fails, possibly with a different start index.
+        """
+        with silx.io.h5py_utils.File(filename) as h5file:
+            for name in names[start_index:]:
+                yield h5file[name]["measurement"]
 
 Additional resources
 --------------------

--- a/src/silx/io/h5py_utils.py
+++ b/src/silx/io/h5py_utils.py
@@ -151,6 +151,17 @@ def retry(**kw):
     return retry_mod.retry(**kw)
 
 
+def retry_iterator(**kw):
+    r"""Decorator for a method that needs to be iterated until it not longer
+    fails on HDF5 IO. Mainly used for reading an HDF5 file that is being
+    written.
+
+    :param \**kw: see `silx.utils.retry`
+    """
+    kw.setdefault("retry_on_error", _retry_h5py_error)
+    return retry_mod.retry_iterator(**kw)
+
+
 def retry_contextmanager(**kw):
     r"""Decorator to make a context manager from a method that needs to be
     entered until it not longer fails on HDF5 IO. Mainly used for reading

--- a/src/silx/io/h5py_utils.py
+++ b/src/silx/io/h5py_utils.py
@@ -151,17 +151,6 @@ def retry(**kw):
     return retry_mod.retry(**kw)
 
 
-def retry_iterator(**kw):
-    r"""Decorator for a method that needs to be iterated until it not longer
-    fails on HDF5 IO. Mainly used for reading an HDF5 file that is being
-    written.
-
-    :param \**kw: see `silx.utils.retry`
-    """
-    kw.setdefault("retry_on_error", _retry_h5py_error)
-    return retry_mod.retry_iterator(**kw)
-
-
 def retry_contextmanager(**kw):
     r"""Decorator to make a context manager from a method that needs to be
     entered until it not longer fails on HDF5 IO. Mainly used for reading

--- a/src/silx/io/test/test_h5py_utils.py
+++ b/src/silx/io/test/test_h5py_utils.py
@@ -451,14 +451,14 @@ class TestH5pyUtils(unittest.TestCase):
             top_level_names_test(txtfilename, filename, **kw)
 
     @subtests
-    def test_retry_iterator(self):
+    def test_retry_generator(self):
         filename = self._new_filename()
         ncausefailure = 3
         faildelay = 0.1
         sufficient_timeout = ncausefailure * (faildelay + 10)
         insufficient_timeout = ncausefailure * faildelay * 0.5
 
-        @h5py_utils.retry_iterator()
+        @h5py_utils.retry()
         def iter_data(filename, name, start_index=0):
             nonlocal failcounter
             if start_index <= 0:

--- a/src/silx/utils/retry.py
+++ b/src/silx/utils/retry.py
@@ -157,12 +157,12 @@ def retry_contextmanager(
                 retry_on_error=_retry_on_error,
             ):
                 with _handle_exception(options):
-                    gen = method(*args, **kw)
-                    result = next(gen)
+                    ctx = method(*args, **kw)
+                    result = next(ctx)
                     options["retry_on_error"] = None
                     yield result
                     try:
-                        next(gen)
+                        next(ctx)
                     except StopIteration:
                         return
                     else:

--- a/src/silx/utils/retry.py
+++ b/src/silx/utils/retry.py
@@ -87,7 +87,9 @@ def _retry_loop(retry_timeout=None, retry_period=None, retry_on_error=None):
         if retry_period is not None:
             time.sleep(retry_period)
         if has_timeout and (time.time() - t0) > retry_timeout:
-            raise RetryTimeoutError from options.get("exception")
+            err_msg = "%s seconds" % retry_timeout
+            cause = options.get("exception")
+            raise RetryTimeoutError(err_msg) from cause
 
 
 def retry(

--- a/src/silx/utils/retry.py
+++ b/src/silx/utils/retry.py
@@ -127,6 +127,57 @@ def retry(
     return decorator
 
 
+def retry_iterator(
+    retry_timeout=None, retry_period=None, retry_on_error=_default_retry_on_error
+):
+    """Decorator for a method that needs to be iterated until it not longer
+    fails or until `retry_on_error` returns False.
+
+    The method should have a `start_index` argument which allows the method
+    to start iterating from the last failure when called on retry.
+
+    The decorator arguments can be overriden by using them when calling the
+    decorated method.
+
+    :param num retry_timeout:
+    :param num retry_period: sleep before retry
+    :param callable or None retry_on_error: checks whether an exception is
+                                            eligible for retry
+    """
+
+    if retry_period is None:
+        retry_period = RETRY_PERIOD
+
+    def decorator(method):
+        @wraps(method)
+        def wrapper(*args, **kw):
+            _retry_timeout = kw.pop("retry_timeout", retry_timeout)
+            _retry_period = kw.pop("retry_period", retry_period)
+            _retry_on_error = kw.pop("retry_on_error", retry_on_error)
+            start_index = kw.pop("start_index", 0)
+            for options in _retry_loop(
+                retry_timeout=_retry_timeout,
+                retry_period=_retry_period,
+                retry_on_error=_retry_on_error,
+            ):
+                with _handle_exception(options):
+                    oretry_on_error = options["retry_on_error"]
+                    it = method(*args, start_index=start_index, **kw)
+                    while True:
+                        try:
+                            result = next(it)
+                        except StopIteration:
+                            return
+                        start_index += 1
+                        options["retry_on_error"] = None
+                        yield result
+                        options["retry_on_error"] = oretry_on_error
+
+        return wrapper
+
+    return decorator
+
+
 def retry_contextmanager(
     retry_timeout=None, retry_period=None, retry_on_error=_default_retry_on_error
 ):

--- a/src/silx/utils/retry.py
+++ b/src/silx/utils/retry.py
@@ -157,6 +157,8 @@ def retry_iterator(
             _retry_period = kw.pop("retry_period", retry_period)
             _retry_on_error = kw.pop("retry_on_error", retry_on_error)
             start_index = kw.pop("start_index", 0)
+            if start_index is None:
+                start_index = 0
             for options in _retry_loop(
                 retry_timeout=_retry_timeout,
                 retry_period=_retry_period,

--- a/src/silx/utils/test/test_retry.py
+++ b/src/silx/utils/test/test_retry.py
@@ -113,43 +113,6 @@ class TestRetry(unittest.TestCase):
         with self.assertRaises(retry.RetryTimeoutError):
             method(True, **kw)
 
-    def test_retry_yield(self):
-        ncausefailure = 3
-        faildelay = 0.1
-        sufficient_timeout = ncausefailure * (faildelay + 10)
-        insufficient_timeout = ncausefailure * faildelay * 0.5
-
-        @retry.retry_iterator()
-        def method(check, kwcheck=None, start_index=0):
-            if start_index <= 0:
-                yield 0
-            assert check
-            assert kwcheck
-            nonlocal failcounter
-            if failcounter < ncausefailure:
-                time.sleep(faildelay)
-                failcounter += 1
-                if start_index <= 1:
-                    yield 1
-                raise retry.RetryError
-            else:
-                if start_index <= 1:
-                    yield 1
-            if start_index <= 2:
-                yield 2
-
-        failcounter = 0
-        kw = {"kwcheck": True, "retry_timeout": sufficient_timeout}
-        self.assertEqual(list(method(True, **kw)), [0, 1, 2])
-
-        failcounter = 0
-        kw = {
-            "kwcheck": True,
-            "retry_timeout": insufficient_timeout,
-        }
-        with self.assertRaises(retry.RetryTimeoutError):
-            list(method(True, **kw))
-
     def test_retry_contextmanager(self):
         ncausefailure = 3
         faildelay = 0.1
@@ -204,3 +167,47 @@ class TestRetry(unittest.TestCase):
             f.write("0")
         with self.assertRaises(retry.RetryTimeoutError):
             _wsubmain(self.ctr_file, **kw)
+
+    def test_retry_generator(self):
+        ncausefailure = 3
+        faildelay = 0.1
+        sufficient_timeout = ncausefailure * (faildelay + 10)
+        insufficient_timeout = ncausefailure * faildelay * 0.5
+
+        @retry.retry()
+        def method(check, kwcheck=None, start_index=0):
+            if start_index <= 0:
+                yield 0
+            assert check
+            assert kwcheck
+            nonlocal failcounter
+            if failcounter < ncausefailure:
+                time.sleep(faildelay)
+                failcounter += 1
+                if start_index <= 1:
+                    yield 1
+                raise retry.RetryError
+            else:
+                if start_index <= 1:
+                    yield 1
+            if start_index <= 2:
+                yield 2
+
+        failcounter = 0
+        kw = {"kwcheck": True, "retry_timeout": sufficient_timeout}
+        self.assertEqual(list(method(True, **kw)), [0, 1, 2])
+
+        failcounter = 0
+        kw = {
+            "kwcheck": True,
+            "retry_timeout": insufficient_timeout,
+        }
+        with self.assertRaises(retry.RetryTimeoutError):
+            list(method(True, **kw))
+
+    def test_retry_wrong_generator(self):
+        with self.assertRaises(TypeError):
+
+            @retry.retry()
+            def method():
+                yield from range(3)


### PR DESCRIPTION
We already had retry decorators for functions and context managers

```python
@retry()
def method(...):
    ....

@retry_contextmanager()
def method(...):
    yield ...
```

This PR adds a decorator for generator functions

```python
@retry()
def method(...):
    yield ...
    yield ...
```