### PR TITLE
silx.io.dictdump: Added support of `pint` in `dicttoh5` and `dicttonx`

### DIFF
--- a/src/silx/io/dictdump.py
+++ b/src/silx/io/dictdump.py
@@ -460,6 +460,7 @@ def nexus_to_h5_dict(
                     value = h5py.SoftLink(first)
             elif is_link(value):
                 key = key[1:]
+
         if isinstance(value, Mapping):
             # HDF5 group
             key_has_nx_class = add_nx_class and _has_nx_class(treedict, key)
@@ -468,9 +469,15 @@ def nexus_to_h5_dict(
                 parents=parents+(key,),
                 add_nx_class=add_nx_class,
                 has_nx_class=key_has_nx_class)
+
+        elif pint is not None and isinstance(value, pint.quantity.Quantity):
+            copy[key] = value.magnitude
+            copy[(key, "units")] = f"{value.units:~}"
+
         else:
             # HDF5 dataset or link
             copy[key] = value
+
     if add_nx_class and not has_nx_class:
         _ensure_nx_class(copy, parents)
     return copy

--- a/src/silx/io/dictdump.py
+++ b/src/silx/io/dictdump.py
@@ -30,8 +30,11 @@ import json
 import logging
 import numpy
 import os.path
-import sys
 import h5py
+try:
+    import pint
+except ImportError:
+    pint = None
 
 from .configdict import ConfigDict
 from .utils import is_group
@@ -64,6 +67,8 @@ def _prepare_hdf5_write_value(array_like):
         ``numpy.array()`` (`str`, `list`, `numpy.ndarray`…)
     :return: ``numpy.ndarray`` ready to be written as an HDF5 dataset
     """
+    if pint is not None and isinstance(array_like, pint.quantity.Quantity):
+        return numpy.array(array_like.magnitude)
     array = numpy.asarray(array_like)
     if numpy.issubdtype(array.dtype, numpy.bytes_):
         return numpy.array(array_like, dtype=vlen_bytes)

--- a/src/silx/io/dictdump.py
+++ b/src/silx/io/dictdump.py
@@ -472,7 +472,7 @@ def nexus_to_h5_dict(
 
         elif pint is not None and isinstance(value, pint.quantity.Quantity):
             copy[key] = value.magnitude
-            copy[(key, "units")] = f"{value.units:~}"
+            copy[(key, "units")] = f"{value.units:~C}"
 
         else:
             # HDF5 dataset or link

--- a/src/silx/io/test/test_dictdump.py
+++ b/src/silx/io/test/test_dictdump.py
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2016-2021 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -26,15 +26,21 @@ __authors__ = ["P. Knobel"]
 __license__ = "MIT"
 __date__ = "17/01/2018"
 
-from collections import OrderedDict
-import numpy
+
+from collections import defaultdict, OrderedDict
+from copy import deepcopy
+from io import BytesIO
 import os
 import tempfile
 import unittest
-import h5py
-from copy import deepcopy
 
-from collections import defaultdict
+import h5py
+import numpy
+try:
+    import pint
+except ImportError:
+    pint = None
+import pytest
 
 from silx.utils.testutils import LoggingValidator
 
@@ -45,6 +51,13 @@ from ..dictdump import h5todict, load
 from ..dictdump import logger as dictdump_logger
 from ..utils import is_link
 from ..utils import h5py_read_dataset
+
+
+@pytest.fixture
+def tmp_h5py_file():
+    with BytesIO() as buffer:
+        with h5py.File(buffer, mode="w") as h5file:
+            yield h5file
 
 
 def tree():
@@ -509,6 +522,22 @@ class TestDictToH5(H5DictTestCase):
         etreedict["group2"]["subgroup2"] = dict()
         etreedict["group2"]["subgroup2"]["dset2"] = dict()
         assert_append("replace")
+
+
+@pytest.mark.skipif(pint is None, reason="Require pint")
+def test_dicttoh5_pint(tmp_h5py_file):
+    ureg = pint.UnitRegistry()
+    treedict = {
+        "array_mm": pint.Quantity([1, 2, 3], ureg.mm),
+        "value_kg": 3 * ureg.kg,
+    }
+
+    dicttoh5(treedict, tmp_h5py_file)
+
+    result = h5todict(tmp_h5py_file)
+    assert set(treedict.keys()) == set(result.keys())
+    for key, value in treedict.items():
+        assert numpy.array_equal(result[key], value.magnitude)
 
 
 class TestH5ToDict(H5DictTestCase):

--- a/src/silx/io/test/test_dictdump.py
+++ b/src/silx/io/test/test_dictdump.py
@@ -841,7 +841,7 @@ def test_dicttonx_pint(tmp_h5py_file):
     result = dictdump.nxtodict(tmp_h5py_file)
     for key, value in treedict.items():
         assert numpy.array_equal(result[key], value.magnitude)
-        assert result[f"{key}@units"] == f"{value.units:~}"
+        assert result[f"{key}@units"] == f"{value.units:~C}"
 
 
 class TestNxToDict(H5DictTestCase):

--- a/src/silx/io/test/test_dictdump.py
+++ b/src/silx/io/test/test_dictdump.py
@@ -828,6 +828,22 @@ class TestDictToNx(H5DictTestCase):
         assert_append("replace", add_nx_class=True)
 
 
+@pytest.mark.skipif(pint is None, reason="Require pint")
+def test_dicttonx_pint(tmp_h5py_file):
+    ureg = pint.UnitRegistry()
+    treedict = {
+        "array_mm": pint.Quantity([1, 2, 3], ureg.mm),
+        "value_kg": 3 * ureg.kg,
+    }
+
+    dictdump.dicttonx(treedict, tmp_h5py_file)
+
+    result = dictdump.nxtodict(tmp_h5py_file)
+    for key, value in treedict.items():
+        assert numpy.array_equal(result[key], value.magnitude)
+        assert result[f"{key}@units"] == f"{value.units:~}"
+
+
 class TestNxToDict(H5DictTestCase):
     def setUp(self):
         self.tempdir = tempfile.mkdtemp()


### PR DESCRIPTION

f24df26ad86f3a470c04fdaa1da5e884260223f4: This PR avoids warnings when passing `pint.Quantity` to `dicttoh5` by using the `.magnitude`.

641c0d0fb5b2008820bf1c9f334a849bf67f6c4f: This PR also proposes to store `pint` units as `@units` HDF5 attributes when calling `dicttonx`.
There is an issue here since [pint units string formatting](https://pint.readthedocs.io/en/stable/formatting.html#unit-format-specifications) is not strictly compatible with NeXus (see https://manual.nexusformat.org/nxdl-types.html?highlight=units#unit-categories-allowed-in-nxdl-specifications, https://manual.nexusformat.org/datarules.html#nexus-data-units): For example power is either `**` or `^`. BTW does anyone have a link to the specification of Nexus units format?

What do you think? Should I remove support in `dicttonx`?

attn @sdebionne 
