### PR TITLE
[silx compare] Create a dedicated app to compare images

### DIFF
--- a/src/silx/__main__.py
+++ b/src/silx/__main__.py
@@ -61,6 +61,9 @@ def main():
     launcher.add_command("convert",
                          module_name="silx.app.convert",
                          description="Convert and concatenate files into a HDF5 file")
+    launcher.add_command("compare",
+                         module_name="silx.app.compare.main",
+                         description="Compare images with a GUI")
     launcher.add_command("test",
                          module_name="silx.app.test_",
                          description="Launch silx unittest")

--- a/src/silx/app/compare/CompareImagesWindow.py
+++ b/src/silx/app/compare/CompareImagesWindow.py
@@ -60,6 +60,7 @@ class CompareImagesWindow(qt.QMainWindow):
         self._selectionTable.sigImageBChanged.connect(self._updateImageB)
 
     def setUrls(self, urls):
+        self.clear()
         for url in urls:
             self._selectionTable.addUrl(url)
 

--- a/src/silx/app/compare/CompareImagesWindow.py
+++ b/src/silx/app/compare/CompareImagesWindow.py
@@ -29,6 +29,7 @@ import logging
 import numpy
 
 import silx.io
+from silx.gui import icons
 from silx.gui import qt
 from silx.io.url import DataUrl
 from silx.gui.plot.CompareImages import CompareImages
@@ -42,6 +43,9 @@ class CompareImagesWindow(qt.QMainWindow):
     def __init__(self, backend=None, settings=None):
         qt.QMainWindow.__init__(self, parent=None)
         self.setWindowTitle("Silx compare")
+
+        silxIcon = icons.getQIcon("silx")
+        self.setWindowIcon(silxIcon)
 
         self.__settings = settings
         if settings:

