### PR TITLE
silx.gui.plot: Updated `BandROI` item

### DIFF
--- a/src/silx/gui/plot/items/_band_roi.py
+++ b/src/silx/gui/plot/items/_band_roi.py
@@ -278,19 +278,20 @@ class BandROI(HandleBasedROI, items.LineMixIn):
         )
 
     def handleDragUpdated(self, handle, origin, previous, current):
-        geometry = self.getGeometry()
-        delta = current - previous
         if handle is self.__handleBegin:
-            self.__updateGeometry(current, geometry.end - delta)
+            self.__updateGeometry(begin=current)
             return
         if handle is self.__handleEnd:
-            self.__updateGeometry(geometry.begin - delta, current)
+            self.__updateGeometry(end=current)
             return
         if handle is self.__handleCenter:
+            geometry = self.getGeometry()
+            delta = current - previous
             self.__updateGeometry(geometry.begin + delta, geometry.end + delta)
             return
         if handle in (self.__handleWidthUp, self.__handleWidthDown):
-            offset = numpy.dot(geometry.normal, delta)
+            geometry = self.getGeometry()
+            offset = numpy.dot(geometry.normal, current - previous)
             if handle is self.__handleWidthDown:
                 offset *= -1
             self.__updateGeometry(

--- a/src/silx/gui/plot/items/_band_roi.py
+++ b/src/silx/gui/plot/items/_band_roi.py
@@ -25,7 +25,7 @@
 
 import functools
 import logging
-from typing import List, NamedTuple, Optional, Sequence, Tuple
+from typing import Iterable, List, NamedTuple, Optional, Sequence, Tuple
 import numpy
 
 from ... import utils
@@ -143,11 +143,15 @@ class BandROI(HandleBasedROI, items.LineMixIn, InteractionModeMixIn):
     """Plot shape which is used for the first interaction"""
 
     BoundedMode = RoiInteractionMode("Bounded", "Band is bounded on both sides")
+    """Interaction mode for a rectangular band ROI"""
+
     UnboundedMode = RoiInteractionMode("Unbounded", "Band is unbounded on both sides")
+    """Interaction mode for unlimited band ROI """
 
     def __init__(self, parent=None):
         HandleBasedROI.__init__(self, parent=parent)
         items.LineMixIn.__init__(self)
+        self.__availableInteractionModes = set((self.BoundedMode, self.UnboundedMode))
         InteractionModeMixIn.__init__(self)
 
         self.__handleBegin = self.addHandle()
@@ -188,7 +192,20 @@ class BandROI(HandleBasedROI, items.LineMixIn, InteractionModeMixIn):
 
     def availableInteractionModes(self) -> List[RoiInteractionMode]:
         """Returns the list of available interaction modes"""
-        return [self.BoundedMode, self.UnboundedMode]
+        return list(self.__availableInteractionModes)
+
+    def setAvailableInteractionModes(self, modes: Iterable[RoiInteractionMode]) -> None:
+        """Allows to restrict interaction modes of the ROI.
+
+        :param modes: Subset of BandROI interaction modes:
+            :attr:`BoundedMode` and :attr:`UnboundedMode`.
+        """
+        modes = set(modes)
+        if not modes <= set((self.BoundedMode, self.UnboundedMode)):
+            raise ValueError("Unsupported interaction modes")
+        self.__availableInteractionModes = set(modes)
+        if self.getInteractionMode() not in self.__availableInteractionModes:
+            self.setInteractionMode(self.availableInteractionModes()[0])
 
     def _interactiveModeUpdated(self, modeId: RoiInteractionMode):
         """Set the interaction mode."""

--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -242,6 +242,8 @@ class Item(qt.QObject):
             # When visibility has changed, always mark as dirty
             self._updated(ItemChangedType.VISIBLE,
                           checkVisibility=False)
+            if visible:
+                self._visibleBoundsChanged()
 
     def isOverlay(self):
         """Return true if item is drawn as an overlay.

--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -492,7 +492,8 @@ class DataItem(Item):
         :param bool checkVisibility:
         """
         if not checkVisibility or self.isVisible():
-            self._visibleBoundsChanged()
+            if self.isVisible():
+                self._visibleBoundsChanged()
 
             # TODO hackish data range implementation
             plot = self.getPlot()

--- a/src/silx/gui/plot/tools/test/testROI.py
+++ b/src/silx/gui/plot/tools/test/testROI.py
@@ -707,7 +707,7 @@ class TestRegionOfInterestManager(TestCaseQt, ParametricTestCase):
         self.qapp.processEvents()
 
         # Initial state
-        self.assertIs(item.getInteractionMode(), roi_items.BandROI.BoundedMode)
+        assert item.getInteractionMode() is roi_items.BandROI.BoundedMode
         self.qWait(500)
 
         # Click on the center
@@ -718,13 +718,23 @@ class TestRegionOfInterestManager(TestCaseQt, ParametricTestCase):
         self.mouseMove(widget, pos=(mx, my))
         self.mouseClick(widget, qt.Qt.LeftButton, pos=(mx, my))
         self.qWait(500)
-        self.assertIs(item.getInteractionMode(), roi_items.BandROI.BoundedMode)
+        assert item.getInteractionMode() is roi_items.BandROI.BoundedMode
 
         # Change the mode
         self.mouseMove(widget, pos=(mx, my))
         self.mouseClick(widget, qt.Qt.LeftButton, pos=(mx, my))
         self.qWait(500)
-        self.assertIs(item.getInteractionMode(), roi_items.BandROI.UnboundedMode)
+        assert item.getInteractionMode() is roi_items.BandROI.UnboundedMode
+
+        # Set available modes that exclude the current one
+        item.setAvailableInteractionModes([roi_items.BandROI.BoundedMode])
+        assert item.getInteractionMode() is roi_items.BandROI.BoundedMode
+
+        # Clicking does not change the mode since there is only one
+        self.mouseMove(widget, pos=(mx, my))
+        self.mouseClick(widget, qt.Qt.LeftButton, pos=(mx, my))
+        self.qWait(500)
+        assert item.getInteractionMode() is roi_items.BandROI.BoundedMode
 
         manager.clear()
         self.qapp.processEvents()

--- a/src/silx/gui/plot/tools/test/testROI.py
+++ b/src/silx/gui/plot/tools/test/testROI.py
@@ -267,6 +267,12 @@ class TestRoiItems(TestCaseQt):
         self.assertAlmostEqual(item.getMax(), vmax)
         self.assertAlmostEqual(item.getCenter(), 2)
 
+    def testBand_getToSetGeometry(self):
+        """Test that we can use getGeometry as input to setGeometry"""
+        item = roi_items.BandROI()
+        item.setFirstShapePoints(numpy.array([[5, 10], [50, 100]]))
+        item.setGeometry(*item.getGeometry())
+
 
 class TestRegionOfInterestManager(TestCaseQt, ParametricTestCase):
     """Tests for RegionOfInterestManager class"""
@@ -676,6 +682,49 @@ class TestRegionOfInterestManager(TestCaseQt, ParametricTestCase):
         self.mouseClick(widget, qt.Qt.LeftButton, pos=(mx, my))
         self.qWait(500)
         self.assertIs(item.getInteractionMode(), roi_items.ArcROI.PolarMode)
+
+        manager.clear()
+        self.qapp.processEvents()
+
+    def testBandRoiSwitchMode(self):
+        """Make sure we can switch mode by clicking on the ROI"""
+        xlimit = self.plot.getXAxis().getLimits()
+        ylimit = self.plot.getYAxis().getLimits()
+        xcenter = 0.5 * (xlimit[0] + xlimit[1])
+        ycenter = 0.5 * (ylimit[0] + ylimit[1])
+
+        # Create the line
+        manager = roi.RegionOfInterestManager(self.plot)
+        item = roi_items.BandROI()
+        item.setGeometry(
+            (xlimit[0], ycenter),
+            (xlimit[1], ycenter),
+            20,
+        )
+        item.setEditable(True)
+        item.setSelectable(True)
+        manager.addRoi(item)
+        self.qapp.processEvents()
+
+        # Initial state
+        self.assertIs(item.getInteractionMode(), roi_items.BandROI.BoundedMode)
+        self.qWait(500)
+
+        # Click on the center
+        widget = self.plot.getWidgetHandle()
+        mx, my = self.plot.dataToPixel(xcenter, ycenter)
+
+        # Select the ROI
+        self.mouseMove(widget, pos=(mx, my))
+        self.mouseClick(widget, qt.Qt.LeftButton, pos=(mx, my))
+        self.qWait(500)
+        self.assertIs(item.getInteractionMode(), roi_items.BandROI.BoundedMode)
+
+        # Change the mode
+        self.mouseMove(widget, pos=(mx, my))
+        self.mouseClick(widget, qt.Qt.LeftButton, pos=(mx, my))
+        self.qWait(500)
+        self.assertIs(item.getInteractionMode(), roi_items.BandROI.UnboundedMode)
 
         manager.clear()
         self.qapp.processEvents()


### PR DESCRIPTION
This PR addresses post-merge comments on PR #3680 (https://github.com/silx-kit/silx/pull/3680#issuecomment-1282635661 and https://github.com/silx-kit/silx/issues/3638#issuecomment-1284199029), it:
- Adds some basic tests
- Changes the rotation center from the center of the ROI to the other edge
- Inherits from `InteractionModeMixIn` in order to integrate the bounds mode change with context menu, click on selection ROI,.... This also allows to extend later for half-bounded ROI.

I also added a `setAvailableInteractionModes` so from the code, one can force the user to do either bounded or unbounded ROIs. This can be put in the `InteractionModeMixIn` so the `ArcROI` can also benefit from it.. but being close to the release I choose not to change the existing ROI, this can be done later if needed.

attn @kklmn
