### PR TITLE
silx.gui.plot.items: Added Marker item font configuration; silx.config: Added `DEFAULT_PLOT_MARKER_TEXT_FONT_SIZE` config

### DIFF
--- a/src/silx/_config.py
+++ b/src/silx/_config.py
@@ -158,8 +158,8 @@ class Config(object):
     .. versionadded:: 2.0
     """
 
-    DEFAULT_PLOT_MARKER_TEXT_FONT = None
-    """Default Qt's QFont for marker text.
+    DEFAULT_PLOT_MARKER_TEXT_FONT_SIZE = None
+    """Default font size for marker text.
 
     It will have an influence on PlotWidget marker items
 

--- a/src/silx/_config.py
+++ b/src/silx/_config.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # /*##########################################################################
 #
-# Copyright (c) 2017-2019 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -154,6 +154,14 @@ class Config(object):
     """Default line width for the active curve.
 
     It will have an influence on PlotWidget curve items
+
+    .. versionadded:: 2.0
+    """
+
+    DEFAULT_PLOT_MARKER_TEXT_FONT = None
+    """Default Qt's QFont for marker text.
+
+    It will have an influence on PlotWidget marker items
 
     .. versionadded:: 2.0
     """

--- a/src/silx/gui/plot/backends/BackendBase.py
+++ b/src/silx/gui/plot/backends/BackendBase.py
@@ -189,7 +189,7 @@ class BackendBase(object):
         return object()
 
     def addMarker(self, x, y, text, color,
-                  symbol, linestyle, linewidth, constraint, yaxis):
+                  symbol, linestyle, linewidth, constraint, yaxis, font):
         """Add a point, vertical line or horizontal line marker to the plot.
 
         :param float x: Horizontal position of the marker in graph coordinates.
@@ -228,6 +228,7 @@ class BackendBase(object):
                           the current cursor position in the plot as input
                           and that returns the filtered coordinates.
         :param str yaxis: The Y axis this marker belongs to in: 'left', 'right'
