### PR TITLE
Fixed `numpy`, `scipy`, `matplotlib` deprecation warnings

### DIFF
--- a/src/silx/math/fft/test/test_fft.py
+++ b/src/silx/math/fft/test/test_fft.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # /*##########################################################################
 #
-# Copyright (c) 2018-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,10 @@ from pkg_resources import parse_version
 import pytest
 from tempfile import TemporaryDirectory
 try:
-    from scipy.misc import ascent
+    try:
+        from scipy.misc import ascent
+    except:
+        from scipy.datasets import ascent
     __have_scipy = True
 except ImportError:
     __have_scipy = False

--- a/src/silx/math/medianfilter/test/test_medianfilter.py
+++ b/src/silx/math/medianfilter/test/test_medianfilter.py
@@ -1,5 +1,5 @@
 # ##########################################################################
-# Copyright (C) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (C) 2017-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -34,10 +34,13 @@ from silx.math.medianfilter.medianfilter import MODES as silx_mf_modes
 from silx.utils.testutils import ParametricTestCase
 try:
     import scipy
-    import scipy.misc
 except:
     scipy = None
 else:
+    try:
+        from scipy.misc import ascent
+    except:
+        from scipy.datasets import ascent
     import scipy.ndimage
 
 import logging
@@ -696,12 +699,9 @@ class TestVsScipy(ParametricTestCase):
 
                     self.assertTrue(numpy.array_equal(resScipy, resSilx))
 
-    def testAscentOrLena(self):
+    def testAscent(self):
         """Test vs scipy with """
-        if hasattr(scipy.misc, 'ascent'):
-            img = scipy.misc.ascent()
-        else:
-            img = scipy.misc.lena()
+        img = ascent()
 
         kernels = [(3, 1), (3, 5), (5, 9), (9, 3)]
         modesToTest = _getScipyAndSilxCommonModes()

--- a/src/silx/math/test/test_colormap.py
+++ b/src/silx/math/test/test_colormap.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2018-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -200,7 +200,7 @@ class TestColormap(ParametricTestCase):
                 with self.subTest(dtype=dtype, normalization=normalization):
                     _logger.info('normalization: %s, dtype: %s',
                                  normalization, dtype)
-                    data = numpy.arange(-5, 15, dtype=dtype).reshape(4, 5)
+                    data = numpy.arange(-5, 15).astype(dtype).reshape(4, 5)
 
                     self._test(data, colors, 1, 10, normalization, None)
 

--- a/src/silx/math/test/test_combo.py
+++ b/src/silx/math/test/test_combo.py
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2016-2020 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -137,7 +137,7 @@ class TestMinMax(ParametricTestCase):
                                       min_positive=min_positive,
                                       data=name):
                         data = numpy.arange(
-                            start, start + step * size, step, dtype=dtype)
+                            start, start + step * size, step).astype(dtype)
 
                         self._test_min_max(data, min_positive)
 

--- a/src/silx/opencl/medfilt.py
+++ b/src/silx/opencl/medfilt.py
@@ -2,7 +2,7 @@
 #    Project: Azimuthal integration
 #             https://github.com/silx-kit/pyFAI
 #
-#    Copyright (C) 2012-2017 European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2012-2022 European Synchrotron Radiation Facility, Grenoble, France
 #
 #    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
 #
@@ -249,7 +249,7 @@ class _MedFilt2d(object):
 
         * The filling mode in scipy.signal.medfilt2d is zero-padding
         * This implementation is equivalent to:
