### PR TITLE
CompareImages: Fix the A-B visualization mode

### DIFF
--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -298,6 +298,7 @@ class CompareImages(qt.QMainWindow):
         if self.__visualizationMode == mode:
             return
         self.__visualizationMode = mode
+        self.__item.setVizualisationMode(mode)
         self.__vline.setVisible(mode == VisualizationMode.VERTICAL_LINE)
         self.__hline.setVisible(mode == VisualizationMode.HORIZONTAL_LINE)
         self.__updateData()
@@ -732,9 +733,6 @@ class CompareImages(qt.QMainWindow):
     def __composeAMinusBImage(self, data1, data2):
         """Returns an intensity image containing the composition of `A-B`.
 
-        The result is returned as an image array of float normalized into the
-        colormap range.
-
         A data image of a size of 0 is considered as missing. This does not
         interrupt the processing.
 
@@ -745,9 +743,6 @@ class CompareImages(qt.QMainWindow):
         if data1.size != 0 and data2.size != 0:
             assert(data1.shape[0:2] == data2.shape[0:2])
 
-        sealed = self.__getSealedColormap()
-        vmin, vmax = sealed.getVRange()
-
         data1 = self.__asIntensityImage(data1)
         data2 = self.__asIntensityImage(data2)
         if data1.size == 0:
@@ -755,14 +750,7 @@ class CompareImages(qt.QMainWindow):
         elif data2.size == 0:
             result = data1
         else:
-            a = (data1.astype(numpy.float32) - vmin) * (1.0 / (vmax - vmin))
-            a[a < 0] = 0
-            a[a > 1] = 1
-            b = (data2.astype(numpy.float32) - vmin) * (1.0 / (vmax - vmin))
-            b[b < 0] = 0
-            b[b > 1] = 1
-            r = a - b
-            result = vmin + (r - r.min()) * ((vmax - vmin) / (r.max() - r.min()))
+            result = data1.astype(numpy.float32) - data2.astype(numpy.float32)
         return result
 
     def __asIntensityImage(self, image: numpy.ndarray):

--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -32,7 +32,6 @@ __date__ = "23/07/2018"
 import logging
 import numpy
 import math
-from typing import Optional
 
 import silx.image.bilinear
 from silx.gui import qt

--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -587,10 +587,10 @@ class CompareImages(qt.QMainWindow):
 
         mode = self.getVisualizationMode()
         if mode == VisualizationMode.COMPOSITE_RED_BLUE_GRAY_NEG:
-            data1 = self.__composeImage(data1, data2, mode)
+            data1 = self.__composeRgbImage(data1, data2, mode)
             data2 = None
         elif mode == VisualizationMode.COMPOSITE_RED_BLUE_GRAY:
-            data1 = self.__composeImage(data1, data2, mode)
+            data1 = self.__composeRgbImage(data1, data2, mode)
             data2 = None
         elif mode == VisualizationMode.COMPOSITE_A_MINUS_B:
             data1 = self.__composeAMinusBImage(data1, data2)
@@ -669,7 +669,7 @@ class CompareImages(qt.QMainWindow):
                 data[:, :, c] = self.__rescaleArray(image[:, :, c], shape)
         return data
 
-    def __composeImage(self, data1, data2, mode):
+    def __composeRgbImage(self, data1, data2, mode):
         """Returns an RBG image containing composition of data1 and data2 in 2
         different channels
 

--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -298,7 +298,6 @@ class CompareImages(qt.QMainWindow):
         if self.__visualizationMode == mode:
             return
         self.__visualizationMode = mode
-        mode = self.getVisualizationMode()
         self.__vline.setVisible(mode == VisualizationMode.VERTICAL_LINE)
         self.__hline.setVisible(mode == VisualizationMode.HORIZONTAL_LINE)
         self.__updateData()

--- a/src/silx/gui/plot/tools/compare/core.py
+++ b/src/silx/gui/plot/tools/compare/core.py
@@ -31,6 +31,7 @@ __date__ = "09/06/2023"
 
 import numpy
 import enum
