### PR TITLE
silx.gui.colors, silx.gui.plot: Added indexed color names in `rgba` and `PlotWidget`

### DIFF
--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -24,13 +24,21 @@
 """This module provides API to manage colors.
 """
 
+from __future__ import annotations
+
 __authors__ = ["T. Vincent", "H.Payno"]
 __license__ = "MIT"
 __date__ = "29/01/2019"
 
+
 import numpy
 import logging
+import numbers
+import re
+from collections.abc import Sequence
+from typing import Optional, Union
 
+import silx
 from silx.gui import qt
 from silx.gui.utils import blockSignals
 from silx.math import colormap as _colormap
@@ -92,53 +100,66 @@ DEFAULT_MAX_LIN = 1
 """Default max value if in linear normalization"""
 
 
-def rgba(color, colorDict=None):
-    """Convert color code '#RRGGBB' and '#RRGGBBAA' to a tuple (R, G, B, A)
-    of floats.
+def rgba(
+        color: Union[str, Sequence[numbers.Real], qt.QColor],
+        colorDict: Optional[dict[str, str]]=None,
+        colors: Optional[Sequence[str]]=None,
+    ) -> tuple[float, float, float, float]:
+    """Convert different kind of color definition to a tuple (R, G, B, A) of floats.
 
-    It also supports RGB(A) from uint8 in [0, 255], float in [0, 1], and
-    QColor as color argument.
+    It supports:
+    - color names: e.g., 'green'
+    - color codes: '#RRGGBB' and '#RRGGBBAA'
+    - indexed color names: e.g., 'color0'
+    - RGB(A) sequence of uint8 in [0, 255] or float in [0, 1]
+    - QColor
 
-    :param str color: The color to convert
-    :param dict colorDict: A dictionary of color name conversion to color code
+    :param color: The color to convert
+    :param colorDict: A dictionary of color name conversion to color code
+    :param colors: Sequence of colors to use for `
     :returns: RGBA colors as floats in [0., 1.]
-    :rtype: tuple
     """
-    if colorDict is None:
-        colorDict = _COLORDICT
+    if isinstance(color, str):
+        # From name
+        colorFromDict = (_COLORDICT if colorDict is None else colorDict).get(color)
+        if colorFromDict is not None:
+            return rgba(colorFromDict, colorDict, colors)
 
-    if hasattr(color, 'getRgb'):  # QColor support
-        color = color.getRgb()
+        # From indexed color name: color{index}
+        match = re.fullmatch(r"color(?P<index>[0-9]+)", color)
+        if match is not None:
+            if colors is None:
+                colors = silx.config.DEFAULT_PLOT_CURVE_COLORS
+            index = int(match['index']) % len(colors)
+            return rgba(colors[index], colorDict, colors)
 
+        # From #code
+        assert len(color) in (7, 9) and color[0] == '#'
+        r = int(color[1:3], 16) / 255.
+        g = int(color[3:5], 16) / 255.
+        b = int(color[5:7], 16) / 255.
+        a = int(color[7:9], 16) / 255. if len(color) == 9 else 1.
+        return r, g, b, a
+
+    # From QColor
+    if isinstance(color, qt.QColor):
+        return rgba(color.getRgb(), colorDict, colors)
+
+    # From array
     values = numpy.asarray(color).ravel()
 
-    if values.dtype.kind in 'iuf':  # integer or float
-        # Color is an array
-        assert len(values) in (3, 4)
+    assert values.dtype.kind in 'iuf'  # integer or float
+    assert len(values) in (3, 4)
 
-        # Convert from integers in [0, 255] to float in [0, 1]
-        if values.dtype.kind in 'iu':
-            values = values / 255.
+    # Convert from integers in [0, 255] to float in [0, 1]
+    if values.dtype.kind in 'iu':
+        values = values / 255.
 
-        # Clip to [0, 1]
-        values[values < 0.] = 0.
-        values[values > 1.] = 1.
+    values = numpy.clip(values, 0., 1.)
 
-        if len(values) == 3:
-            return values[0], values[1], values[2], 1.
-        else:
-            return tuple(values)
-
-    # We assume color is a string
-    if not color.startswith('#'):
-        color = colorDict[color]
-
-    assert len(color) in (7, 9) and color[0] == '#'
-    r = int(color[1:3], 16) / 255.
-    g = int(color[3:5], 16) / 255.
-    b = int(color[5:7], 16) / 255.
-    a = int(color[7:9], 16) / 255. if len(color) == 9 else 1.
-    return r, g, b, a
+    if len(values) == 3:
+        return values[0], values[1], values[2], 1.
+    return tuple(values)
 
 
 def greyed(color, colorDict=None):

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -100,6 +100,9 @@ DEFAULT_MAX_LIN = 1
 """Default max value if in linear normalization"""
 
 
+_INDEXED_COLOR_PATTERN = re.compile(r"color(?P<index>[0-9]+)")
+
+
 def rgba(
         color: Union[str, Sequence[numbers.Real], qt.QColor],
         colorDict: Optional[dict[str, str]]=None,
@@ -126,7 +129,7 @@ def rgba(
             return rgba(colorFromDict, colorDict, colors)
 
         # From indexed color name: color{index}
-        match = re.fullmatch(r"color(?P<index>[0-9]+)", color)
+        match = _INDEXED_COLOR_PATTERN.fullmatch(color)
         if match is not None:
             if colors is None:
                 colors = silx.config.DEFAULT_PLOT_CURVE_COLORS

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -1168,7 +1168,10 @@ class PlotWidget(qt.QMainWindow):
             # Override previous/default values with provided ones
             curve.setInfo(info)
             if color is not None:
-                curve.setColor(color)
+                curve.setColor(
+                    colors.rgba(color, colors=self.getDefaultColors())
+                    if isinstance(color, str) else color
+                )
             if symbol is not None:
                 curve.setSymbol(symbol)
             if linewidth is not None:
@@ -1292,7 +1295,10 @@ class PlotWidget(qt.QMainWindow):
 
         # Override previous/default values with provided ones
         if color is not None:
-            histo.setColor(color)
+            histo.setColor(
+                colors.rgba(color, colors=self.getDefaultColors())
+                if isinstance(color, str) else color
+            )
         if fill is not None:
             histo.setFill(fill)
         if z is not None:


### PR DESCRIPTION
~~! Merge PR #3835 first!~~

This PR should close #3755.
It adds support for `color{index}` name in both `colors.rgba` function and `PlotWidget.addCurve|Histogram`.

To do so, `rgba` takes an extra optional `colors` argument

It all sounds a bit complex to me (e.g., to use `PlotWidget.getDefaultColors()` at some place and use `silx.config.DEFAULT_PLOT_CURVE_COLORS` everywhere else). So need to check how this is going to be used and maybe consider adding a `silx.config.DEFAULT_COLORS`.

Maybe that's better as a `PlotWidget.addCurve|Histogram` only feature at first...