-            scipy.ndimage.filters.median_filter(ary, kernel_size, mode="nearest")
+            scipy.ndimage.median_filter(ary, kernel_size, mode="nearest")
 
         """
         image = numpy.atleast_2d(ary)

--- a/src/silx/opencl/sift/match.py
+++ b/src/silx/opencl/sift/match.py
@@ -4,7 +4,7 @@
 #    Project: Sift implementation in Python + OpenCL
 #             https://github.com/silx-kit/silx
 #
-#    Copyright (C) 2013-2018  European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2013-2022  European Synchrotron Radiation Facility, Grenoble, France
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -286,12 +286,12 @@ def match_py(nkp1, nkp2, raw_results=False):
 
 
 def demo():
-    import scipy.misc
+    try:
+        from scipy.misc import ascent
+    except:
+        from scipy.datasets import ascent
     from .plan import SiftPlan
-    if hasattr(scipy.misc, "ascent"):
-        img1 = scipy.misc.ascent()
-    else:
-        img1 = scipy.misc.lena()
+    img1 = ascent()
 
     splan = SiftPlan(template=img1)
     kp1 = splan(img1)

--- a/src/silx/opencl/sift/plan.py
+++ b/src/silx/opencl/sift/plan.py
@@ -4,7 +4,7 @@
 #    Project: Sift implementation in Python + OpenCL
 #             https://github.com/silx-kit/silx
 #
-#    Copyright (C) 2013-2018  European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2013-2022  European Synchrotron Radiation Facility, Grenoble, France
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -816,11 +816,11 @@ class SiftPlan(OpenclProcessing):
 
 def demo():
     # Prepare debugging
-    import scipy.misc
-    if hasattr(scipy.misc, "ascent"):
-        img = scipy.misc.ascent()
-    else:
-        img = scipy.misc.lena()
+    try:
+        from scipy.misc import ascent
+    except:
+        from scipy.datasets import ascent
+    img = ascent()
 
     s = SiftPlan(template=img)
     print(s.keypoints(img))

--- a/src/silx/opencl/sift/test/test_align.py
+++ b/src/silx/opencl/sift/test/test_align.py
@@ -3,7 +3,7 @@
 #    Project: Sift implementation in Python + OpenCL
 #             https://github.com/silx-kit/silx
 #
-#    Copyright (C) 2013-2017  European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2013-2022  European Synchrotron Radiation Facility, Grenoble, France
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -40,10 +40,15 @@ import unittest
 import logging
 import numpy
 try:
-    import scipy.misc
-    import scipy.ndimage
+    import scipy
 except ImportError:
     scipy = None
+else:
+    import scipy.ndimage
+    try:
+        from scipy.misc import ascent
+    except:
+        from scipy.datasets import ascent
 
 from ...common import ocl
 if ocl:
@@ -77,21 +82,18 @@ class TestLinalign(unittest.TestCase):
         cls.queue = None
 
     def setUp(self):
-        if scipy and ocl is None:
+        if scipy is None or ocl is None:
             return
 
-        if hasattr(scipy.misc, "ascent"):
-            self.lena = scipy.misc.ascent().astype(numpy.float32)
-        else:
-            self.lena = scipy.misc.lena().astype(numpy.float32)
+        self.ascent = ascent().astype(numpy.float32)
 
-        self.shape = self.lena.shape
+        self.shape = self.ascent.shape
         self.extra = (10, 11)
-        self.img = scipy.ndimage.affine_transform(self.lena, [[1.1, -0.1], [0.05, 0.9]], [7, 5])
-        self.align = LinearAlign(self.lena, ctx=self.ctx)
+        self.img = scipy.ndimage.affine_transform(self.ascent, [[1.1, -0.1], [0.05, 0.9]], [7, 5])
+        self.align = LinearAlign(self.ascent, ctx=self.ctx)
 
     def tearDown(self):
-        self.img = self.lena = None
+        self.img = self.ascent = None
 
     @unittest.skipUnless(scipy and ocl, "scipy or pyopencl are missing")
     def test_align(self):
@@ -103,5 +105,5 @@ class TestLinalign(unittest.TestCase):
         out = out["result"]
 
         if self.PROFILE and (out is not None):
-            delta = (out - self.lena)[100:400, 100:400]
+            delta = (out - self.ascent)[100:400, 100:400]
             logger.info({"min": delta.min(), "max:": delta.max(), "mean": delta.mean(), "std:": delta.std()})

--- a/src/silx/opencl/sift/test/test_convol.py
+++ b/src/silx/opencl/sift/test/test_convol.py
@@ -42,10 +42,15 @@ import logging
 import numpy
 
 try:
-    import scipy.misc
-    import scipy.ndimage
+    import scipy
 except ImportError:
     scipy = None
+else:
+    import scipy.ndimage
+    try:
+        from scipy.misc import ascent
+    except:
+        from scipy.datasets import ascent
 
 import unittest
 from silx.opencl import ocl
@@ -90,14 +95,10 @@ class TestConvol(unittest.TestCase):
         cls.queue = None
 
     def setUp(self):
-        if scipy and ocl is None:
+        if scipy is None or ocl is None:
             return
 
-        if hasattr(scipy.misc, "ascent"):
-            self.input = scipy.misc.ascent().astype(numpy.float32)
-        else:
-            self.input = scipy.misc.lena().astype(numpy.float32)
-
+        self.input = ascent().astype(numpy.float32)
         self.input = numpy.ascontiguousarray(self.input[0:507, 0:209])
 
         self.gpu_in = pyopencl.array.to_device(self.queue, self.input)

--- a/src/silx/opencl/sift/test/test_convol.py
+++ b/src/silx/opencl/sift/test/test_convol.py
@@ -3,7 +3,7 @@
 #    Project: Sift implementation in Python + OpenCL
 #             https://github.com/silx-kit/silx
 #
-#    Copyright (C) 2013-2017  European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2013-2022  European Synchrotron Radiation Facility, Grenoble, France
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -60,8 +60,8 @@ def my_blur(img, kernel):
     hand made implementation of gaussian blur with OUR kernel
     which differs from Scipy's if ksize is even
     """
