### PR TITLE
`silx.gui.plot`: Added `margins` argument to `PlotWidget.setLimits`

### DIFF
--- a/src/silx/gui/conftest.py
+++ b/src/silx/gui/conftest.py
@@ -1,5 +1,47 @@
+import weakref
 import pytest
+
+from silx.gui import qt
+from silx.gui.qt.inspect import isValid
+
 
 @pytest.fixture(autouse=True)
 def auto_qapp(qapp):
     pass
+
+
+@pytest.fixture
+def qWidgetFactory(qapp, qapp_utils):
+    """QWidget factory as fixture
+
+    This fixture provides a function taking a QWidget subclass as argument
+    which returns an instance of this QWidget making sure it is shown first
+    and destroyed once the test is done.
+    """
+    widgets = []
+
+    def createWidget(cls, *args, **kwargs):
+        widget = cls(*args, **kwargs)
+        widget.setAttribute(qt.Qt.WA_DeleteOnClose)
+        widget.show()
+        qapp_utils.qWaitForWindowExposed(widget)
+        widgets.append(widget)
+
+        return weakref.proxy(widget)
+
+    yield createWidget
+
+    qapp.processEvents()
+
+    for widget in widgets:
+        widget.close()
+    qapp.processEvents()
+
+    # Wait some time for all widgets to be deleted
+    for _ in range(10):
+        validWidgets = [widget for widget in widgets if isValid(widget)]
+        if validWidgets:
+            qapp_utils.qWait(10)
+
+    validWidgets = [widget for widget in widgets if isValid(widget)]
+    assert not validWidgets, f"Some widgets were not destroyed: {validWidgets}"

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -36,10 +36,10 @@ _logger = logging.getLogger(__name__)
 
 from collections import OrderedDict, namedtuple
 from contextlib import contextmanager
+from typing import Optional, Tuple
 import datetime as dt
 import itertools
 import numbers
-import typing
 import warnings
 
 import numpy
@@ -113,11 +113,11 @@ class _PlotWidgetSelection(qt.QObject):
         parent.sigActiveCurveChanged.connect(self._activeCurveChanged)
         parent.sigActiveScatterChanged.connect(self._activeScatterChanged)
 
-    def __mostRecentActiveItem(self) -> typing.Optional[items.Item]:
+    def __mostRecentActiveItem(self) -> Optional[items.Item]:
         """Returns most recent active item."""
         return self.__history[0] if len(self.__history) >= 1 else None
 
-    def getSelectedItems(self) -> typing.Tuple[items.Item]:
+    def getSelectedItems(self) -> Tuple[items.Item]:
         """Returns the list of currently selected items in the :class:`PlotWidget`.
 
         The list is given from most recently current item to oldest one."""
@@ -134,11 +134,11 @@ class _PlotWidgetSelection(qt.QObject):
 
         return active
 
-    def getCurrentItem(self) -> typing.Optional[items.Item]:
+    def getCurrentItem(self) -> Optional[items.Item]:
         """Returns the current item in the :class:`PlotWidget` or None. """
         return self.__current
 
-    def setCurrentItem(self, item: typing.Optional[items.Item]):
+    def setCurrentItem(self, item: Optional[items.Item]):
         """Set the current item in the :class:`PlotWidget`.
 
         :param item:
@@ -188,8 +188,8 @@ class _PlotWidgetSelection(qt.QObject):
 
     def __activeItemChanged(self,
                             kind: str,
-                            previous: typing.Optional[str],
-                            legend: typing.Optional[str]):
+                            previous: Optional[str],
+                            legend: Optional[str]):
         """Set current item from kind and legend"""
         if previous == legend:
             return  # No-op for update of item

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -2986,19 +2986,23 @@ class PlotWidget(qt.QMainWindow):
                                     dpi=dpi)
             return True
 
-    def getDataMargins(self):
+    def getDataMargins(self) -> Tuple[float, float, float, float]:
         """Get the default data margin ratios, see :meth:`setDataMargins`.
 
         :return: The margin ratios for each side (xMin, xMax, yMin, yMax).
