### PR TITLE
Remove unused imports

### DIFF
--- a/src/silx/app/utils/test/test_parseutils.py
+++ b/src/silx/app/utils/test/test_parseutils.py
@@ -21,8 +21,6 @@
 #
 # ############################################################################*/
 
-import glob
-import logging
 import pytest
 import h5py
 from ..parseutils import filenames_to_dataurls

--- a/src/silx/gui/data/test/test_arraywidget.py
+++ b/src/silx/gui/data/test/test_arraywidget.py
@@ -27,7 +27,6 @@ __date__ = "05/12/2016"
 
 import os
 import tempfile
-import unittest
 
 import numpy
 

--- a/src/silx/gui/data/test/test_numpyaxesselector.py
+++ b/src/silx/gui/data/test/test_numpyaxesselector.py
@@ -27,7 +27,6 @@ __date__ = "29/01/2018"
 
 import os
 import tempfile
-import unittest
 from contextlib import contextmanager
 
 import numpy

--- a/src/silx/gui/dialog/DataFileDialog.py
+++ b/src/silx/gui/dialog/DataFileDialog.py
@@ -36,8 +36,6 @@ from silx.gui.hdf5.Hdf5Formatter import Hdf5Formatter
 import silx.io
 from .AbstractDataFileDialog import AbstractDataFileDialog
 
-import fabio
-
 
 _logger = logging.getLogger(__name__)
 

--- a/src/silx/gui/dialog/test/test_datafiledialog.py
+++ b/src/silx/gui/dialog/test/test_datafiledialog.py
@@ -28,7 +28,6 @@ __license__ = "MIT"
 __date__ = "08/03/2019"
 
 
-import unittest
 import tempfile
 import numpy
 import shutil

--- a/src/silx/gui/dialog/test/test_imagefiledialog.py
+++ b/src/silx/gui/dialog/test/test_imagefiledialog.py
@@ -28,7 +28,6 @@ __license__ = "MIT"
 __date__ = "08/03/2019"
 
 
-import unittest
 import tempfile
 import numpy
 import shutil

--- a/src/silx/gui/fit/test/testBackgroundWidget.py
+++ b/src/silx/gui/fit/test/testBackgroundWidget.py
@@ -21,8 +21,6 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-import unittest
-
 from silx.gui.utils.testutils import TestCaseQt
 
 from .. import BackgroundWidget

--- a/src/silx/gui/fit/test/testFitConfig.py
+++ b/src/silx/gui/fit/test/testFitConfig.py
@@ -27,8 +27,6 @@ __authors__ = ["P. Knobel"]
 __license__ = "MIT"
 __date__ = "05/12/2016"
 
-import unittest
-
 from silx.gui.utils.testutils import TestCaseQt
 from .. import FitConfig
 

--- a/src/silx/gui/fit/test/testFitWidget.py
+++ b/src/silx/gui/fit/test/testFitWidget.py
@@ -23,8 +23,6 @@
 # ###########################################################################*/
 """Basic tests for :class:`FitWidget`"""
 
-import unittest
-
 from silx.gui.utils.testutils import TestCaseQt
 
 from ... import qt

--- a/src/silx/gui/hdf5/test/test_hdf5.py
+++ b/src/silx/gui/hdf5/test/test_hdf5.py
@@ -30,7 +30,6 @@ __date__ = "12/03/2019"
 
 import time
 import os
-import unittest
 import tempfile
 import numpy
 from pkg_resources import parse_version

--- a/src/silx/gui/plot/CurvesROIWidget.py
+++ b/src/silx/gui/plot/CurvesROIWidget.py
@@ -39,7 +39,6 @@ import sys
 import functools
 import numpy
 from silx.io import dictdump
-from silx.utils import deprecation
 from silx.utils.weakref import WeakMethodProxy
 from silx.utils.proxy import docstring
 from .. import icons, qt

--- a/src/silx/gui/plot/ImageView.py
+++ b/src/silx/gui/plot/ImageView.py
@@ -63,7 +63,6 @@ from .tools.RadarView import RadarView
 from .utils.axis import SyncAxes
 from ..utils import blockSignals
 from . import _utils
