### PR TITLE
[silx view] Fixed support of NXData image with 0-length axis

### DIFF
--- a/src/silx/gui/data/NXdataWidgets.py
+++ b/src/silx/gui/data/NXdataWidgets.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2017-2022 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -507,8 +507,14 @@ class ArrayImagePlot(qt.QWidget):
             elif len(y_axis) == 2:
                 y_axis = y_axis[0] * numpy.arange(image.shape[0]) + y_axis[1]
 
-            xcalib = ArrayCalibration(x_axis)
-            ycalib = ArrayCalibration(y_axis)
+            try:
+                xcalib = ArrayCalibration(x_axis)
+            except ValueError:
+                xcalib = NoCalibration()
+            try:
+                ycalib = ArrayCalibration(y_axis)
+            except ValueError:
+                ycalib = NoCalibration()
 
         self._plot.remove(kind=("scatter", "image",))
         if xcalib.is_affine() and ycalib.is_affine():

--- a/src/silx/gui/data/NXdataWidgets.py
+++ b/src/silx/gui/data/NXdataWidgets.py
@@ -466,12 +466,13 @@ class ArrayImagePlot(qt.QWidget):
         self._auxSigSlider.setValue(0)
 
         self._axis_scales = xscale, yscale
-        self._updateImage()
-        self._plot.setKeepDataAspectRatio(keep_ratio)
-        self._plot.resetZoom()
 
         self._selector.selectionChanged.connect(self._updateImage)
         self._auxSigSlider.valueChanged.connect(self._sliderIdxChanged)
+
+        self._updateImage()
+        self._plot.setKeepDataAspectRatio(keep_ratio)
+        self._plot.resetZoom()
 
     def _updateImage(self):
         selection = self._selector.selection()

--- a/src/silx/gui/data/NXdataWidgets.py
+++ b/src/silx/gui/data/NXdataWidgets.py
@@ -722,8 +722,14 @@ class ArrayComplexImagePlot(qt.QWidget):
             elif len(y_axis) == 2:
                 y_axis = y_axis[0] * numpy.arange(image.shape[0]) + y_axis[1]
 
-            xcalib = ArrayCalibration(x_axis)
-            ycalib = ArrayCalibration(y_axis)
+            try:
+                xcalib = ArrayCalibration(x_axis)
+            except ValueError:
+                xcalib = NoCalibration()
+            try:
+                ycalib = ArrayCalibration(y_axis)
+            except ValueError:
+                ycalib = NoCalibration()
 
         self._plot.setData(image)
         if xcalib.is_affine():

--- a/src/silx/math/calibration.py
+++ b/src/silx/math/calibration.py
@@ -131,7 +131,7 @@ class ArrayCalibration(AbstractCalibration):
         raise ValueError("ArrayCalibration must be applied to array of same size "
                          "or to index.")
 
-    @functools.lru_cache
+    @functools.lru_cache()
     def is_affine(self):
         """If all values in the calibration array are regularly spaced,
         return True."""

--- a/src/silx/math/test/test_calibration.py
+++ b/src/silx/math/test/test_calibration.py
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2018 European Synchrotron Radiation Facility
+# Copyright (C) 2018-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -113,6 +113,14 @@ class TestArrayCalibration(unittest.TestCase):
 
         for idx, value in enumerate(self.arr):
             self.assertEqual(self.calib(idx), value)
+
+    def testEmptyArray(self):
+        with self.assertRaises(ValueError):
+            ArrayCalibration(numpy.array([]))
+
+    def testOneElementArray(self):
+        calib = ArrayCalibration(numpy.array([1]))
+        self.assertFalse(calib.is_affine())
 
 
 class TestFunctionCalibration(unittest.TestCase):


### PR DESCRIPTION
This PR updates the `calibration` to raise exceptions for empty arrays and it takes it into account for NXData views in silx view.

It also moves the signal connections before updating the plot so they are registered even if an exception occurs later, just in case.
 
closes #3766
