### PR TITLE
silx.gui: Check Qt/pyopengl platform compatibility; silx view/compare: Use matplotlib if OpenGL is not available

### DIFF
--- a/src/silx/app/view/ApplicationContext.py
+++ b/src/silx/app/view/ApplicationContext.py
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,7 @@ __date__ = "23/05/2018"
 
 import weakref
 import logging
+from collections.abc import Sequence
 
 import silx
 from silx.gui.data.DataViews import DataViewHooks
@@ -75,7 +76,7 @@ class ApplicationContext(DataViewHooks):
 
         # Use matplotlib backend by default
         silx.config.DEFAULT_PLOT_BACKEND = \
-            "opengl" if plotBackend == "opengl" else "matplotlib"
+            ("opengl", "matplotlib") if plotBackend == "opengl" else "matplotlib"
         if plotImageYAxisOrientation != "":
             silx.config.DEFAULT_PLOT_IMAGE_Y_AXIS_ORIENTATION = plotImageYAxisOrientation
 
@@ -121,7 +122,7 @@ class ApplicationContext(DataViewHooks):
             settings.endGroup()
 
         settings.beginGroup("library")
-        settings.setValue("plot.backend", silx.config.DEFAULT_PLOT_BACKEND)
+        settings.setValue("plot.backend", self.getDefaultPlotBackend())
         settings.setValue("plot-image.y-axis-orientation", silx.config.DEFAULT_PLOT_IMAGE_Y_AXIS_ORIENTATION)
         settings.endGroup()
 
@@ -192,3 +193,13 @@ class ApplicationContext(DataViewHooks):
             dialog.setModal(False)
             self.__defaultColormapDialog = dialog
         return self.__defaultColormapDialog
+
+    @staticmethod
+    def getDefaultPlotBackend() -> str:
+        """Returns default plot backend as a str from current config"""
+        backend = silx.config.DEFAULT_PLOT_BACKEND
+        if isinstance(backend, str):
+            return backend
+        if isinstance(backend, Sequence) and len(backend) and isinstance(backend[0], str):
+            return backend[0]
+        return "matplotlib"  # fallback

--- a/src/silx/app/view/Viewer.py
+++ b/src/silx/app/view/Viewer.py
@@ -683,17 +683,18 @@ class Viewer(qt.QMainWindow):
         # plot backend
 
         title = self._plotBackendMenu.title().split(": ", 1)[0]
-        self._plotBackendMenu.setTitle("%s: %s" % (title, silx.config.DEFAULT_PLOT_BACKEND))
+        backend = self.__context.getDefaultPlotBackend()
+        self._plotBackendMenu.setTitle(f"{title}: {backend}")
 
         action = self._usePlotWithMatplotlib
-        action.setChecked(silx.config.DEFAULT_PLOT_BACKEND in ["matplotlib", "mpl"])
+        action.setChecked(backend in ["matplotlib", "mpl"])
         title = action.text().split(" (", 1)[0]
         if not action.isChecked():
             title += " (applied after application restart)"
         action.setText(title)
 
         action = self._usePlotWithOpengl
-        action.setChecked(silx.config.DEFAULT_PLOT_BACKEND in ["opengl", "gl"])
+        action.setChecked(backend in ["opengl", "gl"])
         title = action.text().split(" (", 1)[0]
         if not action.isChecked():
             title += " (applied after application restart)"
@@ -851,7 +852,7 @@ class Viewer(qt.QMainWindow):
         silx.config.DEFAULT_PLOT_BACKEND = "matplotlib"
 
     def __forceOpenglBackend(self):
-        silx.config.DEFAULT_PLOT_BACKEND = "opengl"
+        silx.config.DEFAULT_PLOT_BACKEND = "opengl", "matplotlib"
 
     def appendFile(self, filename):
         if self.__displayIt is None:

--- a/src/silx/app/view/main.py
+++ b/src/silx/app/view/main.py
@@ -149,8 +149,7 @@ def mainQt(options):
 
     if options.use_opengl_plot:
         # It have to be done after the settings (after the Viewer creation)
