### PR TITLE
Updated changelog, bump to version 1.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Change Log
 ==========
 
+1.1.1: 2022/11/30
+-----------------
+
+This is a bug fix version:
+
+* Fixed support of `pint` >= 0.20 (PR #3725, #3728)
+* Fixed continuous integration (PR #3727, #3728)
+* Updated changelog (PR #3729)
+
 1.1.0: 2022/10/27
 -----------------
 

--- a/src/silx/_version.py
+++ b/src/silx/_version.py
@@ -70,7 +70,7 @@ PRERELEASE_NORMALIZED_NAME = {"dev": "a",
 
 MAJOR = 1
 MINOR = 1
-MICRO = 0
+MICRO = 1
 RELEV = "final"  # <16
 SERIAL = 0  # <16
 


### PR DESCRIPTION
This PR prepares a v1.1.1 version.