### PR TITLE
silx view: Stopped displaying a message box for each error

### DIFF
--- a/src/silx/app/view/Viewer.py
+++ b/src/silx/app/view/Viewer.py
@@ -22,6 +22,8 @@
 # ############################################################################*/
 """Browse a data file with a GUI"""
 
+from __future__ import annotations
+
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "15/01/2019"
@@ -30,6 +32,8 @@ __date__ = "15/01/2019"
 import os
 import logging
 import functools
+import traceback
+from types import TracebackType
 from typing import Optional
 
 import silx.io.nxdata
@@ -63,6 +67,8 @@ class Viewer(qt.QMainWindow):
 
         silxIcon = icons.getQIcon("silx")
         self.setWindowIcon(silxIcon)
+
+        self.__error = ""
 
         self.__context = self.createApplicationContext(settings)
         self.__context.restoreLibrarySettings()
@@ -743,6 +749,14 @@ class Viewer(qt.QMainWindow):
         helpMenu.addAction(self._aboutAction)
         helpMenu.addAction(self._documentationAction)
 
+        self.__errorButton = qt.QToolButton(self)
+        self.__errorButton.setIcon(
+            self.style().standardIcon(qt.QStyle.SP_MessageBoxWarning))
+        self.__errorButton.setToolTip("An error occured!\nClick to display last error\nor check messages in the console")
+        self.__errorButton.setVisible(False)
+        self.__errorButton.clicked.connect(self.__errorButtonClicked)
+        self.menuBar().setCornerWidget(self.__errorButton)
+
     def open(self):
         dialog = self.createFileDialog()
         if self.__dialogState is None:
@@ -950,3 +964,31 @@ class Viewer(qt.QMainWindow):
                 action = qt.QAction("Synchronize %s" % obj.local_filename, event.source())
                 action.triggered.connect(lambda: self.__synchronizeH5pyObject(h5))
                 menu.addAction(action)
+
+    def __errorButtonClicked(self):
+        button = qt.QMessageBox.warning(
+            self,
+            "Error",
+            self.getError(),
+            qt.QMessageBox.Reset | qt.QMessageBox.Close,
+            qt.QMessageBox.Close,
+        )
+        if button == qt.QMessageBox.Reset:
+            self.setError("")
+
+    def getError(self) -> str:
+        """Returns error information string"""
+        return self.__error
+
+    def setError(self, error: str):
+        """Set error information string"""
+        if error == self.__error:
+            return
+
+        self.__error = error
+        self.__errorButton.setVisible(error != "")
+
+    def setErrorFromException(self, type_: type[BaseException], value: BaseException, trace: TracebackType):
+        """Set information about the last exception that occured"""
+        formattedTrace = '\n'.join(traceback.format_tb(trace))
+        self.setError(f"{type_.__name__}:\n{value}\n\n{formattedTrace}")

--- a/src/silx/app/view/main.py
+++ b/src/silx/app/view/main.py
@@ -159,12 +159,7 @@ def mainQt(options):
         _logger.error("An error occured in silx view:")
         _logger.error("%s %s %s", type_, value, ''.join(traceback.format_tb(trace)))
         try:
-            label = qt.QLabel()
-            label.setText('<font color="#e60000"><b>⚠ Error</b></font>')
-            label.setToolTip("An error occured:\nCheck error messages in the console")
-
-            statusBar = window.statusBar()
-            statusBar.addPermanentWidget(label)
+            window.setErrorFromException(type_, value, trace)
         except Exception:
             pass
     sys.excepthook = exceptHook

--- a/src/silx/app/view/main.py
+++ b/src/silx/app/view/main.py
@@ -31,6 +31,7 @@ import logging
 import os
 import signal
 import sys
+import traceback
 from silx.app.utils import parseutils
 
 
@@ -136,7 +137,6 @@ def mainQt(options):
         qt.QApplication.quit()
 
     signal.signal(signal.SIGINT, sigintHandler)
-    sys.excepthook = qt.exceptionHandler
 
     timer = qt.QTimer()
     timer.start(500)
@@ -154,6 +154,21 @@ def mainQt(options):
 
     window = createWindow(parent=None, settings=settings)
     window.setAttribute(qt.Qt.WA_DeleteOnClose, True)
+
+    def exceptHook(type_, value, trace):
+        _logger.error("An error occured in silx view:")
+        _logger.error("%s %s %s", type_, value, ''.join(traceback.format_tb(trace)))
+        try:
+            label = qt.QLabel()
+            label.setText('<font color="#e60000"><b>⚠ Error</b></font>')
+            label.setToolTip("An error occured:\nCheck error messages in the console")
+
+            statusBar = window.statusBar()
+            statusBar.addPermanentWidget(label)
+        except Exception:
+            pass
+    sys.excepthook = exceptHook
+
 
     if options.use_opengl_plot:
         # It have to be done after the settings (after the Viewer creation)


### PR DESCRIPTION
This PR makes `silx view` using a dedicated `sys.excepthook` to stop showing a `QMessageBox` for each exception.
Instead, it keeps logging the error and adds a "permanent" widget in the application status bar.

I hesitated with a temporary error message, but since the effects of an exception might make the application unstable afterwards, I decided to use a permanent message instead.

closes #3880

![Screenshot from 2023-10-23 17-08-34](https://github.com/silx-kit/silx/assets/9449698/3229b98d-7a6f-4759-82c0-96b870494a8d)
