### PR TITLE
silx.gui.plot.PlotWidget: Added support for 'other' kind of plot items

### DIFF
--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -909,7 +909,7 @@ class PlotWidget(qt.QMainWindow):
         for kind, itemClasses in cls._KIND_TO_CLASSES.items():
             if isinstance(item, itemClasses):
                 return kind
-        raise ValueError('Unsupported item type %s' % type(item))
+        return 'other'
 
     def _notifyContentChanged(self, item):
         self.notify('contentChanged', action='add',


### PR DESCRIPTION
This allows to add use custom items in a plot widget like `Group` as proposed in PR #3898

Taken from PR #3898