### PR TITLE
silx.gui: Added a warning about pyOpenGL and Qt compatibility

### DIFF
--- a/src/silx/gui/_glutils/gl.py
+++ b/src/silx/gui/_glutils/gl.py
@@ -105,16 +105,18 @@ def testGL() -> bool:
         _logger.error("OpenGL version >=2.1 required, running with %s" % version)
         return False
 
-    from OpenGL.GL.ARB.framebuffer_object import glInitFramebufferObjectARB
-    from OpenGL.GL.ARB.texture_rg import glInitTextureRgARB
+    if major == 2:
+        from OpenGL.GL.ARB.framebuffer_object import glInitFramebufferObjectARB
+        from OpenGL.GL.ARB.texture_rg import glInitTextureRgARB
 
-    if not glInitFramebufferObjectARB():
-        _logger.error("OpenGL GL_ARB_framebuffer_object extension required!")
-        return False
+        if not glInitFramebufferObjectARB():
+            _logger.error("OpenGL GL_ARB_framebuffer_object extension required!")
+            return False
 
-    if not glInitTextureRgARB():
-        _logger.error("OpenGL GL_ARB_texture_rg extension required!")
-        return False
+        if not glInitTextureRgARB():
+            _logger.error("OpenGL GL_ARB_texture_rg extension required!")
+            return False
+
     return True
 
 

--- a/src/silx/gui/_glutils/gl.py
+++ b/src/silx/gui/_glutils/gl.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2014-2017 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -31,6 +31,7 @@ __date__ = "25/07/2016"
 from contextlib import contextmanager as _contextmanager
 from ctypes import c_uint
 import logging
+from typing import Optional
 
 _logger = logging.getLogger(__name__)
 
@@ -48,6 +49,7 @@ else:
 
 import OpenGL.GL as _GL
 from OpenGL.GL import *  # noqa
+import OpenGL.platform
 
 # Extentions core in OpenGL 3
 from OpenGL.GL.ARB import framebuffer_object as _FBO
@@ -61,6 +63,19 @@ try:
 except NameError:
     from ctypes import c_char
     GLchar = c_char
+
+
+def getPlatform() -> Optional[str]:
+    """Returns the name of the PyOpenGL class handling the platform.
+
+    E.g., GLXPlatform, EGLPlatform
+    """
+    try:
+        platform = OpenGL.platform.PLATFORM
+    except AttributeError:
+        return None
+    return platform.__class__.__name__
+
 
 
 def getVersion() -> tuple:


### PR DESCRIPTION
This PR:
- Only init OpenGL extensions when needed, i.e., with OpenGL v2
- Check if there is a possible compatibility issue between Qt and pyopengl. This can occurs if one uses X11 and the other wayland which is supported since pyopengl v3.1.6.

Related to #3733
