### PR TITLE
CompareImage: Feature a consistent autoscale

### DIFF
--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -39,6 +39,7 @@ from silx.gui import qt
 from silx.gui import plot
 from silx.gui.colors import Colormap
 from silx.gui.plot import tools
+from silx.utils.deprecation import deprecated_warning
 from silx.utils.weakref import WeakMethodProxy
 from silx.gui.plot.items import Scatter
 
@@ -445,7 +446,7 @@ class CompareImages(qt.QMainWindow):
     def clear(self):
         self.setData(None, None)
 
-    def setData(self, image1, image2):
+    def setData(self, image1, image2, updateColormap="deprecated"):
         """Set images to compare.
 
         Images can contains floating-point or integer values, or RGB and RGBA
@@ -457,13 +458,16 @@ class CompareImages(qt.QMainWindow):
         :param numpy.ndarray image1: The first image
         :param numpy.ndarray image2: The second image
         """
+        if updateColormap != "deprecated":
+            deprecated_warning("Argument", "setData's updateColormap argument", since_version="2.0.0")
+
         self.__raw1 = image1
         self.__raw2 = image2
         self.__updateData()
         if self.isAutoResetZoom():
             self.__plot.resetZoom()
 
-    def setImage1(self, image1):
+    def setImage1(self, image1, updateColormap="deprecated"):
         """Set image1 to be compared.
 
         Images can contains floating-point or integer values, or RGB and RGBA
@@ -474,12 +478,15 @@ class CompareImages(qt.QMainWindow):
 
         :param numpy.ndarray image1: The first image
         """
+        if updateColormap != "deprecated":
+            deprecated_warning("Argument", "setImage1's updateColormap argument", since_version="2.0.0")
+
         self.__raw1 = image1
         self.__updateData()
         if self.isAutoResetZoom():
             self.__plot.resetZoom()
 
-    def setImage2(self, image2):
+    def setImage2(self, image2, updateColormap="deprecated"):
         """Set image2 to be compared.
 
         Images can contains floating-point or integer values, or RGB and RGBA
@@ -490,6 +497,9 @@ class CompareImages(qt.QMainWindow):
 
         :param numpy.ndarray image2: The second image
         """
+        if updateColormap != "deprecated":
+            deprecated_warning("Argument", "setImage2's updateColormap argument", since_version="2.0.0")
+
         self.__raw2 = image2
         self.__updateData()
         if self.isAutoResetZoom():

--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -313,18 +313,11 @@ class CompareImages(qt.QMainWindow):
         """
         if self.__visualizationMode == mode:
             return
-        previousMode = self.getVisualizationMode()
         self.__visualizationMode = mode
         mode = self.getVisualizationMode()
         self.__vline.setVisible(mode == VisualizationMode.VERTICAL_LINE)
         self.__hline.setVisible(mode == VisualizationMode.HORIZONTAL_LINE)
-        visModeRawDisplay = (VisualizationMode.ONLY_A,
-                             VisualizationMode.ONLY_B,
-                             VisualizationMode.VERTICAL_LINE,
-                             VisualizationMode.HORIZONTAL_LINE)
-        updateColormap = not(previousMode in visModeRawDisplay and
-                             mode in visModeRawDisplay)
-        self.__updateData(updateColormap=updateColormap)
+        self.__updateData()
         self.sigConfigurationChanged.emit()
 
     def centerLines(self):
@@ -358,7 +351,7 @@ class CompareImages(qt.QMainWindow):
         if self.__alignmentMode == mode:
             return
         self.__alignmentMode = mode
-        self.__updateData(updateColormap=False)
+        self.__updateData()
         self.sigConfigurationChanged.emit()
 
     def getAlignmentMode(self):
@@ -472,7 +465,7 @@ class CompareImages(qt.QMainWindow):
     def clear(self):
         self.setData(None, None)
 
-    def setData(self, image1, image2, updateColormap=True):
+    def setData(self, image1, image2):
         """Set images to compare.
 
         Images can contains floating-point or integer values, or RGB and RGBA
@@ -487,11 +480,11 @@ class CompareImages(qt.QMainWindow):
         self.__raw1 = image1
         self.__raw2 = image2
         self._colormap.setPinnedData(self.__raw1, self.__raw2)
-        self.__updateData(updateColormap=updateColormap)
+        self.__updateData()
         if self.isAutoResetZoom():
             self.__plot.resetZoom()
 
-    def setImage1(self, image1, updateColormap=True):
+    def setImage1(self, image1):
         """Set image1 to be compared.
 
         Images can contains floating-point or integer values, or RGB and RGBA
@@ -504,11 +497,11 @@ class CompareImages(qt.QMainWindow):
         """
         self.__raw1 = image1
         self._colormap.setPinnedData(self.__raw1, self.__raw2)
-        self.__updateData(updateColormap=updateColormap)
+        self.__updateData()
         if self.isAutoResetZoom():
             self.__plot.resetZoom()
 
-    def setImage2(self, image2, updateColormap=True):
+    def setImage2(self, image2):
         """Set image2 to be compared.
 
         Images can contains floating-point or integer values, or RGB and RGBA
@@ -521,7 +514,7 @@ class CompareImages(qt.QMainWindow):
         """
         self.__raw2 = image2
         self._colormap.setPinnedData(self.__raw1, self.__raw2)
-        self.__updateData(updateColormap=updateColormap)
+        self.__updateData()
         if self.isAutoResetZoom():
             self.__plot.resetZoom()
 
@@ -534,7 +527,7 @@ class CompareImages(qt.QMainWindow):
             data = [], [], []
         self.__scatter.setData(x=data[0], y=data[1], value=data[2])
 
-    def __updateData(self, updateColormap):
+    def __updateData(self):
         """Compute aligned image when the alignment mode changes.
 
         This function cache input images which are used when

--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -615,7 +615,10 @@ class CompareImages(qt.QMainWindow):
                 colormap2 = None
             self.__plot.addImage(data2, z=0, legend="image2", resetzoom=False, colormap=colormap2)
             self.__image2 = self.__plot.getImage("image2")
+            self.__image2.setVisible(True)
         else:
+            if self.__image2 is not None:
+                self.__image2.setVisible(False)
             self.__image2 = None
             self.__data2 = numpy.empty((0, 0))
         self.__updateKeyPoints()

--- a/src/silx/gui/plot/items/image.py
+++ b/src/silx/gui/plot/items/image.py
@@ -335,9 +335,11 @@ class ImageDataBase(ImageBase, ColormapMixIn):
     def _getColormapForRendering(self):
         colormap = self.getColormap()
         if colormap.isAutoscale():
+            # NOTE: Make sure getColormapRange comes from the original object
+            vrange = colormap.getColormapRange(self)
             # Avoid backend to compute autoscale: use item cache
             colormap = colormap.copy()
-            colormap.setVRange(*colormap.getColormapRange(self))
+            colormap.setVRange(*vrange)
         return colormap
 
     def getRgbaImageData(self, copy=True):


### PR DESCRIPTION
Feature a consistent autoscale for the CompareImage.

Now
- the autoscale statistics are computer globally for the 2 images
- it is also computed on the raw image (instead of in the sliced left/right image)
- This makes the autoscale usable, from the ColormapDialog, including 3stddev
- subsequently when you are about to slice, the statistics are not recomputed -> that's faster

Changelog: 
- CompareImage: Colormap autoscale is now global to the 2 raw images to compare
- CompareImage: `updateColormap=` was dropped, this can be set with `getColormap()`