### PR TITLE
color: Exception if vrange is not finite

### DIFF
--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -668,6 +668,12 @@ class Colormap(qt.QObject):
         """
         if self.isEditable() is False:
             raise NotEditableError('Colormap is not editable')
+
+        if (vmin is not None and not numpy.isfinite(vmin)) or (vmax is not None and not numpy.isfinite(vmax)):
+            err = "Can't set vmin and vmax because vmin or vmax are not finite " \
+                    "vmin = %s, vmax = %s" % (vmin, vmax)
+            raise ValueError(err)
+
         if vmin is not None and vmax is not None:
             if vmin > vmax:
                 err = "Can't set vmin and vmax because vmin >= vmax " \


### PR DESCRIPTION
<!--
You are encouraged to write a PR title that is meaningful by itself.
It will be used to auto-generate the complete changelog.

To highlight a change in the changelog, please add a line starting with `Changelog: ` in the PR description.
It will be used to generate the changelog's summary.

E.g., Changelog: Added new wonderful feature
-->


Changelog: 
- `Colormap.setVRange` raises an exception if the range is not finite