--- a/src/silx/app/compare/CompareImagesWindow.py
+++ b/src/silx/app/compare/CompareImagesWindow.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+# /*##########################################################################
+#
+# Copyright (c) 2016-2023 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Main window used to compare images
+"""
+
+import sys
+import logging
+import numpy
+import argparse
+import os
+
+import silx.io
+from silx.gui import qt
+import silx.test.utils
+from silx.io.url import DataUrl
+from silx.gui.plot.CompareImages import CompareImages
+from silx.gui.widgets.UrlSelectionTable import UrlSelectionTable
+
+_logger = logging.getLogger(__name__)
+
+
+class CompareImagesWindow(qt.QMainWindow):
+    def __init__(self, backend=None):
+        qt.QMainWindow.__init__(self, parent=None)
+        self._plot = CompareImages(parent=self, backend=backend)
+
+        self._selectionTable = UrlSelectionTable(parent=self)
+        self._dockWidgetMenu = qt.QDockWidget(parent=self)
+        self._dockWidgetMenu.layout().setContentsMargins(0, 0, 0, 0)
+        self._dockWidgetMenu.setFeatures(qt.QDockWidget.DockWidgetMovable)
+        self._dockWidgetMenu.setWidget(self._selectionTable)
+        self.addDockWidget(qt.Qt.LeftDockWidgetArea, self._dockWidgetMenu)
+
+        self.setCentralWidget(self._plot)
+
+        self._selectionTable.sigImageAChanged.connect(self._updateImageA)
+        self._selectionTable.sigImageBChanged.connect(self._updateImageB)
+
+    def setUrls(self, urls):
+        for url in urls:
+            self._selectionTable.addUrl(url)
+
+    def setFiles(self, files):
+        urls = list()
+        for _file in files:
+            if os.path.isfile(_file):
+                urls.append(DataUrl(file_path=_file, scheme=None))
+        urls.sort(key=lambda url: url.path())
+        self.setUrls(urls)
+        url1 = urls[0].path() if len(urls) >= 1 else None
+        url2 = urls[1].path() if len(urls) >= 2 else None
+        self._selectionTable.setSelection(
+            url_img_a=url1,
+            url_img_b=url2
+        )
+
+    def clear(self):
+        self._plot.clear()
+        self._selectionTable.clear()
+
+    def _updateImageA(self, urlpath):
+        self._updateImage(urlpath, self._plot.setImage1)
+
+    def _updateImage(self, urlpath, fctptr):
+        def getData():
+            _url = silx.io.url.DataUrl(path=urlpath)
+            for scheme in ('silx', 'fabio'):
+                try:
+                    dataImg = silx.io.utils.get_data(
+                        silx.io.url.DataUrl(file_path=_url.file_path(),
+                                            data_slice=_url.data_slice(),
+                                            data_path=_url.data_path(),
+                                            scheme=scheme))
+                except:
+                    _logger.debug("Error while loading image with %s" % scheme,
+                                  exc_info=True)
+                else:
+                    # TODO: check is an image
+                    return dataImg
+            return None
+
+        data = getData()
+        if data is not None:
+            fctptr(data)
+
+    def _updateImageB(self, urlpath):
+        self._updateImage(urlpath, self._plot.setImage2)

--- a/src/silx/app/compare/CompareImagesWindow.py
+++ b/src/silx/app/compare/CompareImagesWindow.py
@@ -25,15 +25,11 @@
 """Main window used to compare images
 """
 
-import sys
 import logging
 import numpy
-import argparse
-import os
 
 import silx.io
 from silx.gui import qt
-import silx.test.utils
 from silx.io.url import DataUrl
 from silx.gui.plot.CompareImages import CompareImages
 from silx.gui.widgets.UrlSelectionTable import UrlSelectionTable

--- a/src/silx/app/compare/CompareImagesWindow.py
+++ b/src/silx/app/compare/CompareImagesWindow.py
@@ -65,14 +65,6 @@ class CompareImagesWindow(qt.QMainWindow):
         self.clear()
         for url in urls:
             self._selectionTable.addUrl(url)
-
-    def setFiles(self, files):
-        urls = list()
-        for _file in files:
-            if os.path.isfile(_file):
-                urls.append(DataUrl(file_path=_file, scheme=None))
-        urls.sort(key=lambda url: url.path())
-        self.setUrls(urls)
         url1 = urls[0].path() if len(urls) >= 1 else None
         url2 = urls[1].path() if len(urls) >= 2 else None
         self._selectionTable.setSelection(

--- a/src/silx/app/compare/CompareImagesWindow.py
+++ b/src/silx/app/compare/CompareImagesWindow.py
@@ -47,6 +47,7 @@ class CompareImagesWindow(qt.QMainWindow):
         self._plot = CompareImages(parent=self, backend=backend)
 
         self._selectionTable = UrlSelectionTable(parent=self)
+        self._selectionTable.setAcceptDrops(True)
         self._dockWidgetMenu = qt.QDockWidget(parent=self)
         self._dockWidgetMenu.layout().setContentsMargins(0, 0, 0, 0)
         self._dockWidgetMenu.setFeatures(qt.QDockWidget.DockWidgetMovable)

--- a/src/silx/app/compare/CompareImagesWindow.py
+++ b/src/silx/app/compare/CompareImagesWindow.py
@@ -44,6 +44,8 @@ _logger = logging.getLogger(__name__)
 class CompareImagesWindow(qt.QMainWindow):
     def __init__(self, backend=None):
         qt.QMainWindow.__init__(self, parent=None)
+        self.setWindowTitle("Silx compare")
+
         self._plot = CompareImages(parent=self, backend=backend)
 
         self._selectionTable = UrlSelectionTable(parent=self)

--- a/src/silx/app/compare/CompareImagesWindow.py
+++ b/src/silx/app/compare/CompareImagesWindow.py
@@ -52,6 +52,7 @@ class CompareImagesWindow(qt.QMainWindow):
             self.restoreSettings(settings)
 
         self._plot = CompareImages(parent=self, backend=backend)
+        self._plot.setAutoResetZoom(False)
 
         self._selectionTable = UrlSelectionTable(parent=self)
         self._selectionTable.setAcceptDrops(True)
@@ -79,6 +80,7 @@ class CompareImagesWindow(qt.QMainWindow):
             url_img_a=url1,
             url_img_b=url2
         )
+        self._plot.resetZoom()
 
     def clear(self):
         self._plot.clear()

--- a/src/silx/app/compare/__init__.py
+++ b/src/silx/app/compare/__init__.py
@@ -1,0 +1,27 @@
+# /*##########################################################################
+# Copyright (C) 2022-2023 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+"""Package containing source code of the `silx compare` application"""
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "04/13/2023"

--- a/src/silx/app/compare/main.py
+++ b/src/silx/app/compare/main.py
@@ -73,10 +73,21 @@ def mainQt(options):
     else:
         backend = "mpl"
 
-    app = qt.QApplication([])
-    window = CompareImagesWindow(backend=backend)
+    settings = qt.QSettings(qt.QSettings.IniFormat,
+                            qt.QSettings.UserScope,
+                            "silx",
+                            "silx-compare",
+                            None)
 
     urls = list(parseutils.filenames_to_dataurls(options.files))
+
+    if options.use_opengl_plot:
+        # It have to be done after the settings (after the Viewer creation)
+        silx.config.DEFAULT_PLOT_BACKEND = "opengl"
+
+    app = qt.QApplication([])
+    window = CompareImagesWindow(backend=backend, settings=settings)
+    window.setAttribute(qt.Qt.WA_DeleteOnClose, True)
     window.setUrls(urls)
 
     window.setVisible(True)

--- a/src/silx/app/compare/main.py
+++ b/src/silx/app/compare/main.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python
+# /*##########################################################################
+#
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Example demonstrating the use of the widget CompareImages
+"""
+
+import sys
+import logging
+import numpy
+import argparse
+import os
+
+import silx.io
+from silx.gui import qt
+import silx.test.utils
+from silx.io.url import DataUrl
+from silx.gui.plot.CompareImages import CompareImages
+from silx.gui.widgets.UrlSelectionTable import UrlSelectionTable
+
+_logger = logging.getLogger(__name__)
+
+import fabio
+
+try:
+    import PIL
+except ImportError:
+    _logger.debug("Backtrace", exc_info=True)
+    PIL = None
+
+
+class CompareImagesSelection(qt.QMainWindow):
+    def __init__(self, backend):
+        qt.QMainWindow.__init__(self, parent=None)
+        self._plot = CompareImages(parent=self, backend=backend)
+
+        self._selectionTable = UrlSelectionTable(parent=self)
+        self._dockWidgetMenu = qt.QDockWidget(parent=self)
+        self._dockWidgetMenu.layout().setContentsMargins(0, 0, 0, 0)
+        self._dockWidgetMenu.setFeatures(qt.QDockWidget.DockWidgetMovable)
+        self._dockWidgetMenu.setWidget(self._selectionTable)
+        self.addDockWidget(qt.Qt.LeftDockWidgetArea, self._dockWidgetMenu)
+
+        self.setCentralWidget(self._plot)
+
+        self._selectionTable.sigImageAChanged.connect(self._updateImageA)
+        self._selectionTable.sigImageBChanged.connect(self._updateImageB)
+
+    def setUrls(self, urls):
+        for url in urls:
+            self._selectionTable.addUrl(url)
+
+    def setFiles(self, files):
+        urls = list()
+        for _file in files:
+            if os.path.isfile(_file):
+                urls.append(DataUrl(file_path=_file, scheme=None))
+        urls.sort(key=lambda url: url.path())
+        self.setUrls(urls)
+        url1 = urls[0].path() if len(urls) >= 1 else None
+        url2 = urls[1].path() if len(urls) >= 2 else None
+        self._selectionTable.setSelection(
+            url_img_a=url1,
+            url_img_b=url2
+        )
+
+    def clear(self):
+        self._plot.clear()
+        self._selectionTable.clear()
+
+    def _updateImageA(self, urlpath):
+        self._updateImage(urlpath, self._plot.setImage1)
+
+    def _updateImage(self, urlpath, fctptr):
+        def getData():
+            _url = silx.io.url.DataUrl(path=urlpath)
+            for scheme in ('silx', 'fabio'):
+                try:
+                    dataImg = silx.io.utils.get_data(
+                        silx.io.url.DataUrl(file_path=_url.file_path(),
+                                            data_slice=_url.data_slice(),
+                                            data_path=_url.data_path(),
+                                            scheme=scheme))
+                except:
+                    _logger.debug("Error while loading image with %s" % scheme,
+                                  exc_info=True)
+                else:
+                    # TODO: check is an image
+                    return dataImg
+            return None
+
+        data = getData()
+        if data is not None:
+            fctptr(data)
+
+    def _updateImageB(self, urlpath):
+        self._updateImage(urlpath, self._plot.setImage2)
+
+
+def createTestData():
+    data = numpy.arange(100 * 100)
+    data = (data % 100) / 5.0
+    data = numpy.sin(data)
+    data1 = data.copy()
+    data1.shape = 100, 100
+    data2 = silx.test.utils.add_gaussian_noise(data, stdev=0.1)
+    data2.shape = 100, 100
+    return data1, data2
+
+
+def loadImage(filename):
+    try:
+        return silx.io.get_data(filename)
+    except Exception:
+        _logger.debug("Error while loading image with silx.io", exc_info=True)
+
+    try:
+        return fabio.open(filename).data
+    except Exception:
+        _logger.debug("Error while loading image with fabio", exc_info=True)
+
+    if PIL is not None:
+        try:
+            return numpy.asarray(PIL.Image.open(filename))
+        except Exception:
+            _logger.debug("Error while loading image with PIL", exc_info=True)
+
+    raise Exception("Impossible to load '%s' with the available image libraries" % filename)
+
+
+file_description = """
+Image data to compare (HDF5 file with path, EDF files, JPEG/PNG image files).
+Data from HDF5 files can be accessed using dataset path and slicing as an URL: silx:../my_file.h5?path=/entry/data&slice=10
+EDF file frames also can can be accessed using URL: fabio:../my_file.edf?slice=10
+Using URL in command like usually have to be quoted: "URL".
+"""
+
+
+def createParser():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        'files',
+        nargs=argparse.ZERO_OR_MORE,
+        help=file_description)
+    parser.add_argument(
+        '--debug',
+        dest="debug",
+        action="store_true",
+        default=False,
+        help='Set logging system in debug mode')
+    parser.add_argument(
+        '--testdata',
+        dest="testdata",
+        action="store_true",
+        default=False,
+        help='Use synthetic images to test the application')
+    parser.add_argument(
+        '--use-opengl-plot',
+        dest="use_opengl_plot",
+        action="store_true",
+        default=False,
+        help='Use OpenGL for plots (instead of matplotlib)')
+    return parser
+
+
+def main(argv):
+    parser = createParser()
+    options = parser.parse_args(argv[1:])
+
+    if options.debug:
+        logging.root.setLevel(logging.DEBUG)
+
+    if options.use_opengl_plot:
+        backend = "gl"
+    else:
+        backend = "mpl"
+
+    app = qt.QApplication([])
+    if options.testdata or len(options.files) == 2:
+        if options.testdata:
+            _logger.info("Generate test data")
+            data1, data2 = createTestData()
+        else:
+            data1 = loadImage(options.files[0])
+            data2 = loadImage(options.files[1])
+        window = CompareImages(backend=backend)
+        window.setData(data1, data2)
+    else:
+        data = options.files
+        window = CompareImagesSelection(backend=backend)
+        window.setFiles(options.files)
+
+    window.setVisible(True)
+    app.exec()
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/src/silx/app/compare/main.py
+++ b/src/silx/app/compare/main.py
@@ -22,130 +22,15 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-"""Example demonstrating the use of the widget CompareImages
-"""
+"""GUI to compare images"""
 
 import sys
 import logging
