### PR TITLE
silx.gui.data: Fixed issue with hdf5 attributes string formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install libegl1-mesa ocl-icd-opencl-dev intel-opencl-icd libgl1-mesa-glx xserver-xorg-video-dummy libxkbcommon-x11-0 libxkbcommon0 libxkbcommon-dev libxcb-icccm4 libxcb-image0 libxcb-shm0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-sync1 libxcb-xfixes0 libxcb-xinerama0 libxcb-xkb1 libxcb1
+          sudo apt-get install libegl1-mesa ocl-icd-opencl-dev intel-opencl-icd libgl1-mesa-glx xserver-xorg-video-dummy libxkbcommon-x11-0 libxkbcommon0 libxkbcommon-dev libxcb-icccm4 libxcb-image0 libxcb-shm0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-sync1 libxcb-xfixes0 libxcb-xinerama0 libxcb-xkb1 libxcb-cursor0 libxcb1
 
       # Runs a single command using the runners shell
       - name: Set up Python

--- a/src/silx/conftest.py
+++ b/src/silx/conftest.py
@@ -1,6 +1,9 @@
 import pytest
 import logging
 import os
+from io import BytesIO
+
+import h5py
 
 
 logger = logging.getLogger(__name__)
@@ -131,3 +134,10 @@ def qapp_utils(qapp):
     yield utils
     utils.tearDown()
     utils.tearDownClass()
+
+
+@pytest.fixture
+def tmp_h5py_file():
+    with BytesIO() as buffer:
+        with h5py.File(buffer, mode="w") as h5file:
+            yield h5file

--- a/src/silx/gui/data/TextFormatter.py
+++ b/src/silx/gui/data/TextFormatter.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -233,6 +233,8 @@ class TextFormatter(qt.QObject):
         :param data: A binary string of char expected in ASCII
         :rtype: str
         """
+        if isinstance(data, str):
+            return self.__formatText(data)
         try:
             text = "%s" % data.decode("ascii")
             return self.__formatText(text)

--- a/src/silx/gui/data/test/test_textformatter.py
+++ b/src/silx/gui/data/test/test_textformatter.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,7 +25,6 @@ __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "12/12/2017"
 
-import unittest
 import shutil
 import tempfile
 
@@ -34,9 +33,9 @@ import numpy
 from silx.gui.utils.testutils import TestCaseQt
 from silx.gui.utils.testutils import SignalListener
 from ..TextFormatter import TextFormatter
-from silx.io.utils import h5py_read_dataset
 
 import h5py
+import pytest
 
 
 class TestTextFormatter(TestCaseQt):
@@ -196,3 +195,17 @@ class TestTextFormatterWithH5py(TestCaseQt):
         d = self.create_dataset(data=d)
         result = self.read_dataset(d)
         self.assertEqual(result, '[REF NULL_REF]')
+
+
+@pytest.mark.parametrize("data, expected", [
+    (b"bytes", '"bytes"'),
+    ("unicode", '"unicode"'),
+    ((b'elem0', b'elem1'), '["elem0" "elem1"]'),
+    (('elem0', 'elem1'), '["elem0" "elem1"]'),
+])
+def test_formatter_h5py_attr(tmp_h5py_file, data, expected):
+    """Test formatter with h5py attributes"""
+    tmp_h5py_file.attrs['attr'] = data
+    formatter = TextFormatter()
+    result = formatter.toString(tmp_h5py_file.attrs['attr'])
+    assert result == expected

--- a/src/silx/io/test/test_dictdump.py
+++ b/src/silx/io/test/test_dictdump.py
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2016-2022 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,7 +29,6 @@ __date__ = "17/01/2018"
 
 from collections import defaultdict, OrderedDict
 from copy import deepcopy
-from io import BytesIO
 import os
 import tempfile
 import unittest
@@ -51,13 +50,6 @@ from ..dictdump import h5todict, load
 from ..dictdump import logger as dictdump_logger
 from ..utils import is_link
 from ..utils import h5py_read_dataset
-
-
-@pytest.fixture
-def tmp_h5py_file():
-    with BytesIO() as buffer:
-        with h5py.File(buffer, mode="w") as h5file:
-            yield h5file
 
 
 def tree():


### PR DESCRIPTION
Attributes have a different way to handle types and it is possible to read an array with dtype `object` which actually contains `str`. This case was not supported.

Closes #3789
