### PR TITLE
`silx.gui.plot`: Added per-axis toggle of `PlotWidget` zoom

### DIFF
--- a/doc/source/modules/gui/plot/plotwidget.rst
+++ b/doc/source/modules/gui/plot/plotwidget.rst
@@ -115,6 +115,7 @@ Interaction
 Those methods allow to change the interaction mode (e.g., drawing mode)
 of the plot and to toggle the use of a crosshair cursor:
 
+.. automethod:: PlotWidget.interaction
 .. automethod:: PlotWidget.getInteractiveMode
 .. automethod:: PlotWidget.setInteractiveMode
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -4,4 +4,3 @@ python_files =
     test/Test*.py
 python_classes = Test
 python_functions = test
-testpaths = src/silx

--- a/src/silx/gui/plot/PlotInteraction.py
+++ b/src/silx/gui/plot/PlotInteraction.py
@@ -117,18 +117,13 @@ class _PlotInteraction(object):
 
 # Zoom/Pan ####################################################################
 
-class _ZoomOnWheel(ClickOrDrag, _PlotInteraction):
-    """:class:`ClickOrDrag` state machine with zooming on mouse wheel.
+class _PlotInteractionWithClickEvents(ClickOrDrag, _PlotInteraction):
+    """:class:`ClickOrDrag` state machine emitting click and double click events.
 
     Base class for :class:`Pan` and :class:`Zoom`
     """
 
     _DOUBLE_CLICK_TIMEOUT = 0.4
-
-    class Idle(ClickOrDrag.Idle):
-        def onWheel(self, x, y, angle):
-            scaleF = 1.1 if angle > 0 else 1. / 1.1
-            applyZoomToPlot(self.machine.plot, scaleF, (x, y))
 
     def click(self, x, y, btn):
         """Handle clicks by sending events
@@ -181,7 +176,7 @@ class _ZoomOnWheel(ClickOrDrag, _PlotInteraction):
 
 # Pan #########################################################################
 
-class Pan(_ZoomOnWheel):
+class Pan(_PlotInteractionWithClickEvents):
     """Pan plot content and zoom on wheel state machine."""
 
     def _pixelToData(self, x, y):
@@ -266,7 +261,7 @@ class Pan(_ZoomOnWheel):
 
 # Zoom ########################################################################
 
