### PR TITLE
Fix histogram visibility

### DIFF
--- a/src/silx/gui/plot/ImageView.py
+++ b/src/silx/gui/plot/ImageView.py
@@ -604,7 +604,7 @@ class ImageView(PlotWindow):
 
     def isSideHistogramDisplayed(self):
         """True if the side histograms are displayed"""
-        return self._histoHPlot.isVisible()
+        return self._histoHPlot.isVisibleTo(self)
 
     def _updateHistograms(self):
         """Update histograms content using current active image."""


### PR DESCRIPTION
This PR fixes the `setSideHistogramDisplayed(False)` when the widget or one of the ancestor is not visible.

`isVisible()` is one of the property which is not symmetric to `setVisible()`.

As result `isSideHistogramDisplayed` was false is some cases for false reason.
Which was inhibiting `setSideHistogramDisplayed`.

Changelog: 
- Fix ImageView histogram visibility