+        :param font: QFont to use to render text
         :return: Handle used by the backend to univocally access the marker
         """
         return object()

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -42,7 +42,7 @@ _logger = logging.getLogger(__name__)
 from ... import qt
 
 # First of all init matplotlib and set its backend
-from ...utils.matplotlib import FigureCanvasQTAgg
+from ...utils.matplotlib import FigureCanvasQTAgg, qFontToFontProperties
 import matplotlib
 from matplotlib.container import Container
 from matplotlib.figure import Figure
@@ -857,7 +857,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
         return item
 
     def addMarker(self, x, y, text, color,
-                  symbol, linestyle, linewidth, constraint, yaxis):
+                  symbol, linestyle, linewidth, constraint, yaxis, font):
         textArtist = None
 
         xmin, xmax = self.getGraphXLimits()
@@ -881,7 +881,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
             if text is not None:
                 textArtist = _TextWithOffset(x, y, text,
                                              color=color,
-                                             horizontalalignment='left')
+                                             horizontalalignment='left',
+                                             fontproperties=qFontToFontProperties(font))
                 if symbol is not None:
                     textArtist.pixel_offset = 10, 3
         elif x is not None:
@@ -894,7 +895,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
                 textArtist = _TextWithOffset(x, 1., text,
                                              color=color,
                                              horizontalalignment='left',
-                                             verticalalignment='top')
+                                             verticalalignment='top',
+                                             fontproperties=qFontToFontProperties(font))
                 textArtist.pixel_offset = 5, 3
         elif y is not None:
             line = ax.axhline(y,
@@ -907,7 +909,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
                 textArtist = _TextWithOffset(1., y, text,
                                              color=color,
                                              horizontalalignment='right',
-                                             verticalalignment='top')
+                                             verticalalignment='top',
+                                             fontproperties=qFontToFontProperties(font))
                 textArtist.pixel_offset = 5, 3
         else:
             raise RuntimeError('A marker must at least have one coordinate')

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -859,6 +859,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
     def addMarker(self, x, y, text, color,
                   symbol, linestyle, linewidth, constraint, yaxis, font):
         textArtist = None
+        fontProperties = None if font is None else qFontToFontProperties(font)
 
         xmin, xmax = self.getGraphXLimits()
         ymin, ymax = self.getGraphYLimits(axis=yaxis)
@@ -882,7 +883,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                 textArtist = _TextWithOffset(x, y, text,
                                              color=color,
                                              horizontalalignment='left',
-                                             fontproperties=qFontToFontProperties(font))
+                                             fontproperties=fontProperties)
                 if symbol is not None:
                     textArtist.pixel_offset = 10, 3
         elif x is not None:
@@ -896,7 +897,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                                              color=color,
                                              horizontalalignment='left',
                                              verticalalignment='top',
-                                             fontproperties=qFontToFontProperties(font))
+                                             fontproperties=fontProperties)
                 textArtist.pixel_offset = 5, 3
         elif y is not None:
             line = ax.axhline(y,
@@ -910,7 +911,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                                              color=color,
                                              horizontalalignment='right',
                                              verticalalignment='top',
-                                             fontproperties=qFontToFontProperties(font))
+                                             fontproperties=fontProperties)
                 textArtist.pixel_offset = 5, 3
         else:
             raise RuntimeError('A marker must at least have one coordinate')

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -87,7 +87,7 @@ class _ShapeItem(dict):
 
 class _MarkerItem(dict):
     def __init__(self, x, y, text, color,
-                 symbol, linestyle, linewidth, constraint, yaxis):
+                 symbol, linestyle, linewidth, constraint, yaxis, font):
         super(_MarkerItem, self).__init__()
 
         if symbol is None:
@@ -109,6 +109,7 @@ class _MarkerItem(dict):
             'linestyle': linestyle,
             'linewidth': linewidth,
             'yaxis': yaxis,
+            'font': font,
         })
 
 
@@ -548,12 +549,13 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                                 self._plotFrame.margins.right - pixelOffset
                             y = pixelPos[1] - pixelOffset
                             label = glutils.Text2D(
-                                item['text'], x, y,
+                                item['text'], item['font'], x, y,
                                 color=item['color'],
                                 bgColor=bgColor,
                                 align=glutils.RIGHT,
                                 valign=glutils.BOTTOM,
-                                devicePixelRatio=self.getDevicePixelRatio())
+                                devicePixelRatio=self.getDevicePixelRatio(),
+                            )
                             labels.append(label)
 
                         width = self._plotFrame.size[0]
@@ -574,12 +576,13 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                             x = pixelPos[0] + pixelOffset
                             y = self._plotFrame.margins.top + pixelOffset
                             label = glutils.Text2D(
-                                item['text'], x, y,
+                                item['text'], item['font'], x, y,
                                 color=item['color'],
                                 bgColor=bgColor,
                                 align=glutils.LEFT,
                                 valign=glutils.TOP,
-                                devicePixelRatio=self.getDevicePixelRatio())
+                                devicePixelRatio=self.getDevicePixelRatio(),
+                            )
                             labels.append(label)
 
                         height = self._plotFrame.size[1]
@@ -611,12 +614,13 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                         x = pixelPos[0] + pixelOffset
                         y = pixelPos[1] + vPixelOffset
                         label = glutils.Text2D(
-                            item['text'], x, y,
+                            item['text'], item['font'], x, y,
                             color=item['color'],
                             bgColor=bgColor,
                             align=glutils.LEFT,
                             valign=valign,
-                            devicePixelRatio=self.getDevicePixelRatio())
+                            devicePixelRatio=self.getDevicePixelRatio(),
+                        )
                         labels.append(label)
 
                     # For now simple implementation: using a curve for each marker
@@ -980,9 +984,9 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                           linestyle, linewidth, linebgcolor)
 
     def addMarker(self, x, y, text, color,
-                  symbol, linestyle, linewidth, constraint, yaxis):
+                  symbol, linestyle, linewidth, constraint, yaxis, font):
         return _MarkerItem(x, y, text, color,
-                           symbol, linestyle, linewidth, constraint, yaxis)
+                           symbol, linestyle, linewidth, constraint, yaxis, font)
 
     # Remove methods
 

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -985,6 +985,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
     def addMarker(self, x, y, text, color,
                   symbol, linestyle, linewidth, constraint, yaxis, font):
+        font = qt.QApplication.instance().font() if font is None else font
         return _MarkerItem(x, y, text, color,
                            symbol, linestyle, linewidth, constraint, yaxis, font)
 

--- a/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2014-2022 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -44,6 +44,7 @@ from collections import namedtuple
 
 import numpy
 
+from .... import qt
 from ...._glutils import gl, Program
 from ..._utils import checkAxisLimits, FLOAT32_MINPOS
 from .GLSupport import mat4Ortho
@@ -215,6 +216,8 @@ class PlotAxis(object):
         labels = []
         tickLabelsSize = [0., 0.]
 
+        font = qt.QApplication.instance().font()
+
         xTickLength, yTickLength = self._tickLength
         xTickLength *= self.devicePixelRatio
         yTickLength *= self.devicePixelRatio
@@ -225,6 +228,7 @@ class PlotAxis(object):
                 tickScale = 1.
 
                 label = Text2D(text=text,
+                               font=font,
                                color=self._foregroundColor,
                                x=xPixel - xTickLength,
                                y=yPixel - yTickLength,
@@ -258,6 +262,7 @@ class PlotAxis(object):
         # yOffset -= 3 * yTickLength
 
         axisTitle = Text2D(text=self.title,
+                           font=font,
                            color=self._foregroundColor,
                            x=xAxisCenter + xOffset,
                            y=yAxisCenter + yOffset,
@@ -630,6 +635,7 @@ class GLPlotFrame(object):
                   self.margins.right) // 2
         yTitle = self.margins.top - self._TICK_LENGTH_IN_PIXELS
         labels.append(Text2D(text=self.title,
+                             font=qt.QApplication.instance().font(),
                              color=self._foregroundColor,
                              x=xTitle,
                              y=yTitle,

--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -146,6 +146,9 @@ class ItemChangedType(enum.Enum):
     SELECTABLE = 'selectableChanged'
     """Item's selectable state changed flags."""
 
