### PR TITLE
UrlList: allow removal of url from the list

### DIFF
--- a/examples/imageStack.py
+++ b/examples/imageStack.py
@@ -130,6 +130,7 @@ def main():
     widget.setNPrefetch(1)
     urls = create_datasets(folder=dataset_folder)
     widget.setUrls(urls=urls)
+    widget.setUrlsEditable(True)   # allow the user to remove some url from the list
     widget.show()
     qapp.exec()
     widget.close()

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -77,7 +77,7 @@ class UrlList(qt.QListWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._editable = False
-        # are we in 'editable' mode: for now if true then we can remove some item from the list
+        # are we in 'editable' mode: for now if true then we can remove some items from the list
 
         # menu to be triggered when in edition from right-click
         self._menu = qt.QMenu()

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -347,9 +347,9 @@ class ImageStack(qt.QMainWindow):
 
     def removeUrl(self, url: str) -> None:
         """
-        Remove provided URLs from the given one and reset URLs
+        Remove provided URL from the table
 
-        :param urls: URLs as str
+        :param url: URL as str
         """
         # remove the given urls from self._urls and self._urlIndexes
         if not isinstance(url, str):

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -63,7 +63,10 @@ class UrlList(qt.QListWidget):
     """List of URLs the user to select an URL"""
 
     sigCurrentUrlChanged = qt.Signal(str)
-    """Signal emitted when the active/current url change. If url == '' consider it as there is not data to be displayed"""
+    """Signal emitted when the active/current URL has changed.
+
+    This signal emits the empty string when there is no longer an active URL.
+    """
 
     sigUrlsRemoved = qt.Signal(tuple)
     """Signal emit when some URLs have been removed from the URL list.

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -45,7 +45,7 @@ class _HorizontalSlider(HorizontalSliderWithBrowser):
     sigCurrentUrlIndexChanged = qt.Signal(int)
 
     def __init__(self, parent):
-        super(_HorizontalSlider, self).__init__(parent=parent)
+        super().__init__(parent=parent)
         #  connect signal / slot
         self.valueChanged.connect(self._urlChanged)
 
@@ -110,7 +110,7 @@ class _ToggleableUrlSelectionTable(qt.QWidget):
     """Signal emitted when the active/current url change"""
 
     def __init__(self, parent=None) -> None:
-        qt.QWidget.__init__(self, parent)
+        super().__init__(parent)
         self.setLayout(qt.QGridLayout())
         self._toggleButton = qt.QPushButton(parent=self)
         self.layout().addWidget(self._toggleButton, 0, 2, 1, 1)
@@ -161,7 +161,7 @@ class UrlLoader(qt.QThread):
     Thread use to load DataUrl
     """
     def __init__(self, parent, url):
-        super(UrlLoader, self).__init__(parent=parent)
+        super().__init__(parent=parent)
         assert isinstance(url, DataUrl)
         self.url = url
         self.data = None
@@ -188,7 +188,7 @@ class ImageStack(qt.QMainWindow):
     """Signal emitted when the current url change"""
 
     def __init__(self, parent=None) -> None:
-        super(ImageStack, self).__init__(parent)
+        super().__init__(parent)
         self.__n_prefetch = ImageStack.N_PRELOAD
         self._loadingThreads = []
         self.setWindowFlags(qt.Qt.Widget)
@@ -228,7 +228,7 @@ class ImageStack(qt.QMainWindow):
         self._freeLoadingThreads()
         self._waitingOverlay.close()
         self._plot.close()
-        super(ImageStack, self).close()
+        super().close()
 
     def setUrlLoaderClass(self, urlLoader: typing.Type[UrlLoader]) -> None:
         """

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -123,7 +123,7 @@ class UrlList(qt.QListWidget):
     def contextMenuEvent(self, event):
         if self._editable:
             menu = qt.QMenu()
-            removeAction = qt.QAction(text="remove",
+            removeAction = qt.QAction(text="Remove",
                                     parent=menu)
             removeAction.triggered.connect(self._removeSelectedItems)
             menu.addAction(removeAction)

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -97,6 +97,7 @@ class UrlList(qt.QListWidget):
         self.currentItemChanged.connect(self._notifyCurrentUrlChanged)
 
     def setEditable(self, editable: bool):
+    """Toggle whether the user can remove some URLs from the list"""
         if editable != self._editable:
             self._editable = editable
             # discusable choice: should we change the selection mode ? No much meaning

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -66,7 +66,10 @@ class UrlList(qt.QListWidget):
     """Signal emitted when the active/current url change. If url == '' consider it as there is not data to be displayed"""
 
     sigUrlsRemoved = qt.Signal(tuple)
-    """signal emit when some url have been removed from the URL list. Provided as a tuple of url as strings"""
+    """Signal emit when some URLs have been removed from the URL list.
+
+    Provided as a tuple of url as strings.
+    """
 
     def __init__(self, parent=None):
         super().__init__(parent)

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -182,8 +182,8 @@ class _ToggleableUrlSelectionTable(qt.QWidget):
 
         # Signal / slot connection
         self._toggleButton.clicked.connect(self.toggleUrlSelectionTable)
-        self._urlsTable.sigCurrentUrlChanged.connect(self._propagateCurrentUrlChangedSignal)
-        self._urlsTable.sigUrlsRemoved.connect(self._propageUrlsRemovedSignal)
+        self._urlsTable.sigCurrentUrlChanged.connect(self.sigCurrentUrlChanged)
+        self._urlsTable.sigUrlsRemoved.connect(self.sigUrlsRemoved)
 
         # expose API
         self.setUrls = self._urlsTable.setUrls

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -205,12 +205,6 @@ class _ToggleableUrlSelectionTable(qt.QWidget):
     def urlSelectionTableIsVisible(self):
         return self._urlsTable.isVisibleTo(self)
 
-    def _propagateCurrentUrlChangedSignal(self, url):
-        self.sigCurrentUrlChanged.emit(url)
-
-    def _propageUrlsRemovedSignal(self, urls):
-        self.sigUrlsRemoved.emit(urls)
-
     def clear(self):
         self._urlsTable.clear()
 

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -106,11 +106,9 @@ class UrlList(qt.QListWidget):
             if editable:
                 self._removeAction.triggered.connect(self._removeSelectedItems)
                 self.addAction(self._removeAction)
-                self.setSelectionMode(qt.QAbstractItemView.ExtendedSelection)
             else:
                 self._removeAction.triggered.disconnect(self._removeSelectedItems)
                 self.removeAction(self._removeAction)
-                self.setSelectionMode(qt.QAbstractItemView.SingleSelection)
 
     def setUrls(self, urls: list) -> None:
         url_names = []
@@ -401,6 +399,11 @@ class ImageStack(qt.QMainWindow):
 
     def setUrlsEditable(self, editable: bool):
         self._urlsTable._urlsTable.setEditable(editable)
+        if editable:
+            selection_mode = qt.QAbstractItemView.ExtendedSelection
+        else:
+            selection_mode = qt.QAbstractItemView.SingleSelection
+        self._urlsTable._urlsTable.setSelectionMode(selection_mode)
 
     def setUrls(self, urls: list) -> None:
         """list of urls within an index. Warning: urls should contain an image

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -124,6 +124,10 @@ class UrlList(qt.QListWidget):
             self.sigCurrentUrlChanged.emit(current.text())
 
     def setUrl(self, url: typing.Optional[DataUrl]) -> None:
+    """Set the current URL.
+
+    :param url: The new selected URL. Use `None` to clear the selection.
+    """
         if url is None:
             self.clearSelection()
             self.sigCurrentUrlChanged.emit("")

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -441,9 +441,9 @@ class ImageStack(qt.QMainWindow):
 
     def _urlsRemoved(self, urls: tuple) -> None:
         """
-        remove provided urls from the given one and reset urls
+        Remove provided URLs from the given one and reset URLs
 
-        :param tuple urls: urls as str
+        :param urls: URLs as str
         """
         # remove the given urls from self._urls and self._urlIndexes
         for url in urls:

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -97,7 +97,7 @@ class UrlList(qt.QListWidget):
         self.currentItemChanged.connect(self._notifyCurrentUrlChanged)
 
     def setEditable(self, editable: bool):
-    """Toggle whether the user can remove some URLs from the list"""
+        """Toggle whether the user can remove some URLs from the list"""
         if editable != self._editable:
             self._editable = editable
             # discusable choice: should we change the selection mode ? No much meaning
@@ -124,10 +124,10 @@ class UrlList(qt.QListWidget):
             self.sigCurrentUrlChanged.emit(current.text())
 
     def setUrl(self, url: typing.Optional[DataUrl]) -> None:
-    """Set the current URL.
+        """Set the current URL.
 
-    :param url: The new selected URL. Use `None` to clear the selection.
-    """
+        :param url: The new selected URL. Use `None` to clear the selection.
+        """
         if url is None:
             self.clearSelection()
             self.sigCurrentUrlChanged.emit("")

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -35,10 +35,12 @@ from silx.io.utils import get_data
 from silx.gui.widgets.FrameBrowser import HorizontalSliderWithBrowser
 from silx.gui.widgets.UrlList import UrlList
 from silx.gui.utils import blockSignals
+from silx.utils.deprecation import deprecated
 
 import typing
 import logging
 from silx.gui.widgets.WaitingOverlay import WaitingOverlay
+from collections.abc import Iterable
 
 _logger = logging.getLogger(__name__)
 
@@ -89,12 +91,6 @@ class _ToggleableUrlSelectionTable(qt.QWidget):
         self._urlsTable.sigCurrentUrlChanged.connect(self.sigCurrentUrlChanged)
         self._urlsTable.sigUrlRemoved.connect(self.sigUrlRemoved)
 
-        # expose API
-        self.setUrls = self._urlsTable.setUrls
-        self.setUrl = self._urlsTable.setUrl
-        self.removeUrl = self._urlsTable.removeUrl
-        self.currentItem = self._urlsTable.currentItem
-
     def toggleUrlSelectionTable(self):
         visible = not self.urlSelectionTableIsVisible()
         self._setButtonIcon(show=visible)
@@ -114,6 +110,23 @@ class _ToggleableUrlSelectionTable(qt.QWidget):
 
     def clear(self):
         self._urlsTable.clear()
+
+    # expose UrlList API
+    @deprecated(replacement="addUrls", since_version="2.0")
+    def setUrls(self, urls: Iterable[DataUrl]):
+        self._urlsTable.addUrls(urls=urls)
+
+    def addUrls(self, urls: Iterable[DataUrl]):
+        self._urlsTable.addUrls(urls=urls)
+
+    def setUrl(self, url: typing.Optional[DataUrl]):
+        self._urlsTable.setUrl(url=url)
+
+    def removeUrl(self, url: str):
+        self._urlsTable.removeUrl(url)
+
+    def currentItem(self):
+        return self._urlsTable.currentItem()
 
 
 class UrlLoader(qt.QThread):
@@ -334,7 +347,7 @@ class ImageStack(qt.QMainWindow):
         self._urlIndexes = urlsToIndex
 
         with blockSignals(self._urlsTable):
-            self._urlsTable.setUrls(urls=list(self._urls.values()))
+            self._urlsTable.addUrls(urls=list(self._urls.values()))
 
         self._resetSlider()
 

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -71,6 +71,21 @@ class UrlList(qt.QListWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._editable = False
+        # are we in 'editable' mode: for now if true then we can remove some item from the list
+
+        # menu to be triggered when in edition from right-click
+        self._menu = qt.QMenu()
+        self._removeAction = qt.QAction(
+            text="Remove",
+            parent=self
+        )
+        self._removeAction.setShortcuts(
+            [
+                # qt.Qt.Key_Delete,
+                qt.QKeySequence.Delete,
+            ]
+        )
+        self._menu.addAction(self._removeAction)
 
         # connect signal / Slot
         self.currentItemChanged.connect(self._notifyCurrentUrlChanged)
@@ -82,8 +97,12 @@ class UrlList(qt.QListWidget):
             # to be in ExtendedSelection if we are not in editable mode. But does it has more
             # meaning to change the selection mode ?
             if editable:
+                self._removeAction.triggered.connect(self._removeSelectedItems)
+                self.addAction(self._removeAction)
                 self.setSelectionMode(qt.QAbstractItemView.ExtendedSelection)
             else:
+                self._removeAction.triggered.disconnect(self._removeSelectedItems)
+                self.removeAction(self._removeAction)
                 self.setSelectionMode(qt.QAbstractItemView.SingleSelection)
 
     def setUrls(self, urls: list) -> None:
@@ -122,13 +141,8 @@ class UrlList(qt.QListWidget):
 
     def contextMenuEvent(self, event):
         if self._editable:
-            menu = qt.QMenu()
-            removeAction = qt.QAction(text="Remove",
-                                    parent=menu)
-            removeAction.triggered.connect(self._removeSelectedItems)
-            menu.addAction(removeAction)
             globalPos = self.mapToGlobal(event.pos())
-            menu.exec_(globalPos)
+            self._menu.exec_(globalPos)
 
 
 class _ToggleableUrlSelectionTable(qt.QWidget):

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -57,30 +57,22 @@ class _HorizontalSlider(HorizontalSliderWithBrowser):
         self.sigCurrentUrlIndexChanged.emit(value)
 
 
-class UrlList(qt.QWidget):
+class UrlList(qt.QListWidget):
     """List of URLs the user to select an URL"""
 
     sigCurrentUrlChanged = qt.Signal(str)
     """Signal emitted when the active/current url change"""
 
     def __init__(self, parent=None):
-        super(UrlList, self).__init__(parent)
-        self.setLayout(qt.QVBoxLayout())
-        self.layout().setSpacing(0)
-        self.layout().setContentsMargins(0, 0, 0, 0)
-        self._listWidget = qt.QListWidget(parent=self)
-        self.layout().addWidget(self._listWidget)
+        super().__init__(parent)
 
         # connect signal / Slot
-        self._listWidget.currentItemChanged.connect(self._notifyCurrentUrlChanged)
-
-        # expose API
-        self.currentItem = self._listWidget.currentItem
+        self.currentItemChanged.connect(self._notifyCurrentUrlChanged)
 
     def setUrls(self, urls: list) -> None:
         url_names = []
         [url_names.append(url.path()) for url in urls]
-        self._listWidget.addItems(url_names)
+        self.addItems(url_names)
 
     def _notifyCurrentUrlChanged(self, current, previous):
         if current is None:
@@ -90,16 +82,14 @@ class UrlList(qt.QWidget):
 
     def setUrl(self, url: DataUrl) -> None:
         assert isinstance(url, DataUrl)
-        sel_items = self._listWidget.findItems(url.path(), qt.Qt.MatchExactly)
+        sel_items = self.findItems(url.path(), qt.Qt.MatchExactly)
         if sel_items is None:
             _logger.warning(url.path(), ' is not registered in the list.')
         elif len(sel_items) > 0:
             item = sel_items[0]
-            self._listWidget.setCurrentItem(item)
+            self.setCurrentItem(item)
             self.sigCurrentUrlChanged.emit(item.text())
 
-    def clear(self):
-        self._listWidget.clear()
 
 
 class _ToggleableUrlSelectionTable(qt.QWidget):

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -23,6 +23,8 @@
 # ###########################################################################*/
 """Image stack view with data prefetch capabilty."""
 
+from __future__ import annotations
+
 __authors__ = ["H. Payno"]
 __license__ = "MIT"
 __date__ = "04/03/2019"

--- a/src/silx/gui/widgets/UrlList.py
+++ b/src/silx/gui/widgets/UrlList.py
@@ -83,9 +83,7 @@ class UrlList(qt.QListWidget):
 
     def setUrls(self, urls: Iterable[DataUrl]) -> None:
     """Append multiple DataUrl to the list"""
-        url_names = []
-        [url_names.append(url.path()) for url in urls]
-        self.addItems(url_names)
+        self.addItems([url.path() for url in urls])
 
     def removeUrl(self, url: str):
     """Remove given URL from the list"""

--- a/src/silx/gui/widgets/UrlList.py
+++ b/src/silx/gui/widgets/UrlList.py
@@ -1,0 +1,107 @@
+import typing
+from silx.io.url import DataUrl
+from silx.gui import qt
+
+
+class UrlList(qt.QListWidget):
+    """List of URLs the user to select an URL"""
+
+    sigCurrentUrlChanged = qt.Signal(str)
+    """Signal emitted when the active/current URL has changed.
+
+    This signal emits the empty string when there is no longer an active URL.
+    """
+
+    sigUrlRemoved = qt.Signal(str)
+    """Signal emit when an url is removed from the URL list.
+
+    Provides the url (DataUrl) as a string
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._editable = False
+        # are we in 'editable' mode: for now if true then we can remove some items from the list
+
+        # menu to be triggered when in edition from right-click
+        self._menu = qt.QMenu()
+        self._removeAction = qt.QAction(
+            text="Remove",
+            parent=self
+        )
+        self._removeAction.setShortcuts(
+            [
+                # qt.Qt.Key_Delete,
+                qt.QKeySequence.Delete,
+            ]
+        )
+        self._menu.addAction(self._removeAction)
+
+        # connect signal / Slot
+        self.currentItemChanged.connect(self._notifyCurrentUrlChanged)
+
+    def setEditable(self, editable: bool):
+        """Toggle whether the user can remove some URLs from the list"""
+        if editable != self._editable:
+            self._editable = editable
+            # discusable choice: should we change the selection mode ? No much meaning
+            # to be in ExtendedSelection if we are not in editable mode. But does it has more
+            # meaning to change the selection mode ?
+            if editable:
+                self._removeAction.triggered.connect(self._removeSelectedItems)
+                self.addAction(self._removeAction)
+            else:
+                self._removeAction.triggered.disconnect(self._removeSelectedItems)
+                self.removeAction(self._removeAction)
+
+    def setUrls(self, urls: list) -> None:
+        url_names = []
+        [url_names.append(url.path()) for url in urls]
+        self.addItems(url_names)
+
+    def removeUrl(self, url: str):
+        sel_items = self.findItems(url, qt.Qt.MatchExactly)
+        if len(sel_items) > 0:
+            assert len(sel_items) == 0, "at most one item expected"
+            self.removeItemWidget(sel_items[0])
+
+    def _notifyCurrentUrlChanged(self, current, previous):
+        if current is None:
+            self.sigCurrentUrlChanged.emit("")
+        else:
+            self.sigCurrentUrlChanged.emit(current.text())
+
+    def setUrl(self, url: typing.Optional[DataUrl]) -> None:
+        """Set the current URL.
+
+        :param url: The new selected URL. Use `None` to clear the selection.
+        """
+        if url is None:
+            self.clearSelection()
+            self.sigCurrentUrlChanged.emit("")
+        else:
+            assert isinstance(url, DataUrl)
+            sel_items = self.findItems(url.path(), qt.Qt.MatchExactly)
+            if sel_items is None:
+                _logger.warning(url.path(), ' is not registered in the list.')
+            elif len(sel_items) > 0:
+                item = sel_items[0]
+                self.setCurrentItem(item)
+                self.sigCurrentUrlChanged.emit(item.text())
+
+    def _removeSelectedItems(self):
+        if not self._editable:
+            raise ValueError("UrlList is not set as 'editable'")
+        urls = []
+        for item in self.selectedItems():
+            url = item.text()
+            self.takeItem(self.row(item))
+            urls.append(url)
+        # as the connected slot of 'sigUrlRemoved' can modify the items, better handling all at the end
+        for url in urls:
+            self.sigUrlRemoved.emit(url)
+
+    def contextMenuEvent(self, event):
+        if self._editable:
+            globalPos = self.mapToGlobal(event.pos())
+            self._menu.exec_(globalPos)

--- a/src/silx/gui/widgets/UrlList.py
+++ b/src/silx/gui/widgets/UrlList.py
@@ -4,7 +4,7 @@ from silx.gui import qt
 
 
 class UrlList(qt.QListWidget):
-    """List of URLs the user to select an URL"""
+    """List of URLs with user selection"""
 
     sigCurrentUrlChanged = qt.Signal(str)
     """Signal emitted when the active/current URL has changed.

--- a/src/silx/gui/widgets/UrlList.py
+++ b/src/silx/gui/widgets/UrlList.py
@@ -85,11 +85,11 @@ class UrlList(qt.QListWidget):
                 self.removeAction(self._removeAction)
 
     def setUrls(self, urls: Iterable[DataUrl]) -> None:
-    """Append multiple DataUrl to the list"""
+        """Append multiple DataUrl to the list"""
         self.addItems([url.path() for url in urls])
 
     def removeUrl(self, url: str):
-    """Remove given URL from the list"""
+        """Remove given URL from the list"""
         sel_items = self.findItems(url, qt.Qt.MatchExactly)
         if len(sel_items) > 0:
             assert len(sel_items) == 0, "at most one item expected"

--- a/src/silx/gui/widgets/UrlList.py
+++ b/src/silx/gui/widgets/UrlList.py
@@ -88,6 +88,7 @@ class UrlList(qt.QListWidget):
         self.addItems(url_names)
 
     def removeUrl(self, url: str):
+    """Remove given URL from the list"""
         sel_items = self.findItems(url, qt.Qt.MatchExactly)
         if len(sel_items) > 0:
             assert len(sel_items) == 0, "at most one item expected"

--- a/src/silx/gui/widgets/UrlList.py
+++ b/src/silx/gui/widgets/UrlList.py
@@ -90,7 +90,6 @@ class UrlList(qt.QListWidget):
         self.addUrls(urls)
 
     def addUrls(self, urls: Iterable[DataUrl]) -> None:
-
         """Append multiple DataUrl to the list"""
         self.addItems([url.path() for url in urls])
 

--- a/src/silx/gui/widgets/UrlList.py
+++ b/src/silx/gui/widgets/UrlList.py
@@ -81,7 +81,8 @@ class UrlList(qt.QListWidget):
                 self._removeAction.triggered.disconnect(self._removeSelectedItems)
                 self.removeAction(self._removeAction)
 
-    def setUrls(self, urls: list) -> None:
+    def setUrls(self, urls: Iterable[DataUrl]) -> None:
+    """Append multiple DataUrl to the list"""
         url_names = []
         [url_names.append(url.path()) for url in urls]
         self.addItems(url_names)

--- a/src/silx/gui/widgets/UrlList.py
+++ b/src/silx/gui/widgets/UrlList.py
@@ -1,4 +1,31 @@
+# /*##########################################################################
+#
+# Copyright (c) 2023 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+
+from __future__ import annotations
+
 import typing
+from collections.abc import Iterable
 from silx.io.url import DataUrl
 from silx.gui import qt
 

--- a/src/silx/gui/widgets/UrlList.py
+++ b/src/silx/gui/widgets/UrlList.py
@@ -29,6 +29,7 @@ import logging
 from collections.abc import Iterable
 from silx.io.url import DataUrl
 from silx.gui import qt
+from silx.utils.deprecation import deprecated
 
 _logger = logging.getLogger(__name__)
 
@@ -84,7 +85,12 @@ class UrlList(qt.QListWidget):
                 self._removeAction.triggered.disconnect(self._removeSelectedItems)
                 self.removeAction(self._removeAction)
 
+    @deprecated(replacement="addUrls", since_version="2.0")
     def setUrls(self, urls: Iterable[DataUrl]) -> None:
+        self.addUrls(urls)
+
+    def addUrls(self, urls: Iterable[DataUrl]) -> None:
+
         """Append multiple DataUrl to the list"""
         self.addItems([url.path() for url in urls])
 

--- a/src/silx/gui/widgets/UrlList.py
+++ b/src/silx/gui/widgets/UrlList.py
@@ -25,9 +25,12 @@
 from __future__ import annotations
 
 import typing
+import logging
 from collections.abc import Iterable
 from silx.io.url import DataUrl
 from silx.gui import qt
+
+_logger = logging.getLogger(__name__)
 
 
 class UrlList(qt.QListWidget):


### PR DESCRIPTION
when the UrlList is set editable the selection mode is set to `qt.QAbstractItemView.ExtendedSelection`

Here are two screenshots of the feature:

* removing a single item
![Screenshot from 2023-07-24 15-08-19](https://github.com/silx-kit/silx/assets/12907796/1e6d4c51-c766-4422-aec0-2780c117c75b)
* removing several items ()
![Screenshot from 2023-07-24 15-08-49](https://github.com/silx-kit/silx/assets/12907796/5d8c03da-5540-436b-ad1e-423428a8b13e)

closes #3911

Changelog: 
- gui.ImageStack.UrlList: allow removal of url from the list (if the list is editable only)