### PR TITLE
Remove code for support of fabio<0.9

### DIFF
--- a/src/silx/gui/dialog/FileTypeComboBox.py
+++ b/src/silx/gui/dialog/FileTypeComboBox.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2016 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,8 @@ __license__ = "MIT"
 __date__ = "17/01/2019"
 
 import fabio
+from fabio import fabioutils
+
 import silx.io
 from silx.gui import qt
 
@@ -134,20 +136,13 @@ class FileTypeComboBox(qt.QComboBox):
     def __insertFabioFormats(self):
         formats = fabio.fabioformats.get_classes(reader=True)
 
-        from fabio import fabioutils
-        if hasattr(fabioutils, "COMPRESSED_EXTENSIONS"):
-            compressedExtensions = fabioutils.COMPRESSED_EXTENSIONS
-        else:
-            # Support for fabio < 0.9
-            compressedExtensions = set(["gz", "bz2"])
-
         extensions = []
         allExtensions = set([])
 
         def extensionsIterator(reader):
             for extension in reader.DEFAULT_EXTENSIONS:
                 yield "*.%s" % extension
-            for compressedExtension in compressedExtensions:
+            for compressedExtension in fabioutils.COMPRESSED_EXTENSIONS:
                 for extension in reader.DEFAULT_EXTENSIONS:
                     yield "*.%s.%s" % (extension, compressedExtension)
 

--- a/src/silx/io/fabioh5.py
+++ b/src/silx/io/fabioh5.py
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2016-2021 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -401,10 +401,7 @@ class FabioReader(object):
         may fail.
         """
         if self.__must_be_closed:
-            # Make sure the API of fabio provide it a 'close' method
-            # TODO the test can be removed if fabio version >= 0.8
-            if hasattr(self.__fabio_file, "close"):
-                self.__fabio_file.close()
+            self.__fabio_file.close()
         self.__fabio_file = None
 
     def fabio_file(self):

--- a/src/silx/io/fabioh5.py
+++ b/src/silx/io/fabioh5.py
@@ -77,19 +77,6 @@ def supported_extensions():
     return _fabio_extensions
 
 
-class _FileSeries(fabio.file_series.file_series):
-    """
-    .. note:: Overwrite a function to fix an issue in fabio.
-    """
-    def jump(self, num):
-        """
-        Goto a position in sequence
-        """
-        assert num < len(self) and num >= 0, "num out of range"
-        self._current = num
-        return self[self._current]
-
-
 class FrameData(commonh5.LazyLoadableDataset):
     """Expose a cube of image from a Fabio file using `FabioReader` as
     cache."""
@@ -385,7 +372,7 @@ class FabioReader(object):
                 raise TypeError("FabioImage expected but %s found.", fabio_image.__class__)
         elif file_series is not None:
             if isinstance(file_series, list):
-                self.__fabio_file = _FileSeries(file_series)
+                self.__fabio_file = fabio.file_series.file_series(file_series)
             elif isinstance(file_series, fabio.file_series.file_series):
                 self.__fabio_file = file_series
             else:

--- a/src/silx/io/test/test_fabioh5.py
+++ b/src/silx/io/test/test_fabioh5.py
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -36,6 +36,7 @@ import shutil
 _logger = logging.getLogger(__name__)
 
 import fabio
+import fabio.file_series
 import h5py
 
 from .. import commonh5
@@ -602,12 +603,12 @@ class TestFabioH5WithFileSeries(unittest.TestCase):
         self._testH5Image(h5_image)
 
     def testFileSeries(self):
-        file_series = fabioh5._FileSeries(self.edf_filenames)
+        file_series = fabio.file_series.file_series(self.edf_filenames)
         h5_image = fabioh5.File(file_series=file_series)
         self._testH5Image(h5_image)
 
     def testFrameDataCache(self):
-        file_series = fabioh5._FileSeries(self.edf_filenames)
+        file_series = fabio.file_series.file_series(self.edf_filenames)
         reader = fabioh5.FabioReader(file_series=file_series)
         frameData = _TestableFrameData("foo", reader)
         self.assertEqual(frameData.dtype.kind, "i")


### PR DESCRIPTION
This PR removes code for support of fabion <0.9 since there is already a requirement `fabio>=0.9` in `setup.py`.

https://github.com/silx-kit/silx/blob/d398b00d1d9dfe039dcc6d80a3c80b0582c684c8/setup.py#L496-L504

closes #2497