-import numpy
 import argparse
-import os
-
-import silx.io
 from silx.gui import qt
-import silx.test.utils
-from silx.io.url import DataUrl
-from silx.gui.plot.CompareImages import CompareImages
-from silx.gui.widgets.UrlSelectionTable import UrlSelectionTable
+from silx.app.compare.CompareImagesWindow import CompareImagesWindow
 
 _logger = logging.getLogger(__name__)
-
-import fabio
-
-try:
-    import PIL
-except ImportError:
-    _logger.debug("Backtrace", exc_info=True)
-    PIL = None
-
-
-class CompareImagesSelection(qt.QMainWindow):
-    def __init__(self, backend):
-        qt.QMainWindow.__init__(self, parent=None)
-        self._plot = CompareImages(parent=self, backend=backend)
-
-        self._selectionTable = UrlSelectionTable(parent=self)
-        self._dockWidgetMenu = qt.QDockWidget(parent=self)
-        self._dockWidgetMenu.layout().setContentsMargins(0, 0, 0, 0)
-        self._dockWidgetMenu.setFeatures(qt.QDockWidget.DockWidgetMovable)
-        self._dockWidgetMenu.setWidget(self._selectionTable)
-        self.addDockWidget(qt.Qt.LeftDockWidgetArea, self._dockWidgetMenu)
-
-        self.setCentralWidget(self._plot)
-
-        self._selectionTable.sigImageAChanged.connect(self._updateImageA)
-        self._selectionTable.sigImageBChanged.connect(self._updateImageB)
-
-    def setUrls(self, urls):
-        for url in urls:
-            self._selectionTable.addUrl(url)
-
-    def setFiles(self, files):
-        urls = list()
-        for _file in files:
-            if os.path.isfile(_file):
-                urls.append(DataUrl(file_path=_file, scheme=None))
-        urls.sort(key=lambda url: url.path())
-        self.setUrls(urls)
-        url1 = urls[0].path() if len(urls) >= 1 else None
-        url2 = urls[1].path() if len(urls) >= 2 else None
-        self._selectionTable.setSelection(
-            url_img_a=url1,
-            url_img_b=url2
-        )
-
-    def clear(self):
-        self._plot.clear()
-        self._selectionTable.clear()
-
-    def _updateImageA(self, urlpath):
-        self._updateImage(urlpath, self._plot.setImage1)
-
-    def _updateImage(self, urlpath, fctptr):
-        def getData():
-            _url = silx.io.url.DataUrl(path=urlpath)
-            for scheme in ('silx', 'fabio'):
-                try:
-                    dataImg = silx.io.utils.get_data(
-                        silx.io.url.DataUrl(file_path=_url.file_path(),
-                                            data_slice=_url.data_slice(),
-                                            data_path=_url.data_path(),
-                                            scheme=scheme))
-                except:
-                    _logger.debug("Error while loading image with %s" % scheme,
-                                  exc_info=True)
-                else:
-                    # TODO: check is an image
-                    return dataImg
-            return None
-
-        data = getData()
-        if data is not None:
-            fctptr(data)
-
-    def _updateImageB(self, urlpath):
-        self._updateImage(urlpath, self._plot.setImage2)
-
-
-def createTestData():
-    data = numpy.arange(100 * 100)
-    data = (data % 100) / 5.0
-    data = numpy.sin(data)
-    data1 = data.copy()
-    data1.shape = 100, 100
-    data2 = silx.test.utils.add_gaussian_noise(data, stdev=0.1)
-    data2.shape = 100, 100
-    return data1, data2
-
-
-def loadImage(filename):
-    try:
-        return silx.io.get_data(filename)
-    except Exception:
-        _logger.debug("Error while loading image with silx.io", exc_info=True)
-
-    try:
-        return fabio.open(filename).data
-    except Exception:
-        _logger.debug("Error while loading image with fabio", exc_info=True)
-
-    if PIL is not None:
-        try:
-            return numpy.asarray(PIL.Image.open(filename))
-        except Exception:
-            _logger.debug("Error while loading image with PIL", exc_info=True)
-
-    raise Exception("Impossible to load '%s' with the available image libraries" % filename)
 
 
 file_description = """
@@ -169,12 +54,6 @@ def createParser():
         default=False,
         help='Set logging system in debug mode')
     parser.add_argument(
-        '--testdata',
-        dest="testdata",
-        action="store_true",
-        default=False,
-        help='Use synthetic images to test the application')
-    parser.add_argument(
         '--use-opengl-plot',
         dest="use_opengl_plot",
         action="store_true",
@@ -183,10 +62,8 @@ def createParser():
     return parser
 
 
-def main(argv):
-    parser = createParser()
-    options = parser.parse_args(argv[1:])
-
+def mainQt(options):
+    """Part of the main depending on Qt"""
     if options.debug:
         logging.root.setLevel(logging.DEBUG)
 
@@ -196,22 +73,16 @@ def main(argv):
         backend = "mpl"
 
     app = qt.QApplication([])
-    if options.testdata or len(options.files) == 2:
-        if options.testdata:
-            _logger.info("Generate test data")
-            data1, data2 = createTestData()
-        else:
-            data1 = loadImage(options.files[0])
-            data2 = loadImage(options.files[1])
-        window = CompareImages(backend=backend)
-        window.setData(data1, data2)
-    else:
-        data = options.files
-        window = CompareImagesSelection(backend=backend)
-        window.setFiles(options.files)
-
+    window = CompareImagesWindow(backend=backend)
+    window.setFiles(options.files)
     window.setVisible(True)
     app.exec()
+
+
+def main(argv):
+    parser = createParser()
+    options = parser.parse_args(argv[1:])
+    mainQt(options)
 
 
 if __name__ == '__main__':

--- a/src/silx/app/compare/main.py
+++ b/src/silx/app/compare/main.py
@@ -28,6 +28,7 @@ import sys
 import logging
 import argparse
 from silx.gui import qt
+from silx.app.utils import parseutils
 from silx.app.compare.CompareImagesWindow import CompareImagesWindow
 
 _logger = logging.getLogger(__name__)
@@ -74,7 +75,10 @@ def mainQt(options):
 
     app = qt.QApplication([])
     window = CompareImagesWindow(backend=backend)
-    window.setFiles(options.files)
+
+    urls = list(parseutils.filenames_to_dataurls(options.files))
+    window.setUrls(urls)
+
     window.setVisible(True)
     app.exec()
 

--- a/src/silx/app/compare/test/__init__.py
+++ b/src/silx/app/compare/test/__init__.py
@@ -1,0 +1,23 @@
+# /*##########################################################################
+#
+# Copyright (c) 2016-2017 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/

--- a/src/silx/app/compare/test/test_compare.py
+++ b/src/silx/app/compare/test/test_compare.py
@@ -1,0 +1,49 @@
+# /*##########################################################################
+#
+# Copyright (c) 2016-2020 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Module testing silx.app.view"""
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "07/06/2023"
+
+
+import weakref
+import pytest
+from silx.app.compare.CompareImagesWindow import CompareImagesWindow
+from silx.gui.utils.testutils import TestCaseQt
+
+
+@pytest.mark.usefixtures("qapp")
+class TestCompare(TestCaseQt):
+    """Test for Viewer class"""
+
+    def testConstruct(self):
+        widget = CompareImagesWindow()
+        self.qWaitForWindowExposed(widget)
+
+    def testDestroy(self):
+        widget = CompareImagesWindow()
+        ref = weakref.ref(widget)
+        widget = None
+        self.qWaitForDestroy(ref)