-        silx.config.DEFAULT_PLOT_BACKEND = "opengl", "matplotlib"
-
+        silx.config.DEFAULT_PLOT_BACKEND = "opengl"
 
     for url in parseutils.filenames_to_dataurls(options.files):
         # TODO: Would be nice to add a process widget and a cancel button

--- a/src/silx/app/view/main.py
+++ b/src/silx/app/view/main.py
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2016-2022 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -149,7 +149,7 @@ def mainQt(options):
 
     if options.use_opengl_plot:
         # It have to be done after the settings (after the Viewer creation)
-        silx.config.DEFAULT_PLOT_BACKEND = "opengl"
+        silx.config.DEFAULT_PLOT_BACKEND = "opengl", "matplotlib"
 
 
     for url in parseutils.filenames_to_dataurls(options.files):

--- a/src/silx/gui/_glutils/OpenGLWidget.py
+++ b/src/silx/gui/_glutils/OpenGLWidget.py
@@ -278,15 +278,6 @@ class OpenGLWidget(qt.QWidget):
             self.layout().addWidget(label)
             return
 
-        qt_qpa_platform = qt.QGuiApplication.platformName()
-        pyopengl_platform = gl.getPlatform()
-        if (
-            (qt_qpa_platform == 'wayland' and pyopengl_platform != 'EGLPlatform')
-            or (qt_qpa_platform == 'xcb' and pyopengl_platform != 'GLXPlatform')
-        ):
-            _logger.warning(
-                f"Qt/PyOpenGL possible incompatibility: Qt QPA platform '{qt_qpa_platform}', PyOpenGL platform '{pyopengl_platform}'")
-
         self.__openGLWidget = _OpenGLWidget(
             parent=self,
             alphaBufferSize=alphaBufferSize,

--- a/src/silx/gui/utils/glutils/__init__.py
+++ b/src/silx/gui/utils/glutils/__init__.py
@@ -148,7 +148,7 @@ def isOpenGLAvailable(
         or (qt_qpa_platform == 'xcb' and pyopengl_platform != 'GLXPlatform')
     ):
         return _isOpenGLAvailableResult(
-            f"Qt and PyOpenGL use incompatible platforms: Qt QPA platform '{qt_qpa_platform}', PyOpenGL platform '{pyopengl_platform}'"
+            f"Qt platform '{qt_qpa_platform}' is not compatible with PyOpenGL platform '{pyopengl_platform}'"
         )
 
     keyCache = version, shareOpenGLContexts

--- a/src/silx/gui/utils/glutils/__init__.py
+++ b/src/silx/gui/utils/glutils/__init__.py
@@ -23,6 +23,8 @@
 # ###########################################################################*/
 """This module provides the :func:`isOpenGLAvailable` utility function.
 """
+from __future__ import annotations
+
 
 import os
 import sys
@@ -41,9 +43,9 @@ class _isOpenGLAvailableResult:
     an `error` string attribute storting the possible error message.
     """
 
-    def __init__(self, status=True, error=''):
-        self.__status = bool(status)
+    def __init__(self, error: str = '', status: bool = False):
         self.__error = str(error)
+        self.__status = bool(status)
 
     status = property(lambda self: self.__status, doc="True if OpenGL is working")
     error = property(lambda self: self.__error, doc="Error message")
@@ -52,20 +54,22 @@ class _isOpenGLAvailableResult:
         return self.status
 
     def __repr__(self):
-        return '<_isOpenGLAvailableResult: %s, "%s">' % (self.status, self.error)
+        return f'<_isOpenGLAvailableResult: {self.status}, "{self.error}">'
 
 
-def _runtimeOpenGLCheck(version, shareOpenGLContexts):
+def _runtimeOpenGLCheck(
+    version: tuple[int, int],
+    shareOpenGLContexts: bool,
+) -> _isOpenGLAvailableResult:
     """Run OpenGL check in a subprocess.
 
     This is done by starting a subprocess that displays a Qt OpenGL widget.
 
-    :param List[int] version:
+    :param version:
         The minimal required OpenGL version as a 2-tuple (major, minor).
-    :param bool shareOpenGLContexts:
+    :param shareOpenGLContexts:
         True to test the `QApplication` with `AA_ShareOpenGLContexts`.
-    :return: An error string that is empty if no error occured
-    :rtype: str
+    :return: Result status and error message
     """
     major, minor = str(version[0]), str(version[1])
     env = os.environ.copy()
@@ -93,22 +97,26 @@ def _runtimeOpenGLCheck(version, shareOpenGLContexts):
 _runtimeCheckCache = {}  # Cache runtime check results: {version: result}
 
 
-def isOpenGLAvailable(version=(2, 1), runtimeCheck=True, shareOpenGLContexts=False):
+def isOpenGLAvailable(
+    version: tuple[int, int] = (2, 1),
+    runtimeCheck: bool = True,
+    shareOpenGLContexts: bool = False,
+) -> _isOpenGLAvailableResult:
     """Check if OpenGL is available through Qt and actually working.
 
     After some basic tests, this is done by starting a subprocess that
     displays a Qt OpenGL widget.
 
-    :param List[int] version:
+    :param version:
         The minimal required OpenGL version as a 2-tuple (major, minor).
         Default: (2, 1)
-    :param bool shareOpenGLContexts:
+    :param runtimeCheck:
+        True (default) to run the test creating a Qt OpenGL widget in a subprocess,
+        False to avoid this check.
+    :param shareOpenGLContexts:
         True to test the `QApplication` with `AA_ShareOpenGLContexts`.
         This only can be checked with `runtimeCheck` enabled.
         Default is false.
-    :param bool runtimeCheck:
-        True (default) to run the test creating a Qt OpenGL widget in a subprocess,
-        False to avoid this check.
     :return: A result object that evaluates to True if successful and
         which has a `status` boolean attribute (True if successful) and
         an `error` string attribute that is not empty if `status` is False.
@@ -163,10 +171,10 @@ if __name__ == "__main__":
     class _TestOpenGLWidget(OpenGLWidget):
         """Widget checking that OpenGL is indeed available
 
-        :param List[int] version: (major, minor) minimum OpenGL version
+        :param version: (major, minor) minimum OpenGL version
         """
 
-        def __init__(self, version):
+        def __init__(self, version: tuple[int, int]):
             super(_TestOpenGLWidget, self).__init__(
                 alphaBufferSize=0,
                 depthBufferSize=0,

--- a/src/silx/gui/utils/glutils/__init__.py
+++ b/src/silx/gui/utils/glutils/__init__.py
@@ -30,10 +30,6 @@ import os
 import sys
 import subprocess
 from silx.gui import qt
-try:
-    from silx.gui._glutils import gl
-except ImportError:
-    gl = None
 
 
 class _isOpenGLAvailableResult:
@@ -126,7 +122,9 @@ def isOpenGLAvailable(
         return _isOpenGLAvailableResult('DISPLAY environment variable not set')
 
     # Check pyopengl availability
-    if gl is None:
+    try:
+        from silx.gui._glutils import gl
+    except ImportError:
         return _isOpenGLAvailableResult(
             "Cannot import OpenGL wrapper: pyopengl is not installed")
 
@@ -166,6 +164,7 @@ def isOpenGLAvailable(
 
 if __name__ == "__main__":
     from silx.gui._glutils import OpenGLWidget
+    from silx.gui._glutils import gl
     import argparse
 
     class _TestOpenGLWidget(OpenGLWidget):


### PR DESCRIPTION
This PR updates `isOpenGLAvailable` to check the compatibility between Qt and pyopengl selected platforms.
It also updates `silx view` and `silx compare` to fallback on matplotlib if OpenGL is selected but not available.

closes #3630