### PR TITLE
silx view: Added `--slices` option

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -30,8 +30,8 @@ environment:
           WITH_GL_TEST: True
           PIP_OPTIONS: "-q --pre"
 
-        # Python 3.7
-        - PYTHON_DIR: "C:\\Python37-x64"
+        # Python 3.9
+        - PYTHON_DIR: "C:\\Python39-x64"
           QT_BINDING: "PySide6"
           WITH_GL_TEST: False  # OpenGL not working
           PIP_OPTIONS: "-q --pre"

--- a/doc/source/applications/view.rst
+++ b/doc/source/applications/view.rst
@@ -41,25 +41,59 @@ and to view this data in plot widgets or in simple table views.
 Usage
 -----
 
-::
+.. code-block:: none
 
-    silx view [-h] [--debug] [--use-opengl-plot] [files [files ...]]
+    silx view [-h] [--slices SLICES [SLICES ...]] [--debug] [--use-opengl-plot] [-f] [--hdf5-file-locking] [files ...]
 
 
 Options
 -------
 
-  -h, --help           Show this help message and exit
-  --debug              Set logging system in debug mode
-  --use-opengl-plot    Use OpenGL for plots (instead of matplotlib)
-  -f, --fresh          Start the application using new fresh user preferences
-  --hdf5-file-locking  Start the application with HDF5 file locking enabled (it is disabled by default)
+.. code-block:: none
+
+  -h, --help            show this help message and exit
+  --slices SLICES [SLICES ...]
+                        List of slice indices to open (Only for dataset)
+  --debug               Set logging system in debug mode
+  --use-opengl-plot     Use OpenGL for plots (instead of matplotlib)
+  -f, --fresh           Start the application using new fresh user preferences
+  --hdf5-file-locking   Start the application with HDF5 file locking enabled (it is disabled by
+                        default)
 
 Examples of usage
 -----------------
 
-::
+Open file(s)
+............
+
+.. code-block:: none
 
     silx view 31oct98.dat
     silx view *.edf
     silx view myfile.h5
+
+
+Open HDF5 dataset(s)
+....................
+
+Using the HDF5 path to the dataset:
+
+.. code-block:: none
+
+    silx view my_hdf5_file.h5::entry/instrument/detector/data
+
+Using wildcard:
+
+.. code-block:: none
+
+   silx view my_hdf5_file.h5::entry/*/data
+
+
+Open HDF5 dataset slices
+........................
+
+Open first and last slices of datasets:
+
+.. code-block:: none
+
+    silx view my_hdf5_file.h5::entry/*/data --slices 0 -1