-    tmp1 = scipy.ndimage.filters.convolve1d(img, kernel, axis=-1, mode="reflect")
-    return scipy.ndimage.filters.convolve1d(tmp1, kernel, axis=0, mode="reflect")
+    tmp1 = scipy.ndimage.convolve1d(img, kernel, axis=-1, mode="reflect")
+    return scipy.ndimage.convolve1d(tmp1, kernel, axis=0, mode="reflect")
 
 
 @unittest.skipUnless(scipy and ocl, "scipy or opencl not available")
@@ -137,7 +137,7 @@ class TestConvol(unittest.TestCase):
                                 self.gpu_in.data, self.gpu_out.data, gpu_filter.data, numpy.int32(ksize), self.IMAGE_W, self.IMAGE_H)
             res = self.gpu_out.get()
             t1 = time.time()
-            ref = scipy.ndimage.filters.convolve1d(self.input, gaussian, axis=-1, mode="reflect")
+            ref = scipy.ndimage.convolve1d(self.input, gaussian, axis=-1, mode="reflect")
             t2 = time.time()
             delta = abs(ref - res).max()
             if ksize % 2 == 0:  # we have a problem with even kernels !!!
@@ -169,7 +169,7 @@ class TestConvol(unittest.TestCase):
                                                    self.IMAGE_W, self.IMAGE_H)
             res = self.gpu_out.get()
             t1 = time.time()
-            ref = scipy.ndimage.filters.convolve1d(self.input, gaussian, axis=0, mode="reflect")
+            ref = scipy.ndimage.convolve1d(self.input, gaussian, axis=0, mode="reflect")
             t2 = time.time()
             delta = abs(ref - res).max()
             if ksize % 2 == 0:  # we have a problem with even kernels !!!
@@ -200,7 +200,7 @@ class TestConvol(unittest.TestCase):
             k2.wait()
             t1 = time.time()
             ref = my_blur(self.input, gaussian)
-            # ref = scipy.ndimage.filters.gaussian_filter(self.input, sigma, mode="reflect")
+            # ref = scipy.ndimage.gaussian_filter(self.input, sigma, mode="reflect")
             t2 = time.time()
             delta = abs(ref - res).max()
             if ksize % 2 == 0:  # we have a problem with even kernels !!!

--- a/src/silx/opencl/sift/test/test_image_setup.py
+++ b/src/silx/opencl/sift/test/test_image_setup.py
@@ -3,7 +3,7 @@
 #    Project: Sift implementation in Python + OpenCL
 #             https://github.com/silx-kit/silx
 #
-#    Copyright (C) 2013-2017  European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2013-2022  European Synchrotron Radiation Facility, Grenoble, France
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -39,10 +39,15 @@ __date__ = "06/10/2022"
 
 import numpy
 try:
-    import scipy.ndimage
-    import scipy.misc
+    import scipy
 except ImportError:
     scipy = None
+else:
+    import scipy.ndimage
+    try:
+        from scipy.misc import ascent
+    except:
+        from scipy.datasets import ascent
 
 from .test_image_functions import my_gradient, normalize_image, shrink, my_local_maxmin, \
     my_interp_keypoint, my_descriptor, my_orientation