+    FONT = 'fontChanged'
+    """Item's text font changed flag."""
+
 
 class Item(qt.QObject):
     """Description of an item of the plot"""

--- a/src/silx/gui/plot/items/marker.py
+++ b/src/silx/gui/plot/items/marker.py
@@ -35,6 +35,7 @@ from typing import Tuple, Optional
 from ....utils.proxy import docstring
 from .core import (Item, DraggableMixIn, ColorMixIn, LineMixIn, SymbolMixIn,
                    ItemChangedType, YAxisMixIn)
+from silx import config
 from silx.gui import qt
 
 _logger = logging.getLogger(__name__)
@@ -58,7 +59,7 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
         YAxisMixIn.__init__(self)
 
         self._text = ''
-        self._font = None
+        self._font = config.DEFAULT_PLOT_MARKER_TEXT_FONT
         self._x = None
         self._y = None
         self._constraint = self._defaultConstraint

--- a/src/silx/gui/plot/items/marker.py
+++ b/src/silx/gui/plot/items/marker.py
@@ -58,7 +58,7 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
         YAxisMixIn.__init__(self)
 
         self._text = ''
-        self._font = qt.QFont(qt.QApplication.instance().font())
+        self._font = None
         self._x = None
         self._y = None
         self._constraint = self._defaultConstraint
@@ -112,20 +112,20 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
             self._text = text
             self._updated(ItemChangedType.TEXT)
 
-    def getFont(self) -> qt.QFont:
+    def getFont(self) -> Optional[qt.QFont]:
         """Returns a copy of the QFont used to render text.
 
         To modify the text font, use :meth:`setFont`.
         """
-        return qt.QFont(self._font)
+        return None if self._font is None else qt.QFont(self._font)
 
-    def setFont(self, font: qt.QFont):
-        """Set the QFont used to render text.
+    def setFont(self, font: Optional[qt.QFont]):
+        """Set the QFont used to render text, use None for default.
 
         A copy is stored, so further modification of the provided font are not taken into account.
         """
         if font != self._font:
-            self._font = qt.QFont(font)
+            self._font = None if font is None else qt.QFont(font)
             self._updated(ItemChangedType.FONT)
 
     def getXPosition(self):

--- a/src/silx/gui/plot/items/marker.py
+++ b/src/silx/gui/plot/items/marker.py
@@ -59,7 +59,13 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
         YAxisMixIn.__init__(self)
 
         self._text = ''
-        self._font = config.DEFAULT_PLOT_MARKER_TEXT_FONT
+        self._font = None
+        if config.DEFAULT_PLOT_MARKER_TEXT_FONT_SIZE is not None:
+            self._font = qt.QFont(
+                qt.QApplication.instance().font().family(),
+                config.DEFAULT_PLOT_MARKER_TEXT_FONT_SIZE,
+            )
+
         self._x = None
         self._y = None
         self._constraint = self._defaultConstraint

--- a/src/silx/gui/plot/items/marker.py
+++ b/src/silx/gui/plot/items/marker.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2017-2020 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -58,6 +58,7 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
         YAxisMixIn.__init__(self)
 
         self._text = ''
+        self._font = qt.QFont(qt.QApplication.instance().font())
         self._x = None
         self._y = None
         self._constraint = self._defaultConstraint
@@ -75,7 +76,9 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
             linestyle=linestyle,
             linewidth=linewidth,
             constraint=self.getConstraint(),
-            yaxis=self.getYAxis())
+            yaxis=self.getYAxis(),
+            font=self._font,  # Do not use getFont to spare creating a new QFont
+        )
 
     def _addBackendRenderer(self, backend):
         """Update backend renderer"""
@@ -108,6 +111,22 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
         if text != self._text:
             self._text = text
             self._updated(ItemChangedType.TEXT)
+
+    def getFont(self) -> qt.QFont:
+        """Returns a copy of the QFont used to render text.
+
+        To modify the text font, use :meth:`setFont`.
+        """
+        return qt.QFont(self._font)
+
+    def setFont(self, font: qt.QFont):
+        """Set the QFont used to render text.
+
+        A copy is stored, so further modification of the provided font are not taken into account.
+        """
+        if font != self._font:
+            self._font = qt.QFont(font)
+            self._updated(ItemChangedType.FONT)
 
     def getXPosition(self):
         """Returns the X position of the marker line in data coordinates