-from .tools.profile import manager
 from .tools.profile import rois
 from .actions import PlotAction
 

--- a/src/silx/gui/plot/PlotInteraction.py
+++ b/src/silx/gui/plot/PlotInteraction.py
@@ -34,7 +34,6 @@ import time
 import weakref
 
 from .. import colors
-from .. import qt
 from . import items
 from .Interaction import (ClickOrDrag, LEFT_BTN, RIGHT_BTN, MIDDLE_BTN,
                           State, StateMachine)

--- a/src/silx/gui/plot/PlotWindow.py
+++ b/src/silx/gui/plot/PlotWindow.py
@@ -39,7 +39,6 @@ import weakref
 
 import silx
 from silx.utils.weakref import WeakMethodProxy
-from silx.utils.deprecation import deprecated
 from silx.utils.proxy import docstring
 
 from . import PlotWidget

--- a/src/silx/gui/plot/Profile.py
+++ b/src/silx/gui/plot/Profile.py
@@ -34,12 +34,10 @@ import weakref
 
 from .. import qt
 from . import actions
-from .tools.profile import core
 from .tools.profile import manager
 from .tools.profile import rois
 from silx.gui.widgets.MultiModeAction import MultiModeAction
 
-from silx.utils.deprecation import deprecated
 from .tools import roi as roi_mdl
 from silx.gui.plot import items
 

--- a/src/silx/gui/plot/ROIStatsWidget.py
+++ b/src/silx/gui/plot/ROIStatsWidget.py
@@ -34,8 +34,8 @@ __date__ = "22/07/2019"
 from contextlib import contextmanager
 from silx.gui import qt
 from silx.gui import icons
-from silx.gui.plot.StatsWidget import _StatsWidgetBase, StatsTable, _Container
-from silx.gui.plot.StatsWidget import UpdateModeWidget, UpdateMode
+from silx.gui.plot.StatsWidget import _StatsWidgetBase, _Container
+from silx.gui.plot.StatsWidget import UpdateMode
 from silx.gui.widgets.TableWidget import TableWidget
 from silx.gui.plot.items.roi import RegionOfInterest
 from silx.gui.plot import items as plotitems

--- a/src/silx/gui/plot/StackView.py
+++ b/src/silx/gui/plot/StackView.py
@@ -84,14 +84,11 @@ from .tools import LimitsToolBar
 from .Profile import Profile3DToolBar
 from ..widgets.FrameBrowser import HorizontalSliderWithBrowser
 
-from silx.gui.plot.actions import control as actions_control
 from silx.gui.plot.actions import io as silx_io
 from silx.io.nxdata import save_NXdata
 from silx.utils.array_like import DatasetView, ListOfImages
 from silx.math import calibration
-from silx.utils.deprecation import deprecated_warning
 
-import h5py
 from silx.io.utils import is_dataset
 
 _logger = logging.getLogger(__name__)

--- a/src/silx/gui/plot/_utils/test/test_ticklayout.py
+++ b/src/silx/gui/plot/_utils/test/test_ticklayout.py
@@ -27,7 +27,6 @@ __license__ = "MIT"
 __date__ = "17/01/2018"
 
 
-import unittest
 import numpy
 
 from silx.utils.testutils import ParametricTestCase

--- a/src/silx/gui/plot/backends/BackendBase.py
+++ b/src/silx/gui/plot/backends/BackendBase.py
@@ -33,7 +33,6 @@ __license__ = "MIT"
 __date__ = "21/12/2018"
 
 import weakref
-from ... import qt
 
 
 # Names for setCursor

--- a/src/silx/gui/plot/backends/glutils/GLPlotImage.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotImage.py
@@ -33,8 +33,6 @@ __date__ = "03/04/2017"
 import math
 import numpy
 
-from silx.math.combo import min_max
-
 from ...._glutils import gl, Program, Texture
 from ..._utils import FLOAT32_MINPOS
 from .GLSupport import mat4Translate, mat4Scale

--- a/src/silx/gui/plot/items/_roi_base.py
+++ b/src/silx/gui/plot/items/_roi_base.py
@@ -44,7 +44,6 @@ from .. import items
 from ..items import core
 from ...colors import rgba
 import silx.utils.deprecation