@@ -76,13 +81,8 @@ def local_maxmin_setup():
     nb_keypoints = 1000  # constant size !
     doubleimsize = 0  # par.DoubleImSize = 0 by default
 
-    if hasattr(scipy.misc, "ascent"):
-        l2 = scipy.misc.ascent().astype(numpy.float32)
-    else:
-        l2 = scipy.misc.lena().astype(numpy.float32)
-
+    l2 = ascent().astype(numpy.float32)
     l2 = numpy.ascontiguousarray(l2[0:507, 0:209])
-    # l2 = scipy.misc.imread("../aerial.tiff").astype(numpy.float32)
     l = normalize_image(l2)  # do not forget to normalize the image if you want to compare with sift.cpp
     for octave_cnt in range(1, int(numpy.log2(octsize)) + 1 + 1):
 

--- a/src/silx/opencl/sift/test/test_keypoints.py
+++ b/src/silx/opencl/sift/test/test_keypoints.py
@@ -3,7 +3,7 @@
 #    Project: Sift implementation in Python + OpenCL
 #             https://github.com/silx-kit/silx
 #
-#    Copyright (C) 2013-2017  European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2013-2022  European Synchrotron Radiation Facility, Grenoble, France
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -45,9 +45,14 @@ import time
 import logging
 import numpy
 try:
-    import scipy.misc
+    import scipy
 except ImportError:
     scipy = None
+else:
+    try:
+        from scipy.misc import ascent
+    except:
+        from scipy.datasets import ascent
 
 # for Python implementation of tested functions
 from .test_image_functions import my_compact, my_orientation, keypoints_compare, my_descriptor, descriptors_compare
@@ -93,11 +98,7 @@ class _TestKeypoints(unittest.TestCase):
         self.abort = False
         if scipy and ocl is None:
             return
-        try:
-            self.testdata = scipy.misc.ascent()
-        except Exception:
-            # for very old versions of scipy
-            self.testdata = scipy.misc.lena()
+        self.testdata = ascent()
         kernel_base = get_opencl_code(os.path.join("sift", "sift"))
         if self.orientation_script is None:
             self.skipTest("Uninitialized parametric class")

--- a/src/silx/opencl/sift/test/test_matching.py
+++ b/src/silx/opencl/sift/test/test_matching.py
@@ -3,7 +3,7 @@
 #    Project: Sift implementation in Python + OpenCL
 #             https://github.com/silx-kit/silx
 #
-#    Copyright (C) 2013-2018  European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2013-2022  European Synchrotron Radiation Facility, Grenoble, France
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -41,9 +41,14 @@ import time
 import logging
 import numpy
 try:
-    import scipy.misc
+    import scipy
 except ImportError:
     scipy = None
+else:
+    try:
+        from scipy.misc import ascent
+    except:
+        from scipy.datasets import ascent
 
 
 # for Python implementation of tested functions
@@ -105,10 +110,7 @@ class TestMatching(unittest.TestCase):
         '''
         tests keypoints matching kernel
         '''
-        if hasattr(scipy.misc, "ascent"):
-            image = scipy.misc.ascent().astype(numpy.float32)
-        else:
-            image = scipy.misc.lena().astype(numpy.float32)
+        image = ascent().astype(numpy.float32)
 
         if (feature is not None):
             # get the struct keypoints : (x,y,s,angle,[descriptors])

--- a/src/silx/opencl/sift/test/test_preproc.py
+++ b/src/silx/opencl/sift/test/test_preproc.py
@@ -3,7 +3,7 @@
 #    Project: Sift implementation in Python + OpenCL
 #             https://github.com/silx-kit/silx
 #
-#    Copyright (C) 2013-2017  European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2013-2022  European Synchrotron Radiation Facility, Grenoble, France
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -41,9 +41,14 @@ import time
 import logging
 import numpy
 try:
-    import scipy.misc
+    import scipy
 except ImportError:
     scipy = None
+else:
+    try:
+        from scipy.misc import ascent
+    except:
+        from scipy.datasets import ascent
 
 import math
 from silx.opencl import ocl, kernel_workgroup_size
@@ -144,11 +149,7 @@ class TestPreproc(unittest.TestCase):
     def setUp(self):
         if not (ocl and scipy):
             return