-class Zoom(_ZoomOnWheel):
+class Zoom(_PlotInteractionWithClickEvents):
     """Zoom-in/out state machine.
 
     Zoom-in on selected area, zoom-out on right click,
@@ -410,10 +405,6 @@ class Select(StateMachine, _PlotInteraction):
         _PlotInteraction.__init__(self, plot)
         self.parameters = parameters
         StateMachine.__init__(self, states, state)
-
-    def onWheel(self, x, y, angle):
-        scaleF = 1.1 if angle > 0 else 1. / 1.1
-        applyZoomToPlot(self.plot, scaleF, (x, y))
 
     @property
     def color(self):
@@ -1009,10 +1000,6 @@ class SelectFreeLine(ClickOrDrag, _PlotInteraction):
         _PlotInteraction.__init__(self, plot)
         self.parameters = parameters
 
-    def onWheel(self, x, y, angle):
-        scaleF = 1.1 if angle > 0 else 1. / 1.1
-        applyZoomToPlot(self.plot, scaleF, (x, y))
-
     @property
     def color(self):
         return self.parameters.get('color', None)
@@ -1071,10 +1058,6 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
         def __init__(self, *args, **kw):
             super(ItemsInteraction.Idle, self).__init__(*args, **kw)
             self._hoverMarker = None
-
-        def onWheel(self, x, y, angle):
-            scaleF = 1.1 if angle > 0 else 1. / 1.1
-            applyZoomToPlot(self.machine.plot, scaleF, (x, y))
 
         def onMove(self, x, y):
             marker = self.machine.plot._getMarkerAt(x, y)

--- a/src/silx/gui/plot/PlotInteraction.py
+++ b/src/silx/gui/plot/PlotInteraction.py
@@ -46,7 +46,7 @@ from .backends.BackendBase import (CURSOR_POINTING, CURSOR_SIZE_HOR,
                                    CURSOR_SIZE_VER, CURSOR_SIZE_ALL)
 
 from ._utils import (FLOAT32_SAFE_MIN, FLOAT32_MINPOS, FLOAT32_SAFE_MAX,
-                     applyZoomToPlot, ZoomOnAxes)
+                     applyZoomToPlot, EnabledAxes)
 
 
 # Base class ##################################################################
@@ -1643,7 +1643,7 @@ class PlotInteraction(qt.QObject):
     def __init__(self, parent):
         super().__init__(parent)
         self.__zoomOnWheel = True
-        self.__zoomOnAxes = ZoomOnAxes()
+        self.__zoomEnabledAxes = EnabledAxes()
 
         # Default event handler
         self._eventHandler = ItemsInteraction(parent)
@@ -1658,16 +1658,16 @@ class PlotInteraction(qt.QObject):
             self.__zoomOnWheel = enabled
             self.sigChanged.emit()
 
-    def setZoomOnAxes(self, xaxis: bool, yaxis: bool, y2axis: bool):
+    def setZoomEnabledAxes(self, xaxis: bool, yaxis: bool, y2axis: bool):
         """Toggle zoom interaction for each axis"""
-        zoomOnAxes = ZoomOnAxes(xaxis, yaxis, y2axis)
-        if zoomOnAxes != self.__zoomOnAxes:
-            self.__zoomOnAxes = zoomOnAxes
+        zoomEnabledAxes = EnabledAxes(xaxis, yaxis, y2axis)
+        if zoomEnabledAxes != self.__zoomEnabledAxes:
+            self.__zoomEnabledAxes = zoomEnabledAxes
             self.sigChanged.emit()
 
-    def getZoomOnAxes(self) -> ZoomOnAxes:
+    def getZoomEnabledAxes(self) -> EnabledAxes:
         """Returns axes for which zoom is enabled"""
-        return self.__zoomOnAxes
+        return self.__zoomEnabledAxes
 
     def _getInteractiveMode(self):
         """Returns the current interactive mode as a dict.
@@ -1756,12 +1756,12 @@ class PlotInteraction(qt.QObject):
         """Handle wheel events"""
         if not self.isZoomOnWheelEnabled():
             return
-        zoomOnAxes = self.getZoomOnAxes()
-        if zoomOnAxes.isDisabled():
+        zoomEnabledAxes = self.getZoomEnabledAxes()
+        if zoomEnabledAxes.isDisabled():
             return
 
         plotWidget = self.parent()
         if plotWidget is None:
             return
         scale = 1.1 if angle > 0 else 1. / 1.1
-        applyZoomToPlot(plotWidget, scale, (x, y), zoomOnAxes)
+        applyZoomToPlot(plotWidget, scale, (x, y), zoomEnabledAxes)

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -25,6 +25,8 @@
 The :class:`PlotWidget` implements the plot API initially provided in PyMca.
 """
 
+from __future__ import annotations
+
 __authors__ = ["V.A. Sole", "T. Vincent"]
 __license__ = "MIT"
 __date__ = "21/12/2018"
@@ -35,6 +37,7 @@ _logger = logging.getLogger(__name__)
 
 
 from collections import namedtuple
+from collections.abc import Sequence
 from contextlib import contextmanager
 from typing import Optional, Tuple, Union
 import datetime as dt
@@ -3491,28 +3494,35 @@ class PlotWidget(qt.QMainWindow):
         mode, zoomOnWheel = self._previousDefaultMode
         self.setInteractiveMode(mode=mode, zoomOnWheel=zoomOnWheel)
 
-    def setInteractiveMode(self, mode, color='black',
-                           shape='polygon', label=None,
-                           zoomOnWheel=True, source=None, width=None):
+    def setInteractiveMode(
+        self,
+        mode: str,
+        color: Union[str, Sequence[numbers.Real]]='black',
+        shape: str='polygon',
+        label: Optional[str]=None,
+        zoomOnWheel: bool=True,
+        source=None,
+        width: Optional[float]=None
+    ):
         """Switch the interactive mode.
 
