### PR TITLE
Use "C" prefix to identify a color from the default palette

### DIFF
--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -100,7 +100,7 @@ DEFAULT_MAX_LIN = 1
 """Default max value if in linear normalization"""
 
 
-_INDEXED_COLOR_PATTERN = re.compile(r"color(?P<index>[0-9]+)")
+_INDEXED_COLOR_PATTERN = re.compile(r"C(?P<index>[0-9]+)")
 
 
 def rgba(
@@ -113,7 +113,7 @@ def rgba(
     It supports:
     - color names: e.g., 'green'
     - color codes: '#RRGGBB' and '#RRGGBBAA'
-    - indexed color names: e.g., 'color0'
+    - indexed color names: e.g., 'C0'
     - RGB(A) sequence of uint8 in [0, 255] or float in [0, 1]
     - QColor
 

--- a/src/silx/gui/test/test_colors.py
+++ b/src/silx/gui/test/test_colors.py
@@ -48,8 +48,8 @@ RGBA_TEST_CASES = (
     ('#010203', (1. / 255., 2. / 255., 3. / 255., 1.)),
     ('#01020304', (1. / 255., 2. / 255., 3. / 255., 4. / 255.)),
     # index name
-    ('color0', colors.rgba(silx.config.DEFAULT_PLOT_CURVE_COLORS[0])),
-    ('color2', colors.rgba(silx.config.DEFAULT_PLOT_CURVE_COLORS[2])),
+    ('C0', colors.rgba(silx.config.DEFAULT_PLOT_CURVE_COLORS[0])),
+    ('C2', colors.rgba(silx.config.DEFAULT_PLOT_CURVE_COLORS[2])),
     # 3 uint
     (numpy.array((1, 255, 0), dtype=numpy.uint8), (1 / 255., 1., 0., 1.)),
     # 4 uint


### PR DESCRIPTION
This change is done to match the matplotlib syntax "CN".

See https://matplotlib.org/stable/tutorials/colors/colors.html#cn-color-selection

<!--
You are encouraged to write a PR title that is meaningful by itself.
It will be used to auto-generate the complete changelog.

To highlight a change in the changelog, please add a line starting with `Changelog: ` in the PR description.
It will be used to generate the changelog's summary.

E.g., Changelog: Added new wonderful feature
-->


Changelog: 
- Changed indexed color pattern to match "CN" color selection from matplotlib