-from ....utils.proxy import docstring
 
 
 logger = logging.getLogger(__name__)

--- a/src/silx/gui/plot/items/axis.py
+++ b/src/silx/gui/plot/items/axis.py
@@ -33,7 +33,6 @@ import enum
 import logging
 
 import dateutil.tz
-import numpy
 
 from ... import qt
 from .. import _utils

--- a/src/silx/gui/plot/items/curve.py
+++ b/src/silx/gui/plot/items/curve.py
@@ -35,7 +35,7 @@ import numpy
 
 from ... import colors
 from .core import (PointsBase, LabelsMixIn, ColorMixIn, YAxisMixIn,
-                   FillMixIn, LineMixIn, SymbolMixIn, ItemChangedType,
+                   FillMixIn, LineMixIn, SymbolMixIn,
                    BaselineMixIn, HighlightedMixIn, _Style)
 
 

--- a/src/silx/gui/plot/items/histogram.py
+++ b/src/silx/gui/plot/items/histogram.py
@@ -32,7 +32,6 @@ import logging
 import typing
 
 import numpy
-from collections import OrderedDict, namedtuple
 try:
     from collections import abc
 except ImportError:  # Python2 support
@@ -40,7 +39,7 @@ except ImportError:  # Python2 support
 
 from ....utils.proxy import docstring
 from .core import (DataItem, AlphaMixIn, BaselineMixIn, ColorMixIn, FillMixIn,
-                   LineMixIn, YAxisMixIn, ItemChangedType, Item)
+                   LineMixIn, YAxisMixIn, ItemChangedType)
 from ._pick import PickingResult
 
 _logger = logging.getLogger(__name__)

--- a/src/silx/gui/plot/items/shape.py
+++ b/src/silx/gui/plot/items/shape.py
@@ -34,10 +34,9 @@ import logging
 import numpy
 
 from ... import colors
-from ..utils.intersections import lines_intersection
 from .core import (
     Item, DataItem,
-    AlphaMixIn, ColorMixIn, FillMixIn, ItemChangedType, ItemMixInBase, LineMixIn, YAxisMixIn)
+    AlphaMixIn, ColorMixIn, FillMixIn, ItemChangedType, LineMixIn, YAxisMixIn)
 
 
 _logger = logging.getLogger(__name__)

--- a/src/silx/gui/plot/test/testAlphaSlider.py
+++ b/src/silx/gui/plot/test/testAlphaSlider.py
@@ -29,7 +29,6 @@ __license__ = "MIT"
 __date__ = "28/03/2017"
 
 import numpy
-import unittest
 
 from silx.gui import qt
 from silx.gui.utils.testutils import TestCaseQt

--- a/src/silx/gui/plot/test/testColorBar.py
+++ b/src/silx/gui/plot/test/testColorBar.py
@@ -27,7 +27,6 @@ __authors__ = ["H. Payno"]
 __license__ = "MIT"
 __date__ = "24/04/2018"
 
-import unittest
 from silx.gui.utils.testutils import TestCaseQt
 from silx.gui.plot.ColorBar import _ColorScale
 from silx.gui.plot.ColorBar import ColorBarWidget

--- a/src/silx/gui/plot/test/testCompareImages.py
+++ b/src/silx/gui/plot/test/testCompareImages.py
@@ -27,7 +27,6 @@ __authors__ = ["H. Payno"]
 __license__ = "MIT"
 __date__ = "23/07/2018"
 
-import unittest
 import numpy
 import weakref
 

--- a/src/silx/gui/plot/test/testComplexImageView.py
+++ b/src/silx/gui/plot/test/testComplexImageView.py
@@ -28,7 +28,6 @@ __license__ = "MIT"
 __date__ = "17/01/2018"
 
 
-import unittest
 import logging
 import numpy
 

--- a/src/silx/gui/plot/test/testCurvesROIWidget.py
+++ b/src/silx/gui/plot/test/testCurvesROIWidget.py
@@ -30,7 +30,6 @@ __date__ = "16/11/2017"
 
 import logging
 import os.path
-import pytest
 from collections import OrderedDict
 import numpy
 
