### PR TITLE
silx.gui.plot.PlotWidget: do not reset zoom when changing axes scales

### DIFF
--- a/src/silx/gui/plot/items/axis.py
+++ b/src/silx/gui/plot/items/axis.py
@@ -234,7 +234,7 @@ class Axis(qt.QObject):
 
         self._scale = scale
 
-        vmin, _ = self.getLimits()
+        vmin, vmax = self.getLimits()
 
         # TODO hackish way of forcing update of curves and images
         plot = self._getPlot()
@@ -246,10 +246,13 @@ class Axis(qt.QObject):
             self._internalSetLogarithmic(True)
             if vmin <= 0:
                 dataRange = self._getDataRange()
-                if dataRange is not None:
-                    self.setLimits(*dataRange)
-                else:
+                if dataRange is None:
                     self.setLimits(1., 100.)
+                else:
+                    if vmax > 0 and dataRange[0] < vmax:
+                        self.setLimits(dataRange[0], vmax)
+                    else:
+                        self.setLimits(*dataRange)
         elif scale == self.LINEAR:
             self._internalSetLogarithmic(False)
         else:

--- a/src/silx/gui/plot/test/testAxis.py
+++ b/src/silx/gui/plot/test/testAxis.py
@@ -1,0 +1,147 @@
+# /*##########################################################################
+#
+# Copyright (c) 2023 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Tests of PlotWidget Axis items"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "15/06/2023"
+
+
+from silx.gui.plot import PlotWidget
+
+
+def testAxisIsVisible(qapp, qWidgetFactory):
+    """Test Axis.isVisible method"""
+    plotWidget = qWidgetFactory(PlotWidget)
+
+    assert plotWidget.getXAxis().isVisible()
+    assert plotWidget.getYAxis().isVisible()
+    assert not plotWidget.getYAxis("right").isVisible()
+
+    # Add curve on right axis
+    plotWidget.addCurve((0, 1, 2), (1, 2, 3), yaxis="right")
+    qapp.processEvents()
+
+    assert plotWidget.getYAxis("right").isVisible()
+
+    # hide curve on right axis
+    curve = plotWidget.getItems()[0]
+    curve.setVisible(False)
+    qapp.processEvents()
+
+    assert not plotWidget.getYAxis("right").isVisible()
+
+    # show curve on right axis
+    curve.setVisible(True)
+    qapp.processEvents()
+
+    assert plotWidget.getYAxis("right").isVisible()
+
+    # Move curve to left axis
+    curve.setYAxis("left")
+    qapp.processEvents()
+
+    assert not plotWidget.getYAxis("right").isVisible()
+
+
+def testAxisSetScaleLogNoData(qapp, qWidgetFactory):
+    """Test Axis.setScale('log') method with an empty plot
+
+    Limits are reset only when negative
+    """
+    plotWidget = qWidgetFactory(PlotWidget)
+    xaxis = plotWidget.getXAxis()
+    yaxis = plotWidget.getYAxis()
+    y2axis = plotWidget.getYAxis("right")
+
+    xaxis.setLimits(-1., 1.)
+    yaxis.setLimits(2., 3.)
+    y2axis.setLimits(-2., -1.)
+
+    xaxis.setScale("log")
+    qapp.processEvents()
+
+    assert xaxis.getLimits() == (1., 100.)
+    assert yaxis.getLimits() == (2., 3.)
+    assert y2axis.getLimits() == (-2., -1.)
+
+    xaxis.setLimits(10., 20.)
+
+    yaxis.setScale("log")
+    qapp.processEvents()
+
+    assert xaxis.getLimits() == (10., 20.)
+    assert yaxis.getLimits() == (2., 3.)  # Positive range is preserved
+    assert y2axis.getLimits() == (1., 100.)  # Negative min is reset
+
+
+def testAxisSetScaleLogWithData(qapp, qWidgetFactory):
+    """Test Axis.setScale('log') method with data
+
+    Limits are reset only when negative and takes the data range into account
+    """
+    plotWidget = qWidgetFactory(PlotWidget)
+    xaxis = plotWidget.getXAxis()
+    yaxis = plotWidget.getYAxis()
+    plotWidget.addCurve((-1, 1, 2, 3), (-1, 1, 2, 3))
+
+    xaxis.setLimits(-1., 0.5)  # Limits contains no positive data
+    yaxis.setLimits(-1., 2.)  # Limits contains positive data
+
+    xaxis.setScale("log")
+    yaxis.setScale("log")
+    qapp.processEvents()
+
+    assert xaxis.getLimits() == (1., 3.)  # Reset to positive data range
+    assert yaxis.getLimits() == (1., 2.)  # Keep max limit
+
+
+def testAxisSetScaleLinear(qapp, qWidgetFactory):
+    """Test Axis.setScale('linear') method: Limits are not changed"""
+    plotWidget = qWidgetFactory(PlotWidget)
+    xaxis = plotWidget.getXAxis()
+    yaxis = plotWidget.getYAxis()
+    y2axis = plotWidget.getYAxis("right")
+    xaxis.setScale("log")
+    yaxis.setScale("log")
+    plotWidget.resetZoom()
+    qapp.processEvents()
+
+    xaxis.setLimits(10., 1000.)
+    yaxis.setLimits(20., 2000.)
+    y2axis.setLimits(30., 3000.)
+
+    xaxis.setScale("linear")
+    qapp.processEvents()
+
+    assert xaxis.getLimits() == (10., 1000.)
+    assert yaxis.getLimits() == (20., 2000.)
+    assert y2axis.getLimits() == (30., 3000.)
+
+    yaxis.setScale("linear")
+    qapp.processEvents()
+
+    assert xaxis.getLimits() == (10., 1000.)
+    assert yaxis.getLimits() == (20., 2000.)
+    assert y2axis.getLimits() == (30., 3000.)

