### PR TITLE
Drop support of PySide2

### DIFF
--- a/src/silx/app/view/About.py
+++ b/src/silx/app/view/About.py
@@ -225,7 +225,7 @@ class About(qt.QDialog):
 
     def __updateSize(self):
         """Force the size to a QMessageBox like size."""
-        if qt.BINDING in ("PySide2", "PyQt5"):
+        if qt.BINDING == "PyQt5":
             screenSize = qt.QApplication.desktop().availableGeometry(qt.QCursor.pos()).size()
         else:  # Qt6
             screenSize = qt.QApplication.instance().primaryScreen().availableGeometry().size()

--- a/src/silx/conftest.py
+++ b/src/silx/conftest.py
@@ -12,9 +12,6 @@ def _set_qt_binding(binding):
         if binding == "pyqt5":
             logger.info("Force using PyQt5")
             import PyQt5.QtCore  # noqa
-        elif binding == "pyside2":
-            logger.info("Force using PySide2")
-            import PySide2.QtCore  # noqa
         elif binding == "pyside6":
             logger.info("Force using PySide6")
             import PySide6.QtCore  # noqa
@@ -27,7 +24,7 @@ def _set_qt_binding(binding):
 
 def pytest_addoption(parser):
     parser.addoption("--qt-binding", type=str, default=None, dest="qt_binding",
-                     help="Force using a Qt binding: 'PyQt5', 'PySide2', 'PySide6', 'PyQt6'")
+                     help="Force using a Qt binding: 'PyQt5', 'PySide6', 'PyQt6'")
     parser.addoption("--no-gui", dest="gui", default=True,
                      action="store_false",
                      help="Disable the test of the graphical use interface")

--- a/src/silx/gui/fit/FitWidget.py
+++ b/src/silx/gui/fit/FitWidget.py
@@ -207,7 +207,7 @@ class FitWidget(qt.QWidget):
                     self.fitconfig.get("WeightFlag", False))
             self.guiConfig.WeightCheckBox.stateChanged[int].connect(self.weightEvent)
 
-            if qt.BINDING in ('PySide2', 'PyQt5'):
+            if qt.BINDING == 'PyQt5':
                 self.guiConfig.BkgComBox.activated[str].connect(self.bkgEvent)
                 self.guiConfig.FunComBox.activated[str].connect(self.funEvent)
             else:  # Qt6

--- a/src/silx/gui/plot/test/testPlotWindow.py
+++ b/src/silx/gui/plot/test/testPlotWindow.py
@@ -103,11 +103,11 @@ class TestPlotWindow(TestCaseQt):
         self.plot.addTabbedDockWidget(dock2)
         self.qapp.processEvents()
 
-        if qt.BINDING != 'PySide2':
-            # Weird bug with PySide2 later upon gc.collect() when getting the layout
-            self.assertNotEqual(self.plot.layout().indexOf(dock2),
-                                -1,
-                                "dock2 not properly displayed")
+        self.assertNotEqual(
+            self.plot.layout().indexOf(dock2),
+            -1,
+            "dock2 not properly displayed",
+        )
 
     def testToolAspectRatio(self):
         self.plot.toolBar()

--- a/src/silx/gui/plot/tools/profile/manager.py
+++ b/src/silx/gui/plot/tools/profile/manager.py
@@ -1040,7 +1040,7 @@ class ProfileManager(qt.QObject):
 
         window = self.getPlotWidget().window()
         winGeom = window.frameGeometry()
-        if qt.BINDING in ("PySide2", "PyQt5"):
+        if qt.BINDING == "PyQt5":
             qapp = qt.QApplication.instance()
             desktop = qapp.desktop()
             screenGeom = desktop.availableGeometry(window)

--- a/src/silx/gui/plot3d/ParamTreeView.py
+++ b/src/silx/gui/plot3d/ParamTreeView.py
@@ -372,13 +372,7 @@ class ParameterTreeDelegate(qt.QStyledItemDelegate):
                     if userProperty.isValid() and userProperty.hasNotifySignal():
                         notifySignal = userProperty.notifySignal()
                         signature = notifySignal.methodSignature()
