### PR TITLE
ColormapDialog: upgrade `_DataInPlotMode` to `DisplayMode`

### DIFF
--- a/src/silx/gui/data/DataViews.py
+++ b/src/silx/gui/data/DataViews.py
@@ -1657,7 +1657,7 @@ class _NXdataXYVScatterView(_NXdataBaseDataView):
         from silx.gui.data.NXdataWidgets import XYVScatterPlot
         widget = XYVScatterPlot(parent)
         widget.getScatterView().setColormap(self.defaultColormap())
-        widget.getScatterView().getScatterToolBar().getColormapAction().setColorDialog(
+        widget.getScatterView().getScatterToolBar().getColormapAction().setColormapDialog(
             self.defaultColorDialog())
         return widget
 

--- a/src/silx/gui/data/DataViews.py
+++ b/src/silx/gui/data/DataViews.py
@@ -1032,7 +1032,7 @@ class _Plot2dView(DataView):
         from silx.gui import plot
         widget = plot.Plot2D(parent=parent)
         widget.setDefaultColormap(self.defaultColormap())
-        widget.getColormapAction().setColorDialog(self.defaultColorDialog())
+        widget.getColormapAction().setColormapDialog(self.defaultColorDialog())
         widget.getIntensityHistogramAction().setVisible(True)
         widget.setKeepDataAspectRatio(True)
         widget.getXAxis().setLabel('X')
@@ -1148,7 +1148,7 @@ class _ComplexImageView(DataView):
         widget.setColormap(self.defaultColormap(), mode=ComplexImageView.ComplexMode.SQUARE_AMPLITUDE)
         widget.setColormap(self.defaultColormap(), mode=ComplexImageView.ComplexMode.REAL)
         widget.setColormap(self.defaultColormap(), mode=ComplexImageView.ComplexMode.IMAGINARY)
-        widget.getPlot().getColormapAction().setColorDialog(self.defaultColorDialog())
+        widget.getPlot().getColormapAction().setColormapDialog(self.defaultColorDialog())
         widget.getPlot().getIntensityHistogramAction().setVisible(True)
         widget.getPlot().setKeepDataAspectRatio(True)
         widget.getXAxis().setLabel('X')
@@ -1248,7 +1248,7 @@ class _StackView(DataView):
         from silx.gui import plot
         widget = plot.StackView(parent=parent)
         widget.setColormap(self.defaultColormap())
-        widget.getPlotWidget().getColormapAction().setColorDialog(self.defaultColorDialog())
+        widget.getPlotWidget().getColormapAction().setColormapDialog(self.defaultColorDialog())
         widget.setKeepDataAspectRatio(True)
         widget.setLabels(self.axesNames(None, None))
         # hide default option panel
@@ -1720,7 +1720,7 @@ class _NXdataImageView(_NXdataBaseDataView):
         from silx.gui.data.NXdataWidgets import ArrayImagePlot
         widget = ArrayImagePlot(parent)
         widget.getPlot().setDefaultColormap(self.defaultColormap())
-        widget.getPlot().getColormapAction().setColorDialog(self.defaultColorDialog())
+        widget.getPlot().getColormapAction().setColormapDialog(self.defaultColorDialog())
         return widget
 
     def axesNames(self, data, info):
@@ -1775,7 +1775,7 @@ class _NXdataComplexImageView(_NXdataBaseDataView):
     def createWidget(self, parent):
         from silx.gui.data.NXdataWidgets import ArrayComplexImagePlot
         widget = ArrayComplexImagePlot(parent, colormap=self.defaultColormap())
-        widget.getPlot().getColormapAction().setColorDialog(self.defaultColorDialog())
+        widget.getPlot().getColormapAction().setColormapDialog(self.defaultColorDialog())
         return widget
 
     def clear(self):
@@ -1827,7 +1827,7 @@ class _NXdataStackView(_NXdataBaseDataView):
         from silx.gui.data.NXdataWidgets import ArrayStackPlot
         widget = ArrayStackPlot(parent)
         widget.getStackView().setColormap(self.defaultColormap())
-        widget.getStackView().getPlotWidget().getColormapAction().setColorDialog(self.defaultColorDialog())
+        widget.getStackView().getPlotWidget().getColormapAction().setColormapDialog(self.defaultColorDialog())
         return widget
 
     def axesNames(self, data, info):
@@ -1932,7 +1932,7 @@ class _NXdataVolumeAsStackView(_NXdataBaseDataView):
         from silx.gui.data.NXdataWidgets import ArrayStackPlot
         widget = ArrayStackPlot(parent)
         widget.getStackView().setColormap(self.defaultColormap())
-        widget.getStackView().getPlotWidget().getColormapAction().setColorDialog(self.defaultColorDialog())
+        widget.getStackView().getPlotWidget().getColormapAction().setColormapDialog(self.defaultColorDialog())
         return widget
 
     def axesNames(self, data, info):
@@ -1983,7 +1983,7 @@ class _NXdataComplexVolumeAsStackView(_NXdataBaseDataView):
     def createWidget(self, parent):
         from silx.gui.data.NXdataWidgets import ArrayComplexImagePlot
         widget = ArrayComplexImagePlot(parent, colormap=self.defaultColormap())
-        widget.getPlot().getColormapAction().setColorDialog(self.defaultColorDialog())
+        widget.getPlot().getColormapAction().setColormapDialog(self.defaultColorDialog())
         return widget
 
     def axesNames(self, data, info):

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -66,7 +66,7 @@ import enum
 import logging
 
 import numpy
-from typing import Union
+from future import __annotations__
 
 from .. import qt
 from .. import utils

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -567,6 +567,7 @@ class _ColormapHistogram(qt.QWidget):
         self._plotToolbar.addAction(action)
         group.addAction(action)
         self._dataHistogramAction = action
+        group.setExclusive(True)
         group.triggered.connect(self._displayDataInPlotModeChanged)
 
         plotBoxLayout = qt.QHBoxLayout()

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -755,7 +755,7 @@ class _ColormapHistogram(qt.QWidget):
             x = min(x, vmax)
         return x, y
 
-    def setDataInPlotMode(self, mode: Union[str, DataInPlotMode]):
+    def setDataInPlotMode(self, mode: str | DataInPlotMode):
         mode = DataInPlotMode.from_value(mode)
         if mode is DataInPlotMode.HISTOGRAM:
             action = self._dataHistogramAction

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -547,7 +547,7 @@ class _ColormapHistogram(qt.QWidget):
 
         group = qt.QActionGroup(self._plotToolbar)
         group.setExclusive(True)
-
+        # data range mode
         action = qt.QAction("Data range", self)
         action.setToolTip("Display the data range within the colormap range. A fast data processing have to be done.")
         action.setIcon(icons.getQIcon('colormap-range'))
@@ -556,6 +556,8 @@ class _ColormapHistogram(qt.QWidget):
         action.setChecked(action.data() == self._dataInPlotMode)
         self._plotToolbar.addAction(action)
         group.addAction(action)
+        self._dataRangeAction = action
+        # histogram mode
         action = qt.QAction("Histogram", self)
         action.setToolTip("Display the data histogram within the colormap range. A slow data processing have to be done. ")
         action.setIcon(icons.getQIcon('colormap-histogram'))
@@ -564,6 +566,7 @@ class _ColormapHistogram(qt.QWidget):
         action.setChecked(action.data() == self._dataInPlotMode)
         self._plotToolbar.addAction(action)
         group.addAction(action)
+        self._dataHistogramAction = action
         group.triggered.connect(self._displayDataInPlotModeChanged)
 
         plotBoxLayout = qt.QHBoxLayout()

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -85,6 +85,7 @@ from silx.gui.widgets.FormGridLayout import FormGridLayout
 from silx.math.histogram import Histogramnd
 from silx.gui.plot.items.roi import RectangleROI
 from silx.gui.plot.tools.roi import RegionOfInterestManager
+from silx.utils.enum import Enum as _Enum
 
 _logger = logging.getLogger(__name__)
 
@@ -301,7 +302,7 @@ class _AutoScaleButton(qt.QPushButton):
             self.setChecked(autoRange[0] if autoRange[0] == autoRange[1] else False)
 
 @enum.unique
-class DataInPlotMode(enum.Enum):
+class DataInPlotMode(_Enum):
     """Enum for each mode of display of the data in the plot."""
     RANGE = 'range'
     HISTOGRAM = 'histogram'

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -66,6 +66,7 @@ import enum
 import logging
 
 import numpy
+from typing import Union
 
 from .. import qt
 from .. import utils
@@ -300,7 +301,7 @@ class _AutoScaleButton(qt.QPushButton):
             self.setChecked(autoRange[0] if autoRange[0] == autoRange[1] else False)
 
 @enum.unique
-class _DataInPlotMode(enum.Enum):
+class DataInPlotMode(enum.Enum):
     """Enum for each mode of display of the data in the plot."""
     RANGE = 'range'
     HISTOGRAM = 'histogram'
@@ -332,7 +333,7 @@ class _ColormapHistogram(qt.QWidget):
 
     def __init__(self, parent):
         qt.QWidget.__init__(self, parent=parent)
-        self._dataInPlotMode = _DataInPlotMode.RANGE
+        self._dataInPlotMode = DataInPlotMode.RANGE
         self._finiteRange = None, None
         self._initPlot()
 
@@ -550,7 +551,7 @@ class _ColormapHistogram(qt.QWidget):
         action.setToolTip("Display the data range within the colormap range. A fast data processing have to be done.")
         action.setIcon(icons.getQIcon('colormap-range'))
         action.setCheckable(True)
-        action.setData(_DataInPlotMode.RANGE)
+        action.setData(DataInPlotMode.RANGE)
         action.setChecked(action.data() == self._dataInPlotMode)
         self._plotToolbar.addAction(action)
         group.addAction(action)
@@ -558,7 +559,7 @@ class _ColormapHistogram(qt.QWidget):
         action.setToolTip("Display the data histogram within the colormap range. A slow data processing have to be done. ")
         action.setIcon(icons.getQIcon('colormap-histogram'))
         action.setCheckable(True)
-        action.setData(_DataInPlotMode.HISTOGRAM)
+        action.setData(DataInPlotMode.HISTOGRAM)
         action.setChecked(action.data() == self._dataInPlotMode)
         self._plotToolbar.addAction(action)
         group.addAction(action)
@@ -749,15 +750,19 @@ class _ColormapHistogram(qt.QWidget):
             x = min(x, vmax)
         return x, y
 
-    def _setDataInPlotMode(self, mode):
+    def setDataInPlotMode(self, mode: Union[str, DataInPlotMode]):
+        mode = DataInPlotMode.from_value(mode)
         if self._dataInPlotMode == mode:
             return
         self._dataInPlotMode = mode
         self._updateDataInPlot()
 
+    def getDataInPlotMode(self) -> DataInPlotMode:
+        return self._dataInPlotMode
+
     def _displayDataInPlotModeChanged(self, action):
         mode = action.data()
-        self._setDataInPlotMode(mode)
+        self.setDataInPlotMode(mode)
 
     def invalidateData(self):
         self._histogramData = {}
@@ -779,7 +784,7 @@ class _ColormapHistogram(qt.QWidget):
         axis = self._plot.getXAxis()
         axis.setScale(scale)
 
-        if mode == _DataInPlotMode.RANGE:
+        if mode == DataInPlotMode.RANGE:
             dataRange = self._getNormalizedDataRange()
             xmin, xmax = dataRange
             if xmax is None or xmin is None:
@@ -795,7 +800,7 @@ class _ColormapHistogram(qt.QWidget):
                                         fill=True,
                                         z=1)
 