@@ -40,9 +39,7 @@ from silx.gui.plot import Plot1D
 from silx.test.utils import temp_dir
 from silx.gui.utils.testutils import TestCaseQt, SignalListener
 from silx.gui.plot import PlotWindow, CurvesROIWidget
-from silx.gui.plot.CurvesROIWidget import ROITable
 from silx.gui.utils.testutils import getQToolButtonFromAction
-from silx.gui.plot.PlotInteraction import ItemsInteraction
 
 _logger = logging.getLogger(__name__)
 

--- a/src/silx/gui/plot/test/testImageStack.py
+++ b/src/silx/gui/plot/test/testImageStack.py
@@ -28,7 +28,6 @@ __license__ = "MIT"
 __date__ = "15/01/2020"
 
 
-import unittest
 import tempfile
 import numpy
 import h5py

--- a/src/silx/gui/plot/test/testItem.py
+++ b/src/silx/gui/plot/test/testItem.py
@@ -28,8 +28,6 @@ __license__ = "MIT"
 __date__ = "01/09/2017"
 
 
-import unittest
-
 import numpy
 
 from silx.gui.utils.testutils import SignalListener

--- a/src/silx/gui/plot/test/testLegendSelector.py
+++ b/src/silx/gui/plot/test/testLegendSelector.py
@@ -29,7 +29,6 @@ __date__ = "15/05/2017"
 
 
 import logging
-import unittest
 
 from silx.gui import qt
 from silx.gui.utils.testutils import TestCaseQt

--- a/src/silx/gui/plot/test/testMaskToolsWidget.py
+++ b/src/silx/gui/plot/test/testMaskToolsWidget.py
@@ -30,7 +30,6 @@ __date__ = "17/01/2018"
 
 import logging
 import os.path
-import unittest
 
 import numpy
 
@@ -40,8 +39,6 @@ from silx.utils.testutils import ParametricTestCase
 from silx.gui.utils.testutils import getQToolButtonFromAction
 from silx.gui.plot import PlotWindow, MaskToolsWidget
 from .utils import PlotWidgetTestCase
-
-import fabio
 
 
 _logger = logging.getLogger(__name__)

--- a/src/silx/gui/plot/test/testPixelIntensityHistoAction.py
+++ b/src/silx/gui/plot/test/testPixelIntensityHistoAction.py
@@ -29,7 +29,6 @@ __date__ = "02/03/2018"
 
 
 import numpy
-import unittest
 
 from silx.utils.testutils import ParametricTestCase
 from silx.gui.utils.testutils import TestCaseQt, getQToolButtonFromAction

--- a/src/silx/gui/plot/test/testPlotInteraction.py
+++ b/src/silx/gui/plot/test/testPlotInteraction.py
@@ -28,7 +28,6 @@ __license__ = "MIT"
 __date__ = "01/09/2017"
 
 
-import unittest
 from silx.gui import qt
 from .utils import PlotWidgetTestCase
 

--- a/src/silx/gui/plot/test/testPlotWindow.py
+++ b/src/silx/gui/plot/test/testPlotWindow.py
@@ -28,7 +28,6 @@ __license__ = "MIT"
 __date__ = "27/06/2017"
 
 
-import unittest
 import numpy
 import pytest
 

--- a/src/silx/gui/plot/test/testRoiStatsWidget.py
+++ b/src/silx/gui/plot/test/testRoiStatsWidget.py
@@ -32,7 +32,6 @@ from silx.gui.plot.ROIStatsWidget import ROIStatsWidget
 from silx.gui.plot.CurvesROIWidget import ROI
 from silx.gui.plot.items.roi import RectangleROI, PolygonROI
 from silx.gui.plot.StatsWidget import UpdateMode
-import unittest
 import numpy
 
 

--- a/src/silx/gui/plot/test/testScatterMaskToolsWidget.py
+++ b/src/silx/gui/plot/test/testScatterMaskToolsWidget.py
@@ -30,7 +30,6 @@ __date__ = "17/01/2018"
 
 import logging
 import os.path
-import unittest
 
 import numpy
 
@@ -40,8 +39,6 @@ from silx.utils.testutils import ParametricTestCase
 from silx.gui.utils.testutils import getQToolButtonFromAction
 from silx.gui.plot import PlotWindow, ScatterMaskToolsWidget
 from .utils import PlotWidgetTestCase
