### PR TITLE
silx.gui.plot: Added per axes zoom to `PlotWidget`

### DIFF
--- a/examples/plotContextMenu.py
+++ b/examples/plotContextMenu.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # /*##########################################################################
 #
-# Copyright (c) 2017-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -43,7 +43,7 @@ from silx.gui import qt
 from silx.gui.plot import PlotWidget
 from silx.gui.plot.actions.control import ZoomBackAction, CrosshairAction
 from silx.gui.plot.actions.io import SaveAction, PrintAction
-
+from silx.gui.plot.tools.menus import ZoomEnabledAxesMenu
 
 class PlotWidgetWithContextMenu(PlotWidget):
     """This class adds a custom context menu to PlotWidget's plot area."""
@@ -58,6 +58,8 @@ class PlotWidgetWithContextMenu(PlotWidget):
         self._crosshairAction = CrosshairAction(plot=self, parent=self)
         self._saveAction = SaveAction(plot=self, parent=self)
         self._printAction = PrintAction(plot=self, parent=self)
+
+        self._zoomEnabledAxesMenu = ZoomEnabledAxesMenu(plot=self, parent=self)
 
         # Retrieve PlotWidget's plot area widget
         plotArea = self.getWidgetHandle()
@@ -74,6 +76,7 @@ class PlotWidgetWithContextMenu(PlotWidget):
         # Create the context menu
         menu = qt.QMenu(self)
         menu.addAction(self._zoomBackAction)
+        menu.addMenu(self._zoomEnabledAxesMenu)
         menu.addSeparator()
         menu.addAction(self._crosshairAction)
         menu.addSeparator()

--- a/src/silx/gui/plot/PlotInteraction.py
+++ b/src/silx/gui/plot/PlotInteraction.py
@@ -363,12 +363,12 @@ class Zoom(_PlotInteractionWithClickEvents):
             # Patch enabledAxes to display the right Y axis area on the left Y axis
             # since the selection area is always displayed on the left Y axis
             isY2Visible = self.plot.getYAxis("right").isVisible()