-        elif mode == _DataInPlotMode.HISTOGRAM:
+        elif mode == DataInPlotMode.HISTOGRAM:
             histogram, bin_edges = self._getNormalizedHistogram()
             if histogram is None or bin_edges is None:
                 self._plot.remove(legend='Data', kind='histogram')

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -1060,6 +1060,9 @@ class ColormapDialog(qt.QDialog):
 
         self._applyColormap()
 
+    def getHistoWidget(self):
+        return self._histoWidget
+
     def _invalidateColormap(self):
         if self.isVisible():
             self._applyColormap()

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -58,6 +58,8 @@ The updates of the colormap description are also available through the signal:
 :attr:`ColormapDialog.sigColormapChanged`.
 """  # noqa
 
+from __future__ import annotations
+
 __authors__ = ["V.A. Sole", "T. Vincent", "H. Payno"]
 __license__ = "MIT"
 __date__ = "08/12/2020"
@@ -66,7 +68,6 @@ import enum
 import logging
 
 import numpy
-from future import __annotations__
 
 from .. import qt
 from .. import utils

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -757,6 +757,16 @@ class _ColormapHistogram(qt.QWidget):
 
     def setDataInPlotMode(self, mode: Union[str, DataInPlotMode]):
         mode = DataInPlotMode.from_value(mode)
+        if mode is DataInPlotMode.HISTOGRAM:
+            action = self._dataHistogramAction
+        elif mode is DataInPlotMode.RANGE:
+            action = self._dataRangeAction
+        else:
+            raise NotImplementedError
+        action.setChecked(True)
+        self._displayDataInPlotModeChanged(action)
+
+    def _setDataInPlotMode(self, mode):
         if self._dataInPlotMode == mode:
             return
         self._dataInPlotMode = mode
@@ -767,7 +777,7 @@ class _ColormapHistogram(qt.QWidget):
 
     def _displayDataInPlotModeChanged(self, action):
         mode = action.data()
-        self.setDataInPlotMode(mode)
+        self._setDataInPlotMode(mode)
 
     def invalidateData(self):
         self._histogramData = {}

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -762,7 +762,7 @@ class _ColormapHistogram(qt.QWidget):
         elif mode is DataInPlotMode.RANGE:
             action = self._dataRangeAction
         else:
-            raise NotImplementedError
+            raise ValueError("Mode not supported")
         action.setChecked(True)
         self._displayDataInPlotModeChanged(action)
 

--- a/src/silx/gui/plot/actions/control.py
+++ b/src/silx/gui/plot/actions/control.py
@@ -333,17 +333,17 @@ class ColormapAction(PlotAction):
 
     def setColormapDialog(self, dialog):
         """Set a specific colormap dialog instead of using the default one."""
-        assert colormapDialog is not None
+        assert dialog is not None
         if self._dialog is not None:
             self._dialog.visibleChanged.disconnect(self._dialogVisibleChanged)
 
-        self._dialog = colormapDialog
+        self._dialog = dialog
         self._dialog.visibleChanged.connect(self._dialogVisibleChanged, qt.Qt.UniqueConnection)
         self.setChecked(self._dialog.isVisible())
 
     @deprecated(replacement="setColormapDialog", since_version="2.0")
     def setColorDialog(self, colorDialog):
-        self.setColormapDialog(colormapDialog=colorDialog)
+        self.setColormapDialog(colorDialog)
 
     def getColormapDialog(self):
         if self._dialog is None:

--- a/src/silx/gui/plot/actions/control.py
+++ b/src/silx/gui/plot/actions/control.py
@@ -338,6 +338,12 @@ class ColormapAction(PlotAction):
         self._dialog.visibleChanged.connect(self._dialogVisibleChanged)
         self.setChecked(self._dialog.isVisible())
 
+    def getColormapDialog(self):
+        if self._dialog is None:
+            self._dialog = self._createDialog(self.plot)
+            self._dialog.visibleChanged.connect(self._dialogVisibleChanged)
+        return self._dialog
+
     @staticmethod
     def _createDialog(parent):
         """Create the dialog if not already existing