-        :param str mode: The name of the interactive mode.
-                         In 'draw', 'pan', 'select', 'select-draw', 'zoom'.
+        :param mode: The name of the interactive mode.
+                     In 'draw', 'pan', 'select', 'select-draw', 'zoom'.
         :param color: Only for 'draw' and 'zoom' modes.
                       Color to use for drawing selection area. Default black.
         :type color: Color description: The name as a str or
                      a tuple of 4 floats.
-        :param str shape: Only for 'draw' mode. The kind of shape to draw.
-                          In 'polygon', 'rectangle', 'line', 'vline', 'hline',
-                          'freeline'.
-                          Default is 'polygon'.
-        :param str label: Only for 'draw' mode, sent in drawing events.
-        :param bool zoomOnWheel: Toggle zoom on wheel support
+        :param shape: Only for 'draw' mode. The kind of shape to draw.
+                      In 'polygon', 'rectangle', 'line', 'vline', 'hline',
+                      'freeline'.
+                      Default is 'polygon'.
+        :param label: Only for 'draw' mode, sent in drawing events.
+        :param zoomOnWheel: Toggle zoom on wheel support
         :param source: A user-defined object (typically the caller object)
                        that will be send in the interactiveModeChanged event,
                        to identify which object required a mode change.
                        Default: None
-        :param float width: Width of the pencil. Only for draw pencil mode.
+        :param width: Width of the pencil. Only for draw pencil mode.
         """
         self._eventHandler.setInteractiveMode(mode, color, shape, label, width)
         self._eventHandler.zoomOnWheel = zoomOnWheel

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -39,7 +39,7 @@ _logger = logging.getLogger(__name__)
 from collections import namedtuple
 from collections.abc import Sequence
 from contextlib import contextmanager
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 import datetime as dt
 import itertools
 import numbers
@@ -116,7 +116,7 @@ class _PlotWidgetSelection(qt.QObject):
         """Returns most recent active item."""
         return self.__history[0] if len(self.__history) >= 1 else None
 
-    def getSelectedItems(self) -> Tuple[items.Item]:
+    def getSelectedItems(self) -> tuple[items.Item]:
         """Returns the list of currently selected items in the :class:`PlotWidget`.
 
         The list is given from most recently current item to oldest one."""
@@ -2507,7 +2507,7 @@ class PlotWidget(qt.QMainWindow):
         ymax: float,
         y2min: Optional[float]=None,
         y2max: Optional[float]=None,
-        margins: Union[bool, Tuple[float, float, float, float]]=False,
+        margins: Union[bool, tuple[float, float, float, float]]=False,
     ):
         """Set the limits of the X and Y axes at once.
 
@@ -3054,7 +3054,7 @@ class PlotWidget(qt.QMainWindow):
                                     dpi=dpi)
             return True
 
-    def getDataMargins(self) -> Tuple[float, float, float, float]:
+    def getDataMargins(self) -> tuple[float, float, float, float]:
         """Get the default data margin ratios, see :meth:`setDataMargins`.
 
         :return: The margin ratios for each side (xMin, xMax, yMin, yMax).
@@ -3119,7 +3119,7 @@ class PlotWidget(qt.QMainWindow):
 
     def _forceResetZoom(
         self,
-        dataMargins: Optional[Tuple[float, float, float, float]]=None,
+        dataMargins: Optional[tuple[float, float, float, float]]=None,
     ):
         """Reset the plot limits to the bounds of the data and redraw the plot.
 

--- a/src/silx/gui/plot/_utils/__init__.py
+++ b/src/silx/gui/plot/_utils/__init__.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +31,7 @@ __date__ = "21/03/2017"
 import numpy
 
 from .panzoom import FLOAT32_SAFE_MIN, FLOAT32_MINPOS, FLOAT32_SAFE_MAX
