### PR TITLE
Fix colormap dialog data bound

### DIFF
--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -1432,7 +1432,7 @@ class ColormapDialog(qt.QDialog):
             (xmin, xmax, ymin, ymax) Rectangular region in data space
         """
         if bounds is None:
-            return None  # no-op
+            return  # no-op
 
         colormap = self.getColormap()
         if colormap is None:
@@ -1440,7 +1440,7 @@ class ColormapDialog(qt.QDialog):
 
         item = self._getItem()
         if not isinstance(item, items.ColormapMixIn):
-            return None  # no-op
+            return  # no-op
 
         data = item.getColormappedData(copy=False)
 

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -1443,10 +1443,12 @@ class ColormapDialog(qt.QDialog):
             return  # no-op
 
         data = item.getColormappedData(copy=False)
-
         xmin, xmax, ymin, ymax = bounds
 
         if isinstance(item, items.ImageBase):
+            if data.ndim != 2:
+                return  # no-op
+
             ox, oy = item.getOrigin()
             sx, sy = item.getScale()
 


### PR DESCRIPTION
Closes #3857 

Make the colormap dialog safe with derivated image item.

Changelog: 
- Robustness on `ColormapDialog` tool with derivated `ImageBase`