--- a/src/silx/gui/plot/test/testItem.py
+++ b/src/silx/gui/plot/test/testItem.py
@@ -33,7 +33,7 @@ import numpy
 from silx.gui.utils.testutils import SignalListener
 from silx.gui.plot.items.roi import RegionOfInterest
 from silx.gui.plot.items import ItemChangedType
-from silx.gui.plot import PlotWidget, items
+from silx.gui.plot import items
 from .utils import PlotWidgetTestCase
 
 
@@ -386,38 +386,3 @@ def testRegionOfInterestText():
         ItemChangedType.NAME, ItemChangedType.TEXT
     ]
     assert roi.getText() == "even_newer_name"
-
-
-def testAxisIsVisible(qapp, qWidgetFactory):
-    """Test Axis.isVisible method"""
-    plotWidget = qWidgetFactory(PlotWidget)
-
-    assert plotWidget.getXAxis().isVisible()
-    assert plotWidget.getYAxis().isVisible()
-    assert not plotWidget.getYAxis("right").isVisible()
-
-    # Add curve on right axis
-    plotWidget.addCurve((0, 1, 2), (1, 2, 3), yaxis="right")
-    qapp.processEvents()
-
-    assert plotWidget.getYAxis("right").isVisible()
-
-    # hide curve on right axis
-    curve = plotWidget.getItems()[0]
-    curve.setVisible(False)
-    qapp.processEvents()
-
-    assert not plotWidget.getYAxis("right").isVisible()
-
-    # show curve on right axis
-    curve.setVisible(True)
-    qapp.processEvents()
-
-    assert plotWidget.getYAxis("right").isVisible()
-
-    # Move curve to left axis
-    curve.setYAxis("left")
-    qapp.processEvents()
-
-    assert not plotWidget.getYAxis("right").isVisible()
-


### PR DESCRIPTION
This PR replace the previous unconditional `resetZoom` when switching plot axes scales to one  that tries to preserve axis limits as much as possible:
- When switching from "log" to "linear" scale, limits are not updated
- When switching from "linear" to "log" scale:
  - Only the axis that has a scale change is updated.
  - If limits are positive, they are kept
  - If min limit is negative, the data range is used for setting it and the max value is kept if positive and having data below it.

closes #2825
