### PR TITLE
silx.gui.plot: Fixed reset of interaction when closing mask tool

### DIFF
--- a/src/silx/gui/plot/MaskToolsWidget.py
+++ b/src/silx/gui/plot/MaskToolsWidget.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -416,7 +416,7 @@ class MaskToolsWidget(BaseMaskToolsWidget):
 
         if self.isMaskInteractionActivated():
             # Disable drawing tool
-            self.browseAction.trigger()
+            self.plot.resetInteractiveMode()
 
         if self.isItemMaskUpdated():  # No "after-care"
             self._data = numpy.zeros((0, 0), dtype=numpy.uint8)

--- a/src/silx/gui/plot/ScatterMaskToolsWidget.py
+++ b/src/silx/gui/plot/ScatterMaskToolsWidget.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2018-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -287,8 +287,10 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
             self.plot.sigActiveScatterChanged.disconnect(self._activeScatterChanged)
         except (RuntimeError, TypeError):
             _logger.info(sys.exc_info()[1])
-        if not self.browseAction.isChecked():
-            self.browseAction.trigger()  # Disable drawing tool
+
+        if self.isMaskInteractionActivated():
+            # Disable drawing tool
+            self.plot.resetInteractiveMode()
 
         if self.getSelectionMask(copy=False) is not None:
             self.plot.sigActiveScatterChanged.connect(

--- a/src/silx/gui/plot/_BaseMaskToolsWidget.py
+++ b/src/silx/gui/plot/_BaseMaskToolsWidget.py
@@ -918,8 +918,8 @@ class BaseMaskToolsWidget(qt.QWidget):
         if (event.type() == qt.QEvent.EnabledChange and
                 not self.isEnabled() and
                 self.drawActionGroup.checkedAction()):
-            # Disable drawing tool by setting interaction to zoom
-            self.browseAction.trigger()
+            # Disable drawing tool by reseting interaction to pan or zoom
+            self.plot.resetInteractiveMode()
 
     def save(self, filename, kind):
         """Save current mask in a file


### PR DESCRIPTION
This PR fixes the reset of interaction mode when closing the scatter or image mask tool.
It now resets to the previous interaction mode (`pan` or `zoom`).

To backport to 1.x branch.

closes #3718
