### PR TITLE
silx.gui.dialog.ColormapDialog: Fixed ColormapDialog layout

### DIFF
--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1033,6 +1033,7 @@ class ColormapDialog(qt.QDialog):
 
         formLayout.addItem(qt.QSpacerItem(1, 1, qt.QSizePolicy.Fixed, qt.QSizePolicy.Fixed))
         formLayout.addRow(self._histoWidget)
+        formLayout.setRowStretch(formLayout.rowCount() -1, 1)
         formLayout.addRow(rangeLayout)
         formLayout.addItem(qt.QSpacerItem(1, 1, qt.QSizePolicy.Fixed, qt.QSizePolicy.Fixed))
         formLayout.addRow('Scale:', layoutScale)


### PR DESCRIPTION
This PR makes `ColormapDialog` stretch consistent between with/without histogram cases.

closes #3710

![colormap-dialog](https://user-images.githubusercontent.com/9449698/236209457-829e801b-e753-4c44-b57a-10ea4d0e24e5.png)

