### PR TITLE
add split pseudo-voigt with split lorentzian fraction

### DIFF
--- a/doc/source/modules/math/fit/functions.rst
+++ b/doc/source/modules/math/fit/functions.rst
@@ -21,6 +21,7 @@ Fit functions
 .. autofunction:: silx.math.fit.sum_splitgauss
 .. autofunction:: silx.math.fit.sum_splitlorentz
 .. autofunction:: silx.math.fit.sum_splitpvoigt
+.. autofunction:: silx.math.fit.sum_splitpvoigt2
 .. autofunction:: silx.math.fit.sum_stepdown
 .. autofunction:: silx.math.fit.sum_stepup
 

--- a/src/silx/math/fit/functions.pyx
+++ b/src/silx/math/fit/functions.pyx
@@ -144,8 +144,7 @@ def sum_gauss(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if len(params) < 3:
-        raise IndexError("At least 3 parameters are required.")
+    _validate_parameters(params, 3)
 
     # ensure float64 (double) type and 1D contiguous data layout in memory
     x_c = numpy.array(x,
@@ -191,8 +190,7 @@ def sum_agauss(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if len(params) < 3:
-        raise IndexError("At least 3 parameters are required.")
+    _validate_parameters(params, 3)
 
     x_c = numpy.array(x,
                       copy=False,
@@ -240,8 +238,7 @@ def sum_fastagauss(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if len(params) < 3:
-        raise IndexError("At least 3 parameters are required.")
+    _validate_parameters(params, 3)
 
     x_c = numpy.array(x,
                       copy=False,
@@ -288,8 +285,7 @@ def sum_splitgauss(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if len(params) < 4:
-        raise IndexError("At least 4 parameters are required.")
+    _validate_parameters(params, 4)
 
     x_c = numpy.array(x,
                       copy=False,
@@ -338,8 +334,7 @@ def sum_apvoigt(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if len(params) < 4:
-        raise IndexError("At least 4 parameters are required.")
+    _validate_parameters(params, 4)
 
     x_c = numpy.array(x,
                       copy=False,
@@ -388,8 +383,7 @@ def sum_pvoigt(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if len(params) < 4:
-        raise IndexError("At least 4 parameters are required.")
+    _validate_parameters(params, 4)
 
     x_c = numpy.array(x,
                       copy=False,
@@ -442,8 +436,7 @@ def sum_splitpvoigt(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if len(params) < 5:
-        raise IndexError("At least 5 parameters are required.")
+    _validate_parameters(params, 5)
 
     x_c = numpy.array(x,
                       copy=False,
@@ -497,8 +490,7 @@ def sum_splitpvoigt2(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if len(params) < 6:
-        raise IndexError("At least 6 parameters are required.")
+    _validate_parameters(params, 6)
 
     x_c = numpy.array(x,
                       copy=False,
@@ -543,8 +535,7 @@ def sum_lorentz(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if len(params) < 3:
-        raise IndexError("At least 3 parameters are required.")
+    _validate_parameters(params, 3)
 
     x_c = numpy.array(x,
                       copy=False,
@@ -589,8 +580,7 @@ def sum_alorentz(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if len(params) < 3:
-        raise IndexError("At least 3 parameters are required.")
+    _validate_parameters(params, 3)
 
     x_c = numpy.array(x,
                       copy=False,
@@ -636,8 +626,7 @@ def sum_splitlorentz(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if len(params) < 4:
-        raise IndexError("At least 4 parameters are required.")
+    _validate_parameters(params, 4)
 
     x_c = numpy.array(x,
                       copy=False,
@@ -683,8 +672,7 @@ def sum_stepdown(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if len(params) < 3:
-        raise IndexError("At least 3 parameters are required.")
+    _validate_parameters(params, 3)
 
     x_c = numpy.array(x,
                       copy=False,
@@ -731,8 +719,7 @@ def sum_stepup(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if len(params) < 3:
-        raise IndexError("At least 3 parameters are required.")
+    _validate_parameters(params, 3)
 
     x_c = numpy.array(x,
                       copy=False,
@@ -781,8 +768,7 @@ def sum_slit(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if len(params) < 4:
-        raise IndexError("At least 4 parameters are required.")
+    _validate_parameters(params, 4)
 
     x_c = numpy.array(x,
                       copy=False,
@@ -852,8 +838,7 @@ def sum_ahypermet(x, *params,
         double[::1] params_c
         double[::1] y_c
 
-    if len(params) < 8:
-        raise IndexError("At least 8 parameters are required.")
+    _validate_parameters(params, 8)
 
     # Sum binary flags to activate various terms of the equation
     tail_flags = 1 if gaussian_term else 0
@@ -937,8 +922,7 @@ def sum_fastahypermet(x, *params,
         double[::1] params_c
         double[::1] y_c
 
-    if len(params) < 8:
-        raise IndexError("At least 8 parameters are required.")
+    _validate_parameters(params, 8)
 
     # Sum binary flags to activate various terms of the equation
     tail_flags = 1 if gaussian_term else 0
@@ -1015,8 +999,7 @@ def periodic_gauss(x, *params):
     :return: Sum of ``npeaks`` gaussians
     """
 
-    if len(params) < 5:
-        raise IndexError("At least 5 parameters are required.")
+    _validate_parameters(params, 5)
 
     newpars = numpy.zeros((params[0], 3), numpy.float64)
     for i in range(int(params[0])):
@@ -1024,3 +1007,10 @@ def periodic_gauss(x, *params):
         newpars[i, 1] = params[3] + i * params[1]
         newpars[:, 2] = params[4]
     return sum_gauss(x, newpars)
+
+
+def _validate_parameters(params, multiple):
+    if len(params) == 0:
+        raise IndexError("No parameters specified.")
+    if len(params) % multiple:
+        raise IndexError(f"The number of parameters should be a multiple of {multiple}.")

--- a/src/silx/math/fit/functions.pyx
+++ b/src/silx/math/fit/functions.pyx
@@ -144,9 +144,8 @@ def sum_gauss(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if not len(params):
-        raise IndexError("No gaussian parameters specified. " +
-                         "At least 3 parameters are required.")
+    if len(params) < 3:
+        raise IndexError("At least 3 parameters are required.")
 
     # ensure float64 (double) type and 1D contiguous data layout in memory
     x_c = numpy.array(x,
@@ -192,9 +191,8 @@ def sum_agauss(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if not len(params):
-        raise IndexError("No gaussian parameters specified. " +
-                         "At least 3 parameters are required.")
+    if len(params) < 3:
+        raise IndexError("At least 3 parameters are required.")
 
     x_c = numpy.array(x,
                       copy=False,
@@ -242,9 +240,8 @@ def sum_fastagauss(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if not len(params):
-        raise IndexError("No gaussian parameters specified. " +
-                         "At least 3 parameters are required.")
+    if len(params) < 3:
+        raise IndexError("At least 3 parameters are required.")
 
     x_c = numpy.array(x,
                       copy=False,
@@ -291,9 +288,8 @@ def sum_splitgauss(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if not len(params):
-        raise IndexError("No gaussian parameters specified. " +
-                         "At least 4 parameters are required.")
+    if len(params) < 4:
+        raise IndexError("At least 4 parameters are required.")
 
     x_c = numpy.array(x,
                       copy=False,
@@ -342,9 +338,9 @@ def sum_apvoigt(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if not len(params):
-        raise IndexError("No parameters specified. " +
-                         "At least 4 parameters are required.")
+    if len(params) < 4:
+        raise IndexError("At least 4 parameters are required.")
+
     x_c = numpy.array(x,
                       copy=False,
                       dtype=numpy.float64,
@@ -392,9 +388,8 @@ def sum_pvoigt(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if not len(params):
-        raise IndexError("No parameters specified. " +
-                         "At least 4 parameters are required.")
+    if len(params) < 4:
+        raise IndexError("At least 4 parameters are required.")
 
     x_c = numpy.array(x,
                       copy=False,
@@ -447,9 +442,8 @@ def sum_splitpvoigt(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if not len(params):
-        raise IndexError("No parameters specified. " +
-                         "At least 5 parameters are required.")
+    if len(params) < 5:
+        raise IndexError("At least 5 parameters are required.")
 
     x_c = numpy.array(x,
                       copy=False,
@@ -503,9 +497,8 @@ def sum_splitpvoigt2(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if not len(params):
-        raise IndexError("No parameters specified. " +
-                         "At least 6 parameters are required.")
+    if len(params) < 6:
+        raise IndexError("At least 6 parameters are required.")
 
     x_c = numpy.array(x,
                       copy=False,
@@ -550,9 +543,8 @@ def sum_lorentz(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if not len(params):
-        raise IndexError("No parameters specified. " +
-                         "At least 3 parameters are required.")
+    if len(params) < 3:
+        raise IndexError("At least 3 parameters are required.")
 
     x_c = numpy.array(x,
                       copy=False,
@@ -597,9 +589,8 @@ def sum_alorentz(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if not len(params):
-        raise IndexError("No parameters specified. " +
-                         "At least 3 parameters are required.")
+    if len(params) < 3:
+        raise IndexError("At least 3 parameters are required.")
 
     x_c = numpy.array(x,
                       copy=False,
@@ -645,9 +636,8 @@ def sum_splitlorentz(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if not len(params):
-        raise IndexError("No parameters specified. " +
-                         "At least 4 parameters are required.")
+    if len(params) < 4:
+        raise IndexError("At least 4 parameters are required.")
 
     x_c = numpy.array(x,
                       copy=False,
@@ -693,9 +683,9 @@ def sum_stepdown(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if not len(params):
-        raise IndexError("No parameters specified. " +
-                         "At least 3 parameters are required.")
+    if len(params) < 3:
+        raise IndexError("At least 3 parameters are required.")
+
     x_c = numpy.array(x,
                       copy=False,
                       dtype=numpy.float64,
@@ -741,9 +731,8 @@ def sum_stepup(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if not len(params):
-        raise IndexError("No parameters specified. " +
-                         "At least 3 parameters are required.")
+    if len(params) < 3:
+        raise IndexError("At least 3 parameters are required.")
 
     x_c = numpy.array(x,
                       copy=False,
@@ -792,9 +781,8 @@ def sum_slit(x, *params):
         double[::1] params_c
         double[::1] y_c
 
-    if not len(params):
-        raise IndexError("No parameters specified. " +
-                         "At least 4 parameters are required.")
+    if len(params) < 4:
+        raise IndexError("At least 4 parameters are required.")
 
     x_c = numpy.array(x,
                       copy=False,
@@ -864,9 +852,8 @@ def sum_ahypermet(x, *params,
         double[::1] params_c
         double[::1] y_c
 
-    if not len(params):
-        raise IndexError("No parameters specified. " +
-                         "At least 8 parameters are required.")
+    if len(params) < 8:
+        raise IndexError("At least 8 parameters are required.")
 
     # Sum binary flags to activate various terms of the equation
     tail_flags = 1 if gaussian_term else 0
@@ -950,9 +937,8 @@ def sum_fastahypermet(x, *params,
         double[::1] params_c
         double[::1] y_c
 
-    if not len(params):
-        raise IndexError("No parameters specified. " +
-                         "At least 8 parameters are required.")
+    if len(params) < 8:
+        raise IndexError("At least 8 parameters are required.")
 
     # Sum binary flags to activate various terms of the equation
     tail_flags = 1 if gaussian_term else 0
@@ -1012,7 +998,7 @@ def atan_stepup(x, a, b, c):
     return a * (0.5 + (numpy.arctan((1.0 * x - b) / c) / numpy.pi))
 
 
-def periodic_gauss(x, *pars):
+def periodic_gauss(x, *params):
     """
     Return a sum of gaussian functions defined by
     *(npeaks, delta, height, centroid, fwhm)*,
@@ -1025,17 +1011,16 @@ def periodic_gauss(x, *pars):
     - *fwhm* is the full-width at half maximum for all the gaussians
 
     :param x: Independent variable where the function is calculated
-    :param pars: *(npeaks, delta, height, centroid, fwhm)*
+    :param params: *(npeaks, delta, height, centroid, fwhm)*
     :return: Sum of ``npeaks`` gaussians
     """
 
-    if not len(pars):
-        raise IndexError("No parameters specified. " +
-                         "At least 5 parameters are required.")
+    if len(params) < 5:
+        raise IndexError("At least 5 parameters are required.")
 
-    newpars = numpy.zeros((pars[0], 3), numpy.float64)
-    for i in range(int(pars[0])):
-        newpars[i, 0] = pars[2]
-        newpars[i, 1] = pars[3] + i * pars[1]
-        newpars[:, 2] = pars[4]
+    newpars = numpy.zeros((params[0], 3), numpy.float64)
+    for i in range(int(params[0])):
+        newpars[i, 0] = params[2]
+        newpars[i, 1] = params[3] + i * params[1]
+        newpars[:, 2] = params[4]
     return sum_gauss(x, newpars)

--- a/src/silx/math/fit/functions/include/functions.h
+++ b/src/silx/math/fit/functions/include/functions.h
@@ -53,6 +53,7 @@ int sum_splitgauss(double* x, int len_x, double* pgauss, int len_pgauss, double*
 int sum_apvoigt(double* x, int len_x, double* pvoigt, int len_pvoigt, double* y);
 int sum_pvoigt(double* x, int len_x, double* pvoigt, int len_pvoigt, double* y);
 int sum_splitpvoigt(double* x, int len_x, double* pvoigt, int len_pvoigt, double* y);
+int sum_splitpvoigt2(double* x, int len_x, double* pvoigt, int len_pvoigt, double* y);
 
 int sum_lorentz(double* x, int len_x, double* plorentz, int len_plorentz, double* y);
 int sum_alorentz(double* x, int len_x, double* plorentz, int len_plorentz, double* y);

--- a/src/silx/math/fit/functions_wrapper.pxd
+++ b/src/silx/math/fit/functions_wrapper.pxd
@@ -102,6 +102,12 @@ cdef extern from "functions.h":
                          int len_pvoigt,
                          double* y)
 
+    int  sum_splitpvoigt2(double* x,
+                           int len_x,
+                           double* pvoigt,
+                           int len_pvoigt,
+                           double* y)
+
     int  sum_lorentz(double* x,
                      int len_x,
                      double* plorentz,

--- a/src/silx/math/fit/test/test_peaks.py
+++ b/src/silx/math/fit/test/test_peaks.py
@@ -24,115 +24,118 @@
 Tests for peaks module
 """
 
-import unittest
 import numpy
+import pytest
 
 from silx.math.fit import functions
 from silx.math.fit import peaks
 
-class Test_peak_search(unittest.TestCase):
-    """
-    Unit tests of peak_search on various types of multi-peak functions.
-    """
-    def setUp(self):
-        self.x = numpy.arange(5000)
-        # (height1, center1, fwhm1, ...)
-        self.h_c_fwhm = (50, 500, 100,
-                         50, 600, 80,
-                         20, 2000, 100,
-                         50, 2250, 110,
-                         40, 3000, 99,
-                         23, 4980, 80)
-        # (height1, center1, fwhm1, eta1 ...)
-        self.h_c_fwhm_eta = (50, 500, 100, 0.4,
-                             50, 600, 80, 0.5,
-                             20, 2000, 100, 0.6,
-                             50, 2250, 110, 0.7,
-                             40, 3000, 99, 0.8,
-                             23, 4980, 80, 0.3,)
-        # (height1, center1, fwhm11, fwhm21, ...)
-        self.h_c_fwhm_fwhm = (50, 500, 100, 85,
-                              50, 600, 80, 110,
-                              20, 2000, 100, 100,
-                              50, 2250, 110, 99,
-                              40, 3000, 99, 110,
-                              23, 4980, 80, 80,)
-        # (height1, center1, fwhm11, fwhm21, eta1 ...)
-        self.h_c_fwhm_fwhm_eta = (50, 500, 100, 85, 0.4,
-                                  50, 600, 80, 110, 0.5,
-                                  20, 2000, 100, 100, 0.6,
-                                  50, 2250, 110, 99, 0.7,
-                                  40, 3000, 99, 110, 0.8,
-                                  23, 4980, 80, 80, 0.3,)
-        # (height1, center1, fwhm11, fwhm21, eta11, eta21 ...)
-        self.h_c_fwhm_fwhm_eta_eta = (50, 500, 100, 85, 0.4, 0.7,
-                                  50, 600, 80, 110, 0.5, 0.3,
-                                  20, 2000, 100, 100, 0.6, 0.4,
-                                  50, 2250, 110, 99, 0.7, 1,
-                                  40, 3000, 99, 110, 0.8, 0,
-                                  23, 4980, 80, 80, 0.3, 0.5,)
-        # (area1, center1, fwhm1, ...)
-        self.a_c_fwhm = (2550, 500, 100,
-                         2000, 600, 80,
-                         500, 2000, 100,
-                         4000, 2250, 110,
-                         2300, 3000, 99,
-                         3333, 4980, 80)
-        # (area1, center1, fwhm1, eta1 ...)
-        self.a_c_fwhm_eta = (500, 500, 100, 0.4,
-                             500, 600, 80, 0.5,
-                             200, 2000, 100, 0.6,
-                             500, 2250, 110, 0.7,
-                             400, 3000, 99, 0.8,
-                             230, 4980, 80, 0.3,)
-        # (area, position, fwhm, st_area_r, st_slope_r, lt_area_r, lt_slope_r, step_height_r)
-        self.hypermet_params = (1000, 500, 200, 0.2, 100, 0.3, 100, 0.05,
-                                1000, 1000, 200, 0.2, 100, 0.3, 100, 0.05,
-                                1000, 2000, 200, 0.2, 100, 0.3, 100, 0.05,
-                                1000, 2350, 200, 0.2, 100, 0.3, 100, 0.05,
-                                1000, 3000, 200, 0.2, 100, 0.3, 100, 0.05,
-                                1000, 4900, 200, 0.2, 100, 0.3, 100, 0.05,)
+_PEAK_PARAMETERS = {
+    "sum_gauss": (50, 500, 100,
+                    50, 600, 80,
+                    20, 2000, 100,
+                    50, 2250, 110,
+                    40, 3000, 99,
+                    23, 4980, 80),
+    "sum_lorentz": (50, 500, 100,
+                    50, 600, 80,
+                    20, 2000, 100,
+                    50, 2250, 110,
+                    40, 3000, 99,
+                    23, 4980, 80),
+    "sum_pvoigt": (50, 500, 100, 0.4,
+                        50, 600, 80, 0.5,
+                        20, 2000, 100, 0.6,
+                        50, 2250, 110, 0.7,
+                        40, 3000, 99, 0.8,
+                        23, 4980, 80, 0.3,),
+    "sum_splitgauss": (50, 500, 100, 85,
+                        50, 600, 80, 110,
+                        20, 2000, 100, 100,
+                        50, 2250, 110, 99,
+                        40, 3000, 99, 110,
+                        23, 4980, 80, 80,),
+    "sum_splitlorentz": (50, 500, 100, 85,
+                        50, 600, 80, 110,
+                        20, 2000, 100, 100,
+                        50, 2250, 110, 99,
+                        40, 3000, 99, 110,
+                        23, 4980, 80, 80,),
+    "sum_splitpvoigt": (50, 500, 100, 85, 0.4,
+                            50, 600, 80, 110, 0.5,
+                            20, 2000, 100, 100, 0.6,
+                            50, 2250, 110, 99, 0.7,
+                            40, 3000, 99, 110, 0.8,
+                            23, 4980, 80, 80, 0.3,),
+    "sum_splitpvoigt2": (50, 500, 100, 85, 0.4, 0.7,
+                            50, 600, 80, 110, 0.5, 0.3,
+                            20, 2000, 100, 100, 0.6, 0.4,
+                            50, 2250, 110, 99, 0.7, 1,
+                            40, 3000, 99, 110, 0.8, 0,
+                            23, 4980, 80, 80, 0.3, 0.5,),
+    "sum_agauss": (2550, 500, 100,
+                    2000, 600, 80,
+                    500, 2000, 100,
+                    4000, 2250, 110,
+                    2300, 3000, 99,
+                    3333, 4980, 80),
+    "sum_fastagauss": (2550, 500, 100,
+                    2000, 600, 80,
+                    500, 2000, 100,
+                    4000, 2250, 110,
+                    2300, 3000, 99,
+                    3333, 4980, 80),
+    "sum_alorentz": (2550, 500, 100,
+                    2000, 600, 80,
+                    500, 2000, 100,
+                    4000, 2250, 110,
+                    2300, 3000, 99,
+                    3333, 4980, 80),
+    "sum_apvoigt": (500, 500, 100, 0.4,
+                        500, 600, 80, 0.5,
+                        200, 2000, 100, 0.6,
+                        500, 2250, 110, 0.7,
+                        400, 3000, 99, 0.8,
+                        230, 4980, 80, 0.3,),
+    "sum_ahypermet": (1000, 500, 200, 0.2, 100, 0.3, 100, 0.05,
+                        1000, 1000, 200, 0.2, 100, 0.3, 100, 0.05,
+                        1000, 2000, 200, 0.2, 100, 0.3, 100, 0.05,
+                        1000, 2350, 200, 0.2, 100, 0.3, 100, 0.05,
+                        1000, 3000, 200, 0.2, 100, 0.3, 100, 0.05,
+                        1000, 4900, 200, 0.2, 100, 0.3, 100, 0.05,),
+    "sum_fastahypermet": (1000, 500, 200, 0.2, 100, 0.3, 100, 0.05,
+                        1000, 1000, 200, 0.2, 100, 0.3, 100, 0.05,
+                        1000, 2000, 200, 0.2, 100, 0.3, 100, 0.05,
+                        1000, 2350, 200, 0.2, 100, 0.3, 100, 0.05,
+                        1000, 3000, 200, 0.2, 100, 0.3, 100, 0.05,
+                        1000, 4900, 200, 0.2, 100, 0.3, 100, 0.05,)
+}
 
 
-    def tearDown(self):
-        pass
+@pytest.mark.parametrize("peak_profile", list(_PEAK_PARAMETERS))
+def test_peak_functions(peak_profile):
+    x = numpy.arange(5000)
+    peak_params = _PEAK_PARAMETERS[peak_profile]
+    func = getattr(functions, peak_profile)
 
-    def get_peaks(self, function, params):
-        """
+    with pytest.raises(IndexError):
+        func(x)
+    with pytest.raises(IndexError):
+        func(x, *peak_params, 0)
 
-        :param function: Multi-peak function
-        :param params: Parameter for this function
-        :return: list of (peak, relevance) tuples
-        """
-        y = function(self.x, *params)
-        return peaks.peak_search(y=y, fwhm=100, relevance_info=True)
+    y = func(x, *peak_params)
+    assert x.shape == y.shape
 
-    def testPeakSearch_various_functions(self):
-        """Run peak search on a variety of synthetic functions, and
-        check that result falls within +-25 samples of the actual peak
-        (reasonable delta considering a fwhm of ~100 samples) and effects
-        of overlapping peaks)."""
-        f_p = ((functions.sum_gauss, self.h_c_fwhm ),
-               (functions.sum_lorentz, self.h_c_fwhm),
-               (functions.sum_pvoigt, self.h_c_fwhm_eta),
-               (functions.sum_splitgauss, self.h_c_fwhm_fwhm),
-               (functions.sum_splitlorentz, self.h_c_fwhm_fwhm),
-               (functions.sum_splitpvoigt, self.h_c_fwhm_fwhm_eta),
-               (functions.sum_splitpvoigt2, self.h_c_fwhm_fwhm_eta_eta),
-               (functions.sum_agauss, self.a_c_fwhm),
-               (functions.sum_fastagauss, self.a_c_fwhm),
-               (functions.sum_alorentz, self.a_c_fwhm),
-               (functions.sum_apvoigt, self.a_c_fwhm_eta),
-               (functions.sum_ahypermet, self.hypermet_params),
-               (functions.sum_fastahypermet, self.hypermet_params),)
 
-        for function, params in f_p:
-            peaks = self.get_peaks(function, params)
+@pytest.mark.parametrize("peak_profile", list(_PEAK_PARAMETERS))
+def test_peak_search(peak_profile):
+    x = numpy.arange(5000)
+    peak_params = _PEAK_PARAMETERS[peak_profile]
+    func = getattr(functions, peak_profile)
+    y = func(x, *peak_params)
+    estimated_peak_params = peaks.peak_search(y=y, fwhm=100, relevance_info=True)
 
-            self.assertEqual(len(peaks), 6,
-                             "Wrong number of peaks detected")
-
-            for i in range(6):
-                theoretical_peak_index = params[i*(len(params)//6) + 1]
-                found_peak_index = peaks[i][0]
-                self.assertLess(abs(found_peak_index - theoretical_peak_index), 25)
+    assert len(estimated_peak_params)==6, "Wrong number of peaks detected"
+    for i, (peak_position, *_) in enumerate(estimated_peak_params):
+        theoretical_peak_position = peak_params[i*(len(peak_params)//6) + 1]
+        assert abs(peak_position - theoretical_peak_position) < 25

--- a/src/silx/math/fit/test/test_peaks.py
+++ b/src/silx/math/fit/test/test_peaks.py
@@ -64,6 +64,13 @@ class Test_peak_search(unittest.TestCase):
                                   50, 2250, 110, 99, 0.7,
                                   40, 3000, 99, 110, 0.8,
                                   23, 4980, 80, 80, 0.3,)
+        # (height1, center1, fwhm11, fwhm21, eta11, eta21 ...)
+        self.h_c_fwhm_fwhm_eta_eta = (50, 500, 100, 85, 0.4, 0.7,
+                                  50, 600, 80, 110, 0.5, 0.3,
+                                  20, 2000, 100, 100, 0.6, 0.4,
+                                  50, 2250, 110, 99, 0.7, 1,
+                                  40, 3000, 99, 110, 0.8, 0,
+                                  23, 4980, 80, 80, 0.3, 0.5,)
         # (area1, center1, fwhm1, ...)
         self.a_c_fwhm = (2550, 500, 100,
                          2000, 600, 80,
@@ -111,6 +118,7 @@ class Test_peak_search(unittest.TestCase):
                (functions.sum_splitgauss, self.h_c_fwhm_fwhm),
                (functions.sum_splitlorentz, self.h_c_fwhm_fwhm),
                (functions.sum_splitpvoigt, self.h_c_fwhm_fwhm_eta),
+               (functions.sum_splitpvoigt2, self.h_c_fwhm_fwhm_eta_eta),
                (functions.sum_agauss, self.a_c_fwhm),
                (functions.sum_fastagauss, self.a_c_fwhm),
                (functions.sum_alorentz, self.a_c_fwhm),


### PR DESCRIPTION
Allows the Lorentzian fraction to be different on the left and on the right of the centroid:

![image](https://github.com/silx-kit/silx/assets/7264703/41d528b3-4068-4142-9db3-f35215ab2655)

Closes https://github.com/silx-kit/silx/issues/3901

Changelog: add split pseudo-voigt with split lorentzian fraction