--- a/src/silx/app/view/main.py
+++ b/src/silx/app/view/main.py
@@ -45,7 +45,7 @@ def createParser():
         nargs=argparse.ZERO_OR_MORE,
         help='Data file to show (h5 file, edf files, spec files)')
     parser.add_argument(
-        '--slice',
+        '--slices',
         dest='slices',
         default=tuple(),
         type=int,

--- a/src/silx/app/view/main.py
+++ b/src/silx/app/view/main.py
@@ -45,6 +45,14 @@ def createParser():
         nargs=argparse.ZERO_OR_MORE,
         help='Data file to show (h5 file, edf files, spec files)')
     parser.add_argument(
+        '--slice',
+        dest='slices',
+        default=tuple(),
+        type=int,
+        nargs='+',
+        help='List of slice indices to open (Only for dataset)',
+    )
+    parser.add_argument(
         '--debug',
         dest="debug",
         action="store_true",
@@ -151,7 +159,7 @@ def mainQt(options):
         # It have to be done after the settings (after the Viewer creation)
         silx.config.DEFAULT_PLOT_BACKEND = "opengl"
 
-    for url in parseutils.filenames_to_dataurls(options.files):
+    for url in parseutils.filenames_to_dataurls(options.files, options.slices):
         # TODO: Would be nice to add a process widget and a cancel button
         try:
             window.appendFile(url.path())

--- a/src/silx/gui/data/DataViewer.py
+++ b/src/silx/gui/data/DataViewer.py
@@ -286,6 +286,10 @@ class DataViewer(qt.QFrame):
     def __setDataInView(self):
         self.__currentView.setData(self.__displayedData)
         self.__currentView.setDataSelection(self.__displayedSelection)
+
+        if self.__displayedSelection is None:
+            return
+
         # Emit signal only when selection has changed
         if (self.__previousSelection.slice != self.__displayedSelection.slice or
             self.__previousSelection.permutation != self.__displayedSelection.permutation

--- a/src/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/src/silx/gui/hdf5/Hdf5TreeModel.py
@@ -38,6 +38,7 @@ from .Hdf5Item import Hdf5Item
 from .Hdf5LoadingItem import Hdf5LoadingItem
 from . import _utils
 from ... import io as silx_io
+from ...io._sliceh5 import DatasetSlice
 
 import h5py
 
@@ -61,6 +62,8 @@ def _createRootLabel(h5obj):
         if path.startswith("/"):
             path = path[1:]
         label = "%s::%s" % (filename, path)
+        if isinstance(h5obj, DatasetSlice):
+            label += str(list(h5obj.indices))
     return label
 
 
@@ -573,9 +576,12 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         if not isinstance(obj2, type(obj1)):
             return False
         def key(item):
-            if item.file is None:
-                return item.name
-            return item.file.filename, item.file.mode, item.name
+            info = [item.name]
+            if item.file is not None:
+                info += [item.file.filename, item.file.mode]
+            if isinstance(item, DatasetSlice):
+                info.append(item.indices)
+            return tuple(info)
         return key(obj1) == key(obj2)
 
     def h5pyObjectRow(self, h5pyObject):

--- a/src/silx/gui/plot/tools/profile/core.py
+++ b/src/silx/gui/plot/tools/profile/core.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2018-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2018-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -37,6 +37,7 @@ import weakref
 from silx.image.bilinear import BilinearImage
 from silx.gui import qt
 from silx.gui import colors
+import silx.gui.plot.items
 
 
 class CurveProfileData(typing.NamedTuple):
@@ -120,7 +121,7 @@ class ProfileRoiMixIn:
     def _setPlotItem(self, plotItem):
         """Specify the plot item to use with this profile
 
-        :param `~silx.gui.plot.items.item.Item` plotItem: A plot item
+        :param `~silx.gui.plot.items.Item` plotItem: A plot item
         """
         previousPlotItem = self.getPlotItem()
         if previousPlotItem is plotItem:
@@ -131,7 +132,7 @@ class ProfileRoiMixIn:
     def getPlotItem(self):
         """Returns the plot item used by this profile
 
-        :rtype: `~silx.gui.plot.items.item.Item`
+        :rtype: `~silx.gui.plot.items.Item`
         """
         if self.__plotItem is None:
             return None

--- a/src/silx/io/_sliceh5.py
+++ b/src/silx/io/_sliceh5.py
@@ -1,0 +1,217 @@
+# /*##########################################################################
+# Copyright (C) 2022-2023 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+"""Provides a wrapper to expose a dataset slice as a `commonh5.Dataset`."""
+
+from __future__ import annotations
+
+from typing import Tuple, Union
+
+import h5py
+import numpy
+
+from . import commonh5
+from . import utils
+
+
+IndexType = Union[int, slice, type(Ellipsis)]
+IndicesType = Union[IndexType, Tuple[IndexType, ...]]
+NormalisedIndicesType = Tuple[Union[int, slice], ...]
+
+
+def _expand_indices(
+    ndim: int,
+    indices: IndicesType,
+) -> NormalisedIndicesType:
+    """Replace Ellipsis and complete indices to match ndim"""
+    if not isinstance(indices, tuple):
+        indices = (indices,)
+
+    nb_ellipsis = indices.count(Ellipsis)
+    if nb_ellipsis > 1:
+        raise IndexError("an index can only have a single ellipsis ('...')")
+    if nb_ellipsis == 1:
+        ellipsis_index = indices.index(Ellipsis)
+        return (
+            indices[:ellipsis_index]
+            + (slice(None),) * max(0, (ndim - len(indices) + 1))
+            + indices[ellipsis_index + 1 :]
+        )
+
+    if len(indices) > ndim:
+        raise IndexError(
+            f"too many indices ({len(indices)}) for the number of dimensions ({ndim})"
+        )
+    return indices + (slice(None),) * (ndim - len(indices))
+
+
+def _get_selection_shape(
+    shape: tuple[int, ...],
+    indices: NormalisedIndicesType,
+) -> tuple[int, ...]:
+    """Returns the shape of the selection of indices in a dataset of the given shape"""
+    assert len(shape) == len(indices)
+
+    selected_indices = (
+        index.indices(length)
+        for length, index in zip(shape, indices)
+        if isinstance(index, slice)
+    )
+    return tuple(
+        int(max(0, numpy.ceil((stop - start) / stride)))
+        for start, stop, stride in selected_indices
+    )
+
+
+def _combine_indices(
+    outer_shape: tuple[int, ...],
+    outer_indices: NormalisedIndicesType,
+    indices: IndicesType,
+) -> NormalisedIndicesType:
+    """Returns the combination of outer_indices and indices"""
+    inner_shape = _get_selection_shape(outer_shape, outer_indices)
+    inner_indices = _expand_indices(len(inner_shape), indices)
+    inner_iter = zip(range(len(inner_shape)), inner_shape, inner_indices)
+
+    combined_indices = []
+    for outer_length, outer_index in zip(outer_shape, outer_indices):
+        if isinstance(outer_index, int):
+            combined_indices.append(outer_index)
+            continue
+
+        outer_start, outer_stop, outer_stride = outer_index.indices(outer_length)
+        inner_axis, inner_length, inner_index = next(inner_iter)
+
+        if isinstance(inner_index, int):
+            if inner_index < -inner_length or inner_index >= inner_length:
+                raise IndexError(
+                    f"index {inner_index} is out of bounds for axis {inner_axis} with size {inner_length}"
+                )
+            index = outer_start + outer_stride * inner_index
+            if inner_index < 0:
+                index += outer_stride * inner_length
+            combined_indices.append(index)
+            continue
+
+        inner_start, inner_stop, inner_stride = inner_index.indices(inner_length)
+        combined_indices.append(
+            slice(
+                outer_start + outer_stride * inner_start,
+                outer_start + outer_stride * inner_stop,
+                outer_stride * inner_stride,
+            )
+        )
+
+    return tuple(combined_indices)
+
+
+class DatasetSlice(commonh5.Dataset):
+    """Wrapper a dataset indexed selection as a commonh5.Dataset.
+    :param h5file: h5py-like file containing the dataset
+    :param dataset: h5py-like dataset from which to access a slice
+    :param indices: The indexing to select
+    :param attrs: dataset attributes
+    """
+
+    def __init__(
+        self,
+        dataset: Union[h5py.Dataset, commonh5.Dataset],
+        indices: IndicesType,
+        attrs: dict,
+    ):
+        if not utils.is_dataset(dataset):
+            raise ValueError(f"Unsupported dataset '{dataset}'")
+
+        self.__dataset = dataset
+        self.__file = dataset.file  # Keep a ref on file to fix issue recovering it
+        self.__indices = indices
+        self.__expanded_indices = _expand_indices(len(self.__dataset.shape), indices)
+        self.__shape = _get_selection_shape(self.__dataset.shape, self.__expanded_indices)
+        super().__init__(self.__dataset.name, data=None, parent=self.__file, attrs=attrs)
+
+    def _get_data(self) -> Union[h5py.Dataset, commonh5.Dataset]:
+        # Give access to the underlying (h5py) dataset, not the selected data
+        # All commonh5.Dataset methods using _get_data must be overridden
+        return self.__dataset
+
+    @property
+    def dtype(self) -> numpy.dtype:
+        return self.__dataset.dtype
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return self.__shape
+
+    @property
+    def size(self) -> int:
+        return numpy.prod(self.shape)
+
+    def __len__(self) -> int:
+        return self.shape[0]
+
+    def __getitem__(self, item):
+        if item is Ellipsis:
+            return numpy.array(self.__dataset[self.__expanded_indices], copy=False)
+        if item == ():
+            return self.__dataset[self.__expanded_indices]
+
+        if not self.__shape:
+            raise IndexError("invalid index to scalar variable.")
+
+        return self.__dataset[
+            _combine_indices(
+                self.__dataset.shape,
+                self.__expanded_indices,
+                item,
+            )
+        ]
+
+    @property
+    def value(self):
+        return self[()]
+
+    def __iter__(self):
+        return self[()].__iter__()
+
+    @property
+    def file(self) -> Union[h5py.File, commonh5.File]:
+        if isinstance(self.__file, h5py.File) and not self.__file.id:
+            return None
+        return self.__file
+
+    @property
+    def name(self) -> str:
+        return self.basename
+
+    @property
+    def indices(self) -> IndicesType:
+        return self.__indices
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+
+    def close(self):
+        """Close the file"""
+        self.__file.close()

--- a/src/silx/io/test/test_sliceh5.py
+++ b/src/silx/io/test/test_sliceh5.py
@@ -1,0 +1,104 @@
+# /*##########################################################################
+# Copyright (C) 2022-2023 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+import contextlib
+from io import BytesIO
+
+import h5py
+import numpy
+import pytest
+
+import silx.io
+from silx.io import commonh5
+from silx.io._sliceh5 import DatasetSlice, _combine_indices
+
+
+@contextlib.contextmanager
+def h5py_file(filename, mode):
+    with BytesIO() as buffer:
+        with h5py.File(buffer, mode) as h5file:
+            yield h5file
+
+
+@pytest.fixture(params=[commonh5.File, h5py_file])
+def temp_h5file(request):
+    temp_file_context = request.param
+    with temp_file_context("tempfile.h5", "w") as h5file:
+        yield h5file
+
+
+@pytest.mark.parametrize("indices", [1, slice(None), (1, slice(1, 4))])
+def test_datasetslice(temp_h5file, indices):
+    data = numpy.arange(50).reshape(10, 5)
+    ref_data = numpy.array(data[indices], copy=False)
+
+    h5dataset = temp_h5file.create_group("group").create_dataset("dataset", data=data)
+
+    with DatasetSlice(h5dataset, indices, attrs={}) as dset:
+        assert silx.io.is_dataset(dset)
+        assert dset.file == temp_h5file
+        assert dset.shape == ref_data.shape
+        assert dset.size == ref_data.size
+        assert dset.dtype == ref_data.dtype
+        assert len(dset) == len(ref_data)
+        assert numpy.array_equal(dset[()], ref_data)
+        assert dset.name == h5dataset.name
+
+
+def test_datasetslice_on_external_link(tmp_path):
+    data = numpy.arange(10).reshape(5, 2)
+
+    external_filename = str(tmp_path / "external.h5")
+    ext_dataset_name = "/external_data"
+    with h5py.File(external_filename, "w") as h5file:
+        h5file[ext_dataset_name] = data
+
+    with h5py.File(tmp_path / "test.h5", "w") as h5file:
+        h5file["group/data"] = h5py.ExternalLink(external_filename, ext_dataset_name)
+
+        with DatasetSlice(h5file["group/data"], slice(None), attrs={}) as dset:
+            assert dset.name == ext_dataset_name
+            assert numpy.array_equal(dset[()], data)
+
+
+@pytest.mark.parametrize(
+    "shape,outer_indices,indices",
+    [
+        ((2, 5, 10), (-1, slice(None), slice(None)), slice(None)),
+        ((2, 5, 10), (-1, slice(None), slice(None)), Ellipsis),
+        # negative strides
+        ((5, 10), (slice(1, 5, 2), slice(2, 8)), (slice(2, 3), slice(4, None, -2))),
+        (
+            (5, 10),
+            (slice(4, None, -1), slice(9, 3, -2)),
+            (slice(1, 3), slice(3, 0, -1)),
+        ),
+        ((5, 10), (slice(1, 8, 2), slice(None)), slice(2, 8)),  # slice overflow
+    ],
+)
+def test_combine_indices(shape, outer_indices, indices):
+    data = numpy.arange(numpy.prod(shape)).reshape(shape)
+    ref_data = data[outer_indices][indices]
+
+    combined_indices = _combine_indices(shape, outer_indices, indices)
+
+    assert numpy.array_equal(data[combined_indices], ref_data)


### PR DESCRIPTION
This PR adds the option to pass multiple integers for displaying slices with `silx view` through a `--slice` option.

To do so, it adds a `DatasetSlice` class to expose the opened slice as a dataset and makes the necessary changes to make it work.

The content of this PR is adapted from PR #3677 (which was hard to rebase).
It is a simpler version of PR #3677 since it only provides `--slice` and not URL `#fragment` support which could be added later if needed.
