### PR TITLE
Issue #3942 - silx compare typo

### DIFF
--- a/src/silx/app/compare/CompareImagesWindow.py
+++ b/src/silx/app/compare/CompareImagesWindow.py
@@ -138,7 +138,7 @@ class CompareImagesWindow(qt.QMainWindow):
 
         if data.ndim == 2:
             return data
-        if data.ndim == 3 and data.shape[0] in set(3, 4):
+        if data.ndim == 3 and data.shape[0] in set([3, 4]):
             return data
 
         raise ValueError(f"URL '{urlPath}' does not link to an numpy image")


### PR DESCRIPTION
Fix python `set(3,4)` command with `set([3,4])`.
