### PR TITLE
Added populateContextMenu to ROIs

### DIFF
--- a/src/silx/gui/plot/items/_roi_base.py
+++ b/src/silx/gui/plot/items/_roi_base.py
@@ -37,6 +37,7 @@ __date__ = "28/06/2018"
 import logging
 import numpy
 import weakref
+import functools
 from typing import Optional
 
 from ....utils.weakref import WeakList
@@ -190,6 +191,28 @@ class InteractionModeMixIn(object):
         :rtype: RoiInteractionMode
         """
         return self.__modeId
+
+    def createMenuForInteractionMode(self, parent: qt.QWidget) -> qt.QMenu:
+        """Create a menu providing access to the different interaction modes"""
+        availableModes = self.availableInteractionModes()
+        currentMode = self.getInteractionMode()
+        submenu = qt.QMenu(parent)
+        modeGroup = qt.QActionGroup(parent)
+        modeGroup.setExclusive(True)
+        for mode in availableModes:
+            action = qt.QAction(parent)
+            action.setText(mode.label)
+            action.setToolTip(mode.description)
+            action.setCheckable(True)
+            if mode is currentMode:
+                action.setChecked(True)
+            else:
+                callback = functools.partial(self.setInteractionMode, mode)
+                action.triggered.connect(callback)
+            modeGroup.addAction(action)
+            submenu.addAction(action)
+        submenu.setTitle("Interaction mode")
+        return submenu
 
 
 class RegionOfInterest(_RegionOfInterestBase, core.HighlightedMixIn):

--- a/src/silx/gui/plot/items/_roi_base.py
+++ b/src/silx/gui/plot/items/_roi_base.py
@@ -654,7 +654,7 @@ class RegionOfInterest(_RegionOfInterestBase, core.HighlightedMixIn):
 
     def populateContextMenu(self, menu: qt.QMenu):
         """Populate a menu used as a context menu"""
-        ...
+        pass
 
 
 class HandleBasedROI(RegionOfInterest):

--- a/src/silx/gui/plot/items/_roi_base.py
+++ b/src/silx/gui/plot/items/_roi_base.py
@@ -652,6 +652,10 @@ class RegionOfInterest(_RegionOfInterestBase, core.HighlightedMixIn):
     def _editingFinished(self):
         self.sigEditingFinished.emit()
 
+    def populateContextMenu(self, menu: qt.QMenu):
+        """Populate a menu used as a context menu"""
+        ...
+
 
 class HandleBasedROI(RegionOfInterest):
     """Manage a ROI based on a set of handles"""

--- a/src/silx/gui/plot/tools/roi.py
+++ b/src/silx/gui/plot/tools/roi.py
@@ -622,6 +622,8 @@ class RegionOfInterestManager(qt.QObject):
         removeAction.triggered.connect(callback)
         roiMenu.addAction(removeAction)
 
+        roi.populateContextMenu(roiMenu)
+
         return roiMenu
 
     # RegionOfInterest API

--- a/src/silx/gui/plot/tools/roi.py
+++ b/src/silx/gui/plot/tools/roi.py
@@ -605,8 +605,8 @@ class RegionOfInterestManager(qt.QObject):
                     roiMenu = self._createMenuForRoi(menu, roi)
                     menu.addMenu(roiMenu)
 
-    def _isMouseHoverRoi(self, roi: RegionOfInterest):
-        """Check that the mouse hover this roi"""
+    def _isMouseHoverRoi(self, roi: RegionOfInterest) -> bool:
+        """Check that the mouse hovers this roi"""
         plot = self.parent()
 
         if self._lastHoveredMarkerLabel is not None:
@@ -622,8 +622,8 @@ class RegionOfInterestManager(qt.QObject):
         data = plot.pixelToData(pos.x(), pos.y())
         return roi.contains(data)
 
-    def _createMenuForRoi(self, parent: qt.QWidget, roi: RegionOfInterest):
-        """Create a """
+    def _createMenuForRoi(self, parent: qt.QWidget, roi: RegionOfInterest) -> qt.QMenu:
+        """Create a QMenu for the given RegionOfInterest"""
         roiMenu = qt.QMenu(parent)
         roiMenu.setTitle(roi.getName())
 

--- a/src/silx/gui/plot/tools/roi.py
+++ b/src/silx/gui/plot/tools/roi.py
@@ -34,6 +34,7 @@ import logging
 import time
 import weakref
 import functools
+from typing import Optional
 
 import numpy
 
@@ -42,6 +43,7 @@ from ...utils import blockSignals
 from ...utils import LockReentrant
 from .. import PlotWidget
 from ..items import roi as roi_items
+from ..items.roi import RegionOfInterest
 
 from ...colors import rgba
 
@@ -521,7 +523,7 @@ class RegionOfInterestManager(qt.QObject):
                         return roi
         return None
 
-    def setCurrentRoi(self, roi):
+    def setCurrentRoi(self, roi: Optional[RegionOfInterest]):
         """Set the currently selected ROI, and emit a signal.
 
         :param Union[RegionOfInterest,None] roi: The ROI to select