+import contextlib
 from typing import NamedTuple
 
 from silx.gui.plot.items.image import ImageBase
@@ -89,6 +90,7 @@ class _CompareImageItem(ImageBase, ColormapMixIn):
         ColormapMixIn.__init__(self)
         self.__image1 = None
         self.__image2 = None
+        self.__vizualisationMode = VisualizationMode.ONLY_A
 
     def getImageData1(self):
         return self.__image1
@@ -108,6 +110,53 @@ class _CompareImageItem(ImageBase, ColormapMixIn):
         self.__image2 = image2
         self._updated(ItemChangedType.DATA)
 
+    def getVizualisationMode(self) -> VisualizationMode:
+        return self.__vizualisationMode
+
+    @contextlib.contextmanager
+    def _updateColormapRange(self, previousMode, mode):
+        """COMPOSITE_A_MINUS_B don't have the same data range than others.
+
+        If the colormap is using a fixed range, it is updated in order to set
+        a similar range with the new data.
+        """
+        normalize_colormap = (previousMode == VisualizationMode.COMPOSITE_A_MINUS_B
+                              or mode == VisualizationMode.COMPOSITE_A_MINUS_B)
+        if normalize_colormap:
+            data = self._getConcatenatedData(copy=False)
+            if data is None or data.size == 0:
+                normalize_colormap = False
+            else:
+                std1 = numpy.nanstd(data)
+                mean1 = numpy.nanmean(data)
+        yield
+
+        def transfer(v, std1, mean1, std2, mean2):
+            """Transfer a value from a data range to another using statistics"""
+            if v is None:
+                return None
+            rv = (v - mean1) / std1
+            return rv * std2 + mean2
+
+        if normalize_colormap:
+            data = self._getConcatenatedData(copy=False)
+            if data is not None and data.size != 0:
+                std2 = numpy.nanstd(data)
+                mean2 = numpy.nanmean(data)
+                c = self.getColormap()
+                if c is not None:
+                    vmin, vmax = c.getVRange()
+                    vmin = transfer(vmin, std1, mean1, std2, mean2)
+                    vmax = transfer(vmax, std1, mean1, std2, mean2)
+                    c.setVRange(vmin, vmax)
+
+    def setVizualisationMode(self, mode: VisualizationMode):
+        if self.__vizualisationMode == mode:
+            return None
+        with self._updateColormapRange(self.__vizualisationMode, mode):
+            self.__vizualisationMode = mode
+        self._updated(ItemChangedType.DATA)
+
     def _getConcatenatedData(self, copy=True):
         if self.__image1 is None and self.__image2 is None:
             return None
@@ -116,9 +165,14 @@ class _CompareImageItem(ImageBase, ColormapMixIn):
         if self.__image2 is None:
             return numpy.array(self.__image1, copy=copy)
 
-        d1 = self.__image1[numpy.isfinite(self.__image1)]
-        d2 = self.__image2[numpy.isfinite(self.__image2)]
-        return numpy.concatenate((d1, d2))
+        if self.__vizualisationMode == VisualizationMode.COMPOSITE_A_MINUS_B:
+            # In this case the histogram have to be special
+            if self.__image1.shape == self.__image2.shape:
+                return self.__image1.astype(numpy.float32) - self.__image2.astype(numpy.float32)
+        else:
+            d1 = self.__image1[numpy.isfinite(self.__image1)]
+            d2 = self.__image2[numpy.isfinite(self.__image2)]
+            return numpy.concatenate((d1, d2))
 
     def _updated(self, event=None, checkVisibility=True):
         # Synchronizes colormapped data if changed


### PR DESCRIPTION
The previous implementation was trying to constraint the data on the same data range, anyway the visualization mode.

This approach is fine for most of the modes, except A-B.

- Now A-B is handled in a special way, in order to use the basic operation `A-B`
- The colormap is now updated (when we switch between the visualization mode) in order to stay in the same data range
- Plus an RGB improvement to use any colormap normaization (before it was only a linear scale)

No changelog is needed as it's just a kind of partial revert of the previous change

Changelog: 
