### PR TITLE
Fixed support of cython 3.0.0b1

### DIFF
--- a/src/silx/math/_colormap.pyx
+++ b/src/silx/math/_colormap.pyx
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2018-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -34,6 +34,7 @@ cimport cython
 from cython.parallel import prange
 cimport numpy as cnumpy
 from libc.math cimport frexp, sinh, sqrt
+from libc.math cimport pow as c_pow
 from .math_compatibility cimport asinh, isnan, isfinite, lrint, INFINITY, NAN
 
 import logging
@@ -227,7 +228,7 @@ cdef class LogarithmicNormalization(Normalization):
         return result
 
     cdef double revert_double(self, double value, double vmin, double vmax) nogil:
-        return 10**value
+        return c_pow(10, value)
 
 
 cdef class ArcsinhNormalization(Normalization):
@@ -247,7 +248,7 @@ cdef class SqrtNormalization(Normalization):
         return sqrt(value)
 
     cdef double revert_double(self, double value, double vmin, double vmax) nogil:
-        return value**2
+        return value*value
 
 
 cdef class PowerNormalization(Normalization):
@@ -268,6 +269,7 @@ cdef class PowerNormalization(Normalization):
         # Needed for multiple inheritance to work
         pass
 
+    @cython.cdivision(True)
     cdef double apply_double(self, double value, double vmin, double vmax) nogil:
         if vmin == vmax:
             return 0.
@@ -276,15 +278,16 @@ cdef class PowerNormalization(Normalization):
         elif value >= vmax:
             return 1.
         else:
-            return ((value - vmin) / (vmax - vmin))**self.gamma
+            return c_pow(((value - vmin) / (vmax - vmin)), self.gamma)
 
+    @cython.cdivision(True)
     cdef double revert_double(self, double value, double vmin, double vmax) nogil:
         if value <= 0.:
             return vmin
         elif value >= 1.:
             return vmax
         else:
-            return vmin + (vmax - vmin) * value**(1.0/self.gamma)
+            return vmin + (vmax - vmin) * c_pow(value, (1.0/self.gamma))
 
 
 # Colormap


### PR DESCRIPTION
This PR makes silx build with cython3.0.0b1 regarding the support of power `**`.
This PR makes direct use of the `pow` function from `libc.math` since this looks to work across different versions of cython (0.29.x and 3.0).

Some background information for the record:

See https://cython.readthedocs.io/en/latest/src/userguide/migrating_to_cy30.html#power-operator

Also cython 3.0.0b1 introduced a `cpow` [compiler directive](https://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html#compiler-directives) to use the C `pow` function for `**`... but this directive is not available in previous versions of Cython.


<details>
<summary>Details of different behaviors from cython.cpow doc</summary>

Type of a | Type of b | cpow==True | cpow==False
-- | -- | -- | --
C integer | Negative integer compile-time constant | Return type is C double | Return type is C double (special case)
C integer | C integer (known to be >= 0 at compile time) | Return type is integer | Return type is integer
C integer | C integer (may be negative) | Return type is integer | Return type is C double (note that Python would dynamically pick int or float here, while Cython doesn’t)
C floating point | C integer | Return type is floating point | Return type is floating point
C floating point (or C integer) | C floating point | Return type is floating point, result is NaN if the result would be complex | Either a C  real or complex number at cost of some speed

</details>
