### PR TITLE
Eventless OpenCL profiling

### DIFF
--- a/src/silx/opencl/processing.py
+++ b/src/silx/opencl/processing.py
@@ -331,24 +331,21 @@ class OpenclProcessing(object):
             for event_desc in event_lists:
                 if isinstance(event_desc, ProfileDescsription):
                     self.events.append(event_desc)
-
                 else:
                     if isinstance(event_desc, EventDescription):
                         desc, event = event_desc
-                        try:
-                            profile = event.profile
-                            start = profile.start
-                            end = profile.end
-                        except Exception:
-                            continue
                     else:
-                        name = "?"
-                        try:
-                            start = e.profile.start
-                            end = e.profile.end
-                        except Exception:
-                            continue
-                    self.events.append(ProfileDescsription(desc, start, end))
+                        desc = "?"
+                        event = event_desc
+                    try:
+                        profile = event.profile
+                        start = profile.start
+                        end = profile.end
+                    except Exception:
+                        # probably an unfinished job ... use old-style.
+                        self.events.append(event_desc)
+                    else:
+                        self.events.append(ProfileDescsription(desc, start, end))
 
     def log_profile(self, stats=False):
         """If we are in profiling mode, prints out all timing for every single OpenCL call

--- a/src/silx/opencl/processing.py
+++ b/src/silx/opencl/processing.py
@@ -316,7 +316,7 @@ class OpenclProcessing(object):
         if self.profile:
             try:
                 profile = event.profile
-                self.events.append(ProfileDescsription(desc, profile.start, profile.end))
+                self.events.append(ProfileDescription(desc, profile.start, profile.end))
             except Exception:
                 # Probably the driver does not support profiling
                 pass

--- a/src/silx/opencl/processing.py
+++ b/src/silx/opencl/processing.py
@@ -53,7 +53,7 @@ import platform
 
 BufferDescription = namedtuple("BufferDescription", ["name", "size", "dtype", "flags"])
 EventDescription = namedtuple("EventDescription", ["name", "event"])  # Deprecated, please use ProfileDescsription
-ProfileDescsription = namedtuple("EventDescription", ["name", "start", "stop"])
+ProfileDescsription = namedtuple("ProfileDescsription", ["name", "start", "stop"])
 
 logger = logging.getLogger(__name__)
 
@@ -372,7 +372,7 @@ class OpenclProcessing(object):
                     name = e[0]
                     t0 = e[1]
                     t1 = e[2]
-                elif isinstance(e, ProfileDescsription):
+                elif isinstance(e, EventDescription):
                     name = e[0]
                     pr = e[1].profile
                     t0 = pr.start

--- a/src/silx/opencl/processing.py
+++ b/src/silx/opencl/processing.py
@@ -365,7 +365,7 @@ class OpenclProcessing(object):
 
         if self.profile:
             for e in self.events:
-                if isinstance(e, ProfileDescsription):
+                if isinstance(e, ProfileDescription):
                     name = e[0]
                     t0 = e[1]
                     t1 = e[2]

--- a/src/silx/opencl/processing.py
+++ b/src/silx/opencl/processing.py
@@ -52,8 +52,8 @@ from .utils import concatenate_cl_kernel
 import platform
 
 BufferDescription = namedtuple("BufferDescription", ["name", "size", "dtype", "flags"])
-EventDescription = namedtuple("EventDescription", ["name", "event"])  # Deprecated, please use ProfileDescsription
-ProfileDescsription = namedtuple("ProfileDescsription", ["name", "start", "stop"])
+EventDescription = namedtuple("EventDescription", ["name", "event"])  # Deprecated, please use ProfileDescription
+ProfileDescription = namedtuple("ProfileDescription", ["name", "start", "stop"])
 
 logger = logging.getLogger(__name__)
 

--- a/src/silx/opencl/processing.py
+++ b/src/silx/opencl/processing.py
@@ -329,7 +329,7 @@ class OpenclProcessing(object):
         """
         if self.profile:
             for event_desc in event_lists:
-                if isinstance(event_desc, ProfileDescsription):
+                if isinstance(event_desc, ProfileDescription):
                     self.events.append(event_desc)
                 else:
                     if isinstance(event_desc, EventDescription) or "__len__" in dir(e) and len(e) == 2:

--- a/src/silx/opencl/processing.py
+++ b/src/silx/opencl/processing.py
@@ -337,7 +337,7 @@ class OpenclProcessing(object):
                         desc, event = event_desc
                         try:
                             profile = event.profile
-                            start = profile.start,
+                            start = profile.start
                             end = profile.end
                         except Exception:
                             continue

--- a/src/silx/opencl/processing.py
+++ b/src/silx/opencl/processing.py
@@ -321,6 +321,35 @@ class OpenclProcessing(object):
                 # Probably the driver does not support profiling
                 pass
 
