### PR TITLE
DRAFT: Fix retry

### DIFF
--- a/src/silx/io/h5py_utils.py
+++ b/src/silx/io/h5py_utils.py
@@ -117,6 +117,7 @@ def _is_h5py_exception(e):
     :returns bool:
     """
     for frame in traceback.walk_tb(e.__traceback__):
+        # to my understanding something should be done here to catch the "Unable to synchronously open file" exception
         for namespace in (frame[0].f_locals, frame[0].f_globals):
             if namespace.get("__package__", None) == "h5py":
                 return True
@@ -136,6 +137,9 @@ def _retry_h5py_error(e):
             # KeyError: 'Unable to open object (bad object header version number)'
             return "Unable to open object" in str(e)
     elif isinstance(e, retry_mod.RetryError):
+        return True
+    elif isinstance(e, FileNotFoundError):
+        # handles "Unable to synchronously open file" for example. Which is raised since h5py
         return True
     return False
 


### PR DESCRIPTION
Looks like that on recent version of h5py we can get the following error from using `retry` (that used to be handled on the older version - < 3.10):

``` bash
period = 0.01, spectrum_cu_from_larch = <est.core.types.spectrum.Spectrum object at 0x7fa83e658b10>, tmpdir = local('/tmp/pytest-of-payno/pytest-60/test_get_data_0_01_0')

    @pytest.mark.parametrize("period", [0.01, 0.1, 0.5])
    def test_get_data(period, spectrum_cu_from_larch, tmpdir):
        filename = str(tmpdir / "data.h5")
        scan = "1.1"
        npoints = len(spectrum_cu_from_larch.energy)
        positioners = {"energy": spectrum_cu_from_larch.energy}
        detectors = {"mu": spectrum_cu_from_larch.mu}
        npoints = spectrum_cu_from_larch.energy.size
        blocksize = max(int(npoints / 10), 1)
        est_time = npoints / blocksize * period
        tmax = time.time() + est_time + 5
        print("Estimated scan time", est_time, "s")
    
        urls = [
            f"silx://{filename}::/{scan}/measurement/energy",
            f"silx://{filename}::/{scan}/measurement/mu",
        ]
        with nxwriter_process(filename, scan, positioners, detectors, blocksize, period):
            nprogress = 0
            while nprogress != npoints:
>               data = [get_data(url, retry_timeout=3) for url in urls]

src/est/tests/test_acquisition.py:34: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
src/est/tests/test_acquisition.py:34: in <listcomp>
    data = [get_data(url, retry_timeout=3) for url in urls]
/home/payno/.local/share/virtualenvs/est_venv/lib/python3.11/site-packages/silx/utils/retry.py:169: in wrapper
    return method(*args, **kw)
src/est/io/utils/read.py:57: in get_data
    with silx.io.h5py_utils.File(url.file_path(), "r") as h5:
/home/payno/.local/share/virtualenvs/est_venv/lib/python3.11/site-packages/silx/io/h5py_utils.py:407: in __init__
    super().__init__(filename, mode=mode, swmr=swmr, libver=libver, **kwargs)
/home/payno/.local/share/virtualenvs/est_venv/lib/python3.11/site-packages/h5py/_hl/files.py:562: in __init__
    fid = make_fid(name, mode, userblock_size, fapl, fcpl, swmr=swmr)
/home/payno/.local/share/virtualenvs/est_venv/lib/python3.11/site-packages/h5py/_hl/files.py:235: in make_fid
    fid = h5f.open(name, flags, fapl=fapl)
h5py/_objects.pyx:54: in h5py._objects.with_phil.wrapper
    ???
h5py/_objects.pyx:55: in h5py._objects.with_phil.wrapper
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   FileNotFoundError: [Errno 2] Unable to synchronously open file (unable to open file: name = '/tmp/pytest-of-payno/pytest-60/test_get_data_0_01_0/data.h5', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0)

h5py/h5f.pyx:102: FileNotFoundError

```


Changelog: 
fix `retry` for h5py version >= 3.10

Related to https://gitlab.esrf.fr/workflow/ewoksapps/est/-/issues/78