### PR TITLE
Fix: Datasets with many rows fail to load due to incorrect variable type

### DIFF
--- a/examples/plot3dUpdateScatterFromThread.py
+++ b/examples/plot3dUpdateScatterFromThread.py
@@ -49,7 +49,7 @@ from silx.gui.plot3d.SceneWindow import SceneWindow
 from silx.gui.plot3d import items
 
 
-MAX_NUMBER_OF_POINTS = int(10**6)
+MAX_NUMBER_OF_POINTS = 10**6
 
 
 class UpdateScatterThread(threading.Thread):


### PR DESCRIPTION
## Issue 

Fixes #3925

`MAX_NUMBER_OF_ROWS` is defined with a float literal, thus if a dataset has more than `MAX_NUMBER_OF_ROWS`, `rowCount()` returns a `float` instead of `int` and the dataset does not load.

```
>>> type(10e6)
<class 'float'>
```

## Fix

Set limits as integers, not floats.
