### PR TITLE
silx.gui.plot: Fixed PlotWidget mouse cursor update

### DIFF
--- a/src/silx/gui/plot/PlotInteraction.py
+++ b/src/silx/gui/plot/PlotInteraction.py
@@ -1098,8 +1098,10 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
             self._hoverMarker = None
 
         def enterState(self):
-            plot = self.machine.plot
-            position = plot.getWidgetHandle().mapFromGlobal(qt.QCursor.pos())
+            widget = self.machine.plot.getWidgetHandle()
+            if widget is None or not widget.isVisible():
+                return
+            position = widget.mapFromGlobal(qt.QCursor.pos())
             self.onMove(position.x(), position.y())
 
         def onMove(self, x, y):
@@ -1342,7 +1344,10 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
 
     def cancel(self):
         self._pan.cancel()
-        position = self.plot.getWidgetHandle().mapFromGlobal(qt.QCursor.pos())
+        widget = self.plot.getWidgetHandle()
+        if widget is None or not widget.isVisible():
+            return
+        position = widget.mapFromGlobal(qt.QCursor.pos())
         self.__terminateDrag(position.x(), position.y())
 
 


### PR DESCRIPTION
This PR fixes the update of the mouse cursor when finishing an interaction with a ROI.
This is an alternative to PR #3893.

Compared to PR #3893, it does not need to use a global variable, removes a blinking cursor (set to default in `__terminateDrag` and changed in `Idle.enterState`) and updates the cursor according to the item that interaction will occur on (= the top-most marker) rather than the last one used for interaction.

closes #3892