-        try:
-            testdata = scipy.misc.ascent()
-        except:
-            # for very old version of scipy
-            testdata = scipy.misc.lena()
+        testdata = ascent()
         self.input = numpy.ascontiguousarray(testdata[:510, :511])
         self.gpudata = pyopencl.array.empty(self.queue, self.input.shape, dtype=numpy.float32, order="C")
         kernel_src = get_opencl_code(os.path.join("sift", "preprocess"))

--- a/src/silx/opencl/sift/test/test_transform.py
+++ b/src/silx/opencl/sift/test/test_transform.py
@@ -44,10 +44,15 @@ import logging
 import numpy
 import pytest
 try:
-    import scipy.misc
-    import scipy.ndimage
+    import scipy
 except ImportError:
     scipy = None
+else:
+    import scipy.ndimage
+    try:
+        from scipy.misc import ascent
+    except:
+        from scipy.datasets import ascent
 
 from silx.opencl import ocl, kernel_workgroup_size
 if ocl:
@@ -90,10 +95,7 @@ class TestTransform(unittest.TestCase):
         kernel_src = get_opencl_code(os.path.join("sift", "transform"))
         self.program = pyopencl.Program(self.ctx, kernel_src).build()  # .build('-D WORKGROUP_SIZE=%s' % wg_size)
         self.wg = (1, 128)
-        if hasattr(scipy.misc, "ascent"):
-            self.image = scipy.misc.ascent().astype(numpy.float32)
-        else:
-            self.image = scipy.misc.lena().astype(numpy.float32)
+        self.image = ascent().astype(numpy.float32)
 
     def tearDown(self):
         self.program = None

--- a/src/silx/opencl/sift/test/test_transform.py
+++ b/src/silx/opencl/sift/test/test_transform.py
@@ -3,7 +3,7 @@
 #    Project: Sift implementation in Python + OpenCL
 #             https://github.com/silx-kit/silx
 #
-#    Copyright (C) 2013-2017  European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2013-2022  European Synchrotron Radiation Facility, Grenoble, France
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -121,7 +121,7 @@ class TestTransform(unittest.TestCase):
         # ---------------
         matrix = numpy.array([[1.0, -0.75], [0.7, 0.5]], dtype=numpy.float32)
         offset_value = numpy.array([250.0, -150.0], dtype=numpy.float32)
-        transformation = lambda img: scipy.ndimage.interpolation.affine_transform(img, matrix, offset=offset_value, order=1, mode="constant")
+        transformation = lambda img: scipy.ndimage.affine_transform(img, matrix, offset=offset_value, order=1, mode="constant")
         image_transformed = transformation(self.image)
 
         fill_value = numpy.float32(0.0)
@@ -175,12 +175,12 @@ class TestTransform(unittest.TestCase):
 
         # Reference result
         t1 = time.time()
-        ref = scipy.ndimage.interpolation.affine_transform(image_transformed, correction_matrix,
-                                                           offset=offset_value,
-                                                           output_shape=(output_height, output_width),
-                                                           order=1,
-                                                           mode="constant",
-                                                           cval=fill_value)
+        ref = scipy.ndimage.affine_transform(image_transformed, correction_matrix,
+                                             offset=offset_value,
+                                             output_shape=(output_height, output_width),
+                                             order=1,
+                                             mode="constant",
+                                             cval=fill_value)
         t2 = time.time()
 
         # Compare the implementations

--- a/src/silx/opencl/test/test_array_utils.py
+++ b/src/silx/opencl/test/test_array_utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +30,6 @@ __copyright__ = "2013-2017 European Synchrotron Radiation Facility, Grenoble, Fr
 __date__ = "14/06/2017"
 
 
-import time
 import logging
 import numpy as np
 import unittest
@@ -42,17 +41,9 @@ from ..common import ocl
 if ocl:
     import pyopencl as cl
     import pyopencl.array as parray
-    from .. import linalg
 from ..utils import get_opencl_code
-from silx.test.utils import utilstest
 
 logger = logging.getLogger(__name__)
-try:
-    from scipy.ndimage.filters import laplace
-    _has_scipy = True
-except ImportError:
-    _has_scipy = False
-
 
 
 @unittest.skipUnless(ocl and mako, "PyOpenCl is missing")

