### PR TITLE
`silx.gui.plot.tools.PositionInfo`: Fixed support of dark theme

### DIFF
--- a/src/silx/gui/plot/tools/PositionInfo.py
+++ b/src/silx/gui/plot/tools/PositionInfo.py
@@ -187,7 +187,7 @@ class PositionInfo(qt.QWidget):
         if plot is None:
             return
 
-        styleSheet = "color: rgb(0, 0, 0);"  # Default style
+        styleSheet = ""  # Default style
         xData, yData = x, y
 
         snappingMode = self.getSnappingMode()
@@ -250,7 +250,7 @@ class PositionInfo(qt.QWidget):
                         yData = item.getValueData(copy=False)[index]
 
                         # Update label style sheet
-                        styleSheet = "color: rgb(0, 0, 0);"
+                        styleSheet = ""
                         break
 
                 else:  # Curve, Scatter
@@ -279,7 +279,7 @@ class PositionInfo(qt.QWidget):
 
                     if closestSqDistInPixels <= sqDistInPixels:
                         # Update label style sheet
-                        styleSheet = "color: rgb(0, 0, 0);"
+                        styleSheet = ""
 
                         # if close enough, snap to data point coord
                         xData, yData = xArray[closestIndex], yArray[closestIndex]


### PR DESCRIPTION
This PR fixes `PositionInfo widget when used with a "dark theme" where setting default text color to black is no the right thing to do.