### PR TITLE
Build: Removed constraint on `setuptools` version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,46 +24,46 @@ jobs:
           - name-suffix: "PyQt5 sdist"
             os: ubuntu-20.04
             python-version: '3.7'
-            BUILD_COMMAND: sdist
+            BUILD_OPTION: --sdist
             QT_BINDING: PyQt5
             RUN_TESTS_OPTIONS: --qt-binding=PyQt5 --no-opencl --low-mem
           - name-suffix: "PyQt5 wheel"
             os: macos-latest
             python-version: '3.10'
-            BUILD_COMMAND: bdist_wheel
+            BUILD_OPTION: --wheel
             QT_BINDING: PyQt5
             RUN_TESTS_OPTIONS: --qt-binding=PyQt5 --no-opencl --low-mem
 
           - name-suffix: "PySide6 sdist"
             os: ubuntu-latest
             python-version: '3.8'
-            BUILD_COMMAND: sdist
+            BUILD_OPTION: --sdist
             QT_BINDING: PySide6
             RUN_TESTS_OPTIONS: --qt-binding=PySide6 --no-opencl --low-mem
           - name-suffix: "PySide6 wheel"
             os: macos-latest
             python-version: '3.9'
-            BUILD_COMMAND: bdist_wheel
+            BUILD_OPTION: --wheel
             QT_BINDING: PySide6
             RUN_TESTS_OPTIONS: --qt-binding=PySide6 --no-opencl --low-mem
 
           - name-suffix: "PyQt6 wheel"
             os: ubuntu-latest
             python-version: '3.7'
-            BUILD_COMMAND: bdist_wheel
+            BUILD_OPTION: --wheel
             QT_BINDING: PyQt6
             RUN_TESTS_OPTIONS: --qt-binding=PyQt6 --no-opengl --low-mem
           - name-suffix: "PyQt6 wheel"
             os: macos-latest
             python-version: '3.10'
-            BUILD_COMMAND: bdist_wheel
+            BUILD_OPTION: --wheel
             QT_BINDING: PyQt6
             RUN_TESTS_OPTIONS: --qt-binding=PyQt6 --no-opencl --low-mem
 
           - name-suffix: "No GUI wheel"
             os: windows-latest
             python-version: '3.9'
-            BUILD_COMMAND: bdist_wheel
+            BUILD_OPTION: --wheel
             QT_BINDING:
             RUN_TESTS_OPTIONS: --no-gui --low-mem
             # No GUI tests on Windows
@@ -93,11 +93,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # Use latest setuptools using Python's distutils
       - name: Upgrade distribution modules
         run: |
-          pip install --upgrade "setuptools<60.0.0"
-          python -m pip install --upgrade pip wheel
+          python -m pip install --upgrade pip
+          pip install --upgrade build setuptools wheel
           pip install --upgrade --pre numpy cython
 
       - name: Print python info used for build
@@ -110,7 +109,7 @@ jobs:
           if [ ${{ runner.os }} == 'macOS' ]; then
               export MACOSX_DEPLOYMENT_TARGET=10.9;
           fi
-          python setup.py ${{ matrix.BUILD_COMMAND }}
+          python -m build --no-isolation ${{ matrix.BUILD_OPTION }}
           ls dist
 
       - name: Pre-install dependencies

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -53,7 +53,6 @@ install:
     - "SET PATH=%PYTHON_DIR%;%PYTHON_DIR%\\Scripts;%PATH%"
 
     # Upgrade/install distribution modules
-    - "pip install %PIP_OPTIONS% --upgrade setuptools"
     - "python -m pip install %PIP_OPTIONS% --upgrade pip"
 
     # Download Mesa OpenGL in Python directory when testing OpenGL
@@ -65,7 +64,8 @@ build_script:
     - "%VENV_BUILD_DIR%\\Scripts\\activate.bat"
 
     # Install build dependencies
-    - "pip install %PIP_OPTIONS% --upgrade setuptools<60.0.0"
+    - "pip install %PIP_OPTIONS% --upgrade build"
+    - "pip install %PIP_OPTIONS% --upgrade setuptools"
     - "pip install %PIP_OPTIONS% --upgrade wheel"
     - "pip install %PIP_OPTIONS% --upgrade numpy"
     - "pip install %PIP_OPTIONS% --upgrade cython"
@@ -75,7 +75,7 @@ build_script:
     - "pip list --format=columns"
 
     # Build
-    - "python setup.py bdist_wheel"
+    - "python -m build --no-isolation --wheel"
     - ps: "ls dist"
 
     # Leave build virtualenv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "wheel",
-    "setuptools<60.0.0",
+    "setuptools",
     "numpy>=1.12",
     "Cython>=0.21.1"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 
 # Required dependencies (from setup.py setup_requires and install_requires)
 numpy >= 1.12
-setuptools < 60.0.0
+setuptools
 Cython >= 0.21.1
 h5py
 fabio >= 0.9


### PR DESCRIPTION
This PR removes the constraint of using `setuptools<60` that was introduced in PR #3583 to avoid issues with `numpy.distutils`.
`silx` no longer relies on `numpy.distutils`, so let's lift this constraint which should no longer be needed.

This PR also modernises CI config to use `python -m build` rather than `python setup.py`