### PR TITLE
Fix rgb profile

### DIFF
--- a/src/silx/gui/plot/tools/profile/rois.py
+++ b/src/silx/gui/plot/tools/profile/rois.py
@@ -1072,6 +1072,12 @@ class _DefaultImageStackProfileRoiMixIn(_DefaultImageProfileRoiMixIn):
 
         assert kind == "2D"
 
+        currentData = numpy.array(item.getStackData(copy=False))
+        origin = item.getOrigin()
+        scale = item.getScale()
+        colormap = item.getColormap()
+        method = self.getProfileMethod()
+
         def createProfile2(currentData):
             coords, profile, _area, profileName, xLabel = core.createProfile(
                 roiInfo=self._getRoiInfo(),
@@ -1081,12 +1087,6 @@ class _DefaultImageStackProfileRoiMixIn(_DefaultImageProfileRoiMixIn):
                 lineWidth=self.getProfileLineWidth(),
                 method=method)
             return coords, profile, profileName, xLabel
-
-        currentData = numpy.array(item.getStackData(copy=False))
-        origin = item.getOrigin()
-        scale = item.getScale()
-        colormap = item.getColormap()
-        method = self.getProfileMethod()
 
         coords, profile, profileName, xLabel = createProfile2(currentData)
 

--- a/src/silx/gui/plot/tools/profile/rois.py
+++ b/src/silx/gui/plot/tools/profile/rois.py
@@ -294,10 +294,11 @@ class _DefaultImageProfileRoiMixIn(core.ProfileRoiMixIn):
         scale = item.getScale()
         method = self.getProfileMethod()
         lineWidth = self.getProfileLineWidth()
+        roiInfo = self._getRoiInfo()
 
         def createProfile2(currentData):
             coords, profile, _area, profileName, xLabel = core.createProfile(
-                roiInfo=self._getRoiInfo(),
+                roiInfo=roiInfo,
                 currentData=currentData,
                 origin=origin,
                 scale=scale,
@@ -1077,10 +1078,11 @@ class _DefaultImageStackProfileRoiMixIn(_DefaultImageProfileRoiMixIn):
         scale = item.getScale()
         colormap = item.getColormap()
         method = self.getProfileMethod()
+        roiInfo = self._getRoiInfo()
 
         def createProfile2(currentData):
             coords, profile, _area, profileName, xLabel = core.createProfile(
-                roiInfo=self._getRoiInfo(),
+                roiInfo=roiInfo,
                 currentData=currentData,
                 origin=origin,
                 scale=scale,


### PR DESCRIPTION
Closes #3844

Make sure the ROI description is extracted once, in order to be thread safe when multiple profiles have to be computed (i.e. profiles on R, G, B)

Changelog: 
- Fixed concurrency issue with RGB profiles