@@ -545,10 +547,8 @@ class RegionOfInterestManager(qt.QObject):
             self._currentRoi.setHighlighted(True)
         self.sigCurrentRoiChanged.emit(roi)
 
-    def getCurrentRoi(self):
+    def getCurrentRoi(self) -> Optional[RegionOfInterest]:
         """Returns the currently selected ROI, else None.
-
-        :rtype: Union[RegionOfInterest,None]
         """
         return self._currentRoi
 
@@ -585,7 +585,7 @@ class RegionOfInterestManager(qt.QObject):
         else:
             self.setCurrentRoi(None)
 
-    def __updateMode(self, roi):
+    def __updateMode(self, roi: RegionOfInterest):
         if isinstance(roi, roi_items.InteractionModeMixIn):
             available = roi.availableInteractionModes()
             mode = roi.getInteractionMode()
@@ -593,7 +593,7 @@ class RegionOfInterestManager(qt.QObject):
             mode = available[(imode + 1) % len(available)]
             roi.setInteractionMode(mode)
 
-    def _feedContextMenu(self, menu):
+    def _feedContextMenu(self, menu: qt.QMenu):
         """Called when the default plot context menu is about to be displayed"""
         roi = self.getCurrentRoi()
         if roi is not None:
@@ -604,35 +604,25 @@ class RegionOfInterestManager(qt.QObject):
                 pos = plot.getWidgetHandle().mapFromGlobal(qt.QCursor.pos())
                 data = plot.pixelToData(pos.x(), pos.y())
                 if roi.contains(data):
-                    if isinstance(roi, roi_items.InteractionModeMixIn):
-                        self._contextMenuForInteractionMode(menu, roi)
+                    roiMenu = self._createMenuForRoi(menu, roi)
+                    menu.addMenu(roiMenu)
 
-                removeAction = qt.QAction(menu)
-                removeAction.setText("Remove %s" % roi.getName())
-                callback = functools.partial(self.removeRoi, roi)
-                removeAction.triggered.connect(callback)
-                menu.addAction(removeAction)
+    def _createMenuForRoi(self, parent: qt.QWidget, roi: RegionOfInterest):
+        """Create a """
+        roiMenu = qt.QMenu(parent)
+        roiMenu.setTitle(roi.getName())
 
-    def _contextMenuForInteractionMode(self, menu, roi):
-        availableModes = roi.availableInteractionModes()
-        currentMode = roi.getInteractionMode()
-        submenu = qt.QMenu(menu)
-        modeGroup = qt.QActionGroup(menu)
-        modeGroup.setExclusive(True)
-        for mode in availableModes:
-            action = qt.QAction(menu)
-            action.setText(mode.label)
-            action.setToolTip(mode.description)
-            action.setCheckable(True)
-            if mode is currentMode:
-                action.setChecked(True)
-            else:
-                callback = functools.partial(roi.setInteractionMode, mode)
-                action.triggered.connect(callback)
-            modeGroup.addAction(action)
-            submenu.addAction(action)
-        submenu.setTitle("%s interaction mode" % roi.getName())
-        menu.addMenu(submenu)
+        if isinstance(roi, roi_items.InteractionModeMixIn):
+            interactionMenu = roi.createMenuForInteractionMode(roiMenu)
+            roiMenu.addMenu(interactionMenu)
+
+        removeAction = qt.QAction(roiMenu)
+        removeAction.setText("Remove")
+        callback = functools.partial(self.removeRoi, roi)
+        removeAction.triggered.connect(callback)
+        roiMenu.addAction(removeAction)
+
+        return roiMenu
 
     # RegionOfInterest API
 


### PR DESCRIPTION
Closes #3882

This PR provides a `populateContextMenu`  plus a rework of the default context menu in order to move actions from a dedicated ROI in to a dedicated submenu.

This also fixes 2 bugs:
- The context menu was not properly dropped for ROIs based on a single marker (for example the profiles)
- The `remove` action was also included when the mouse was not hovering the ROI (which is counter intitive for a context menu)

Changelog: 
- Added `populateContextMenu` to the ROIs (including profile ROIs)