-
-import fabio
 
 
 _logger = logging.getLogger(__name__)

--- a/src/silx/gui/plot/test/testScatterView.py
+++ b/src/silx/gui/plot/test/testScatterView.py
@@ -28,8 +28,6 @@ __license__ = "MIT"
 __date__ = "06/03/2018"
 
 
-import unittest
-
 import numpy
 
 from silx.gui.plot.items import Axis, Scatter

--- a/src/silx/gui/plot/test/testStackView.py
+++ b/src/silx/gui/plot/test/testStackView.py
@@ -28,7 +28,6 @@ __license__ = "MIT"
 __date__ = "20/03/2017"
 
 
-import unittest
 import numpy
 
 from silx.gui.utils.testutils import TestCaseQt, SignalListener

--- a/src/silx/gui/plot/test/testStats.py
+++ b/src/silx/gui/plot/test/testStats.py
@@ -34,13 +34,11 @@ from silx.gui.plot import StatsWidget
 from silx.gui.plot.stats import statshandler
 from silx.gui.utils.testutils import TestCaseQt, SignalListener
 from silx.gui.plot import Plot1D, Plot2D
-from silx.gui.plot3d.SceneWidget import SceneWidget
 from silx.gui.plot.items.roi import RectangleROI, PolygonROI
 from silx.gui.plot.tools.roi import  RegionOfInterestManager
 from silx.gui.plot.stats.stats import Stats
 from silx.gui.plot.CurvesROIWidget import ROI
 from silx.utils.testutils import ParametricTestCase
-import unittest
 import logging
 import numpy
 

--- a/src/silx/gui/plot/test/testUtilsAxis.py
+++ b/src/silx/gui/plot/test/testUtilsAxis.py
@@ -28,7 +28,6 @@ __license__ = "MIT"
 __date__ = "20/11/2018"
 
 
-import unittest
 from silx.gui.plot import PlotWidget
 from silx.gui.utils.testutils import TestCaseQt
 from silx.gui.plot.utils.axis import SyncAxes

--- a/src/silx/gui/plot/test/utils.py
+++ b/src/silx/gui/plot/test/utils.py
@@ -30,7 +30,6 @@ __date__ = "26/01/2018"
 
 import logging
 import pytest
-import unittest
 
 from silx.gui.utils.testutils import TestCaseQt
 

--- a/src/silx/gui/plot/tools/test/testCurveLegendsWidget.py
+++ b/src/silx/gui/plot/tools/test/testCurveLegendsWidget.py
@@ -26,8 +26,6 @@ __license__ = "MIT"
 __date__ = "02/08/2018"
 
 
-import unittest
-
 from silx.gui import qt
 from silx.utils.testutils import ParametricTestCase
 from silx.gui.utils.testutils import TestCaseQt

--- a/src/silx/gui/plot/tools/test/testROI.py
+++ b/src/silx/gui/plot/tools/test/testROI.py
@@ -26,7 +26,6 @@ __license__ = "MIT"
 __date__ = "28/06/2018"
 
 
-import unittest
 import numpy.testing
 
 from silx.gui import qt

--- a/src/silx/gui/plot/tools/test/testScatterProfileToolBar.py
+++ b/src/silx/gui/plot/tools/test/testScatterProfileToolBar.py
@@ -26,7 +26,6 @@ __license__ = "MIT"
 __date__ = "28/06/2018"
 
 
-import unittest
 import numpy
 
 from silx.gui import qt

--- a/src/silx/gui/plot/tools/test/testTools.py
+++ b/src/silx/gui/plot/tools/test/testTools.py
@@ -29,11 +29,9 @@ __date__ = "02/03/2018"
 
 
 import functools
-import unittest
 import numpy
 
 from silx.utils.testutils import LoggingValidator
-from silx.gui.utils.testutils import qWaitForWindowExposedAndActivate
 from silx.gui import qt
 from silx.gui.plot import PlotWindow
 from silx.gui.plot import tools

--- a/src/silx/gui/plot3d/items/mixins.py
+++ b/src/silx/gui/plot3d/items/mixins.py
@@ -32,8 +32,6 @@ __date__ = "24/04/2018"
 import collections
 import numpy
 