--- a/src/silx/gui/plot/actions/control.py
+++ b/src/silx/gui/plot/actions/control.py
@@ -333,9 +333,11 @@ class ColormapAction(PlotAction):
     def setColormapDialog(self, colorDialog):
         """Set a specific color dialog instead of using the default dialog."""
         assert(colorDialog is not None)
-        assert(self._dialog is None)
+        if self._dialog is not None:
+            self._dialog.visibleChanged.disconnect(self._dialogVisibleChanged)
+
         self._dialog = colorDialog
-        self._dialog.visibleChanged.connect(self._dialogVisibleChanged)
+        self._dialog.visibleChanged.connect(self._dialogVisibleChanged, qt.Qt.UniqueConnection)
         self.setChecked(self._dialog.isVisible())
 
     def getColormapDialog(self):

--- a/src/silx/gui/plot/actions/control.py
+++ b/src/silx/gui/plot/actions/control.py
@@ -330,7 +330,7 @@ class ColormapAction(PlotAction):
         self.plot.sigActiveImageChanged.connect(self._updateColormap)
         self.plot.sigActiveScatterChanged.connect(self._updateColormap)
 
-    def setColorDialog(self, colorDialog):
+    def setColormapDialog(self, colorDialog):
         """Set a specific color dialog instead of using the default dialog."""
         assert(colorDialog is not None)
         assert(self._dialog is None)