-        :rtype: A 4-tuple of floats.
         """
         return self._defaultDataMargins
 
-    def setDataMargins(self, xMinMargin=0., xMaxMargin=0.,
-                       yMinMargin=0., yMaxMargin=0.):
+    def setDataMargins(
+        self,
+        xMinMargin: float=0.,
+        xMaxMargin: float=0.,
+        yMinMargin: float=0.,
+        yMaxMargin: float=0.,
+    ):
         """Set the default data margins to use in :meth:`resetZoom`.
 
-        Set the default ratios of margins (as floats) to add around the data
+        Set the default ratios of margins to add around the data
         inside the plot area for each side.
         """
         self._defaultDataMargins = (xMinMargin, xMaxMargin,
@@ -3045,7 +3049,10 @@ class PlotWidget(qt.QMainWindow):
         """Request to draw the plot."""
         self._backend.replot()
 
-    def _forceResetZoom(self, dataMargins=None):
+    def _forceResetZoom(
+        self,
+        dataMargins: Optional[Tuple[float, float, float, float]]=None,
+    ):
         """Reset the plot limits to the bounds of the data and redraw the plot.
 
         This method forces a reset zoom and does not check axis autoscale.
@@ -3056,9 +3063,9 @@ class PlotWidget(qt.QMainWindow):
         data (xMin, xMax, yMin and yMax limits).
         For log scale, extra margins are applied in log10 of the data.
 
