### PR TITLE
`silx.gui.plot`: Fixed display of `PlotWindow` zoom in/out actions

### DIFF
--- a/src/silx/gui/plot/PlotWindow.py
+++ b/src/silx/gui/plot/PlotWindow.py
@@ -131,10 +131,14 @@ class PlotWindow(PlotWidget):
         self.resetZoomAction.setVisible(resetzoom)
         self.addAction(self.resetZoomAction)
 
-        self.zoomInAction = actions.control.ZoomInAction(self, parent=self)
+        self.zoomInAction = self.group.addAction(
+            actions.control.ZoomInAction(self, parent=self))
+        self.zoomInAction.setVisible(False)
         self.addAction(self.zoomInAction)
 
-        self.zoomOutAction = actions.control.ZoomOutAction(self, parent=self)
+        self.zoomOutAction = self.group.addAction(
+            actions.control.ZoomOutAction(self, parent=self))
+        self.zoomOutAction.setVisible(False)
         self.addAction(self.zoomOutAction)
 
         self.xAxisAutoScaleAction = self.group.addAction(


### PR DESCRIPTION
Fix for those 2 actions of `PlotWindow` that were not added the the action group and thus not to the toolbar... They are hidden by default to be consistent with the previous behaviour.