--- a/src/silx/app/compare/test/test_launcher.py
+++ b/src/silx/app/compare/test/test_launcher.py
@@ -1,0 +1,140 @@
+# /*##########################################################################
+#
+# Copyright (c) 2016-2023 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Module testing silx.app.view"""
+
+__authors__ = ["V. Valls"]
+__license__ = "MIT"
+__date__ = "07/06/2023"
+
+
+import os
+import sys
+import shutil
+import logging
+import subprocess
+import pytest
+
+from .. import main
+from silx import __main__ as silx_main
+
+_logger = logging.getLogger(__name__)
+
+
+def test_help(qapp):
+    # option -h must cause a raise SystemExit or a return 0
+    try:
+        parser = main.createParser()
+        parser.parse_args(["compare", "--help"])
+        result = 0
+    except SystemExit as e:
+        result = e.args[0]
+    assert result == 0
+
+
+def test_wrong_option(qapp):
+    try:
+        parser = main.createParser()
+        parser.parse_args(["compare", "--foo"])
+        self.fail()
+    except SystemExit as e:
+        result = e.args[0]
+    assert result != 0
+
+
+def test_wrong_file(qapp):
+    try:
+        parser = main.createParser()
+        result = parser.parse_args(["compare", "__file.not.found__"])
+        result = 0
+    except SystemExit as e:
+        result = e.args[0]
+    assert result == 0
+
+
+def _create_test_env():
+    """
+    Returns an associated environment with a working project.
+    """
+    env = dict((str(k), str(v)) for k, v in os.environ.items())
+    env["PYTHONPATH"] = os.pathsep.join(sys.path)
+    return env
+
+
+@pytest.fixture
+def execute_as_script(tmp_path):
+    """Execute a command line.
+
+    Log output as debug in case of bad return code.
+    """
+    def execute_as_script(filename, *args):
+        env = _create_test_env()
+
+        # Copy file to temporary dir to avoid import from current dir.
+        script = os.path.join(tmp_path, 'launcher.py')
+        shutil.copyfile(filename, script)
+        command_line = [sys.executable, script] + list(args)
+
+        _logger.info("Execute: %s", " ".join(command_line))
+        p = subprocess.Popen(command_line,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE,
+                             env=env)
+        out, err = p.communicate()
+        _logger.info("Return code: %d", p.returncode)
+        try:
+            out = out.decode('utf-8')
+        except UnicodeError:
+            pass
+        try:
+            err = err.decode('utf-8')
+        except UnicodeError:
+            pass
+ 
+        if p.returncode != 0:
+            _logger.error("stdout:")
+            _logger.error("%s", out)
+            _logger.error("stderr:")
+            _logger.error("%s", err)
+        else:
+            _logger.debug("stdout:")
+            _logger.debug("%s", out)
+            _logger.debug("stderr:")
+            _logger.debug("%s", err)
+        assert p.returncode == 0
+    return execute_as_script
+
+def test_execute_compare_help(qapp, execute_as_script):
+    """Test if the main module is well connected.
+
+    Uses subprocess to avoid to parasite the current environment.
+    """
+    execute_as_script(main.__file__, "--help")
+
+
+def test_execute_silx_compare_help(qapp, execute_as_script):
+    """Test if the main module is well connected.
+
+    Uses subprocess to avoid to parasite the current environment.
+    """
+    execute_as_script(silx_main.__file__, "view", "--help")

