### PR TITLE
silx.gui.qt: Raise exception when using PyQt5 incompatible with Python 3.10

### DIFF
--- a/src/silx/gui/qt/_qt.py
+++ b/src/silx/gui/qt/_qt.py
@@ -90,6 +90,11 @@ else:  # Then try Qt bindings
 
 if BINDING == 'PyQt5':
     _logger.debug('Using PyQt5 bindings')
+    from PyQt5 import QtCore
+    if sys.version_info >= (3, 10) and QtCore.PYQT_VERSION < 0x50e02:
+        raise RuntimeError(
+            "PyQt5 v%s is not supported, please upgrade it." % QtCore.PYQT_VERSION_STR
+        )
 
     import PyQt5 as QtBinding  # noqa
 


### PR DESCRIPTION
This raise a clear exception early rather than waiting for other exceptions later.

closes #3618