### PR TITLE
silx.gui.plot: Deprecate PlotWidget's Curve and Image sequence-like access

### DIFF
--- a/src/silx/gui/plot/items/curve.py
+++ b/src/silx/gui/plot/items/curve.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -33,6 +33,7 @@ import logging
 
 import numpy
 
+from ....utils.deprecation import deprecated_warning
 from ... import colors
 from .core import (PointsBase, LabelsMixIn, ColorMixIn, YAxisMixIn,
                    FillMixIn, LineMixIn, SymbolMixIn,
@@ -208,6 +209,7 @@ class Curve(PointsBase, ColorMixIn, YAxisMixIn, FillMixIn, LabelsMixIn,
 
     def __getitem__(self, item):
         """Compatibility with PyMca and silx <= 0.4.0"""
+        deprecated_warning("Attributes", "__getitem__", since_version="2.0.0", replacement="Use Curve methods")
         if isinstance(item, slice):
             return [self[index] for index in range(*item.indices(5))]
         elif item == 0:

--- a/src/silx/gui/plot/items/image.py
+++ b/src/silx/gui/plot/items/image.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -38,6 +38,7 @@ import logging
 import numpy
 
 from ....utils.proxy import docstring
+from ....utils.deprecation import deprecated_warning
 from .core import (DataItem, LabelsMixIn, DraggableMixIn, ColormapMixIn,
                    AlphaMixIn, ItemChangedType)
 
@@ -105,6 +106,7 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
 
     def __getitem__(self, item):
         """Compatibility with PyMca and silx <= 0.4.0"""
+        deprecated_warning("Attributes", "__getitem__", since_version="2.0.0", replacement="Use ImageBase methods")
         if isinstance(item, slice):
             return [self[index] for index in range(*item.indices(5))]
         elif item == 0:
@@ -408,6 +410,7 @@ class ImageData(ImageDataBase):
 
     def __getitem__(self, item):
         """Compatibility with PyMca and silx <= 0.4.0"""
+        deprecated_warning("Attributes", "__getitem__", since_version="2.0.0", replacement="Use ImageData methods")
         if item == 3:
             return self.getAlternativeImageData(copy=False)
 


### PR DESCRIPTION
This PR deprecates the access of Curve and Images PlotWidget Items as sequence-like that was there initially.

The same information is accessible through those Item's API, so let's deprecate the compatibilty mechanism.

attn @vasole do you rely on this compatibility in pymca?