--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -459,8 +459,8 @@ class CompareImagesStatusBar(qt.QStatusBar):
         """Update the content of the status bar"""
         widget = self.getCompareWidget()
         if widget is None:
-            self._label1.setText("Image1: NA")
-            self._label2.setText("Image2: NA")
+            self._label1.setText("ImageA: NA")
+            self._label2.setText("ImageB: NA")
             self._transform.setVisible(False)
         else:
             transform = widget.getTransformation()
@@ -511,8 +511,8 @@ class CompareImagesStatusBar(qt.QStatusBar):
                 self._transform.setToolTip(text)
 
             if self._pos is None:
-                self._label1.setText("Image1: NA")
-                self._label2.setText("Image2: NA")
+                self._label1.setText("ImageA: NA")
+                self._label2.setText("ImageB: NA")
             else:
                 data1, data2 = widget.getRawPixelData(self._pos[0], self._pos[1])
                 if isinstance(data1, str):
@@ -527,8 +527,8 @@ class CompareImagesStatusBar(qt.QStatusBar):
                 else:
                     self._label2.setToolTip("")
                     text2 = self._formatData(data2)
-                self._label1.setText("Image1: %s" % text1)
-                self._label2.setText("Image2: %s" % text2)
+                self._label1.setText("ImageA: %s" % text1)
+                self._label2.setText("ImageB: %s" % text2)
 
 
 class CompareImages(qt.QMainWindow):

--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -160,7 +160,7 @@ class CompareImagesToolBar(qt.QToolBar):
         action = qt.QAction(icon, "Yellow/cyan compare mode (subtractive mode)", self)
         action.setIconVisibleInMenu(True)
         action.setCheckable(True)
-        action.setShortcut(qt.QKeySequence(qt.Qt.Key_W))
+        action.setShortcut(qt.QKeySequence(qt.Qt.Key_Y))
         action.setProperty("mode", VisualizationMode.COMPOSITE_RED_BLUE_GRAY_NEG)
         menu.addAction(action)
         self.__ycChannelModeAction = action

--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -856,6 +856,9 @@ class CompareImages(qt.QMainWindow):
         else:
             assert(False)
 
+    def clear(self):
+        self.setData(None, None)
+
     def setData(self, image1, image2, updateColormap=True):
         """Set images to compare.
 

--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -677,10 +677,15 @@ class CompareImages(qt.QMainWindow):
             It also could be a string containing information is some cases.
         :rtype: Tuple(Union[int,float,numpy.ndarray,str],Union[int,float,numpy.ndarray,str])
         """
-        data2 = None
         alignmentMode = self.__alignmentMode
         raw1, raw2 = self.__raw1, self.__raw2
-        if alignmentMode == AlignmentMode.ORIGIN:
+
+        if raw1 is None or raw2 is None:
+            x1 = x
+            y1 = y
+            x2 = x
+            y2 = y
+        elif alignmentMode == AlignmentMode.ORIGIN:
             x1 = x
             y1 = y
             x2 = x
@@ -701,22 +706,29 @@ class CompareImages(qt.QMainWindow):
             x1 = x
             y1 = y
             # Not implemented
-            data2 = "Not implemented with sift"
+            x2 = -1
+            y2 = -1
         else:
             assert(False)
 
         x1, y1 = int(x1), int(y1)