-        :param dataMargins: Ratios of margins to add around the data inside
-                            the plot area for each side (default: no margins).
-        :type dataMargins: A 4-tuple of float as (xMin, xMax, yMin, yMax).
+        :param dataMargins:
+            Ratios of margins to add around the data inside the plot area for each side.
+            If None (the default), use margins from :meth:`getDataMargins`.
         """
         if dataMargins is None:
             dataMargins = self._defaultDataMargins

--- a/src/silx/gui/plot/test/testPlotWidget.py
+++ b/src/silx/gui/plot/test/testPlotWidget.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1815,7 +1815,7 @@ class TestPlotImageLog(PlotWidgetTestCase):
 
         rgb = numpy.array(
             (((0, 0, 0), (128, 0, 0), (255, 0, 0)),
-             ((0, 128, 0), (0, 128, 128), (0, 128, 256))),
+             ((0, 128, 0), (0, 128, 128), (0, 128, 255))),
             dtype=numpy.uint8)
 
         self.plot.addImage(rgb, legend="rgb",

--- a/src/silx/gui/plot/test/testPlotWidgetDataMargins.py
+++ b/src/silx/gui/plot/test/testPlotWidgetDataMargins.py
@@ -1,0 +1,143 @@
+# /*##########################################################################
+#
+# Copyright (c) 2023 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Test PlotWidget features related to data margins"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "11/05/2023"
+
+import numpy
+import pytest
+
+from silx.gui.plot import PlotWidget
+
+
+@pytest.fixture
+def plotWidget(qWidgetFactory):
+    """Fixture providing a PlotWidget"""
+    yield qWidgetFactory(PlotWidget)
+
+
+def testDefaultDataMargins(plotWidget):
+    """Test default PlotWidget data margins: No margins"""
+    assert plotWidget.getDataMargins() == (0, 0, 0, 0)
+
+
+def testResetZoomDataMarginsLinearAxes(qapp, plotWidget):
+    """Test PlotWidget.setDataMargins effect on resetZoom with linear axis scales"""
+
+    margins = 0.1, 0.2, 0.3, 0.4
+    plotWidget.setDataMargins(*margins)
+
+    plotWidget.resetZoom()
+    qapp.processEvents()
+
+    retrievedMargins = plotWidget.getDataMargins()
+    assert retrievedMargins == margins
+
+    dataRange = 100 - 1
+    expectedXLimits = 1 - 0.1 * dataRange, 100 + 0.2 * dataRange
+    expectedYLimits = 1 - 0.3 * dataRange, 100 + 0.4 * dataRange
+
+    assert plotWidget.getXAxis().getLimits() == expectedXLimits
+    assert plotWidget.getYAxis().getLimits() == expectedYLimits
+    assert plotWidget.getYAxis(axis="right").getLimits() == expectedYLimits
+
+
+def testResetZoomDataMarginsLogAxes(qapp, plotWidget):
+    """Test PlotWidget.setDataMargins effect on resetZoom with log axis scales"""
+    plotWidget.getXAxis().setScale("log")
+    plotWidget.getYAxis().setScale("log")
+
+    dataMargins = 0.1, 0.2, 0.3, 0.4
+    plotWidget.setDataMargins(*dataMargins)
+
+    plotWidget.resetZoom()
+    qapp.processEvents()
+
+    retrievedMargins = plotWidget.getDataMargins()
+    assert retrievedMargins == dataMargins
+
+    logMin, logMax = numpy.log10(1), numpy.log10(100)
+    logRange = logMax - logMin
+    expectedXLimits = pow(10.0, logMin - 0.1 * logRange), pow(
+        10.0, logMax + 0.2 * logRange
+    )
+    expectedYLimits = pow(10.0, logMin - 0.3 * logRange), pow(
+        10.0, logMax + 0.4 * logRange
+    )
+
+    assert plotWidget.getXAxis().getLimits() == expectedXLimits
+    assert plotWidget.getYAxis().getLimits() == expectedYLimits
+    assert plotWidget.getYAxis(axis="right").getLimits() == expectedYLimits
+
+
+@pytest.mark.parametrize("margins", [False, True, (0, 0, 0, 0)])
+def testSetLimitsNoDataMargins(plotWidget, margins):
+    """Test PlotWidget.setLimits without data margins"""
+    xlimits = 1, 2
+    ylimits = 3, 4
+    y2limits = 5, 6
+    plotWidget.setLimits(*xlimits, *ylimits, *y2limits, margins=margins)
+
+    assert plotWidget.getXAxis().getLimits() == xlimits
+    assert plotWidget.getYAxis().getLimits() == ylimits
+    assert plotWidget.getYAxis(axis="right").getLimits() == y2limits
+
+
+@pytest.mark.parametrize(
+    "margins,expectedLimits",
+    [
+        # margins=False: use limits as is
+        (
+            False,
+            (1, 2, 3, 4, 5, 6),
+        ),
+        # margins=True: apply data margins
+        (
+            True,
+            (1 - 0.1, 2 + 0.2, 3 - 0.3, 4 + 0.4, 5 - 0.3, 6 + 0.4),
+        ),
+        # margins=tuple: apply provided margins
+        (
+            (0.4, 0.3, 0.2, 0.1),
+            (1 - 0.4, 2 + 0.3, 3 - 0.2, 4 + 0.1, 5 - 0.2, 6 + 0.1),
+        ),
+    ],
+)
+def testSetLimitsWithDataMargins(qapp, plotWidget, margins, expectedLimits):
+    """Test PlotWidget.setLimits with data margins"""
+    dataMargins = 0.1, 0.2, 0.3, 0.4
+    limits = 1, 2, 3, 4, 5, 6
+
+    plotWidget.setDataMargins(*dataMargins)
+    plotWidget.setLimits(*limits, margins=margins)
+    qapp.processEvents()
+
+    retrievedLimits = (
+        *plotWidget.getXAxis().getLimits(),
+        *plotWidget.getYAxis().getLimits(),
+        *plotWidget.getYAxis(axis="right").getLimits(),
+    )
+    assert retrievedLimits == expectedLimits


### PR DESCRIPTION
This PR adds a `margins` argument to `PlotWidget.setLimits` which allows to choose between:
- `margins=True`: to apply the "default" margins from `PlotWigdet.getDataMargins()`
- `margins=False`: to apply no margins
- `margins=4-tuple of float`: to apply provided margins.

To achieve this, it moves some logic from `_forceResetZoom` to `setLimits`.

There is a few more minor things (see the different commits):
- Added typing to a few methods and some tests related to `get|setDataMargins`.
- To write those, I added a `qWidgetFactory` fixture to handle the life-cycle of QWidget in tests.
- Fix a warning in the tests 

closes #3753 