-            areaZoomOnAxes = EnabledAxes(
+            areaZoomEnabledAxes = EnabledAxes(
                 self.enabledAxes.xaxis,
                 self.enabledAxes.yaxis and (not isY2Visible or self.enabledAxes.y2axis),
                 self.enabledAxes.y2axis,
             )
-            extents = self._getAxesExtent(self.x0, self.y0, x1, y1, areaZoomOnAxes)
+            extents = self._getAxesExtent(self.x0, self.y0, x1, y1, areaZoomEnabledAxes)
             areaCorners = (
                 (extents.xmin, extents.ymin),
                 (extents.xmax, extents.ymin),
@@ -1454,7 +1454,7 @@ class ZoomAndSelect(ItemsInteraction):
         return self._zoom.enabledAxes
 
     @zoomEnabledAxes.setter
-    def zoomEnableAxes(self, enabledAxes: EnabledAxes):
+    def zoomEnabledAxes(self, enabledAxes: EnabledAxes):
         self._zoom.enabledAxes = enabledAxes
 
     def click(self, x, y, btn):
@@ -1709,7 +1709,7 @@ class PlotInteraction(qt.QObject):
 
         This is taken into account only if the plot does not keep aspect ratio.
         """
-        zoomEnabledAxes = ZoomEnabledAxes(xaxis, yaxis, y2axis)
+        zoomEnabledAxes = EnabledAxes(xaxis, yaxis, y2axis)
         if zoomEnabledAxes != self.__zoomEnabledAxes:
             self.__zoomEnabledAxes = zoomEnabledAxes
             if isinstance(self._eventHandler, ZoomAndSelect):

--- a/src/silx/gui/plot/PlotWindow.py
+++ b/src/silx/gui/plot/PlotWindow.py
@@ -854,6 +854,8 @@ class Plot1D(PlotWindow):
         action.setXRangeUpdatedOnZoom(True)
         action.setFittedItemUpdatedFromActiveCurve(True)
 
+        self.getInteractiveModeToolBar().getZoomModeAction().setAxesMenuEnabled(True)
+
 
 class Plot2D(PlotWindow):
     """PlotWindow with a toolbar specific for images.

--- a/src/silx/gui/plot/actions/mode.py
+++ b/src/silx/gui/plot/actions/mode.py
@@ -38,6 +38,7 @@ __date__ = "16/08/2017"
 
 from silx.gui import qt
 
+from ..tools.menus import ZoomEnabledAxesMenu
 from . import PlotAction
 
 
@@ -55,18 +56,7 @@ class ZoomModeAction(PlotAction):
             triggered=self._actionTriggered,
             checkable=True, parent=parent)
 
-        self.__menu = qt.QMenu(self.plot)
-        self.__menu.addSection("Enabled axes")
-
-        self.__xAxisAction = qt.QAction("X axis", parent=self.__menu)
-        self.__yAxisAction = qt.QAction("Y left axis", parent=self.__menu)
-        self.__y2AxisAction = qt.QAction("Y right axis", parent=self.__menu)
-
-        for action in (self.__xAxisAction, self.__yAxisAction, self.__y2AxisAction):
-            action.setCheckable(True)
-            action.setChecked(True)
-            action.triggered.connect(self._axesActionTriggered)
-            self.__menu.addAction(action)
+        self.__menu = ZoomEnabledAxesMenu(self.plot, self.plot)
 
         # Listen to interaction configuration change
         self.plot.interaction().sigChanged.connect(self._interactionChanged)
@@ -100,10 +90,6 @@ class ZoomModeAction(PlotAction):
             return
 
         self.setChecked(plot.getInteractiveMode()["mode"] == "zoom")
-        enabledAxes = plot.interaction().getZoomEnabledAxes()
-        self.__xAxisAction.setChecked(enabledAxes.xaxis)
-        self.__yAxisAction.setChecked(enabledAxes.yaxis)
-        self.__y2AxisAction.setChecked(enabledAxes.y2axis)
 
     def _actionTriggered(self, checked=False):
         plot = self.plot
@@ -111,17 +97,6 @@ class ZoomModeAction(PlotAction):
             return
 
         plot.setInteractiveMode('zoom', source=self)
-
-    def _axesActionTriggered(self, checked=False):
-        plot = self.plot
-        if plot is None:
-            return
-
-        plot.interaction().setZoomEnabledAxes(
-            self.__xAxisAction.isChecked(),
-            self.__yAxisAction.isChecked(),
-            self.__y2AxisAction.isChecked(),
-        )
 
 
 class PanModeAction(PlotAction):

--- a/src/silx/gui/plot/actions/mode.py
+++ b/src/silx/gui/plot/actions/mode.py
@@ -100,10 +100,10 @@ class ZoomModeAction(PlotAction):
             return
 
         self.setChecked(plot.getInteractiveMode()["mode"] == "zoom")
-        zoomOnAxes = plot.interaction().getZoomOnAxes()
-        self.__xAxisAction.setChecked(zoomOnAxes.xaxis)
-        self.__yAxisAction.setChecked(zoomOnAxes.yaxis)
-        self.__y2AxisAction.setChecked(zoomOnAxes.y2axis)
+        enabledAxes = plot.interaction().getZoomEnabledAxes()
+        self.__xAxisAction.setChecked(enabledAxes.xaxis)
+        self.__yAxisAction.setChecked(enabledAxes.yaxis)
+        self.__y2AxisAction.setChecked(enabledAxes.y2axis)
 
     def _actionTriggered(self, checked=False):
         plot = self.plot
@@ -117,7 +117,7 @@ class ZoomModeAction(PlotAction):
         if plot is None:
             return
 
-        plot.interaction().setZoomOnAxes(
+        plot.interaction().setZoomEnabledAxes(
             self.__xAxisAction.isChecked(),
             self.__yAxisAction.isChecked(),
             self.__y2AxisAction.isChecked(),

--- a/src/silx/gui/plot/backends/BackendBase.py
+++ b/src/silx/gui/plot/backends/BackendBase.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -478,6 +478,10 @@ class BackendBase(object):
     def isYAxisInverted(self):
         """Return True if left Y axis is inverted, False otherwise."""
         return self.__yAxisInverted
+
+    def isYRightAxisVisible(self) -> bool:
+        """Return True if the Y axis on the right side of the plot is visible"""
+        return False
 
     def isKeepDataAspectRatio(self):
         """Returns whether the plot is keeping data aspect ratio or not."""

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2004-2022 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -1204,6 +1204,9 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
     def isYAxisInverted(self):
         return self.ax.yaxis_inverted()
+
+    def isYRightAxisVisible(self):
+        return self.ax2.yaxis.get_visible()
 
     def isKeepDataAspectRatio(self):
         return self.ax.get_aspect() in (1.0, 'equal')

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -1375,6 +1375,9 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
     def isYAxisInverted(self):
         return self._plotFrame.isYAxisInverted
 
+    def isYRightAxisVisible(self):
+        return self._plotFrame.isY2Axis
+
     def isKeepDataAspectRatio(self):
         if self._plotFrame.xAxis.isLog or self._plotFrame.yAxis.isLog:
             return False

--- a/src/silx/gui/plot/items/axis.py
+++ b/src/silx/gui/plot/items/axis.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2017-2022 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -170,6 +170,10 @@ class Axis(qt.QObject):
         if isInverted == self.isInverted():
             return
         raise NotImplementedError()
+
+    def isVisible(self) -> bool:
+        """Returns whether the axis is displayed or not"""
+        return True
 
     def getLabel(self):
         """Return the current displayed label of this axis.
@@ -503,6 +507,10 @@ class YRightAxis(Axis):
     def isInverted(self):
         """Return True if Y axis goes from top to bottom, False otherwise."""
         return self.__mainAxis.isInverted()
+
+    def isVisible(self) -> bool:
+        """Returns whether the axis is displayed or not"""
+        return self._getBackend().isYRightAxisVisible()
 
     def getScale(self):
         """Return the name of the scale used by this axis.

--- a/src/silx/gui/plot/test/testItem.py
+++ b/src/silx/gui/plot/test/testItem.py
@@ -33,7 +33,7 @@ import numpy
 from silx.gui.utils.testutils import SignalListener
 from silx.gui.plot.items.roi import RegionOfInterest
 from silx.gui.plot.items import ItemChangedType
-from silx.gui.plot import items
+from silx.gui.plot import PlotWidget, items
 from .utils import PlotWidgetTestCase
 
 
@@ -386,3 +386,38 @@ def testRegionOfInterestText():
         ItemChangedType.NAME, ItemChangedType.TEXT
     ]
     assert roi.getText() == "even_newer_name"
+
+
+def testAxisIsVisible(qapp, qWidgetFactory):
+    """Test Axis.isVisible method"""
+    plotWidget = qWidgetFactory(PlotWidget)
+
+    assert plotWidget.getXAxis().isVisible()
+    assert plotWidget.getYAxis().isVisible()
+    assert not plotWidget.getYAxis("right").isVisible()
+
+    # Add curve on right axis
+    plotWidget.addCurve((0, 1, 2), (1, 2, 3), yaxis="right")
+    qapp.processEvents()
+
+    assert plotWidget.getYAxis("right").isVisible()
+
+    # hide curve on right axis
+    curve = plotWidget.getItems()[0]
+    curve.setVisible(False)
+    qapp.processEvents()
+
+    assert not plotWidget.getYAxis("right").isVisible()
+
+    # show curve on right axis
+    curve.setVisible(True)
+    qapp.processEvents()
+
+    assert plotWidget.getYAxis("right").isVisible()
+
+    # Move curve to left axis
+    curve.setYAxis("left")
+    qapp.processEvents()
+
+    assert not plotWidget.getYAxis("right").isVisible()
+

--- a/src/silx/gui/plot/test/testPlotInteraction.py
+++ b/src/silx/gui/plot/test/testPlotInteraction.py
@@ -164,8 +164,8 @@ class TestSelectPolygon(PlotWidgetTestCase):
 @pytest.mark.parametrize("xaxis", [True, False])
 @pytest.mark.parametrize("yaxis", [True, False])
 @pytest.mark.parametrize("y2axis", [True, False])
-def testZoomOnAxesEnabled(qapp, qWidgetFactory, scale, xaxis, yaxis, y2axis):
-    """Test PlotInteraction.setZoomOnAxesEnabled effect on zoom interaction"""
+def testZoomEnabledAxes(qapp, qWidgetFactory, scale, xaxis, yaxis, y2axis):
+    """Test PlotInteraction.setZoomEnabledAxes effect on zoom interaction"""
     plotWidget = qWidgetFactory(PlotWidget)
     plotWidget.getXAxis().setScale(scale)
     plotWidget.getYAxis("left").setScale(scale)
@@ -178,11 +178,11 @@ def testZoomOnAxesEnabled(qapp, qWidgetFactory, scale, xaxis, yaxis, y2axis):
 
     interaction = plotWidget.interaction()
 
-    assert interaction.getZoomOnAxes() == (True, True, True)
+    assert interaction.getZoomEnabledAxes() == (True, True, True)
 
-    zoomOnAxes = xaxis, yaxis, y2axis
-    interaction.setZoomOnAxes(*zoomOnAxes)
-    assert interaction.getZoomOnAxes() == zoomOnAxes
+    enabledAxes = xaxis, yaxis, y2axis
+    interaction.setZoomEnabledAxes(*enabledAxes)
+    assert interaction.getZoomEnabledAxes() == enabledAxes
 
     cx, cy = plotWidget.width() // 2, plotWidget.height() // 2
     plotWidget.onMouseWheel(cx, cy, 10)
@@ -192,9 +192,9 @@ def testZoomOnAxesEnabled(qapp, qWidgetFactory, scale, xaxis, yaxis, y2axis):
     yZoomed = plotWidget.getYAxis("left").getLimits() != yLimits
     y2Zoomed = plotWidget.getYAxis("right").getLimits() != y2Limits
 
-    assert xZoomed == zoomOnAxes[0]
-    assert yZoomed == zoomOnAxes[1]
-    assert y2Zoomed == zoomOnAxes[2]
+    assert xZoomed == enabledAxes[0]
+    assert yZoomed == enabledAxes[1]
+    assert y2Zoomed == enabledAxes[2]
 
 
 @pytest.mark.parametrize("scale", ["linear", "log"])

--- a/src/silx/gui/plot/tools/menus.py
+++ b/src/silx/gui/plot/tools/menus.py
@@ -1,0 +1,93 @@
+# /*##########################################################################
+#
+# Copyright (c) 2023 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""
+This module provides :class:`PlotWidget`-related QMenu.
+
+The following QMenu is available:
+
+- :class:`ZoomEnabledAxesMenu`
+"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "12/06/2023"
+
+
+import weakref
+from typing import Optional
+
+from silx.gui import qt
+
+from ..PlotWidget import PlotWidget
+
+
+class ZoomEnabledAxesMenu(qt.QMenu):
+    """Menu to toggle axes for zoom interaction"""
+
+    def __init__(self, plot: PlotWidget, parent: Optional[qt.QWidget]=None):
+        super().__init__(parent)
+        self.setTitle("Zoom axes")
+
+        assert isinstance(plot, PlotWidget)
+        self.__plotRef = weakref.ref(plot)
+
+        self.addSection("Enabled axes")
+        self.__xAxisAction = qt.QAction("X axis", parent=self)
+        self.__yAxisAction = qt.QAction("Y left axis", parent=self)
+        self.__y2AxisAction = qt.QAction("Y right axis", parent=self)
+
+        for action in (self.__xAxisAction, self.__yAxisAction, self.__y2AxisAction):
+            action.setCheckable(True)
+            action.setChecked(True)
+            action.triggered.connect(self._axesActionTriggered)
+            self.addAction(action)
+
+        # Listen to interaction configuration change
+        plot.interaction().sigChanged.connect(self._interactionChanged)
+        # Init the state
+        self._interactionChanged()
+
+    def getPlotWidget(self) -> Optional[PlotWidget]:
+        return self.__plotRef()
+
+    def _axesActionTriggered(self, checked=False):
+        plot = self.getPlotWidget()
+        if plot is None:
+            return
+
+        plot.interaction().setZoomEnabledAxes(
+            self.__xAxisAction.isChecked(),
+            self.__yAxisAction.isChecked(),
+            self.__y2AxisAction.isChecked(),
+        )
+
+    def _interactionChanged(self):
+        plot = self.getPlotWidget()
+        if plot is None:
+            return
+
+        enabledAxes = plot.interaction().getZoomEnabledAxes()
+        self.__xAxisAction.setChecked(enabledAxes.xaxis)
+        self.__yAxisAction.setChecked(enabledAxes.yaxis)
+        self.__y2AxisAction.setChecked(enabledAxes.y2axis)


### PR DESCRIPTION
Merge PR #3842 first !

This PR adds support for per-axis zoom toggle for zoom on mouse selection.
It also adds an optional menu to `ZoomModeAction` to interactively select which axis should be zoomed.
This menu can be enabled with `ZoomModeAction.setAxesMenuEnabled`.

This feature needed to know whether the Y axis on right is visible or not, so I added an `Axis.isVisible` method.

Since there is a conflict between keeping data aspect ratio and disabling zoom on some axes, when keep aspect ratio is enabled, all axes are zoomed, no matter of the zoomOnAxes config.

related to #3743