-from silx.math.combo import min_max
-
 from ...plot.items.core import ItemMixInBase
 from ...plot.items.core import ColormapMixIn as _ColormapMixIn
 from ...plot.items.core import SymbolMixIn as _SymbolMixIn

--- a/src/silx/gui/plot3d/scene/test/test_utils.py
+++ b/src/silx/gui/plot3d/scene/test/test_utils.py
@@ -27,7 +27,6 @@ __license__ = "MIT"
 __date__ = "17/01/2018"
 
 
-import unittest
 from silx.utils.testutils import ParametricTestCase
 
 import numpy

--- a/src/silx/gui/plot3d/tools/test/testPositionInfoWidget.py
+++ b/src/silx/gui/plot3d/tools/test/testPositionInfoWidget.py
@@ -27,8 +27,6 @@ __license__ = "MIT"
 __date__ = "03/10/2018"
 
 
-import unittest
-
 import numpy
 
 from silx.gui.utils.testutils import TestCaseQt

--- a/src/silx/gui/qt/_pyqt6.py
+++ b/src/silx/gui/qt/_pyqt6.py
@@ -32,7 +32,6 @@ import enum
 import logging
 
 import PyQt6.sip
-from PyQt6.QtCore import Qt
 
 
 _logger = logging.getLogger(__name__)

--- a/src/silx/gui/utils/test/test.py
+++ b/src/silx/gui/utils/test/test.py
@@ -28,7 +28,6 @@ __license__ = "MIT"
 __date__ = "01/08/2019"
 
 
-import unittest
 from silx.gui import qt
 from silx.gui.utils.testutils import TestCaseQt, SignalListener
 

--- a/src/silx/gui/utils/test/test_async.py
+++ b/src/silx/gui/utils/test/test_async.py
@@ -29,8 +29,6 @@ __date__ = "09/03/2018"
 
 
 import threading
-import unittest
-
 
 from concurrent.futures import wait
 from silx.gui import qt

--- a/src/silx/gui/utils/test/test_image.py
+++ b/src/silx/gui/utils/test/test_image.py
@@ -28,7 +28,6 @@ __license__ = "MIT"
 __date__ = "16/01/2017"
 
 import numpy
-import unittest
 
 from silx.gui import qt
 from silx.utils.testutils import ParametricTestCase

--- a/src/silx/gui/utils/test/test_qtutils.py
+++ b/src/silx/gui/utils/test/test_qtutils.py
@@ -28,7 +28,6 @@ __license__ = "MIT"
 __date__ = "01/08/2019"
 
 
-import unittest
 from silx.gui import qt
 from silx.gui import utils
 from silx.gui.utils.testutils import TestCaseQt

--- a/src/silx/gui/utils/test/test_testutils.py
+++ b/src/silx/gui/utils/test/test_testutils.py
@@ -30,7 +30,6 @@ __date__ = "16/01/2017"
 import unittest
 import sys
 
-from silx.gui import qt
 from ..testutils import TestCaseQt
 
 

--- a/src/silx/gui/widgets/test/test_boxlayoutdockwidget.py
+++ b/src/silx/gui/widgets/test/test_boxlayoutdockwidget.py
@@ -27,8 +27,6 @@ __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "06/03/2018"
 
-import unittest
-
 from silx.gui.widgets.BoxLayoutDockWidget import BoxLayoutDockWidget
 from silx.gui import qt
 from silx.gui.utils.testutils import TestCaseQt

--- a/src/silx/gui/widgets/test/test_flowlayout.py
+++ b/src/silx/gui/widgets/test/test_flowlayout.py
@@ -27,8 +27,6 @@ __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "02/08/2018"
 
-import unittest
-
 from silx.gui.widgets.FlowLayout import FlowLayout
 from silx.gui import qt
 from silx.gui.utils.testutils import TestCaseQt

--- a/src/silx/gui/widgets/test/test_framebrowser.py
+++ b/src/silx/gui/widgets/test/test_framebrowser.py
@@ -26,8 +26,6 @@ __license__ = "MIT"
 __date__ = "23/03/2018"
 
 