--- a/src/silx/gui/utils/matplotlib.py
+++ b/src/silx/gui/utils/matplotlib.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -41,6 +41,36 @@ import numpy
 
 from .. import qt
 
+# This must be performed before any import from matplotlib
+if qt.BINDING in ("PySide6", "PyQt6", "PyQt5"):
+    matplotlib.use("Qt5Agg", force=False)
+    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg  # noqa
+
+else:
+    raise ImportError("Unsupported Qt binding: %s" % qt.BINDING)
+
+
+from matplotlib.font_manager import FontProperties
+from matplotlib.mathtext import MathTextParser
+from matplotlib import figure
+
+
+_FONT_STYLES = {
+    qt.QFont.StyleNormal: "normal",
+    qt.QFont.StyleItalic: "italic",
+    qt.QFont.StyleOblique: "oblique",
+}
+
+def qFontToFontProperties(font: qt.QFont):
+    """Convert a QFont to a matplotlib FontProperties"""
+    weightFactor = 10 if qt.BINDING == "PyQt5" else 1
+    return FontProperties(
+        family=[font.family(), font.defaultFamily()],
+        style=_FONT_STYLES[font.style()],
+        weight=weightFactor * font.weight(),
+        size=font.pointSizeF(),
+    )
+
 
 def rasterMathText(text, font, size=-1, weight=-1, italic=False, devicePixelRatio=1.0):
     """Raster text using matplotlib supporting latex-like math syntax.
@@ -67,12 +97,6 @@ def rasterMathText(text, font, size=-1, weight=-1, italic=False, devicePixelRati
     """
     # Implementation adapted from:
     # https://github.com/matplotlib/matplotlib/blob/d624571a19aec7c7d4a24123643288fc27db17e7/lib/matplotlib/mathtext.py#L264
-
-    # Lazy import to avoid imports before setting matplotlib's rcParams
-    from matplotlib.font_manager import FontProperties
-    from matplotlib.mathtext import MathTextParser
-    from matplotlib import figure
-
     dpi = 96  # default
     qapp = qt.QApplication.instance()
     if qapp:
@@ -92,15 +116,14 @@ def rasterMathText(text, font, size=-1, weight=-1, italic=False, devicePixelRati
 
     if not isinstance(font, qt.QFont):
         font = qt.QFont(font, size, weight, italic)
-    prop = FontProperties(
-        family=font.family(),
-        style="italic" if font.italic() else "normal",
-        weight=10 * font.weight(),
-        size=font.pointSize(),
-    )
 
     fig = figure.Figure(figsize=(width / dpi, height / dpi))
-    fig.text(0, depth / height, stripped_text, fontproperties=prop)
+    fig.text(
+        0,
+        depth / height,
+        stripped_text,
+        fontproperties=qFontToFontProperties(font),
+    )
     with io.BytesIO() as buffer:
         fig.savefig(buffer, dpi=dpi, format="raw")
         buffer.seek(0)
@@ -125,11 +148,3 @@ def rasterMathText(text, font, size=-1, weight=-1, italic=False, devicePixelRati
     )
 
     return clipped_array, image.shape[0] - 1  # baseline not available
-
-
-if qt.BINDING in ("PySide6", "PyQt6", "PyQt5"):
-    matplotlib.use("Qt5Agg", force=False)
-    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg  # noqa
-
-else:
-    raise ImportError("Unsupported Qt binding: %s" % qt.BINDING)


### PR DESCRIPTION
This PR adds:
- Control over marker text's `QFont` through `MarkerBase.get|setFont` methods.
- General configuration of marker text's `QFont` through `silx.config.DEFAULT_PLOT_MARKER_TEXT_FONT`

A marker QFont can be `None` (the default) to use the default. This is useful for letting `matplotlib` pick its own default.

closes #3931