### PR TITLE
Fixed support of `pint` >= 0.20

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,5 @@ PyOpenGL                  # For silx.gui.plot3d
 python-dateutil           # For silx.gui.plot
 scipy                     # For silx.math.fit demo, silx.image.sift demo, silx.image.sift.test
 Pillow                    # For silx.opencl.image.test
+pint                      # For silx.io.dictdump
 PyQt5  # PySide6, PyQt6>=6.3 # For silx.gui

--- a/src/silx/io/dictdump.py
+++ b/src/silx/io/dictdump.py
@@ -32,9 +32,12 @@ import numpy
 import os.path
 import h5py
 try:
-    import pint
+    from pint import Quantity as PintQuantity
 except ImportError:
-    pint = None
+    try:
+        from pint.quantity import Quantity as PintQuantity
+    except ImportError:
+        PintQuantity = None
 
 from .configdict import ConfigDict
 from .utils import is_group
@@ -67,7 +70,7 @@ def _prepare_hdf5_write_value(array_like):
         ``numpy.array()`` (`str`, `list`, `numpy.ndarray`…)
     :return: ``numpy.ndarray`` ready to be written as an HDF5 dataset
     """
-    if pint is not None and isinstance(array_like, pint.quantity.Quantity):
+    if PintQuantity is not None and isinstance(array_like, PintQuantity):
         return numpy.array(array_like.magnitude)
     array = numpy.asarray(array_like)
     if numpy.issubdtype(array.dtype, numpy.bytes_):
@@ -470,7 +473,7 @@ def nexus_to_h5_dict(
                 add_nx_class=add_nx_class,
                 has_nx_class=key_has_nx_class)
 
-        elif pint is not None and isinstance(value, pint.quantity.Quantity):
+        elif PintQuantity is not None and isinstance(value, PintQuantity):
             copy[key] = value.magnitude
             copy[(key, "units")] = f"{value.units:~C}"
 


### PR DESCRIPTION
This PR fixes `silx.io.dictdump` support of `pint` for versions >= 0.20.

At the same time, older versions of `pint` where `Quantity` is not available through `pint.Quantity` but through `pint.quantity.Quantity` are no longer supported (it's possible to add it if needed).

`pint` is also added to `requirements.txt` and so it is installed when running the CI... This would have spotted the removal of `pint.quantity` (see #3724).

closes #3724