### PR TITLE
Dedicated function to parse gl version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
         run: |
           pip install pytest
           pip install pytest-xvfb
+          pip install pytest-mock
 
       - name: Install silx package
         run: pip install --pre --find-links dist/ silx

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -100,6 +100,7 @@ before_test:
     # Install pytest
     - "pip install %PIP_OPTIONS% pytest"
     - "pip install %PIP_OPTIONS% pytest-xvfb"
+    - "pip install %PIP_OPTIONS% pytest-mock"
 
     # Install the generated wheel package to test it
     # Make sure silx does not come from cache or pypi

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -13,6 +13,7 @@ pandoc            # For documentation Qt snapshot updates
 pytest            # For testing
 pytest-xvfb       # For GUI testing
 pytest-cov        # For coverage
+pytest-mock
 
 hdf5plugin        # For HDF5 compression filters handling
 

--- a/setup.py
+++ b/setup.py
@@ -523,6 +523,7 @@ def get_project_configuration():
     test_requires = [
         "pytest",
         "pytest-xvfb",
+        "pytest-mock",
         'bitshuffle'
     ]
 

--- a/src/silx/gui/_glutils/gl.py
+++ b/src/silx/gui/_glutils/gl.py
@@ -63,13 +63,29 @@ except NameError:
     GLchar = c_char
 
 
+def getVersion() -> tuple:
+    """Returns the GL version as tuple of integers.
+
+    Raises:
+        ValueError: If the version returned by the driver is not supported
+    """
+    try:
+        desc = glGetString(GL_VERSION)
+        if isinstance(desc, bytes):
+            desc = desc.decode("ascii")
+        version = desc.split(" ", 1)[0]
+        return tuple([int(i) for i in version.split('.')])
+    except Exception as e:
+        raise ValueError("GL version not properly formatted") from e
+
+
 def testGL() -> bool:
     """Test if required OpenGL version and extensions are available.
 
     This MUST be run with an active OpenGL context.
     """
-    version = glGetString(GL_VERSION).split()[0]  # get version number
-    major, minor = int(version[0]), int(version[2])
+    version = getVersion()
+    major, minor = version[0], version[1]
     if major < 2 or (major == 2 and minor < 1):
         _logger.error("OpenGL version >=2.1 required, running with %s" % version)
         return False

--- a/src/silx/gui/_glutils/test/__init__.py
+++ b/src/silx/gui/_glutils/test/__init__.py
@@ -1,0 +1,23 @@
+# /*##########################################################################
+#
+# Copyright (c) 2015-2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/

--- a/src/silx/gui/_glutils/test/test_gl.py
+++ b/src/silx/gui/_glutils/test/test_gl.py
@@ -1,0 +1,36 @@
+# /*##########################################################################
+#
+# Copyright (c) 2015-2019 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+
+from .. import gl
+
+
+def test_version_bytes(mocker):
+    mocker.patch('silx.gui._glutils.gl.glGetString', return_value=b"3.0 Mock")
+    assert gl.getVersion() == (3, 0)
+
+
+def test_version_str(mocker):
+    """In case glGetString returns str"""
+    mocker.patch('silx.gui._glutils.gl.glGetString', return_value="3.0 Mock")
+    assert gl.getVersion() == (3, 0)

--- a/src/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -854,8 +854,8 @@ class Points2D(object):
     @classmethod
     def init(cls):
         """OpenGL context initialization"""
-        version = gl.glGetString(gl.GL_VERSION)
-        majorVersion = int(version[0])
+        version = gl.getVersion()
+        majorVersion = version[0]
         assert majorVersion >= 2
         gl.glEnable(gl.GL_VERTEX_PROGRAM_POINT_SIZE)  # OpenGL 2
         gl.glEnable(gl.GL_POINT_SPRITE)  # OpenGL 2


### PR DESCRIPTION
I found that the GL version was not properly parsed.

It was returning `51, 48` for a string version `3.0`.
Because the string was bytes and indexes was returning ordinal of char `3` and `0`

This parsing issue was probably broken in python 3 since the beginning. Or it is a change in the behavior of PyOpenGL.

This PR create a dedicated function to return this version.

Changelog: 
- Fix GL version parsing