-                        if qt.BINDING == 'PySide2':
-                            signature = signature.data()
-                        else:
-                            signature = bytes(signature)
-
-                        if hasattr(signature, 'decode'):  # For PySide with python3
-                            signature = signature.decode('ascii')
+                        signature = bytes(signature).decode('ascii')
                         signalName = signature.split('(')[0]
 
                         signal = getattr(editor, signalName)

--- a/src/silx/gui/plot3d/tools/PositionInfoWidget.py
+++ b/src/silx/gui/plot3d/tools/PositionInfoWidget.py
@@ -101,7 +101,7 @@ class PositionInfoWidget(qt.QWidget):
         widget.setTextInteractionFlags(qt.Qt.TextSelectableByMouse)
 
         metrics = widget.fontMetrics()
-        if qt.BINDING in ('PySide2', 'PyQt5'):
+        if qt.BINDING == 'PyQt5':
             width = metrics.width("#######")
         else:  # Qt6
             width = metrics.horizontalAdvance("#######")

--- a/src/silx/gui/qt/__init__.py
+++ b/src/silx/gui/qt/__init__.py
@@ -25,11 +25,10 @@
 
 - `PyQt5 <http://pyqt.sourceforge.net/Docs/PyQt5/>`_
 - `PySide6 <https://pypi.org/project/PySide6/>`_
-- `PySide2 <https://pypi.org/project/PySide2/>`_
 - `PyQt6 <https://pypi.org/project/PyQt6/>`_
 
 If a Qt binding is already loaded, it will use it, otherwise the different
-Qt bindings are tried in this order: PyQt5, PySide6, PySide2, PyQt6.
+Qt bindings are tried in this order: PyQt5, PySide6, PyQt6.
 
 The name of the loaded Qt binding is stored in the BINDING variable.
 

--- a/src/silx/gui/qt/_qt.py
+++ b/src/silx/gui/qt/_qt.py
@@ -38,10 +38,10 @@ _logger = logging.getLogger(__name__)
 
 
 BINDING = None
-"""The name of the Qt binding in use: PyQt5, PySide2, PySide6, PyQt6."""
+"""The name of the Qt binding in use: PyQt5, PySide6, PyQt6."""
 
 QtBinding = None  # noqa
-"""The Qt binding module in use: PyQt5, PySide2, PySide6, PyQt6."""
+"""The Qt binding module in use: PyQt5, PySide6, PyQt6."""
 
 HAS_SVG = False
 """True if Qt provides support for Scalable Vector Graphics (QtSVG)."""
@@ -50,7 +50,7 @@ HAS_OPENGL = False
 """True if Qt provides support for OpenGL (QtOpenGL)."""
 
 # First check for an already loaded wrapper
-for _binding in ('PySide2', 'PyQt5', 'PySide6', 'PyQt6'):
+for _binding in ('PyQt5', 'PySide6', 'PyQt6'):
     if _binding + '.QtCore' in sys.modules:
         BINDING = _binding
         break
@@ -66,22 +66,15 @@ else:  # Then try Qt bindings
             if 'PySide6' in sys.modules:
                 del sys.modules["PySide6"]
             try:
-                import PySide2.QtCore  # noqa
+                import PyQt6.QtCore  # noqa
             except ImportError:
-                if 'PySide2' in sys.modules:
-                    del sys.modules["PySide2"]
-                try:
-                    import PyQt6.QtCore  # noqa
-                except ImportError:
-                    if 'PyQt6' in sys.modules:
-                        del sys.modules["PyQt6"]
+                if 'PyQt6' in sys.modules:
+                    del sys.modules["PyQt6"]
 
-                    raise ImportError(
-                        'No Qt wrapper found. Install PyQt5, PySide2, PySide6, PyQt6.')
-                else:
-                    BINDING = 'PyQt6'
+                raise ImportError(
+                    'No Qt wrapper found. Install PyQt5, PySide6, PyQt6.')
             else:
-                BINDING = 'PySide2'
+                BINDING = 'PyQt6'
         else:
             BINDING = 'PySide6'
     else:
