### PR TITLE
silx.gui.plot: Fixed issue when PlotWidget has a size of 0

### DIFF
--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1485,6 +1485,9 @@ class BackendMatplotlibQt(BackendMatplotlib, FigureCanvasQTAgg):
 
         This is directly called by matplotlib for widget resize.
         """
+        if self.size().isEmpty():
+            return  # Skip rendering of 0-sized canvas
+
         self.updateZOrder()
 
         # Starting with mpl 2.1.0, toggling autoscale raises a ValueError


### PR DESCRIPTION
This PR fixes an issue when rendering a PlotWidget with width or height of 0.
 
closes #3719
