### PR TITLE
Use linewidth2 as default selected style

### DIFF
--- a/src/silx/_config.py
+++ b/src/silx/_config.py
@@ -145,3 +145,19 @@ class Config(object):
 
     .. versionadded:: 0.10
     """
+
+    DEFAULT_PLOT_ACTIVE_CURVE_COLOR = "#000000"
+    """Default color for the active curve.
+
+    It will have an influence on PlotWidget curve items
+
+    .. versionadded:: 2.0
+    """
+
+    DEFAULT_PLOT_ACTIVE_CURVE_LINEWIDTH = None
+    """Default line width for the active curve.
+
+    It will have an influence on PlotWidget curve items
+
+    .. versionadded:: 2.0
+    """

--- a/src/silx/_config.py
+++ b/src/silx/_config.py
@@ -146,7 +146,7 @@ class Config(object):
     .. versionadded:: 0.10
     """
 
-    DEFAULT_PLOT_ACTIVE_CURVE_COLOR = "#000000"
+    DEFAULT_PLOT_ACTIVE_CURVE_COLOR = None
     """Default color for the active curve.
 
     It will have an influence on PlotWidget curve items
@@ -154,7 +154,7 @@ class Config(object):
     .. versionadded:: 2.0
     """
 
-    DEFAULT_PLOT_ACTIVE_CURVE_LINEWIDTH = None
+    DEFAULT_PLOT_ACTIVE_CURVE_LINEWIDTH = 2
     """Default line width for the active curve.
 
     It will have an influence on PlotWidget curve items

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -394,7 +394,10 @@ class PlotWidget(qt.QMainWindow):
         self._styleIndex = 0
 
         self._activeCurveSelectionMode = "atmostone"
-        self._activeCurveStyle = CurveStyle(color='#000000')
+        self._activeCurveStyle = CurveStyle(
+            color=silx.config.DEFAULT_PLOT_ACTIVE_CURVE_COLOR,
+            linewidth=silx.config.DEFAULT_PLOT_ACTIVE_CURVE_LINEWIDTH,
+        )
         self._activeLegend = {'curve': None, 'image': None,
                               'scatter': None}
 


### PR DESCRIPTION
Closes #3849

This PR uses linewidth2 as default selected style

# Previously

![image](https://github.com/silx-kit/silx/assets/7579321/ce70c3e8-e2e9-46ec-93ca-bed7005b5cd7)


# Now

![image](https://github.com/silx-kit/silx/assets/7579321/80194510-841c-436f-8cd2-67bdf61ec15e)



Changelog:
- Added `DEFAULT_PLOT_ACTIVE_CURVE_COLOR` to `silx.config`
- Added `DEFAULT_PLOT_ACTIVE_CURVE_LINEWIDTH` to `silx.config`
- Changed default active curve style as linewidth=2