@@ -131,66 +124,6 @@ if BINDING == 'PyQt5':
     # See https://www.riverbankcomputing.com/static/Docs/PyQt5/multiinheritance.html?highlight=inheritance
     class _Foo(object): pass
     class QObject(QObject, _Foo): pass
-
-
-elif BINDING == 'PySide2':
-    deprecation.deprecated_warning(
-        type_="Qt Binding",
-        name="PySide2",
-        replacement="PySide6",
-        since_version="1.1",
-    )
-
-    import PySide2 as QtBinding  # noqa
-
-    from PySide2.QtCore import *  # noqa
-    from PySide2.QtGui import *  # noqa
-    from PySide2.QtWidgets import *  # noqa
-    from PySide2.QtPrintSupport import *  # noqa
-
-    try:
-        from PySide2.QtOpenGL import *  # noqa
-    except ImportError:
-        _logger.info("PySide2.QtOpenGL not available")
-        HAS_OPENGL = False
-    else:
-        HAS_OPENGL = True
-
-    try:
-        from PySide2.QtSvg import *  # noqa
-    except ImportError:
-        _logger.info("PySide2.QtSvg not available")
-        HAS_SVG = False
-    else:
-        HAS_SVG = True
-
-    pyqtSignal = Signal
-
-    # Qt6 compatibility:
-    # with PySide2 `exec` method has a special behavior
-    class _ExecMixIn:
-        """Mix-in class providind `exec` compatibility"""
-        def exec(self, *args, **kwargs):
-            return super().exec_(*args, **kwargs)
-
-    # QtWidgets
-    QApplication.exec = QApplication.exec_
-    class QColorDialog(_ExecMixIn, QColorDialog): pass
-    class QDialog(_ExecMixIn, QDialog): pass
-    class QErrorMessage(_ExecMixIn, QErrorMessage): pass
-    class QFileDialog(_ExecMixIn, QFileDialog): pass
-    class QFontDialog(_ExecMixIn, QFontDialog): pass
-    class QInputDialog(_ExecMixIn, QInputDialog): pass
-    class QMenu(_ExecMixIn, QMenu): pass
-    class QMessageBox(_ExecMixIn, QMessageBox): pass
-    class QProgressDialog(_ExecMixIn, QProgressDialog): pass
-    #QtCore
-    class QCoreApplication(_ExecMixIn, QCoreApplication): pass
-    class QEventLoop(_ExecMixIn, QEventLoop): pass
-    if hasattr(QTextStreamManipulator, "exec_"):
-        # exec_ only wrapped in PySide2 and NOT in PyQt5
-        class QTextStreamManipulator(_ExecMixIn, QTextStreamManipulator): pass
-    class QThread(_ExecMixIn, QThread): pass
 
 
 elif BINDING == 'PySide6':
@@ -278,7 +211,7 @@ elif BINDING == 'PyQt6':
     class QObject(QObject, _Foo): pass
 
 else:
-    raise ImportError('No Qt wrapper found. Install PyQt5, PySide2, PySide6 or PyQt6')
+    raise ImportError('No Qt wrapper found. Install PyQt5, PySide6 or PyQt6')
 
 
 # provide a exception handler but not implement it by default

--- a/src/silx/gui/qt/_utils.py
+++ b/src/silx/gui/qt/_utils.py
@@ -38,7 +38,7 @@ def getMouseEventPosition(event):
     :param QMouseEvent event:
     :returns: (x, y) as a tuple of float
     """
-    if _qt.BINDING in ("PyQt5", "PySide2"):
+    if _qt.BINDING == "PyQt5":
         return float(event.x()), float(event.y())
     # Qt6
     position = event.position()
@@ -48,13 +48,8 @@ def getMouseEventPosition(event):
 def supportedImageFormats():
     """Return a set of string of file format extensions supported by the
     Qt runtime."""
-    if _qt.BINDING == 'PySide2':
-        def convert(data):
-            return str(data.data(), 'ascii')
-    else:
-        convert = lambda data: str(data, 'ascii')
     formats = _qt.QImageReader.supportedImageFormats()
-    return set([convert(data) for data in formats])
+    return set([str(data, 'ascii') for data in formats])
 
 
 __globalThreadPoolInstance = None

--- a/src/silx/gui/qt/inspect.py
+++ b/src/silx/gui/qt/inspect.py
@@ -55,16 +55,6 @@ if qt.BINDING == 'PyQt5':
         """
         return not _isdeleted(obj)
 