+    def profile_multi(self, event_lists):
+        """
+        Extract profiling info from several OpenCL event, if profiling is enabled.
+
+        :param event_lists: list of ("desc", pyopencl.NanyEvent).
+        """
+        if self.profile:
+            for event_desc in event_lists:
+                if isinstance(event_desc, ProfileDescsription):
+                    self.events.append(event_desc)
+
+                else:
+                    if isinstance(event_desc, EventDescription):
+                        desc, event = event_desc
+                        try:
+                            profile = event.profile
+                            start = profile.start,
+                            end = profile.end
+                        except Exception:
+                            continue
+                    else:
+                        name = "?"
+                        try:
+                            start = e.profile.start
+                            end = e.profile.end
+                        except Exception:
+                            continue
+                    self.events.append(ProfileDescsription(desc, start, end))
+
     def log_profile(self, stats=False):
         """If we are in profiling mode, prints out all timing for every single OpenCL call
         

--- a/src/silx/opencl/processing.py
+++ b/src/silx/opencl/processing.py
@@ -332,7 +332,7 @@ class OpenclProcessing(object):
                 if isinstance(event_desc, ProfileDescsription):
                     self.events.append(event_desc)
                 else:
-                    if isinstance(event_desc, EventDescription):
+                    if isinstance(event_desc, EventDescription) or "__len__" in dir(e) and len(e) == 2:
                         desc, event = event_desc
                     else:
                         desc = "?"
@@ -369,7 +369,7 @@ class OpenclProcessing(object):
                     name = e[0]
                     t0 = e[1]
                     t1 = e[2]
-                elif isinstance(e, EventDescription):
+                elif isinstance(e, EventDescription) or "__len__" in dir(e) and len(e) == 2:
                     name = e[0]
                     pr = e[1].profile
                     t0 = pr.start

--- a/src/silx/opencl/processing.py
+++ b/src/silx/opencl/processing.py
@@ -345,7 +345,7 @@ class OpenclProcessing(object):
                         # probably an unfinished job ... use old-style.
                         self.events.append(event_desc)
                     else:
-                        self.events.append(ProfileDescsription(desc, start, end))
+                        self.events.append(ProfileDescription(desc, start, end))
 
     def log_profile(self, stats=False):
         """If we are in profiling mode, prints out all timing for every single OpenCL call

--- a/src/silx/opencl/sift/test/test_image_setup.py
+++ b/src/silx/opencl/sift/test/test_image_setup.py
@@ -35,7 +35,7 @@ __authors__ = ["Jérôme Kieffer", "Pierre Paleo"]
 __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"
 __copyright__ = "2013 European Synchrotron Radiation Facility, Grenoble, France"
-__date__ = "25/06/2018"
+__date__ = "06/10/2022"
 
 import numpy
 try:
@@ -59,8 +59,8 @@ def my_blur(img, sigma):
     x = numpy.arange(ksize) - (ksize - 1.0) / 2.0
     gaussian = numpy.exp(-(x / sigma) ** 2 / 2.0).astype(numpy.float32)
     gaussian /= gaussian.sum(dtype=numpy.float32)
-    tmp1 = scipy.ndimage.filters.convolve1d(img, gaussian, axis=-1, mode="reflect")
-    return scipy.ndimage.filters.convolve1d(tmp1, gaussian, axis=0, mode="reflect")
+    tmp1 = scipy.ndimage.convolve1d(img, gaussian, axis=-1, mode="reflect")
+    return scipy.ndimage.convolve1d(tmp1, gaussian, axis=0, mode="reflect")
 
 
 def local_maxmin_setup():
@@ -92,7 +92,7 @@ def local_maxmin_setup():
         # Blurs and DoGs pre-allocating
         g = (numpy.zeros(6 * height * width).astype(numpy.float32)).reshape(6, height, width)  # vector of 6 blurs
         DOGS = numpy.zeros((5, height, width), dtype=numpy.float32)  # vector of 5 DoGs
-        g[0, :, :] = numpy.copy(l)
+        g[0,:,:] = numpy.copy(l)
         '''
         sift.cpp pre-process
         '''
@@ -105,9 +105,9 @@ def local_maxmin_setup():
             # Convolving initial image to achieve std = initsigma = 1.6
             if (initsigma > cursigma):
                 sigma = numpy.sqrt(initsigma ** 2 - cursigma ** 2)
-                g[0, :, :] = my_blur(l, sigma)
+                g[0,:,:] = my_blur(l, sigma)
         else:
-            g[0, :, :] = numpy.copy(l)
+            g[0,:,:] = numpy.copy(l)
         '''
         Blurs and DoGs
         '''
@@ -152,7 +152,7 @@ def orientation_setup():
     # actual_nb_keypoints = numpy.int32(len((keypoints_prev[:,0])[keypoints_prev[:,1] != -1]))
     ref = numpy.copy(keypoints_prev)
     # There are actually less than "actual_nb_keypoints" keypoints ("holes" in the vector), but we can use it as a boundary
-    for i, k in enumerate(ref[:actual_nb_keypoints, :]):
+    for i, k in enumerate(ref[:actual_nb_keypoints,:]):
         ref[i] = my_interp_keypoint(DOGS, s, k[1], k[2], 5, peakthresh, width, height)
 
     grad, ori = my_gradient(blur)  # gradient is applied on blur[s]


### PR DESCRIPTION
A memory leak was found when keeping all events from PyOpenCL for profiling purposes.
https://github.com/inducer/pyopencl/issues/625

This PR extracts earlier the timing info to avoid keeping references on input buffers.

Changelog: 
New OpenCL profiling (fix memory leak)
