### PR TITLE
Urlselectiontable with 3 columns

### DIFF
--- a/src/silx/gui/widgets/UrlSelectionTable.py
+++ b/src/silx/gui/widgets/UrlSelectionTable.py
@@ -35,7 +35,7 @@ import logging
 from silx.gui import qt
 from silx.gui import utils as qtutils
 from silx.gui.widgets.TableWidget import TableWidget
-from silx.io.url import DataUrl
+from silx.io.url import DataUrl, slice_sequence_to_string
 from silx.utils.deprecation import deprecated, deprecated_warning
 from silx.gui import constants
 
@@ -74,22 +74,11 @@ class _DataUrlItem(qt.QTableWidgetItem):
     def __init__(self, url):
         qt.QTableWidgetItem.__init__(self)
         self._url = url
-
-        def slice_to_string(data_slice):
-            if data_slice == Ellipsis:
-                return "..."
-            elif data_slice == slice(None):
-                return ":"
-            elif isinstance(data_slice, int):
-                return str(data_slice)
-            else:
-                raise TypeError("Unexpected slicing type. Found %s" % type(data_slice))
-
         text = os.path.basename(url.file_path())
         if url.data_path() is not None:
             text += f" {url.data_path()}"
         if url.data_slice() is not None:
-            text += f" [{slice_to_string(url.data_slice())}]"
+            text += f" [{slice_sequence_to_string(url.data_slice())}]"
 
         self.setText(text)
         self.setToolTip(url.path())


### PR DESCRIPTION
Split the URL column in 3 columns for filename/datapath/slice.

This is just for readability.

And it make it easy to hide one of the columns from the API.

I have removed the `URL_COLUMN`, but we also can restore it by default if you prefer.
So it could be easy to display it and to hide the others on your side.

![image](https://github.com/silx-kit/silx/assets/7579321/e228d8a2-221f-417f-8c69-798a68bd661a)

![image](https://github.com/silx-kit/silx/assets/7579321/743064a2-b29f-4f18-936e-53a14d4fcc93)

Changelog: 
- UrlSelectionTable: Split the URL column in 3 columns