--- a/src/silx/gui/plot/actions/control.py
+++ b/src/silx/gui/plot/actions/control.py
@@ -358,16 +358,13 @@ class ColormapAction(PlotAction):
 
     def _actionTriggered(self, checked=False):
         """Create a cmap dialog and update active image and default cmap."""
-        if self._dialog is None:
-            self._dialog = self._createDialog(self.plot)
-            self._dialog.visibleChanged.connect(self._dialogVisibleChanged)
-
+        dialog = self.getColormapDialog()
         # Run the dialog listening to colormap change
         if checked is True:
             self._updateColormap()
-            self._dialog.show()
+            dialog.show()
         else:
-            self._dialog.hide()
+            dialog.hide()
 
     def _dialogVisibleChanged(self, isVisible):
         self.setChecked(isVisible)

--- a/src/silx/gui/plot/actions/control.py
+++ b/src/silx/gui/plot/actions/control.py
@@ -330,13 +330,13 @@ class ColormapAction(PlotAction):
         self.plot.sigActiveImageChanged.connect(self._updateColormap)
         self.plot.sigActiveScatterChanged.connect(self._updateColormap)
 
-    def setColormapDialog(self, colorDialog):
+    def setColormapDialog(self, colormapDialog):
         """Set a specific color dialog instead of using the default dialog."""
