### PR TITLE
silx view: Fixed setting focus at startup when opening a dataset

### DIFF
--- a/src/silx/app/view/Viewer.py
+++ b/src/silx/app/view/Viewer.py
@@ -453,9 +453,9 @@ class Viewer(qt.QMainWindow):
         layout.addWidget(customNxdataWidget)
         return widget
 
-    def __h5FileLoaded(self, loadedH5):
+    def __h5FileLoaded(self, loadedH5, filename):
         self.__context.pushRecentFile(loadedH5.file.filename)
-        if loadedH5.file.filename == self.__displayIt:
+        if filename == self.__displayIt:
             self.__displayIt = None
             self.displayData(loadedH5)
 

--- a/src/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/src/silx/gui/hdf5/Hdf5TreeModel.py
@@ -250,7 +250,6 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         """Static method to close explicit references to internal objects."""
         _logger.debug("Clear Hdf5TreeModel")
         for obj in fileList:
-            _logger.debug("Close file %s", obj.filename)
             obj.close()
         fileList[:] = []
 

--- a/src/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/src/silx/gui/hdf5/Hdf5TreeModel.py
@@ -72,7 +72,7 @@ class LoadingItemRunnable(qt.QRunnable):
 
     class __Signals(qt.QObject):
         """Signal holder"""
-        itemReady = qt.Signal(object, object, object)
+        itemReady = qt.Signal(object, object, object, str)
         runnerFinished = qt.Signal(object)
 
     def __init__(self, filename, item):
@@ -129,7 +129,7 @@ class LoadingItemRunnable(qt.QRunnable):
             if h5file is not None:
                 h5file.close()
 
-        self.itemReady.emit(self.oldItem, newItem, error)
+        self.itemReady.emit(self.oldItem, newItem, error, self.filename)
         self.runnerFinished.emit(self)
 
     def autoDelete(self):
@@ -184,7 +184,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
     ]
     """List of logical columns available"""
 
-    sigH5pyObjectLoaded = qt.Signal(object)
+    sigH5pyObjectLoaded = qt.Signal(object, str)
     """Emitted when a new root item was loaded and inserted to the model."""
 
     sigH5pyObjectRemoved = qt.Signal(object)
@@ -269,14 +269,21 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
                 index2 = self.index(i, self.columnCount() - 1, qt.QModelIndex())
                 self.dataChanged.emit(index1, index2)
 
-    def __itemReady(self, oldItem, newItem, error):
+    def __itemReady(
+            self,
+            oldItem: Hdf5Node,
+            newItem: Optional[Hdf5Node],
+            error: Optional[Exception],
+            filename: str,
+        ):
         """Called at the end of a concurent file loading, when the loading
         item is ready. AN error is defined if an exception occured when
         loading the newItem .
 
-        :param Hdf5Node oldItem: current displayed item
-        :param Hdf5Node newItem: item loaded, or None if error is defined
-        :param Exception error: An exception, or None if newItem is defined
+        :param oldItem: current displayed item
+        :param newItem: item loaded, or None if error is defined
+        :param error: An exception, or None if newItem is defined
+        :param filename: The filename used to load the new item
         """
         row = self.__root.indexOfChild(oldItem)
 
@@ -294,7 +301,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
             self.endInsertRows()
 
             if isinstance(oldItem, Hdf5LoadingItem):
-                self.sigH5pyObjectLoaded.emit(newItem.obj)
+                self.sigH5pyObjectLoaded.emit(newItem.obj, filename)
             else:
                 self.sigH5pyObjectSynchronized.emit(oldItem.obj, newItem.obj)
 
@@ -703,7 +710,7 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
             h5file = silx_io.open(filename)
             if self.__ownFiles:
                 self.__openedFiles.append(h5file)
-            self.sigH5pyObjectLoaded.emit(h5file)
+            self.sigH5pyObjectLoaded.emit(h5file, filename)
             self.insertH5pyObject(h5file, row=row, filename=filename)
         except IOError:
             _logger.debug("File '%s' can't be read.", filename, exc_info=True)


### PR DESCRIPTION
This PR aims at opening the vis at startup when providing a data path along with the file to open: closes  #3916

To achieve so, this PR adds an extra argument to `Hdf5TreeModel.sigH5pyObjectLoaded` in order to pass the full filename used to open the item.