### PR TITLE
silx.gui.plot.PlotWidget: Fixed OpenGL empty text rendering

### DIFF
--- a/src/silx/gui/_glutils/font.py
+++ b/src/silx/gui/_glutils/font.py
@@ -147,8 +147,11 @@ def rasterTextQt(text, font, size=-1, weight=-1, italic=False, devicePixelRatio=
 
     # Remove leading and trailing empty columns/rows but one on each side
     filled_rows = numpy.nonzero(numpy.sum(array, axis=1))[0]
-    min_row = max(0, filled_rows[0] - 1)
     filled_columns = numpy.nonzero(numpy.sum(array, axis=0))[0]
+    if len(filled_rows) == 0 or len(filled_columns) == 0:
+        return array, metrics.ascent()
+
+    min_row = max(0, filled_rows[0] - 1)
     array = array[
         min_row : filled_rows[-1] + 2,
         max(0, filled_columns[0] - 1) : filled_columns[-1] + 2,

--- a/src/silx/gui/plot/backends/glutils/GLText.py
+++ b/src/silx/gui/plot/backends/glutils/GLText.py
@@ -240,7 +240,7 @@ class Text2D(object):
         return vertices
 
     def render(self, matrix):
-        if not self.text:
+        if not self.text.strip():
             return
 
         prog = self._program

--- a/src/silx/gui/utils/matplotlib.py
+++ b/src/silx/gui/utils/matplotlib.py
@@ -115,6 +115,9 @@ def rasterMathText(text, font, size=-1, weight=-1, italic=False, devicePixelRati
     # Remove leading and trailing empty columns/rows but one on each side
     filled_rows = numpy.nonzero(numpy.sum(array, axis=1))[0]
     filled_columns = numpy.nonzero(numpy.sum(array, axis=0))[0]
+    if len(filled_rows) == 0 or len(filled_columns) == 0:
+        return array, image.shape[0] - 1
+
     clipped_array = numpy.ascontiguousarray(
         array[
             max(0, filled_rows[0] - 1) : filled_rows[-1] + 2,


### PR DESCRIPTION
This is fixed at 2 levels: 
- Make raster text functions works with whitespace only strings
- Do not render whitespace only text in plot

closes  #3700