### PR TITLE
`silx.opencl.backprojection`: Remove deprecated `fourier_filter` function

### DIFF
--- a/src/silx/opencl/backprojection.py
+++ b/src/silx/opencl/backprojection.py
@@ -34,7 +34,6 @@ import numpy as np
 from .common import pyopencl
 from .processing import EventDescription, OpenclProcessing, BufferDescription
 from .sinofilter import SinoFilter
-from .sinofilter import fourier_filter as fourier_filter_
 
 if pyopencl:
     mf = pyopencl.mem_flags
@@ -376,7 +375,3 @@ class Backprojection(OpenclProcessing):
         return res
 
     __call__ = filtered_backprojection
-
-
-def fourier_filter(sino, filter_=None, fft_size=None):
-    return fourier_filter_(sino, filter_=filter_, fft_size=fft_size)


### PR DESCRIPTION
This is a follow-up of PR #3799.

As `silx.opencl.sinofilter.fourier_filter` was marked as deprecated since v0.10, `silx.opencl.backprojection.fourier_filter` was also printing a deprecation warning, so let's remove it too.

closes #3813