### PR TITLE
`silx.io.nxdata.parser`: Fixed `NXdata` validation

### DIFF
--- a/src/silx/io/nxdata/parse.py
+++ b/src/silx/io/nxdata/parse.py
@@ -313,13 +313,6 @@ class NXdata(object):
                     elif axis_len in (1, 2):
                         polynomial_axes_names.append(axis_name)
                     is_scatter = False
-                else:
-                    if not is_scatter:
-                        self.issues.append(
-                                "Axis %s number of elements is equal " % axis_name +
-                                "to the length of the signal, but this does not seem" +
-                                " to be a scatter (other axes have different sizes)")
-                        continue
 
                 # Test individual uncertainties
                 errors_name = axis_name + "_errors"


### PR DESCRIPTION
This PR removes a validation check that is too strict an fails under correct condition if one dimension of the signal is `1`.

closes #3781