-        if raw1 is None or y1 < 0 or y1 >= raw1.shape[0] or x1 < 0 or x1 >= raw1.shape[1]:
-            data1 = None
+        x2, y2 = int(x2), int(y2)
+
+        if raw1 is None:
+            data1 = "No image A"
+        elif y1 < 0 or y1 >= raw1.shape[0] or x1 < 0 or x1 >= raw1.shape[1]:
+            data1 = ""
         else:
             data1 = raw1[y1, x1]
 
-        if data2 is None:
-            x2, y2 = int(x2), int(y2)
-            if raw2 is None or y2 < 0 or y2 >= raw2.shape[0] or x2 < 0 or x2 >= raw2.shape[1]:
-                data2 = None
-            else:
-                data2 = raw2[y2, x2]
+        if raw2 is None:
+            data2 = "No image B"
+        elif alignmentMode == AlignmentMode.AUTO:
+            data2 = "Not implemented with sift"
+        elif y2 < 0 or y2 >= raw2.shape[0] or x2 < 0 or x2 >= raw2.shape[1]:
+            data2 = None
+        else:
+            data2 = raw2[y2, x2]
 
         return data1, data2
 

--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -1261,6 +1261,11 @@ class CompareImages(qt.QMainWindow):
         self.__transformation = self.__toAffineTransformation(result)
         return data1, data2
 
+    def resetZoom(self, dataMargins=None):
+        """Reset the plot limits to the bounds of the data and redraw the plot.
+        """
+        self.__plot.resetZoom(dataMargins)
+
     def setAutoResetZoom(self, activate=True):
         """
 

--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -931,8 +931,12 @@ class CompareImages(qt.QMainWindow):
         vertical/horizontal separators moves.
         """
         raw1, raw2 = self.__raw1, self.__raw2
-        if raw1 is None or raw2 is None:
-            return
+        if raw1 is None:
+            raw1 = numpy.empty((1, 1))
+            raw1[0, 0] = numpy.nan
+        if raw2 is None:
+            raw2 = numpy.empty((1, 1))
+            raw2[0, 0] = numpy.nan
 
         alignmentMode = self.getAlignmentMode()
         self.__transformation = None

--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -1004,7 +1004,7 @@ class CompareImages(qt.QMainWindow):
 
         mode = self.getVisualizationMode()
         if mode == VisualizationMode.COMPOSITE_RED_BLUE_GRAY_NEG:
-            data1 = self.__composeImage(data1, data2, mode)
+            data1 = data1.astype(numpy.float64) - data2.astype(numpy.float64)
             data2 = numpy.empty((0, 0))
         elif mode == VisualizationMode.COMPOSITE_RED_BLUE_GRAY:
             data1 = self.__composeImage(data1, data2, mode)