-from .panzoom import applyZoomToPlot, applyPan, checkAxisLimits
+from .panzoom import applyZoomToPlot, applyPan, checkAxisLimits, ZoomOnAxes
 
 
 def addMarginsToLimits(margins, isXLog, isYLog,

--- a/src/silx/gui/plot/_utils/__init__.py
+++ b/src/silx/gui/plot/_utils/__init__.py
@@ -31,7 +31,7 @@ __date__ = "21/03/2017"
 import numpy
 
 from .panzoom import FLOAT32_SAFE_MIN, FLOAT32_MINPOS, FLOAT32_SAFE_MAX
-from .panzoom import applyZoomToPlot, applyPan, checkAxisLimits, ZoomOnAxes
+from .panzoom import applyZoomToPlot, applyPan, checkAxisLimits, EnabledAxes
 
 
 def addMarginsToLimits(margins, isXLog, isYLog,

--- a/src/silx/gui/plot/_utils/panzoom.py
+++ b/src/silx/gui/plot/_utils/panzoom.py
@@ -49,11 +49,11 @@ FLOAT32_SAFE_MAX = 1e37
 # TODO double support
 
 
-def checkAxisLimits(vmin, vmax, isLog: bool=False, name: str=""):
+def checkAxisLimits(vmin: float, vmax: float, isLog: bool=False, name: str=""):
     """Makes sure axis range is not empty and within supported range.
 
-    :param float vmin: Min axis value
-    :param float vmax: Max axis value
+    :param vmin: Min axis value
+    :param vmax: Max axis value
     :return: (min, max) making sure min < max
     :rtype: 2-tuple of float
     """
@@ -78,18 +78,19 @@ def checkAxisLimits(vmin, vmax, isLog: bool=False, name: str=""):
     return vmin, vmax
 
 
-def scale1DRange(min_, max_, center, scale, isLog):
+def scale1DRange(
+    min_: float, max_: float, center: float, scale: float, isLog: bool
+) -> tuple[float, float]:
     """Scale a 1D range given a scale factor and an center point.
 
     Keeps the values in a smaller range than float32.
 
-    :param float min_: The current min value of the range.
-    :param float max_: The current max value of the range.
-    :param float center: The center of the zoom (i.e., invariant point).
-    :param float scale: The scale to use for zoom
-    :param bool isLog: Whether using log scale or not.
-    :return: The zoomed range.
-    :rtype: tuple of 2 floats: (min, max)
+    :param min_: The current min value of the range.
+    :param max_: The current max value of the range.
+    :param center: The center of the zoom (i.e., invariant point).
+    :param scale: The scale to use for zoom
+    :param isLog: Whether using log scale or not.
+    :return: The zoomed range (min, max)
     """
     if isLog:
         # Min and center can be < 0 when

--- a/src/silx/gui/plot/_utils/panzoom.py
+++ b/src/silx/gui/plot/_utils/panzoom.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -23,6 +23,8 @@
 # ###########################################################################*/
 """Functions to apply pan and zoom on a Plot"""
 
+from __future__ import annotations
+
 __authors__ = ["T. Vincent", "V. Valls"]
 __license__ = "MIT"
 __date__ = "08/08/2017"
@@ -30,6 +32,7 @@ __date__ = "08/08/2017"
 
 import logging
 import math
+from typing import NamedTuple
 import numpy
 
 
@@ -116,16 +119,33 @@ def scale1DRange(min_, max_, center, scale, isLog):
     return newMin, newMax
 
 
-def applyZoomToPlot(plot, scaleF, center=None):
+class ZoomOnAxes(NamedTuple):
+    """Toggle zoom for each axis"""
+    xaxis: bool = True
+    yaxis: bool = True
+    y2axis: bool = True
+
+    def isDisabled(self) -> bool:
+        """True only if all axes are disabled"""
+        return not (self.xaxis or self.yaxis or self.y2axis)
+
+
+def applyZoomToPlot(
+    plot,
+    scale: float,
+    center: tuple[float, float]=None,
+    enabled: ZoomOnAxes=ZoomOnAxes(),
+):
     """Zoom in/out plot given a scale and a center point.
 
     :param plot: The plot on which to apply zoom.
-    :param float scaleF: Scale factor of zoom.
+    :param scale: Scale factor of zoom.
     :param center: (x, y) coords in pixel coordinates of the zoom center.
-    :type center: 2-tuple of float
+    :param enabled: Toggle zoom for each axis independently
     """
     xMin, xMax = plot.getXAxis().getLimits()
     yMin, yMax = plot.getYAxis().getLimits()
+    y2Min, y2Max = plot.getYAxis(axis="right").getLimits()
 
     if center is None:
         left, top, width, height = plot.getPlotBoundsInPixels()
@@ -136,18 +156,20 @@ def applyZoomToPlot(plot, scaleF, center=None):
     dataCenterPos = plot.pixelToData(cx, cy)
     assert dataCenterPos is not None
 
-    xMin, xMax = scale1DRange(xMin, xMax, dataCenterPos[0], scaleF,
-                              plot.getXAxis()._isLogarithmic())
+    if enabled.xaxis:
+        xMin, xMax = scale1DRange(xMin, xMax, dataCenterPos[0], scale,
+                                  plot.getXAxis()._isLogarithmic())
 
-    yMin, yMax = scale1DRange(yMin, yMax, dataCenterPos[1], scaleF,
-                              plot.getYAxis()._isLogarithmic())
+    if enabled.yaxis:
+        yMin, yMax = scale1DRange(yMin, yMax, dataCenterPos[1], scale,
+                                  plot.getYAxis()._isLogarithmic())
 
-    dataPos = plot.pixelToData(cx, cy, axis="right")
-    assert dataPos is not None
-    y2Center = dataPos[1]
-    y2Min, y2Max = plot.getYAxis(axis="right").getLimits()
-    y2Min, y2Max = scale1DRange(y2Min, y2Max, y2Center, scaleF,
-                                plot.getYAxis()._isLogarithmic())
+    if enabled.y2axis:
+        dataPos = plot.pixelToData(cx, cy, axis="right")
+        assert dataPos is not None
+        y2Center = dataPos[1]
+        y2Min, y2Max = scale1DRange(y2Min, y2Max, y2Center, scale,
+                                    plot.getYAxis()._isLogarithmic())
 
     plot.setLimits(xMin, xMax, yMin, yMax, y2Min, y2Max)
 

--- a/src/silx/gui/plot/_utils/panzoom.py
+++ b/src/silx/gui/plot/_utils/panzoom.py
@@ -120,7 +120,7 @@ def scale1DRange(
     return newMin, newMax
 
 
-class ZoomOnAxes(NamedTuple):
+class EnabledAxes(NamedTuple):
     """Toggle zoom for each axis"""
     xaxis: bool = True
     yaxis: bool = True
@@ -135,7 +135,7 @@ def applyZoomToPlot(
     plot,
     scale: float,
     center: tuple[float, float]=None,
-    enabled: ZoomOnAxes=ZoomOnAxes(),
+    enabled: EnabledAxes=EnabledAxes(),
 ):
     """Zoom in/out plot given a scale and a center point.
 

--- a/src/silx/gui/plot/actions/control.py
+++ b/src/silx/gui/plot/actions/control.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2004-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -615,7 +615,7 @@ class ClosePolygonInteractionAction(PlotAction):
         self.setEnabled(enabled)
 
     def _actionTriggered(self, checked=False):
-        self.plot._eventHandler.validate()
+        self.plot.interaction()._validate()
 
 
 class OpenGLAction(PlotAction):


### PR DESCRIPTION
This PR aims at allowing to configure zoom on the different axes independently.

With this PR, only zoom on wheel is managed.
To provide more control over the interaction, it adds a `PlotWidget.interaction` method to retrieve the interaction handler.
For now it only allows to toggle zoom on wheel and to select which axes can be zoomed.
This paves the way for adding more control over the interaction.

Related to #3743