-import unittest
-
 from silx.gui.utils.testutils import TestCaseQt
 from silx.gui.widgets.FrameBrowser import FrameBrowser
 

--- a/src/silx/gui/widgets/test/test_hierarchicaltableview.py
+++ b/src/silx/gui/widgets/test/test_hierarchicaltableview.py
@@ -25,8 +25,6 @@ __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "07/04/2017"
 
-import unittest
-
 from .. import HierarchicalTableView
 from silx.gui.utils.testutils import TestCaseQt
 from silx.gui import qt

--- a/src/silx/gui/widgets/test/test_legendiconwidget.py
+++ b/src/silx/gui/widgets/test/test_legendiconwidget.py
@@ -27,8 +27,6 @@ __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "23/10/2020"
 
-import unittest
-
 from silx.gui import qt
 from silx.gui.widgets.LegendIconWidget import LegendIconWidget
 from silx.gui.utils.testutils import TestCaseQt

--- a/src/silx/gui/widgets/test/test_periodictable.py
+++ b/src/silx/gui/widgets/test/test_periodictable.py
@@ -25,8 +25,6 @@ __authors__ = ["P. Knobel"]
 __license__ = "MIT"
 __date__ = "05/12/2016"
 
-import unittest
-
 from .. import PeriodicTable
 from silx.gui.utils.testutils import TestCaseQt
 from silx.gui import qt

--- a/src/silx/gui/widgets/test/test_printpreview.py
+++ b/src/silx/gui/widgets/test/test_printpreview.py
@@ -28,7 +28,6 @@ __license__ = "MIT"
 __date__ = "19/07/2017"
 
 
-import unittest
 from silx.gui.utils.testutils import TestCaseQt
 from silx.gui.widgets.PrintPreview import PrintPreviewDialog
 from silx.gui import qt

--- a/src/silx/gui/widgets/test/test_rangeslider.py
+++ b/src/silx/gui/widgets/test/test_rangeslider.py
@@ -27,8 +27,6 @@ __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "01/08/2018"
 
-import unittest
-
 from silx.gui import qt, colors
 from silx.gui.widgets.RangeSlider import RangeSlider
 from silx.gui.utils.testutils import TestCaseQt

--- a/src/silx/gui/widgets/test/test_tablewidget.py
+++ b/src/silx/gui/widgets/test/test_tablewidget.py
@@ -28,7 +28,6 @@ __license__ = "MIT"
 __date__ = "05/12/2016"
 
 
-import unittest
 from silx.gui.utils.testutils import TestCaseQt
 from silx.gui.widgets.TableWidget import TableWidget
 

--- a/src/silx/gui/widgets/test/test_threadpoolpushbutton.py
+++ b/src/silx/gui/widgets/test/test_threadpoolpushbutton.py
@@ -28,7 +28,6 @@ __license__ = "MIT"
 __date__ = "17/01/2018"
 
 
-import unittest
 import time
 from silx.gui import qt
 from silx.gui.utils.testutils import TestCaseQt

--- a/src/silx/image/backprojection.py
+++ b/src/silx/image/backprojection.py
@@ -21,4 +21,4 @@
 #
 # ############################################################################*/
 
-from silx.opencl.backprojection import *
+from silx.opencl.backprojection import *  # noqa

--- a/src/silx/image/projection.py
+++ b/src/silx/image/projection.py
@@ -21,4 +21,4 @@
 #
 # ############################################################################*/
 
-from silx.opencl.projection import *
+from silx.opencl.projection import *  # noqa

--- a/src/silx/image/reconstruction.py
+++ b/src/silx/image/reconstruction.py
@@ -21,4 +21,4 @@
 #
 # ############################################################################*/
 
-from silx.opencl.reconstruction import *
+from silx.opencl.reconstruction import *  # noqa

--- a/src/silx/image/sift.py
+++ b/src/silx/image/sift.py
@@ -21,4 +21,4 @@
 #
 # ############################################################################*/
 
-from silx.opencl.sift import *
+from silx.opencl.sift import *  # noqa

--- a/src/silx/io/test/test_fioh5.py
+++ b/src/silx/io/test/test_fioh5.py
@@ -23,19 +23,11 @@
 """Tests for fioh5"""
 import numpy
 import os
