### PR TITLE
silx.gui.plot.PlotWidget: Fixed OpenGL rendering

### DIFF
--- a/ci/requirements-pinned.txt
+++ b/ci/requirements-pinned.txt
@@ -9,3 +9,6 @@ pybind11  # Required to build pyopencl
 # Anyway, we don't test OpenCL on appveyor
 pyopencl == 2020.3.1; sys_platform == 'win32' and python_version < '3.8'
 pyopencl == 2022.1.6; sys_platform == 'win32' and python_version >= '3.8'
+
+# Workaround https://github.com/matplotlib/matplotlib/issues/24155
+PySide6<6.4.0

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -614,17 +614,15 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
                     # For now simple implementation: using a curve for each marker
                     # Should pack all markers to a single set of points
-                    markerCurve = glutils.GLPlotCurve2D(
-                        numpy.array((pixelPos[0],), dtype=numpy.float64),
-                        numpy.array((pixelPos[1],), dtype=numpy.float64),
-                        lineStyle=None,
+                    marker = glutils.Points2D(
+                        (pixelPos[0],),
+                        (pixelPos[1],),
                         marker=item['symbol'],
-                        markerColor=item['color'],
-                        markerSize=11)
-
+                        color=item['color'],
+                        size=11,
+                    )
                     context.matrix = self.matScreenProj
-                    markerCurve.render(context)
-                    markerCurve.discard()
+                    marker.render(context)
 
             else:
                 _logger.error('Unsupported item: %s', str(item))

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -617,15 +617,12 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                     markerCurve = glutils.GLPlotCurve2D(
                         numpy.array((pixelPos[0],), dtype=numpy.float64),
                         numpy.array((pixelPos[1],), dtype=numpy.float64),
+                        lineStyle=None,
                         marker=item['symbol'],
                         markerColor=item['color'],
                         markerSize=11)
 
-                    context = glutils.RenderContext(
-                        matrix=self.matScreenProj,
-                        isXLog=False,
-                        isYLog=False,
-                        dpi=self.getDotsPerInch())
+                    context.matrix = self.matScreenProj
                     markerCurve.render(context)
                     markerCurve.discard()
 

--- a/src/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -901,8 +901,6 @@ class _Points2D(object):
 
         gl.glDrawArrays(gl.GL_POINTS, 0, self.xVboData.size)
 
-        gl.glUseProgram(0)
-
 
 # error bars ##################################################################
 


### PR DESCRIPTION
This PR changes the way anchors are rendered which was causing issues with some GPUs.

It is now passing vertex attributes directly from memory (the old way) as the other rendering do rather than creating/deleting a vertex buffer object.

closes #3681