### PR TITLE
Removed features deprecated since <=0.7.0

### DIFF
--- a/src/silx/gui/fit/FitWidget.py
+++ b/src/silx/gui/fit/FitWidget.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2023 European Synchrotron Radiation Facility
 #
 # This file is part of the PyMca X-ray Fluorescence Toolkit developed at
 # the ESRF by the Software group.
@@ -50,7 +50,6 @@ from .FitWidgets import (FitActionsButtons, FitStatusLines,
                          FitConfigWidget, ParametersTab)
 from .FitConfig import getFitConfigDialog
 from .BackgroundWidget import getBgDialog, BackgroundDialog
-from ...utils.deprecation import deprecated
 
 DEBUG = 0
 _logger = logging.getLogger(__name__)
@@ -319,10 +318,6 @@ class FitWidget(qt.QWidget):
 
         configuration.update(self.configure())
 
-    @deprecated(replacement='setData', since_version='0.3.0')
-    def setdata(self, x, y, sigmay=None, xmin=None, xmax=None):
-        self.setData(x, y, sigmay, xmin, xmax)
-
     def setData(self, x=None, y=None, sigmay=None, xmin=None, xmax=None):
         """Set data to be fitted.
 
@@ -543,10 +538,6 @@ class FitWidget(qt.QWidget):
             'event': 'EstimateFinished',
             'data': self.fitmanager.fit_results}
         self._emitSignal(ddict)
-
-    @deprecated(replacement='startFit', since_version='0.3.0')
-    def startfit(self):
-        self.startFit()
 
     def startFit(self):
         """Run fit, then emit :attr:`sigFitWidgetSignal` with a dictionary

--- a/src/silx/gui/icons.py
+++ b/src/silx/gui/icons.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -37,7 +37,6 @@ import weakref
 from . import qt
 import silx.resources
 from silx.utils import weakref as silxweakref
-from silx.utils.deprecation import deprecated
 
 
 _logger = logging.getLogger(__name__)
@@ -92,7 +91,7 @@ class AbstractAnimatedIcon(qt.QObject):
     """Signal sent with a QIcon everytime the animation changed."""
 
     def register(self, obj):
-        """Register an object to the AnimatedIcon.
+        """Register an object to the AbstractAnimatedIcon.
         If no object are registred, the animation is paused.
         Object are stored in a weaked list.
 
@@ -120,7 +119,7 @@ class AbstractAnimatedIcon(qt.QObject):
         return len(self.__targets)
 
     def isRegistered(self, obj):
-        """Returns true if the object is registred in the AnimatedIcon.
+        """Returns true if the object is registred in the AbstractAnimatedIcon.
 
         :param object obj: An object
         :rtype: bool
@@ -191,7 +190,7 @@ class MovieAnimatedIcon(AbstractAnimatedIcon):
 
     def _updateState(self):
         """Update the movie play according to internal stat of the
-        AnimatedIcon."""
+        MovieAnimatedIcon."""
         self.__movie.setPaused(not self.hasRegistredObjects())
 
 
@@ -255,22 +254,6 @@ class MultiImageAnimatedIcon(AbstractAnimatedIcon):
         else:
             if self.__timer.isActive():
                 self.__timer.stop()
-
-
-class AnimatedIcon(MovieAnimatedIcon):
-    """Store a looping QMovie to provide icons for each frames.
-    Provides an event with the new icon everytime the movie frame
-    is updated.
-
-    It may not be available anymore for the silx release 0.6.
-
-    .. deprecated:: 0.5
-       Use :class:`MovieAnimatedIcon` instead.
-    """
-
-    @deprecated
-    def __init__(self, filename, parent=None):
-        MovieAnimatedIcon.__init__(self, filename, parent=parent)
 
 
 def getWaitIcon():

--- a/src/silx/gui/plot/CurvesROIWidget.py
+++ b/src/silx/gui/plot/CurvesROIWidget.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -348,12 +348,6 @@ class CurvesROIWidget(qt.QWidget):
     def setHeader(self, text='ROIs'):
         """Set the header text of this widget"""
         self.headerLabel.setText("<b>%s<\b>" % text)
-
-    @deprecation.deprecated(replacement="calculateRois",
-                            reason="CamelCase convention",
-                            since_version="0.7")
-    def calculateROIs(self, *args, **kw):
-        self.calculateRois(*args, **kw)
 
     def calculateRois(self, roiList=None, roiDict=None):
         """Compute ROI information"""

--- a/src/silx/gui/plot/PlotWindow.py
+++ b/src/silx/gui/plot/PlotWindow.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -997,10 +997,6 @@ class Plot2D(PlotWindow):
         See :class:`silx.gui.plot.Profile.ProfileToolBar`
         """
         return self.profile
-
-    @deprecated(replacement="getProfilePlot", since_version="0.5.0")
-    def getProfileWindow(self):
-        return self.getProfilePlot()
 
     def getProfilePlot(self):
         """Return plot window used to display profile curve.

--- a/src/silx/gui/plot/Profile.py
+++ b/src/silx/gui/plot/Profile.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -225,11 +225,6 @@ class ProfileToolBar(qt.QToolBar):
     @deprecated(since_version="0.6.0")
     def browseAction(self):
         return self._browseAction
-
-    @property
-    @deprecated(replacement="getProfilePlot", since_version="0.5.0")
-    def profileWindow(self):
-        return self.getProfilePlot()
 
     def getProfileManager(self):
         """Return the manager of the profiles.

