### PR TITLE
silx.gui.utils.image: Added support of `QImage.Format_Grayscale8` to `convertQImageToArray`

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -10,11 +10,11 @@ This table summarizes the support matrix of silx:
 +------------+--------------+--------------------------------+
 | System     | Python vers. | Qt and its bindings            |
 +------------+--------------+--------------------------------+
-| `Windows`_ | 3.7-3.10     | PyQt5.6+, PySide6.4+, PyQt6.3+ |
+| `Windows`_ | 3.7-3.10     | PyQt5.9+, PySide6.4+, PyQt6.3+ |
 +------------+--------------+--------------------------------+
-| `MacOS`_   | 3.7-3.10     | PyQt5.6+, PySide6.4+, PyQt6.3+ |
+| `MacOS`_   | 3.7-3.10     | PyQt5.9+, PySide6.4+, PyQt6.3+ |
 +------------+--------------+--------------------------------+
-| `Linux`_   | 3.7-3.10     | PyQt5.6+, PySide6.4+, PyQt6.3+ |
+| `Linux`_   | 3.7-3.10     | PyQt5.9+, PySide6.4+, PyQt6.3+ |
 +------------+--------------+--------------------------------+
 
 For the description of *silx* dependencies, see the Dependencies_ section.

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -14,7 +14,7 @@ This table summarizes the support matrix of silx:
 +------------+--------------+--------------------------------+
 | `MacOS`_   | 3.7-3.10     | PyQt5.6+, PySide6.4+, PyQt6.3+ |
 +------------+--------------+--------------------------------+
-| `Linux`_   | 3.7-3.10     | PyQt5.3+, PySide6.4+, PyQt6.3+ |
+| `Linux`_   | 3.7-3.10     | PyQt5.6+, PySide6.4+, PyQt6.3+ |
 +------------+--------------+--------------------------------+
 
 For the description of *silx* dependencies, see the Dependencies_ section.

--- a/src/silx/gui/_glutils/font.py
+++ b/src/silx/gui/_glutils/font.py
@@ -101,7 +101,7 @@ def rasterTextQt(text, font, size=-1, weight=-1, italic=False, devicePixelRatio=
         font = qt.QFont(font, size, weight, italic)
 
     # get text size
-    image = qt.QImage(1, 1, qt.QImage.Format_RGB888)
+    image = qt.QImage(1, 1, qt.QImage.Format_Grayscale8)
     painter = qt.QPainter()
     painter.begin(image)
     painter.setPen(qt.Qt.white)
@@ -125,11 +125,11 @@ def rasterTextQt(text, font, size=-1, weight=-1, italic=False, devicePixelRatio=
     # align line size to 32 bits to ease conversion to numpy array
     width = 4 * ((width + 3) // 4)
     image = qt.QImage(
-        int(width), int(bounds.height() * devicePixelRatio + 2), qt.QImage.Format_RGB888
+        int(width),
+        int(bounds.height() * devicePixelRatio + 2),
+        qt.QImage.Format_Grayscale8,
     )
     image.setDevicePixelRatio(devicePixelRatio)
-
-    # TODO if Qt5 use Format_Grayscale8 instead
     image.fill(0)
 
     # Raster text
@@ -141,9 +141,6 @@ def rasterTextQt(text, font, size=-1, weight=-1, italic=False, devicePixelRatio=
     painter.end()
 
     array = convertQImageToArray(image)
-
-    # RGB to R
-    array = numpy.ascontiguousarray(array[:, :, 0])
 
     # Remove leading and trailing empty columns/rows but one on each side
     filled_rows = numpy.nonzero(numpy.sum(array, axis=1))[0]

--- a/src/silx/gui/utils/image.py
+++ b/src/silx/gui/utils/image.py
@@ -85,31 +85,41 @@ def convertArrayToQImage(array):
 def convertQImageToArray(image):
     """Convert a QImage to a numpy array.
 
-    If QImage format is not Format_RGB888, Format_RGBA8888 or Format_ARGB32,
-    it is first converted to one of this format depending on
-    the presence of an alpha channel.
+    If QImage format is not one of:
+        - Format_Grayscale8
+        - Format_RGB888
+        - Format_RGBA8888
+        - Format_ARGB32,
+    it is first converted to one of this format.
 
     The created numpy array is using a copy of the QImage data.
 
     :param QImage image: The QImage to convert.
-    :return: The image array of RGB or RGBA channels of shape
-        (height, width, channels (3 or 4))
-    :rtype: numpy.ndarray of uint8
+    :return: Image array of uint8 of shape:
+        - (height, width) for grayscale images
+        - (height, width, channels (3 or 4)) for RGB and RGBA images
     """
-    rgba8888 = getattr(qt.QImage, 'Format_RGBA8888', None)  # Only in Qt5
+    supportedFormats = (
+        qt.QImage.Format_Grayscale8,
+        qt.QImage.Format_ARGB32,
+        qt.QImage.Format_RGB888,
+        qt.QImage.Format_RGBA8888,
+    )
 
     # Convert to supported format if needed
-    if image.format() not in (qt.QImage.Format_ARGB32,
-                              qt.QImage.Format_RGB888,
-                              rgba8888):
+    if image.format() not in supportedFormats:
         if image.hasAlphaChannel():
-            image = image.convertToFormat(
-                rgba8888 if rgba8888 is not None else qt.QImage.Format_ARGB32)
+            image = image.convertToFormat(qt.QImage.Format_RGBA8888)
         else:
             image = image.convertToFormat(qt.QImage.Format_RGB888)
 
     format_ = image.format()
-    channels = 3 if format_ == qt.QImage.Format_RGB888 else 4
+    if format_ == qt.QImage.Format_Grayscale8:
+        channels = 1
+    elif format_ == qt.QImage.Format_RGB888:
+        channels = 3
+    else:
+        channels = 4
 
     ptr = image.bits()
     if qt.BINDING == 'PyQt5':
@@ -134,6 +144,9 @@ def convertQImageToArray(image):
             view = view[:, :, (2, 1, 0, 3)]
         else:  # big endian: ARGB -> RGBA
             view = view[:, :, (1, 2, 3, 0)]
+
+    if channels == 1:  # Remove channel dimension
+        view = view[:, :, 0]
 
     # Format_RGB888 and Format_RGBA8888 do not need reshuffling channels:
     # They are byte-ordered and already in the right order


### PR DESCRIPTION
Using grayscale8 QImage (available in Qt>=5.5) avoids some array copies/conversion when dealing with text in the OpenGL backend.

This moves minimum required version from Qt5.3 to Qt5.5... I documented minimum version to 5.6 ton Linux to be inline with Windows and macOS. BTW, we don't test with an old version of pyQt... so the effective min version requirement is probably higher.

Small improvement/clean-up done while working on PR #3956