### PR TITLE
`silx.opencl.common`: Reworked initialisation of the module

### DIFF
--- a/src/silx/opencl/common.py
+++ b/src/silx/opencl/common.py
@@ -62,13 +62,12 @@ else:
         except pyopencl.LogicError:
             logger.warning("The module pyOpenCL has been imported but can't be used here")
             pyopencl = None
-        else:
-            import pyopencl.array as array
-            mf = pyopencl.mem_flags
-            from .atomic import check_atomic32, check_atomic64
 
-if pyopencl is None:
-
+if pyopencl is not None:
+    import pyopencl.array as array
+    mf = pyopencl.mem_flags
+    from .atomic import check_atomic32, check_atomic64
+else:
     # Define default mem flags
     class mf(object):
         WRITE_ONLY = 1


### PR DESCRIPTION
This PR changes the way to initialise `mf` in order to hopefully simplify reading the code by separating probing the the import of `pyopencl` from `mf` init.
There should be no difference in behavior.

closes #3878