### PR TITLE
Allow to check AA_ShareOpenGLContexts in isOpenGLAvailable

### DIFF
--- a/src/silx/gui/utils/glutils/__init__.py
+++ b/src/silx/gui/utils/glutils/__init__.py
@@ -51,14 +51,15 @@ class _isOpenGLAvailableResult:
         return '<_isOpenGLAvailableResult: %s, "%s">' % (self.status, self.error)
 
 
-def _runtimeOpenGLCheck(version):
+def _runtimeOpenGLCheck(version, shareOpenGLContexts):
     """Run OpenGL check in a subprocess.
 
     This is done by starting a subprocess that displays a Qt OpenGL widget.
 
     :param List[int] version:
         The minimal required OpenGL version as a 2-tuple (major, minor).
-        Default: (2, 1)
+    :param bool shareOpenGLContexts:
+        True to test the `QApplication` with `AA_ShareOpenGLContexts`.
     :return: An error string that is empty if no error occured
     :rtype: str
     """
@@ -68,10 +69,10 @@ def _runtimeOpenGLCheck(version):
         [os.path.abspath(p) for p in sys.path])
 
     try:
-        error = subprocess.check_output(
-            [sys.executable, '-s', '-S', __file__, major, minor],
-            env=env,
-            timeout=2)
+        cmd = [sys.executable, '-s', '-S', __file__, major, minor]
+        if shareOpenGLContexts:
+            cmd.append("--shareOpenGLContexts")
+        error = subprocess.check_output(cmd, env=env, timeout=2)
     except subprocess.TimeoutExpired:
         status = False
         error = "Qt OpenGL widget hang"
@@ -89,7 +90,7 @@ def _runtimeOpenGLCheck(version):
 _runtimeCheckCache = {}  # Cache runtime check results: {version: result}
 
 
-def isOpenGLAvailable(version=(2, 1), runtimeCheck=True):
+def isOpenGLAvailable(version=(2, 1), shareOpenGLContexts=False, runtimeCheck=True):
     """Check if OpenGL is available through Qt and actually working.
 
     After some basic tests, this is done by starting a subprocess that
@@ -98,6 +99,10 @@ def isOpenGLAvailable(version=(2, 1), runtimeCheck=True):
     :param List[int] version:
         The minimal required OpenGL version as a 2-tuple (major, minor).
         Default: (2, 1)
+    :param bool shareOpenGLContexts:
+        True to test the `QApplication` with `AA_ShareOpenGLContexts`.
+        This only can be checked with `runtimeCheck` enabled.
+        Default is false.
     :param bool runtimeCheck:
         True (default) to run the test creating a Qt OpenGL widgt in a subprocess,
         False to avoid this check.
@@ -130,12 +135,13 @@ def isOpenGLAvailable(version=(2, 1), runtimeCheck=True):
 
     result = _isOpenGLAvailableResult(error == '', error)
 
+    keyCache = version, shareOpenGLContexts
     if result:  # No error so far, runtime check
         if version in _runtimeCheckCache:  # Use cache
-            result = _runtimeCheckCache[version]
+            result = _runtimeCheckCache[keyCache]
         elif runtimeCheck:  # Run test in subprocess
-            result = _runtimeOpenGLCheck(version)
-            _runtimeCheckCache[version] = result
+            result = _runtimeOpenGLCheck(version, shareOpenGLContexts)
+            _runtimeCheckCache[keyCache] = result
 
     return result
 
@@ -177,9 +183,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('major')
     parser.add_argument('minor')
+    parser.add_argument('--shareOpenGLContexts', action="store_true")
 
     args = parser.parse_args(args=sys.argv[1:])
 
+    if args.shareOpenGLContexts:
+        qt.QCoreApplication.setAttribute(qt.Qt.AA_ShareOpenGLContexts)
     app = qt.QApplication([])
     window = qt.QMainWindow(flags=
         qt.Qt.Popup |

--- a/src/silx/gui/utils/glutils/__init__.py
+++ b/src/silx/gui/utils/glutils/__init__.py
@@ -90,7 +90,7 @@ def _runtimeOpenGLCheck(version, shareOpenGLContexts):
 _runtimeCheckCache = {}  # Cache runtime check results: {version: result}
 
 
-def isOpenGLAvailable(version=(2, 1), shareOpenGLContexts=False, runtimeCheck=True):
+def isOpenGLAvailable(version=(2, 1), runtimeCheck=True, shareOpenGLContexts=False):
     """Check if OpenGL is available through Qt and actually working.
 
     After some basic tests, this is done by starting a subprocess that
@@ -104,7 +104,7 @@ def isOpenGLAvailable(version=(2, 1), shareOpenGLContexts=False, runtimeCheck=Tr
         This only can be checked with `runtimeCheck` enabled.
         Default is false.
     :param bool runtimeCheck:
-        True (default) to run the test creating a Qt OpenGL widgt in a subprocess,
+        True (default) to run the test creating a Qt OpenGL widget in a subprocess,
         False to avoid this check.
     :return: A result object that evaluates to True if successful and
         which has a `status` boolean attribute (True if successful) and
@@ -137,7 +137,7 @@ def isOpenGLAvailable(version=(2, 1), shareOpenGLContexts=False, runtimeCheck=Tr
 
     keyCache = version, shareOpenGLContexts
     if result:  # No error so far, runtime check
-        if version in _runtimeCheckCache:  # Use cache
+        if keyCache in _runtimeCheckCache:  # Use cache
             result = _runtimeCheckCache[keyCache]
         elif runtimeCheck:  # Run test in subprocess
             result = _runtimeOpenGLCheck(version, shareOpenGLContexts)

--- a/src/silx/gui/utils/test/test_glutils.py
+++ b/src/silx/gui/utils/test/test_glutils.py
@@ -29,26 +29,24 @@ __date__ = "15/01/2020"
 
 
 import logging
-import unittest
+import pytest
+
 from silx.gui.utils.glutils import isOpenGLAvailable
 
 
 _logger = logging.getLogger(__name__)
 
 
-class TestIsOpenGLAvailable(unittest.TestCase):
-    """Test isOpenGLAvailable"""
-
-    def test(self):
-        for version in ((2, 1), (2, 1), (1000, 1)):
-            with self.subTest(version=version):
-                result = isOpenGLAvailable(version=version)
-                _logger.info("isOpenGLAvailable returned: %s", str(result))
-                if version[0] == 1000:
-                    self.assertFalse(result)
-                if not result:
-                    self.assertFalse(result.status)
-                    self.assertTrue(len(result.error) > 0)
-                else:
-                    self.assertTrue(result.status)
-                    self.assertTrue(len(result.error) == 0)
+@pytest.mark.parametrize("params", (((2, 1), False), ((2, 1), False), ((1000, 1), False), ((2, 1), True)))
+def testOpenGLAvailable(params):
+    version, shareOpenGLContexts = params
+    result = isOpenGLAvailable(version=version, shareOpenGLContexts=shareOpenGLContexts)
+    _logger.info("isOpenGLAvailable returned: %s", str(result))
+    if version[0] == 1000:
+        assert not result
+    if not result:
+        assert not result.status
+        assert len(result.error) > 0
+    else:
+        assert result.status
+        assert len(result.error) == 0


### PR DESCRIPTION
Allow to check `AA_ShareOpenGLContexts` in `isOpenGLAvailable`

Default is false.

Changelog: 
- Allow to check AA_ShareOpenGLContexts in isOpenGLAvailable