--- a/src/silx/gui/plot/Profile.py
+++ b/src/silx/gui/plot/Profile.py
@@ -221,11 +221,6 @@ class ProfileToolBar(qt.QToolBar):
             enabled = image.getData(copy=False).size > 0
             self._setRoiActionEnabled(type(image), enabled)
 
-    @property
-    @deprecated(since_version="0.6.0")
-    def browseAction(self):
-        return self._browseAction
-
     def getProfileManager(self):
         """Return the manager of the profiles.
 

--- a/src/silx/gui/plot/StackView.py
+++ b/src/silx/gui/plot/StackView.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -839,18 +839,7 @@ class StackView(qt.QMainWindow):
             assert vmax is None, errmsg
             assert colors is None, errmsg
 
-            if isinstance(colormap, dict):
-                reason = 'colormap parameter should now be an object'
-                replacement = 'Colormap()'
-                since_version = '0.6'
-                deprecated_warning(type_='function',
-                                   name='setColormap',
-                                   reason=reason,
-                                   replacement=replacement,
-                                   since_version=since_version)
-                _colormap = Colormap._fromDict(colormap)
-            else:
-                _colormap = colormap
+            _colormap = colormap
         else:
             norm = normalization if normalization is not None else 'linear'
             name = colormap if colormap is not None else 'gray'

--- a/src/silx/gui/plot3d/scene/interaction.py
+++ b/src/silx/gui/plot3d/scene/interaction.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2015-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -58,8 +58,6 @@ class ClickOrDrag(StateMachine):
         def enterState(self, x, y):
             self.initPos = x, y
 
-        enter = enterState  # silx v.0.3 support, remove when 0.4 out
-
         def onMove(self, x, y):
             dx = (x - self.initPos[0]) ** 2
             dy = (y - self.initPos[1]) ** 2
@@ -76,8 +74,6 @@ class ClickOrDrag(StateMachine):
             self.initPos = initPos
             self.machine.beginDrag(*initPos)
             self.machine.drag(*curPos)
-
-        enter = enterState  # silx v.0.3 support, remove when 0.4 out
 
         def onMove(self, x, y):
             self.machine.drag(x, y)
@@ -403,8 +399,6 @@ class FocusManager(StateMachine):
         def enterState(self, eventHandler, btn):
             self.eventHandler = eventHandler
             self.focusBtns = {btn}  # Set
-
-        enter = enterState  # silx v.0.3 support, remove when 0.4 out
 
         def onPress(self, x, y, btn):
             self.focusBtns.add(btn)

--- a/src/silx/io/convert.py
+++ b/src/silx/io/convert.py
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2016-2021 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -28,26 +28,6 @@ Read the documentation of :mod:`silx.io.spech5`, :mod:`silx.io.fioh5` and :mod:`
 information on the structure of the output HDF5 files.
 
 Text strings are written to the HDF5 datasets as variable-length utf-8.
-
-.. warning::
-
-    The output format for text strings changed in silx version 0.7.0.
-    Prior to that, text was output as fixed-length ASCII.
-
-    To be on the safe side, when reading back a HDF5 file written with an
-    older version of silx, you can test for the presence of a *decode*
-    attribute. To ensure that you always work with unicode text::
-
-        >>> import h5py
-        >>> h5f = h5py.File("my_scans.h5", "r")
-        >>> title = h5f["/68.1/title"]
-        >>> if hasattr(title, "decode"):
-        ...     title = title.decode()
-
-
-.. note:: This module has a dependency on the `h5py <http://www.h5py.org/>`_
-    library, which is not a mandatory dependency for `silx`. You might need
-    to install it if you don't already have it.
 """
 
 __authors__ = ["P. Knobel"]

--- a/src/silx/io/spech5.py
+++ b/src/silx/io/spech5.py
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2016-2021 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -155,32 +155,6 @@ You can test for existence of data or groups::
     True
     >>> "spam" in sfh5["1.1"]
     False
-
-.. note::
-
-    Text used to be stored with a dtype ``numpy.string_`` in silx versions
-    prior to *0.7.0*. The type ``numpy.string_`` is a byte-string format.
-    The consequence of this is that you had to decode strings before using
-    them in **Python 3**::
-
-        >>> from silx.io.spech5 import SpecH5
-        >>> sfh5 = SpecH5("31oct98.dat")
-        >>> sfh5["/68.1/title"]
-        b'68  ascan  tx3 -28.5 -24.5  20 0.5'
-        >>> sfh5["/68.1/title"].decode()
-        '68  ascan  tx3 -28.5 -24.5  20 0.5'
-
-    From silx version *0.7.0* onwards, text is now stored as unicode. This
-    corresponds to the default text type in python 3, and to the *unicode*
-    type in Python 2.
-
-    To be on the safe side, you can test for the presence of a *decode*
-    attribute, to ensure that you always work with unicode text::
-
-        >>> title = sfh5["/68.1/title"]
-        >>> if hasattr(title, "decode"):
-        ...     title = title.decode()
-
 """
 
 import datetime


### PR DESCRIPTION
This is a first round of deprecated features removal marked as such since at least March 2018.

It also removes outdated docstrings.

related to #3754
