### PR TITLE
Documentation: Added `silx.gui.plot.items.roi` base classes to documentation

### DIFF
--- a/doc/source/modules/gui/plot/items.rst
+++ b/doc/source/modules/gui/plot/items.rst
@@ -118,3 +118,34 @@ Axis
 
 .. automodule:: silx.gui.plot.items.roi
    :members:
+   :show-inheritance:
+
+   .. autoclass:: silx.gui.plot.items.roi.ArcROI
+      :members:
+      :show-inheritance:
+
+   .. autoclass:: silx.gui.plot.items.roi.BandROI
+      :members:
+      :show-inheritance:
+
+
+Base class for regions of interest
+++++++++++++++++++++++++++++++++++
+
+.. autoclass:: silx.gui.plot.items._roi_base._RegionOfInterestBase
+   :members:
+   :show-inheritance:
+
+.. autoclass:: silx.gui.plot.items.roi.RegionOfInterest
+   :members:
+   :show-inheritance:
+
+.. autoclass:: silx.gui.plot.items.roi.HandleBasedROI
+   :members:
+   :show-inheritance:
+
+.. autoclass:: silx.gui.plot.items.roi.InteractionModeMixIn
+   :members:
+
+.. autoclass:: silx.gui.plot.items.roi.RoiInteractionMode
+   :members:

--- a/src/silx/gui/plot/items/_roi_base.py
+++ b/src/silx/gui/plot/items/_roi_base.py
@@ -118,10 +118,12 @@ class RoiInteractionMode(object):
 
     @property
     def label(self):
+        """Short name"""
         return self._label
 
     @property
     def description(self):
+        """Longer description of the interaction mode"""
         return self._description
 
 


### PR DESCRIPTION
This PR adds missing ROI classes in the doc: base class of ROIs , and  `ArcROI` and `BandROI`


closes #3756