--- a/src/silx/opencl/test/test_convolution.py
+++ b/src/silx/opencl/test/test_convolution.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # /*##########################################################################
 #
-# Copyright (c) 2019 European Synchrotron Radiation Facility
+# Copyright (c) 2019-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -41,7 +41,10 @@ from silx.image.utils import gaussian_kernel
 
 try:
     from scipy.ndimage import convolve, convolve1d
-    from scipy.misc import ascent
+    try:
+        from scipy.misc import ascent
+    except:
+        from scipy.datasets import ascent
 
     scipy_convolve = convolve
     scipy_convolve1d = convolve1d

--- a/src/silx/opencl/test/test_linalg.py
+++ b/src/silx/opencl/test/test_linalg.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +30,6 @@ __copyright__ = "2013-2017 European Synchrotron Radiation Facility, Grenoble, Fr
 __date__ = "01/08/2019"
 
 
-import time
 import logging
 import numpy as np
 import unittest
@@ -47,7 +46,7 @@ from silx.test.utils import utilstest
 
 logger = logging.getLogger(__name__)
 try:
-    from scipy.ndimage.filters import laplace
+    from scipy.ndimage import laplace
     _has_scipy = True
 except ImportError:
     _has_scipy = False

--- a/src/silx/opencl/test/test_medfilt.py
+++ b/src/silx/opencl/test/test_medfilt.py
@@ -31,7 +31,7 @@ Simple test of the median filter
 __authors__ = ["Jérôme Kieffer"]
 __contact__ = "jerome.kieffer@esrf.eu"
 __license__ = "MIT"
-__copyright__ = "2013-2017 European Synchrotron Radiation Facility, Grenoble, France"
+__copyright__ = "2013-2022 European Synchrotron Radiation Facility, Grenoble, France"
 __date__ = "05/07/2018"
 
 
@@ -58,9 +58,13 @@ Result = namedtuple("Result", ["size", "error", "sp_time", "oc_time"])
 try:
     from scipy.misc import ascent
 except:
-    def ascent():
-        """Dummy image from random data"""
-        return numpy.random.random((512, 512))
+    try:
+        from scipy.datasets import ascent
+    except:
+        def ascent():
+            """Dummy image from random data"""
+            return numpy.random.random((512, 512))
+
 try:
     from scipy.ndimage import filters
     median_filter = filters.median_filter

--- a/src/silx/opencl/test/test_medfilt.py
+++ b/src/silx/opencl/test/test_medfilt.py
@@ -66,8 +66,7 @@ except:
             return numpy.random.random((512, 512))
 
 try:
-    from scipy.ndimage import filters
-    median_filter = filters.median_filter
+    from scipy.ndimage import median_filter
     HAS_SCIPY = True
 except:
     HAS_SCIPY = False

--- a/src/silx/resources/opencl/sift/transform.cl
+++ b/src/silx/resources/opencl/sift/transform.cl
@@ -3,7 +3,7 @@
  *            kernel for maximum and minimum calculation
  *
  *
- *   Copyright (C) 2013-2017 European Synchrotron Radiation Facility
+ *   Copyright (C) 2013-2022 European Synchrotron Radiation Facility
  *                           Grenoble, France
  *
  *   Principal authors: J. Kieffer (kieffer@esrf.fr)
@@ -130,7 +130,7 @@ kernel void transform(
                 }
         }
 
-        //to be coherent with scipy.ndimage.interpolation.affine_transform
+        //to be coherent with scipy.ndimage.affine_transform
         float u = -1.0; //-0.5; //-0.95
         float v = -1.0; //-0.5;
         if (tx >= image_width+u) 
@@ -229,7 +229,7 @@ kernel void transform_RGB(
         }
 
 
-        //to be coherent with scipy.ndimage.interpolation.affine_transform
+        //to be coherent with scipy.ndimage.affine_transform
         float u = -0.5; //-0.95
         float v = -0.5;
         if (tx >= image_width+u) 


### PR DESCRIPTION
This PR removes some deprecation warnings issued during the tests.

I does not remove the deprecation warning for `scipy.misc.ascent` since the replacement (`scipy.datasets.ascent`) requires an extra dependency (`pooch`) which is not available in older Debian, but it makes the test code ready for the removal of `scipy.misc.ascent`.


closes #3734
closes #3715