-        assert(colorDialog is not None)
+        assert(colormapDialog is not None)
         if self._dialog is not None:
             self._dialog.visibleChanged.disconnect(self._dialogVisibleChanged)
 
-        self._dialog = colorDialog
+        self._dialog = colormapDialog
         self._dialog.visibleChanged.connect(self._dialogVisibleChanged, qt.Qt.UniqueConnection)
         self.setChecked(self._dialog.isVisible())
 

--- a/src/silx/gui/plot/actions/control.py
+++ b/src/silx/gui/plot/actions/control.py
@@ -55,6 +55,7 @@ from silx.gui.plot import items
 from silx.gui.plot._utils import applyZoomToPlot as _applyZoomToPlot
 from silx.gui import qt
 from silx.gui import icons
+from silx.utils.deprecation import deprecated
 
 _logger = logging.getLogger(__name__)
 
@@ -339,6 +340,10 @@ class ColormapAction(PlotAction):
         self._dialog = colormapDialog
         self._dialog.visibleChanged.connect(self._dialogVisibleChanged, qt.Qt.UniqueConnection)
         self.setChecked(self._dialog.isVisible())
+
+    @deprecated(replacement="setColormapDialog", since_version="2.0")
+    def setColorDialog(self, colorDialog):
+        self.setColormapDialog(colormapDialog=colorDialog)
 
     def getColormapDialog(self):
         if self._dialog is None:


### PR DESCRIPTION
The goal of this PR is to allow user select the display mode of the ColormapDialog for the min / max value (`data histogram` or `data range`)

# TODO

- [x] move _DataInPlotMode to public API
- [x] add getter for `_dataInPlotMode`
- [x] rename `setColorDialog` to `setColormapDialog` ? This would make more sense to me. Especially as we are moving to 2.0
    - [x] add deprecation warning
- [x] add a getColor(map)Dialog to ColormapAction

# EXTRA
Changelog: 

move _DataInPlotMode to public API.
close #3963 