### PR TITLE
silx.gui: Fixed support of PySide6.4 enums

### DIFF
--- a/src/silx/gui/plot/MaskToolsWidget.py
+++ b/src/silx/gui/plot/MaskToolsWidget.py
@@ -712,7 +712,7 @@ class MaskToolsWidget(BaseMaskToolsWidget):
         """Open Save mask dialog"""
         dialog = qt.QFileDialog(self)
         dialog.setWindowTitle("Save Mask")
-        dialog.setOption(dialog.DontUseNativeDialog)
+        dialog.setOption(qt.QFileDialog.DontUseNativeDialog)
         dialog.setModal(1)
         hdf5Filter = 'HDF5 (%s)' % _HDF5_EXT_STR
         filters = [
@@ -733,9 +733,9 @@ class MaskToolsWidget(BaseMaskToolsWidget):
             # disable overwrite confirmation for HDF5,
             # because we append the data to existing files
             if filt_ == hdf5Filter:
-                dialog.setOption(dialog.DontConfirmOverwrite)
+                dialog.setOption(qt.QFileDialog.DontConfirmOverwrite)
             else:
-                dialog.setOption(dialog.DontConfirmOverwrite, False)
+                dialog.setOption(qt.QFileDialog.DontConfirmOverwrite, False)
 
         dialog.filterSelected.connect(onFilterSelection)
         if not dialog.exec():

--- a/src/silx/gui/plot/actions/io.py
+++ b/src/silx/gui/plot/actions/io.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -628,21 +628,21 @@ class SaveAction(PlotAction):
 
         # Create and run File dialog
         dialog = qt.QFileDialog(self.plot)
-        dialog.setOption(dialog.DontUseNativeDialog)
+        dialog.setOption(qt.QFileDialog.DontUseNativeDialog)
         dialog.setWindowTitle("Output File Selection")
         dialog.setModal(1)
         dialog.setNameFilters(list(filters.keys()))
 
-        dialog.setFileMode(dialog.AnyFile)
-        dialog.setAcceptMode(dialog.AcceptSave)
+        dialog.setFileMode(qt.QFileDialog.AnyFile)
+        dialog.setAcceptMode(qt.QFileDialog.AcceptSave)
 
         def onFilterSelection(filt_):
             # disable overwrite confirmation for NXdata types,
             # because we append the data to existing files
             if filt_ in self._appendFilters:
-                dialog.setOption(dialog.DontConfirmOverwrite)
+                dialog.setOption(qt.QFileDialog.DontConfirmOverwrite)
             else:
-                dialog.setOption(dialog.DontConfirmOverwrite, False)
+                dialog.setOption(qt.QFileDialog.DontConfirmOverwrite, False)
 
         dialog.filterSelected.connect(onFilterSelection)
 

--- a/src/silx/gui/plot3d/actions/io.py
+++ b/src/silx/gui/plot3d/actions/io.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -226,8 +226,8 @@ class VideoAction(Plot3DAction):
         dialog.setModal(True)
         dialog.setNameFilters([self.PNG_SERIE_FILTER,
                                self.MNG_FILTER])
-        dialog.setFileMode(dialog.AnyFile)
-        dialog.setAcceptMode(dialog.AcceptSave)
+        dialog.setFileMode(qt.QFileDialog.AnyFile)
+        dialog.setAcceptMode(qt.QFileDialog.AcceptSave)
 
         if not dialog.exec():
             return


### PR DESCRIPTION
This PR solves issue #3730 for `QFileDialog`.

I also checked similar cases for all `QDialog` and inherited classes.

closes #3730 even if there is probably other enum issues but the one reported should be fixed.