### PR TITLE
silx.io.dictdump: Removed `dicttoh5` `overwrite_data` argument

### DIFF
--- a/src/silx/io/dictdump.py
+++ b/src/silx/io/dictdump.py
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2016-2022 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -49,7 +49,6 @@ from .utils import is_file as is_h5_file_like
 from .utils import open as h5open
 from .utils import h5py_read_dataset
 from .utils import H5pyAttributesReadWrapper
-from silx.utils.deprecation import deprecated_warning
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
@@ -177,9 +176,14 @@ def _normalize_h5_path(h5root, h5path):
     return h5file, h5path
 
 
-def dicttoh5(treedict, h5file, h5path='/',
-             mode="w", overwrite_data=None,
-             create_dataset_args=None, update_mode=None):
+def dicttoh5(
+    treedict,
+    h5file,
+    h5path='/',
+    mode="w",
+    create_dataset_args=None,
+    update_mode=None,
+):
     """Write a nested dictionary to a HDF5 file, using keys as member names.
 
     If a dictionary value is a sub-dictionary, a group is created. If it is
@@ -209,9 +213,6 @@ def dicttoh5(treedict, h5file, h5path='/',
         ``"w"`` (write, existing file is lost), ``"w-"`` (write, fail if
         exists) or ``"a"`` (read/write if exists, create otherwise).
         This parameter is ignored if ``h5file`` is a file handle.
-    :param overwrite_data: Deprecated. ``True`` is approximately equivalent
-        to ``update_mode="modify"`` and ``False`` is equivalent to
-        ``update_mode="add"``.
     :param create_dataset_args: Dictionary of args you want to pass to
         ``h5f.create_dataset``. This allows you to specify filters and
         compression parameters. Don't specify ``name`` and ``data``.
@@ -253,32 +254,14 @@ def dicttoh5(treedict, h5file, h5path='/',
                  create_dataset_args=create_ds_args)
     """
 
-    if overwrite_data is not None:
-        reason = (
-            "`overwrite_data=True` becomes `update_mode='modify'` and "
-            "`overwrite_data=False` becomes `update_mode='add'`"
-        )
-        deprecated_warning(
-            type_="argument",
-            name="overwrite_data",
-            reason=reason,
-            replacement="update_mode",
-            since_version="0.15",
-        )
-
     if update_mode is None:
-        if overwrite_data:
-            update_mode = "modify"
-        else:
-            update_mode = "add"
-    else:
-        if update_mode not in UPDATE_MODE_VALID_EXISTING_VALUES:
-            raise ValueError((
-                "Argument 'update_mode' can only have values: {}"
-                "".format(UPDATE_MODE_VALID_EXISTING_VALUES)
-            ))
-        if overwrite_data is not None:
-            logger.warning("The argument `overwrite_data` is ignored")
+        update_mode = "add"
+
+    if update_mode not in UPDATE_MODE_VALID_EXISTING_VALUES:
+        raise ValueError((
+            "Argument 'update_mode' can only have values: {}"
+            "".format(UPDATE_MODE_VALID_EXISTING_VALUES)
+        ))
 
     if not isinstance(treedict, Mapping):
         raise TypeError("'treedict' must be a dictionary")

--- a/src/silx/io/test/test_dictdump.py
+++ b/src/silx/io/test/test_dictdump.py
@@ -171,23 +171,6 @@ class TestDictToH5(H5DictTestCase):
                 min(ddict["city attributes"]["Europe"]["France"]["Grenoble"]["coordinates"]),
                 5.7196)
 
-    def testH5OverwriteDeprecatedApi(self):
-        dd = ConfigDict({'t': True})
-
-        dicttoh5(h5file=self.h5_fname, treedict=dd, mode='a')
-        dd = ConfigDict({'t': False})
-        dicttoh5(h5file=self.h5_fname, treedict=dd, mode='a',
-                 overwrite_data=False)
-
-        res = h5todict(self.h5_fname)
-        assert(res['t'] == True)
-
-        dicttoh5(h5file=self.h5_fname, treedict=dd, mode='a',
-                 overwrite_data=True)
-
-        res = h5todict(self.h5_fname)
-        assert(res['t'] == False)
-
     def testAttributes(self):
         """Any kind of attribute can be described"""
         ddict = {


### PR DESCRIPTION
This PR removes `dicttoh5`'s `overwrite_data` argument that is deprecated since v0.15.0.

Do you think it's OK, or it's best to keep maximum compatibility here?

related to #3754