### PR TITLE
silx.gui: Fixed PyQt6 support by not using deprecated `qt.QPalette.Normal`

### DIFF
--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -219,7 +219,7 @@ class _BoundaryWidget(qt.QWidget):
             color = palette.color(qt.QPalette.Disabled, qt.QPalette.Base)
             icon = self._iconAuto
         else:
-            color = palette.color(qt.QPalette.Normal, qt.QPalette.Base)
+            color = palette.color(qt.QPalette.Active, qt.QPalette.Base)
             icon = self._iconFixed
         palette.setColor(qt.QPalette.Base, color)
         self._numVal.setPalette(palette)
@@ -515,7 +515,7 @@ class _ColormapHistogram(qt.QWidget):
         self._plot.setMinimumSize(qt.QSize(250, 200))
         self._plot.sigPlotSignal.connect(self._plotEventReceived)
         palette = self.palette()
-        color = palette.color(qt.QPalette.Normal, qt.QPalette.Window)
+        color = palette.color(qt.QPalette.Active, qt.QPalette.Window)
         self._plot.setBackgroundColor(color)
         self._plot.setDataBackgroundColor("white")
 

--- a/src/silx/gui/plot/LegendSelector.py
+++ b/src/silx/gui/plot/LegendSelector.py
@@ -194,7 +194,7 @@ class LegendModel(qt.QAbstractListModel):
         elif role == qt.Qt.BackgroundRole:
             # Background color, must be QBrush
             if isActive:
-                brush = self._palette.brush(qt.QPalette.Normal, qt.QPalette.Highlight)
+                brush = self._palette.brush(qt.QPalette.Active, qt.QPalette.Highlight)
             elif idx % 2:
                 brush = qt.QBrush(qt.QColor(240, 240, 240))
             else:
@@ -203,9 +203,9 @@ class LegendModel(qt.QAbstractListModel):
         elif role == qt.Qt.ForegroundRole:
             # ForegroundRole color, must be QBrush
             if isActive:
-                brush = self._palette.brush(qt.QPalette.Normal, qt.QPalette.HighlightedText)
+                brush = self._palette.brush(qt.QPalette.Active, qt.QPalette.HighlightedText)
             else:
-                brush = self._palette.brush(qt.QPalette.Normal, qt.QPalette.WindowText)
+                brush = self._palette.brush(qt.QPalette.Active, qt.QPalette.WindowText)
             return brush
         elif role == qt.Qt.CheckStateRole:
             return bool(item[2])  # item[2] == True


### PR DESCRIPTION
Replace `qt.QPalette.Normal` by `qt.QPalette.Active` to support pyqt6

closes #3962