### PR TITLE
Dropped python 3.6 support, Removed CI for `PySide2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         include:
           - name-suffix: "PySide2 sdist"
             os: ubuntu-20.04
-            python-version: '3.6'
+            python-version: '3.7'
             BUILD_COMMAND: sdist
             QT_BINDING: PySide2
             RUN_TESTS_OPTIONS: --qt-binding=PySide2 --no-opengl --low-mem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - name-suffix: "PySide2 sdist"
-            os: ubuntu-20.04
-            python-version: '3.7'
-            BUILD_COMMAND: sdist
-            QT_BINDING: PySide2
-            RUN_TESTS_OPTIONS: --qt-binding=PySide2 --no-opengl --low-mem
-
           - name-suffix: "PyQt5 sdist"
             os: ubuntu-20.04
             python-version: '3.7'
@@ -131,9 +124,6 @@ jobs:
             pip install -r ci/requirements-pinned.txt;
           fi
           pip install --pre -r requirements.txt
-          if [ "${{ matrix.QT_BINDING }}" == "PySide2" ]; then
-            pip install --pre pyside2;
-          fi
           if [ "${{ matrix.QT_BINDING }}" == "PySide6" ]; then
             pip install --pre pyside6;
           fi

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -30,12 +30,6 @@ environment:
           WITH_GL_TEST: True
           PIP_OPTIONS: "-q --pre"
 
-        # Python 3.8
-        - PYTHON_DIR: "C:\\Python38-x64"
-          QT_BINDING: "PySide2"
-          WITH_GL_TEST: True
-          PIP_OPTIONS: "-q"
-
         # Python 3.7
         - PYTHON_DIR: "C:\\Python37-x64"
           QT_BINDING: "PySide6"

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -24,8 +24,8 @@ environment:
         VENV_TEST_DIR: "venv_test"
 
     matrix:
-        # Python 3.6
-        - PYTHON_DIR: "C:\\Python36-x64"
+        # Python 3.8
+        - PYTHON_DIR: "C:\\Python38-x64"
           QT_BINDING: "PyQt5"
           WITH_GL_TEST: True
           PIP_OPTIONS: "-q --pre"

--- a/ci/info_platform.py
+++ b/ci/info_platform.py
@@ -60,7 +60,7 @@ else:
                 print("    %s max_workgroup_size is %s" % (d, d.max_work_group_size))
 
 
-for binding_name in ("PyQt5", "PySide2", "PySide6", "PyQt6"):
+for binding_name in ("PyQt5", "PySide6", "PyQt6"):
     # Check Qt version in subprocess to avoid issues with importing multiple Qt bindins
     cmd = [
         sys.executable,

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -10,11 +10,11 @@ This table summarizes the support matrix of silx:
 +------------+--------------+-----------------------------+
 | System     | Python vers. | Qt and its bindings         |
 +------------+--------------+-----------------------------+
-| `Windows`_ | 3.6-3.9      | PyQt5.6+, PySide6, PyQt6.3+ |
+| `Windows`_ | 3.7-3.10     | PyQt5.6+, PySide6, PyQt6.3+ |
 +------------+--------------+-----------------------------+
-| `MacOS`_   | 3.6-3.9      | PyQt5.6+, PySide6, PyQt6.3+ |
+| `MacOS`_   | 3.7-3.10     | PyQt5.6+, PySide6, PyQt6.3+ |
 +------------+--------------+-----------------------------+
-| `Linux`_   | 3.6-3.9      | PyQt5.3+, PySide6, PyQt6.3+ |
+| `Linux`_   | 3.7-3.10     | PyQt5.3+, PySide6, PyQt6.3+ |
 +------------+--------------+-----------------------------+
 
 For the description of *silx* dependencies, see the Dependencies_ section.

--- a/doc/source/license.rst
+++ b/doc/source/license.rst
@@ -15,7 +15,7 @@ Note:
   silx uses the Qt library for its graphical user interfaces.
   A word of caution is to be provided.
   If users develop and distribute software using modules accessing Qt by means of Riverbank Computing Qt bindings PyQt4 or PyQt5, those users will be conditioned by the license of their PyQt4/5 software (GPL or commercial).
-  If the end user does not own a commercial license of PyQt4 or PyQt5 and wishes to be free of any distribution condition, (s)he should be able to use PySide2 because it uses the LGPL license.
+  If the end user does not own a commercial license of PyQt4 or PyQt5 and wishes to be free of any distribution condition, (s)he should be able to use PySide6 because it uses the LGPL license.
 
 The following list provides the copyright and license of the different source files of the project:
 

--- a/doc/source/modules/gui/plot/getting_started.rst
+++ b/doc/source/modules/gui/plot/getting_started.rst
@@ -20,8 +20,6 @@ For a complete description of the API, see :mod:`silx.gui.plot`.
 Use :mod:`silx.gui.plot` from (I)Python console
 -----------------------------------------------
 
-We recommend to use (I)Python >=3.6 and PyQt5.
-
 From a Python or IPython interpreter, the simplest way is to import the :mod:`silx.sx` module:
 
 >>> from silx import sx

--- a/doc/source/virtualenv.rst
+++ b/doc/source/virtualenv.rst
@@ -12,7 +12,7 @@ Prerequisites
 
 This guide assumes that your system meets the following requirements:
 
-   - a version of python compatible with *silx* is installed (Python >= 3.5)
+   - a version of python compatible with *silx* is installed
    - the *pip* installer for python packages is installed
 
 Installation procedure
@@ -54,11 +54,11 @@ Virtual environments are created using a builtin standard library, ``venv`` (Pyt
     ``--system-site-packages``
 
 To use a different python interpreter, use it to create the virtual environment.
-For example, to use python 3.5:
+For example, to use python 3.10:
 
 .. code-block:: bash
 
-    /usr/bin/python3.5 -m venv silx_venv
+    /usr/bin/python3.10 -m venv silx_venv
 
 
 Activate a virtualenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 --trusted-host www.silx.org
 --find-links http://www.silx.org/pub/wheelhouse/
---only-binary numpy,h5py,scipy,PySide2,PyQt5,PySide6,PyQt6
+--only-binary numpy,h5py,scipy,PyQt5,PySide6,PyQt6
 
 # Required dependencies (from setup.py setup_requires and install_requires)
 numpy >= 1.12

--- a/setup.py
+++ b/setup.py
@@ -776,7 +776,7 @@ def get_project_configuration():
         long_description=get_readme(),
         install_requires=install_requires,
         extras_require=extras_require,
-        python_requires='>=3.5',
+        python_requires='>=3.7',
         cmdclass=cmdclass,
         zip_safe=False,
         entry_points=entry_points,


### PR DESCRIPTION
Better to merge PR #3711 first!

- Drop Python3.6: closes #3654
- Remove `PySide2` from CI: related to #3666 