### PR TITLE
Fixed `silx.io.h5py_utils.retry`

### DIFF
--- a/src/silx/io/h5py_utils.py
+++ b/src/silx/io/h5py_utils.py
@@ -117,8 +117,9 @@ def _is_h5py_exception(e):
     :returns bool:
     """
     for frame in traceback.walk_tb(e.__traceback__):
-        if frame[0].f_locals.get("__package__", None) == "h5py":
-            return True
+        for namespace in (frame[0].f_locals, frame[0].f_globals):
+            if namespace.get("__package__", None) == "h5py":
+                return True
     return False
 
 


### PR DESCRIPTION
For some reason(?) we ended-up in a situation where checking that an exception was coming from `h5py` failed because `__package__` was not defined in `f_locals` in this function:

https://github.com/silx-kit/silx/blob/16888f095a247b508c7627b410b60a6231267fd9/src/silx/io/h5py_utils.py#L114-L122

This PR proposes to fix this by also looking for `__package__` == "h5py" in the frame's `f_globals`.
Not sure it is the right way to fix it, but looking in `f_globals` fixed the issue at hand.

attn @vallsv 