### PR TITLE
`silx.gui.plot`: Fixed `ImageStack` handling of visible state

### DIFF
--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -235,7 +235,7 @@ class _ToggleableUrlSelectionTable(qt.QWidget):
         self._toggleButton.setIcon(icon)
 
     def urlSelectionTableIsVisible(self):
-        return self._urlsTable.isVisible()
+        return self._urlsTable.isVisibleTo(self)
 
     def _propagateSignal(self, url):
         self.sigCurrentUrlChanged.emit(url)


### PR DESCRIPTION
This PR replaces `isVisible` with `isVisibleTo` to make it symmetrical with `setVisible` for `_ToggleableUrlSelectionTable.toggleUrlSelectionTable` to behave as a toggle in all conditions.

This is a minor fix, since conditions leading to an issue are not supposed to happen: this method should only be called from a button click... so `isVisible` should return True if it was set to True... but correct behavior relied on this assumption.

closes #3744