### PR TITLE
`silx.math.colormap`: Added `normalize` function to normalize to `uint8`.

### DIFF
--- a/src/silx/math/colormap.py
+++ b/src/silx/math/colormap.py
@@ -29,6 +29,8 @@ __date__ = "25/08/2021"
 
 
 import collections
+import numbers
+from typing import NamedTuple
 import warnings
 import numpy
 
@@ -404,7 +406,27 @@ _BASIC_NORMALIZATIONS = {
     "arcsinh": ArcsinhNormalization(),
 }
 
+
+def _get_normalizer(norm, gamma):
+    """Returns corresponding Normalization instance"""
+    if norm == "gamma":
+        return GammaNormalization(gamma)
+    return _BASIC_NORMALIZATIONS[norm]
+
+
+def _get_range(normalizer, data, autoscale, vmin, vmax):
+    """Returns effective range"""
+    if vmin is None or vmax is None:
+        auto_vmin, auto_vmax = normalizer.autoscale(data, autoscale)
+        if vmin is None:  # Set vmin respecting provided vmax
+            vmin = auto_vmin if vmax is None else min(auto_vmin, vmax)
+        if vmax is None:
+            vmax = max(auto_vmax, vmin)  # Handle max_ <= 0 for log scale
+    return vmin, vmax
+
+
 _DEFAULT_NAN_COLOR = 255, 255, 255, 0
+
 
 def apply_colormap(data,
                    colormap: str,
@@ -426,19 +448,8 @@ def apply_colormap(data,
     :returns: Array of colors
     """
     colors = get_colormap_lut(colormap)
-
-    if norm == "gamma":
-        normalizer = GammaNormalization(gamma)
-    else:
-        normalizer = _BASIC_NORMALIZATIONS[norm]
-
-    if vmin is None or vmax is None:
-        auto_vmin, auto_vmax = normalizer.autoscale(data, autoscale)
-        if vmin is None:  # Set vmin respecting provided vmax
-            vmin = auto_vmin if vmax is None else min(auto_vmin, vmax)
-        if vmax is None:
-            vmax = max(auto_vmax, vmin)  # Handle max_ <= 0 for log scale
-
+    normalizer = _get_normalizer(norm, gamma)
+    vmin, vmax = _get_range(normalizer, data, autoscale, vmin, vmax)
     return _colormap.cmap(
         data,
         colors,
@@ -447,3 +458,45 @@ def apply_colormap(data,
         normalizer,
         _DEFAULT_NAN_COLOR,
     )
+
+
+_UINT8_LUT = numpy.arange(256, dtype=numpy.uint8).reshape(-1, 1)
+
+
+class NormalizeResult(NamedTuple):
+    data: numpy.ndarray
+    vmin: numbers.Number
+    vmax: numbers.Number
+
+
+def normalize(
+    data,
+    norm: str = "linear",
+    autoscale: str = "minmax",
+    vmin=None,
+    vmax=None,
+    gamma=1.0,
+):
+    """Normalize data to an array of uint8.
+
+    :param numpy.ndarray data: Data to normalize
+    :param str norm: Normalization to apply
+    :param str autoscale: Autoscale mode: "minmax" (default) or "stddev3"
+    :param vmin: Lower bound, None (default) to autoscale
+    :param vmax: Upper bound, None (default) to autoscale
+    :param float gamma:
+        Gamma correction parameter (used only for "gamma" normalization)
+    :returns: Array of normalized values, vmin, vmax
+    """
+    normalizer = _get_normalizer(norm, gamma)
+    vmin, vmax = _get_range(normalizer, data, autoscale, vmin, vmax)
+    norm_data = _colormap.cmap(
+        data,
+        _UINT8_LUT,
+        vmin,
+        vmax,
+        normalizer,
+        nan_color=_UINT8_LUT[0],
+    )
+    norm_data.shape = data.shape
+    return NormalizeResult(norm_data, vmin, vmax)

--- a/src/silx/math/test/test_colormap.py
+++ b/src/silx/math/test/test_colormap.py
@@ -32,6 +32,7 @@ import logging
 import sys
 
 import numpy
+import pytest
 
 from silx.utils.testutils import ParametricTestCase
 from silx.math import colormap
@@ -264,3 +265,31 @@ def test_apply_colormap():
         vmax=None,
         gamma=1.0)
     assert numpy.array_equal(colors, expected_colors)
+
+
+testdata_normalize = [
+    (numpy.arange(512), numpy.arange(512) // 2, 0, 511),
+    ((numpy.nan, numpy.inf, -numpy.inf), (0, 255, 0), 0, 1),
+    ((numpy.nan, numpy.inf, -numpy.inf, 1), (0, 255, 0, 0), 1, 1),
+]
+
+@pytest.mark.parametrize(
+    "data,expected_data,expected_vmin,expected_vmax",
+    testdata_normalize,
+)
+def test_normalize(data, expected_data, expected_vmin, expected_vmax):
+    """Basic test of silx.math.colormap.normalize"""
+    result = colormap.normalize(
+        numpy.asarray(data),
+        norm="linear",
+        autoscale="minmax",
+        vmin=None,
+        vmax=None,
+        gamma=1.0,
+    )
+    assert result.vmin == expected_vmin
+    assert result.vmax == expected_vmax
+    assert numpy.array_equal(
+        result.data,
+        numpy.asarray(expected_data, dtype=numpy.uint8),
+    )


### PR DESCRIPTION
This PR adds a `normalize` function that converts an array to an array of `uint8` by applying a normalization as done for applying colormaps.

closes #3769