@@ -1109,13 +1109,6 @@ class CompareImages(qt.QMainWindow):
         :rtype: numpy.ndarray
         """
         assert(data1.shape[0:2] == data2.shape[0:2])
-        if mode == VisualizationMode.COMPOSITE_A_MINUS_B:
-            # TODO: this calculation has no interest of generating a 'composed'
-            # rgb image, this could be moved in an other function or doc
-            # should be modified
-            _type = data1.dtype
-            result = data1.astype(numpy.float64) - data2.astype(numpy.float64)
-            return result
         mode1 = self.__getImageMode(data1)
         if mode1 in ["rgb", "rgba"]:
             intensity1 = self.__luminosityImage(data1)

--- a/src/silx/gui/plot/test/testCompareImages.py
+++ b/src/silx/gui/plot/test/testCompareImages.py
@@ -108,3 +108,16 @@ def testSetImageSeparately(compareImages):
     compareImages.setImage2(numpy.random.rand(10, 10))
     for mode in CompareImages.VisualizationMode:
         compareImages.setVisualizationMode(mode)
+
+
+@pytest.mark.parametrize("data",
+    [
+        (CompareImages.AlignmentMode.STRETCH,),
+        (CompareImages.AlignmentMode.AUTO,),
+        (CompareImages.AlignmentMode.CENTER,),
+        (CompareImages.AlignmentMode.ORIGIN,),
+    ]
+)
+def testAlignemntModeWithoutImages(compareImages, data):
+    alignmentMode, = data
+    compareImages.setAlignmentMode(alignmentMode)

--- a/src/silx/gui/plot/test/testCompareImages.py
+++ b/src/silx/gui/plot/test/testCompareImages.py
@@ -100,7 +100,6 @@ def testGetPixel(compareImages):
 
 def testImageEmpty(compareImages):
     compareImages.setData(image1=None, image2=None)
-    assert compareImages.getRawPixelData(11 / 2.0, 11 / 2.0) == (None, None)
 
 
 def testSetImageSeparately(compareImages):
@@ -121,3 +120,34 @@ def testSetImageSeparately(compareImages):
 def testAlignemntModeWithoutImages(compareImages, data):
     alignmentMode, = data
     compareImages.setAlignmentMode(alignmentMode)
+
+
+@pytest.mark.parametrize("data",
+    [
+        (CompareImages.AlignmentMode.STRETCH,),
+        (CompareImages.AlignmentMode.AUTO,),
+        (CompareImages.AlignmentMode.CENTER,),
+        (CompareImages.AlignmentMode.ORIGIN,),
+    ]
+)
+def testAlignemntModeWithSingleImage(compareImages, data):
+    alignmentMode, = data
+    compareImages.setImage1(numpy.arange(9).reshape(3, 3))
+    compareImages.setAlignmentMode(alignmentMode)
+
+
+def testTooltip(compareImages):
+    compareImages.setImage1(numpy.arange(9).reshape(3, 3))
+    compareImages.setImage2(numpy.arange(9).reshape(3, 3))
+    compareImages.getRawPixelData(1.5, 1.5)
+
+
+def testTooltipWithoutImage(compareImages):
+    compareImages.setImage1(numpy.arange(9).reshape(3, 3))
+    compareImages.setImage2(numpy.arange(9).reshape(3, 3))
+    compareImages.getRawPixelData(1.5, 1.5)
+
+
+def testTooltipWithSingleImage(compareImages):
+    compareImages.setImage1(numpy.arange(9).reshape(3, 3))
+    compareImages.getRawPixelData(1.5, 1.5)

--- a/src/silx/gui/plot/test/testCompareImages.py
+++ b/src/silx/gui/plot/test/testCompareImages.py
@@ -105,8 +105,73 @@ def testImageEmpty(compareImages):
 def testSetImageSeparately(compareImages):
     compareImages.setImage1(numpy.random.rand(10, 10))
     compareImages.setImage2(numpy.random.rand(10, 10))
-    for mode in CompareImages.VisualizationMode:
-        compareImages.setVisualizationMode(mode)
+
+
+@pytest.mark.parametrize("data",
+    [
+        (CompareImages.VisualizationMode.COMPOSITE_A_MINUS_B,),
+        (CompareImages.VisualizationMode.COMPOSITE_RED_BLUE_GRAY,),
+        (CompareImages.VisualizationMode.HORIZONTAL_LINE,),
+        (CompareImages.VisualizationMode.VERTICAL_LINE,),
+        (CompareImages.VisualizationMode.ONLY_A,),
+        (CompareImages.VisualizationMode.ONLY_B,),
+    ]
+)
+def testVisualizationMode(compareImages, data):
+    visualizationMode, = data
+    compareImages.setImage1(numpy.random.rand(10, 10))
+    compareImages.setImage2(numpy.random.rand(10, 10))
+    compareImages.setVisualizationMode(visualizationMode)
+
+
+@pytest.mark.parametrize("data",
+    [
+        (CompareImages.VisualizationMode.COMPOSITE_A_MINUS_B,),
+        (CompareImages.VisualizationMode.COMPOSITE_RED_BLUE_GRAY,),
+        (CompareImages.VisualizationMode.HORIZONTAL_LINE,),
+        (CompareImages.VisualizationMode.VERTICAL_LINE,),
+        (CompareImages.VisualizationMode.ONLY_A,),
+        (CompareImages.VisualizationMode.ONLY_B,),
+    ]
+)
+def testVisualizationModeWithoutImage(compareImages, data):
+    visualizationMode, = data
+    compareImages.setImage1(None)
+    compareImages.setImage2(None)
+    compareImages.setVisualizationMode(visualizationMode)
+
+@pytest.mark.parametrize("data",
+    [
+        (CompareImages.VisualizationMode.COMPOSITE_A_MINUS_B,),
+        (CompareImages.VisualizationMode.COMPOSITE_RED_BLUE_GRAY,),
+        (CompareImages.VisualizationMode.HORIZONTAL_LINE,),
+        (CompareImages.VisualizationMode.VERTICAL_LINE,),
+        (CompareImages.VisualizationMode.ONLY_A,),
+        (CompareImages.VisualizationMode.ONLY_B,),
+    ]
+)
+def testVisualizationModeWithOnlyImage1(compareImages, data):
+    visualizationMode, = data
+    compareImages.setImage1(numpy.random.rand(10, 10))
+    compareImages.setImage2(None)
+    compareImages.setVisualizationMode(visualizationMode)
+
+
+@pytest.mark.parametrize("data",
+    [
+        (CompareImages.VisualizationMode.COMPOSITE_A_MINUS_B,),
+        (CompareImages.VisualizationMode.COMPOSITE_RED_BLUE_GRAY,),
+        (CompareImages.VisualizationMode.HORIZONTAL_LINE,),
+        (CompareImages.VisualizationMode.VERTICAL_LINE,),
+        (CompareImages.VisualizationMode.ONLY_A,),
+        (CompareImages.VisualizationMode.ONLY_B,),
+    ]
+)
+def testVisualizationModeWithOnlyImage2(compareImages, data):
+    visualizationMode, = data
+    compareImages.setImage1(None)
+    compareImages.setImage2(numpy.random.rand(10, 10))
+    compareImages.setVisualizationMode(visualizationMode)
 
 
 @pytest.mark.parametrize("data",

--- a/src/silx/gui/plot/test/testCompareImages.py
+++ b/src/silx/gui/plot/test/testCompareImages.py
@@ -27,78 +27,84 @@ __authors__ = ["H. Payno"]
 __license__ = "MIT"
 __date__ = "23/07/2018"
 
+import pytest
 import numpy
 import weakref
 
-from silx.gui.utils.testutils import TestCaseQt
+from silx.gui import qt
 from silx.gui.plot.CompareImages import CompareImages
 
 
-class TestCompareImages(TestCaseQt):
-    """Test that CompareImages widget is working in some cases"""
+@pytest.fixture
+def compareImages(qapp, qapp_utils):
+    widget = CompareImages()
+    widget.setAttribute(qt.Qt.WA_DeleteOnClose)
+    yield widget
+    widget.close()
+    ref = weakref.ref(widget)
+    widget = None
+    qapp_utils.qWaitForDestroy(ref)
 
-    def setUp(self):
-        super(TestCompareImages, self).setUp()
-        self.widget = CompareImages()
 
-    def tearDown(self):
-        ref = weakref.ref(self.widget)
-        self.widget = None
-        self.qWaitForDestroy(ref)
-        super(TestCompareImages, self).tearDown()
+def testIntensityImage(compareImages):
+    image1 = numpy.random.rand(10, 10)
+    image2 = numpy.random.rand(10, 10)
+    compareImages.setData(image1, image2)
 
-    def testIntensityImage(self):
-        image1 = numpy.random.rand(10, 10)
-        image2 = numpy.random.rand(10, 10)
-        self.widget.setData(image1, image2)
 
-    def testRgbImage(self):
-        image1 = numpy.random.randint(0, 255, size=(10, 10, 3))
-        image2 = numpy.random.randint(0, 255, size=(10, 10, 3))
-        self.widget.setData(image1, image2)
+def testRgbImage(compareImages):
+    image1 = numpy.random.randint(0, 255, size=(10, 10, 3))
+    image2 = numpy.random.randint(0, 255, size=(10, 10, 3))
+    compareImages.setData(image1, image2)
 
-    def testRgbaImage(self):
-        image1 = numpy.random.randint(0, 255, size=(10, 10, 4))
-        image2 = numpy.random.randint(0, 255, size=(10, 10, 4))
-        self.widget.setData(image1, image2)
 
-    def testVizualisations(self):
-        image1 = numpy.random.rand(10, 10)
-        image2 = numpy.random.rand(10, 10)
-        self.widget.setData(image1, image2)
-        for mode in CompareImages.VisualizationMode:
-            self.widget.setVisualizationMode(mode)
+def testRgbaImage(compareImages):
+    image1 = numpy.random.randint(0, 255, size=(10, 10, 4))
+    image2 = numpy.random.randint(0, 255, size=(10, 10, 4))
+    compareImages.setData(image1, image2)
 
-    def testAlignemnt(self):
-        image1 = numpy.random.rand(10, 10)
-        image2 = numpy.random.rand(5, 5)
-        self.widget.setData(image1, image2)
-        for mode in CompareImages.AlignmentMode:
-            self.widget.setAlignmentMode(mode)
 
-    def testGetPixel(self):
-        image1 = numpy.random.rand(11, 11)
-        image2 = numpy.random.rand(5, 5)
-        image1[5, 5] = 111.111
-        image2[2, 2] = 222.222
-        self.widget.setData(image1, image2)
-        expectedValue = {}
-        expectedValue[CompareImages.AlignmentMode.CENTER] = 222.222
-        expectedValue[CompareImages.AlignmentMode.STRETCH] = 222.222
-        expectedValue[CompareImages.AlignmentMode.ORIGIN] = None
-        for mode in expectedValue.keys():
-            self.widget.setAlignmentMode(mode)
-            data = self.widget.getRawPixelData(11 / 2.0, 11 / 2.0)
-            data1, data2 = data
-            self.assertEqual(data1, 111.111)
-            self.assertEqual(data2, expectedValue[mode])
+def testVizualisations(compareImages):
+    image1 = numpy.random.rand(10, 10)
+    image2 = numpy.random.rand(10, 10)
+    compareImages.setData(image1, image2)
+    for mode in CompareImages.VisualizationMode:
+        compareImages.setVisualizationMode(mode)
 
-    def testImageEmpty(self):
-        self.widget.setData(image1=None, image2=None)
-        self.assertTrue(self.widget.getRawPixelData(11 / 2.0, 11 / 2.0) == (None, None))
 
-    def testSetImageSeparately(self):
-        self.widget.setImage1(numpy.random.rand(10, 10))
-        self.widget.setImage2(numpy.random.rand(10, 10))
-        for mode in CompareImages.VisualizationMode:
-            self.widget.setVisualizationMode(mode)
+def testAlignemnt(compareImages):
+    image1 = numpy.random.rand(10, 10)
+    image2 = numpy.random.rand(5, 5)
+    compareImages.setData(image1, image2)
+    for mode in CompareImages.AlignmentMode:
+        compareImages.setAlignmentMode(mode)
+
+
+def testGetPixel(compareImages):
+    image1 = numpy.random.rand(11, 11)
+    image2 = numpy.random.rand(5, 5)
+    image1[5, 5] = 111.111
+    image2[2, 2] = 222.222
+    compareImages.setData(image1, image2)
+    expectedValue = {}
+    expectedValue[CompareImages.AlignmentMode.CENTER] = 222.222
+    expectedValue[CompareImages.AlignmentMode.STRETCH] = 222.222
+    expectedValue[CompareImages.AlignmentMode.ORIGIN] = None
+    for mode in expectedValue.keys():
+        compareImages.setAlignmentMode(mode)
+        data = compareImages.getRawPixelData(11 / 2.0, 11 / 2.0)
+        data1, data2 = data
+        assert data1 == 111.111
+        assert data2 == expectedValue[mode]
+
+
+def testImageEmpty(compareImages):
+    compareImages.setData(image1=None, image2=None)
+    assert compareImages.getRawPixelData(11 / 2.0, 11 / 2.0) == (None, None)
+
+
+def testSetImageSeparately(compareImages):
+    compareImages.setImage1(numpy.random.rand(10, 10))
+    compareImages.setImage2(numpy.random.rand(10, 10))
+    for mode in CompareImages.VisualizationMode:
+        compareImages.setVisualizationMode(mode)


### PR DESCRIPTION
This PR introduce a `silx compare` UI to make is easy to use.

```
silx compare --help
usage: silx compare [-h] [--debug] [--use-opengl-plot] [files [files ...]]

GUI to compare images

positional arguments:
  files              Image data to compare (HDF5 file with path, EDF files,
                     JPEG/PNG image files). Data from HDF5 files can be
                     accessed using dataset path and slicing as an URL:
                     silx:../my_file.h5?path=/entry/data&slice=10 EDF file
                     frames also can can be accessed using URL:
                     fabio:../my_file.edf?slice=10 Using URL in command like
                     usually have to be quoted: "URL".

optional arguments:
  -h, --help         show this help message and exit
  --debug            Set logging system in debug mode
  --use-opengl-plot  Use OpenGL for plots (instead of matplotlib)
```

```
silx compare ../bliss.git/blissdemo/src/blissdemo/demo_data/ID11_MA4752.h5::**/data ../bliss.git/blissdemo/src/blissdemo/demo_data/ID13_kevlar.h5::**/data
```

![image](https://user-images.githubusercontent.com/7579321/232425521-5c7f30b8-0d08-4e0c-8673-33b3b64f1127.png)


```
silx compare /tmp/RECONSTRUCTIONS.h5::ad1b7ad99b94749cd4a92a75eef06f18a69c0201/*
```

![Screenshot from 2023-04-17 10-27-44](https://user-images.githubusercontent.com/7579321/232429181-0b1b5cb1-a971-4ecd-9c8f-3906412d8d69.png)

Changelog:
- `silx compare`:
    -  Create a `silx compare` UI from an example


closes #3759