-import io
-import sys
 import tempfile
 import unittest
-import datetime
-import logging
 
-from silx.utils import testutils
+from ..fioh5 import FioH5, is_fiofile, logger1, dtypeConverter
 
-from .. import fioh5
-from ..fioh5 import (FioH5, FioH5NodeDataset, is_fiofile, logger1, dtypeConverter)
-
-import h5py
 
 __authors__ = ["T. Fuchs"]
 __license__ = "MIT"

--- a/src/silx/io/test/test_specfilewrapper.py
+++ b/src/silx/io/test/test_specfilewrapper.py
@@ -26,7 +26,6 @@ __authors__ = ["P. Knobel"]
 __license__ = "MIT"
 __date__ = "15/05/2017"
 
-import locale
 import logging
 import numpy
 import os

--- a/src/silx/io/test/test_spectoh5.py
+++ b/src/silx/io/test/test_spectoh5.py
@@ -24,7 +24,6 @@
 
 from numpy import array_equal
 import os
-import sys
 import tempfile
 import unittest
 

--- a/src/silx/io/test/test_write_to_h5.py
+++ b/src/silx/io/test/test_write_to_h5.py
@@ -30,7 +30,6 @@ from silx.io import spech5
 from silx.io.convert import write_to_h5
 from silx.io.dictdump import h5todict
 from silx.io import commonh5
-from silx.io.spech5 import SpecH5
 
 
 def test_with_commonh5(tmp_path):

--- a/src/silx/math/fit/test/test_peaks.py
+++ b/src/silx/math/fit/test/test_peaks.py
@@ -26,7 +26,6 @@ Tests for peaks module
 
 import unittest
 import numpy
-import math
 
 from silx.math.fit import functions
 from silx.math.fit import peaks

--- a/src/silx/math/test/benchmark_combo.py
+++ b/src/silx/math/test/benchmark_combo.py
@@ -28,13 +28,10 @@ __date__ = "17/01/2018"
 
 
 import logging
-import os.path
 import time
-import unittest
 
 import numpy
 
-from silx.test.utils import temp_dir
 from silx.utils.testutils import ParametricTestCase
 
 from silx.math import combo

--- a/src/silx/math/test/test_combo.py
+++ b/src/silx/math/test/test_combo.py
@@ -27,8 +27,6 @@ __license__ = "MIT"
 __date__ = "17/01/2018"
 
 
-import unittest
-
 import numpy
 
 from silx.utils.testutils import ParametricTestCase

--- a/src/silx/math/test/test_histogramnd_nominal.py
+++ b/src/silx/math/test/test_histogramnd_nominal.py
@@ -25,7 +25,6 @@ Nominal tests of the histogramnd function.
 """
 
 import unittest
-import pytest
 
 import numpy as np
 

--- a/src/silx/math/test/test_histogramnd_vs_np.py
+++ b/src/silx/math/test/test_histogramnd_vs_np.py
@@ -25,7 +25,6 @@ Tests for the histogramnd function.
 Results are compared to numpy's histogramdd.
 """
 
-import os
 import unittest
 import operator
 import pytest

--- a/src/silx/math/test/test_marchingcubes.py
+++ b/src/silx/math/test/test_marchingcubes.py
@@ -26,8 +26,6 @@ __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "17/01/2018"
 
-import unittest
-
 import numpy
 
 from silx.utils.testutils import ParametricTestCase

--- a/src/silx/utils/array_like.py
+++ b/src/silx/utils/array_like.py
@@ -46,8 +46,6 @@ Functions:
 
 """
 
-import sys
-
 import numpy
 import numbers
 

--- a/src/silx/utils/test/test_number.py
+++ b/src/silx/utils/test/test_number.py
@@ -28,7 +28,6 @@ __date__ = "05/06/2018"
 
 import logging
 import numpy
-import unittest
 import pkg_resources
 from silx.utils import number
 from silx.utils import testutils


### PR DESCRIPTION
This PR cleans-up most of the unused imports spotted by `pylint`.
I left the ones with side effects (matplotlib, Qt bindings) and didn't touch `silx.opencl`.
