### PR TITLE
silx.opencl.common: Remove `OpenCL.create_context` `useFp64` argument

### DIFF
--- a/src/silx/opencl/common.py
+++ b/src/silx/opencl/common.py
@@ -3,7 +3,7 @@
 #    Project: S I L X project
 #             https://github.com/silx-kit/silx
 #
-#    Copyright (C) 2012-2021 European Synchrotron Radiation Facility, Grenoble, France
+#    Copyright (C) 2012-2023 European Synchrotron Radiation Facility, Grenoble, France
 #
 #    Principal author:       Jérôme Kieffer (Jerome.Kieffer@ESRF.eu)
 #
@@ -436,7 +436,7 @@ class OpenCL(object):
         # Nothing found
         return None
 
-    def create_context(self, devicetype="ALL", useFp64=False, platformid=None,
+    def create_context(self, devicetype="ALL", platformid=None,
                        deviceid=None, cached=True, memory=None, extensions=None):
         """
         Choose a device and initiate a context.
@@ -447,7 +447,6 @@ class OpenCL(object):
         E.g.: If Nvidia driver is installed, GPU will succeed but CPU will fail.
               The AMD SDK kit is required for CPU via OpenCL.
         :param devicetype: string in ["cpu","gpu", "all", "acc"]
-        :param useFp64: boolean specifying if double precision will be used: deprecated use extensions=["cl_khr_fp64"]
         :param platformid: integer
         :param deviceid: integer
         :param cached: True if we want to cache the context
@@ -457,9 +456,6 @@ class OpenCL(object):
         """
         if extensions is None:
             extensions = []
-        if useFp64:
-            logger.warning("Deprecation: please select your device using the extension name!, i.e. extensions=['cl_khr_fp64']")
-            extensions.append('cl_khr_fp64')
 
         if (platformid is not None) and (deviceid is not None):
             platformid = int(platformid)


### PR DESCRIPTION
This argument is deprecated since v0.11.0, so I'd propose to remove it.

The issue with removing deprecated arguments is that if it's not used as keyword args it breaks the compatibility.
It's fine for me, but up to you to see how much impact it can have.

related to #3754