-elif qt.BINDING == 'PySide2':
-    try:
-        from PySide2.shiboken2 import isValid  # noqa
-        from PySide2.shiboken2 import createdByPython  # noqa
-        from PySide2.shiboken2 import ownedByPython  # noqa
-    except ImportError:
-        from shiboken2 import isValid  # noqa
-        from shiboken2 import createdByPython  # noqa
-        from shiboken2 import ownedByPython  # noqa
-
 elif qt.BINDING == 'PySide6':
     from shiboken6 import isValid, createdByPython, ownedByPython  # noqa
 

--- a/src/silx/gui/test/test_qt.py
+++ b/src/silx/gui/test/test_qt.py
@@ -185,8 +185,8 @@ class TestQtInspect(unittest.TestCase):
         self.assertFalse(qt_inspect.isValid(obj))
 
 
-@pytest.mark.skipif(qt.BINDING not in ("PyQt5", "PySide2"),
-                    reason="PyQt5/PySide2 only test")
+@pytest.mark.skipif(qt.BINDING != "PyQt5",
+                    reason="PyQt5 only test")
 def test_exec_():
     """Test the exec_ is still useable with Qt5 bindings"""
     klasses = [

--- a/src/silx/gui/utils/glutils/__init__.py
+++ b/src/silx/gui/utils/glutils/__init__.py
@@ -128,7 +128,7 @@ def isOpenGLAvailable(version=(2, 1), runtimeCheck=True, shareOpenGLContexts=Fal
                 if not qt.HAS_OPENGL:
                     error = '%s.QtOpenGL not available' % qt.BINDING
 
-                elif qt.BINDING in ('PySide2', 'PyQt5') and qt.QApplication.instance() and not qt.QGLFormat.hasOpenGL():
+                elif qt.BINDING == 'PyQt5' and qt.QApplication.instance() and not qt.QGLFormat.hasOpenGL():
                     # qt.QGLFormat.hasOpenGL MUST be called with a QApplication created
                     # so this is only checked if the QApplication is already created
                     error = 'Qt reports OpenGL not available'

--- a/src/silx/gui/utils/image.py
+++ b/src/silx/gui/utils/image.py
@@ -116,7 +116,7 @@ def convertQImageToArray(image):
         ptr.setsize(image.byteCount())
     elif qt.BINDING == 'PyQt6':
         ptr.setsize(image.sizeInBytes())
-    elif qt.BINDING in ('PySide2', 'PySide6'):
+    elif qt.BINDING == 'PySide6':
         ptr = ptr.tobytes()
     else:
         raise RuntimeError("Unsupported Qt binding: %s" % qt.BINDING)

--- a/src/silx/gui/utils/matplotlib.py
+++ b/src/silx/gui/utils/matplotlib.py
@@ -128,23 +128,8 @@ def rasterMathText(text, font, size=-1, weight=-1, italic=False, devicePixelRati
     return clipped_array, image.shape[0] - 1  # baseline not available
 
 
-def _matplotlib_use(backend, force):
-    """Wrapper of `matplotlib.use` to set-up backend.
-
-    It adds extra initialization for PySide2 with matplotlib < 2.2.
-    """
-    # This is kept for compatibility with matplotlib < 2.2
-    if (
-        parse_version(matplotlib.__version__) < parse_version("2.2")
-        and qt.BINDING == "PySide2"
-    ):
-        matplotlib.rcParams["backend.qt5"] = "PySide2"
-
-    matplotlib.use(backend, force=force)
-
-
-if qt.BINDING in ("PySide6", "PyQt6", "PyQt5", "PySide2"):
-    _matplotlib_use("Qt5Agg", force=False)
+if qt.BINDING in ("PySide6", "PyQt6", "PyQt5"):
+    matplotlib.use("Qt5Agg", force=False)
     from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg  # noqa
 
 else:

--- a/src/silx/gui/utils/testutils.py
+++ b/src/silx/gui/utils/testutils.py
@@ -42,9 +42,7 @@ from silx.gui import qt
 from silx.gui.qt import inspect as _inspect
 
 
-if qt.BINDING == 'PySide2':
-    from PySide2.QtTest import QTest
-elif qt.BINDING == 'PyQt5':
+if qt.BINDING == 'PyQt5':
     from PyQt5.QtTest import QTest
 elif qt.BINDING == 'PySide6':
     from PySide6.QtTest import QTest
@@ -85,7 +83,7 @@ class TestCaseQt(unittest.TestCase):
     To allow some widgets to remain alive at the end of a test, set the
     allowedLeakingWidgets attribute to the number of widgets that can remain
     alive at the end of the test.
-    With PySide2, this test is not run for now as it seems PySide2
+    With PySide, this test is not run for now as it seems PySide
     is leaking widgets internally.
 
     All keyboard and mouse event simulation methods call qWait(20) after
@@ -133,7 +131,7 @@ class TestCaseQt(unittest.TestCase):
     def setUp(self):
         """Get the list of existing widgets."""
         self.allowedLeakingWidgets = 0
-        if qt.BINDING in ('PySide2', 'PySide6'):
+        if qt.BINDING == 'PySide6':
             self.__previousWidgets = None
         else:
             self.__previousWidgets = self.qapp.allWidgets()
@@ -161,7 +159,7 @@ class TestCaseQt(unittest.TestCase):
     def _checkForUnreleasedWidgets(self):
         """Test fixture checking that no more widgets exists."""
         if self.__previousWidgets is None:
-            return  # Do not test for leaking widgets with PySide2
+            return  # Do not test for leaking widgets with PySide
 
         gc.collect()
 
@@ -321,8 +319,8 @@ class TestCaseQt(unittest.TestCase):
         if ms is None:
             ms = cls.DEFAULT_TIMEOUT_WAIT
 
-        if qt.BINDING in ('PySide2', 'PySide6'):
-            # PySide2 has no qWait, provide a replacement
+        if qt.BINDING == 'PySide6':
+            # PySide has no qWait, provide a replacement
             timeout = int(ms)
             endTimeMS = int(time.time() * 1000) + timeout
             qapp = qt.QApplication.instance()
@@ -503,7 +501,7 @@ def getQToolButtonFromAction(action):
 
 
 def findChildren(parent, kind, name=None):
-    if qt.BINDING in ("PySide2", "PySide6") and name is not None:
+    if qt.BINDING == "PySide6" and name is not None:
         result = []
         for obj in parent.findChildren(kind):
             if obj.objectName() == name:

--- a/src/silx/gui/widgets/ElidedLabel.py
+++ b/src/silx/gui/widgets/ElidedLabel.py
@@ -62,7 +62,7 @@ class ElidedLabel(qt.QLabel):
 
     def __updateMinimumSize(self):
         metrics = self.fontMetrics()
-        if qt.BINDING in ('PySide2', 'PyQt5'):
+        if qt.BINDING == 'PyQt5':
             width = metrics.width("...")
         else:  # Qt6
             width = metrics.horizontalAdvance("...")

--- a/src/silx/gui/widgets/WaitingPushButton.py
+++ b/src/silx/gui/widgets/WaitingPushButton.py
@@ -105,7 +105,7 @@ class WaitingPushButton(qt.QPushButton):
 
         contentSize = qt.QSize(w, h)
         sizeHint = self.style().sizeFromContents(qt.QStyle.CT_PushButton, opt, contentSize, self)
-        if qt.BINDING in ('PySide2', 'PyQt5'):  # Qt6: globalStrut not available
+        if qt.BINDING == 'PyQt5':  # Qt6: globalStrut not available
             sizeHint = sizeHint.expandedTo(qt.QApplication.globalStrut())
         return sizeHint
 


### PR DESCRIPTION
As announced in v1.1.0.

This PR clean-up codes for supporting `PySide2` (except for the `loadUi` function done in PR #3783).

closes #3666

