### PR TITLE
silx.gui.colors: Added typing

### DIFF
--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -43,7 +43,7 @@ from ....utils.enum import Enum as _Enum
 from ....math.combo import min_max
 from ... import qt
 from ... import colors
-from ...colors import Colormap
+from ...colors import Colormap, _Colormappable
 from ._pick import PickingResult
 
 from silx import config
@@ -591,7 +591,7 @@ class DraggableMixIn(ItemMixInBase):
         raise NotImplementedError("Must be implemented in subclass")
 
 
-class ColormapMixIn(ItemMixInBase):
+class ColormapMixIn(_Colormappable, ItemMixInBase):
     """Mix-in class for items with colormap"""
 
     def __init__(self):


### PR DESCRIPTION
This PR adds typing to `silx.gui.colors` and defines input and output types for `colors.rgba`.
Since this function is used everywhere for colors, it should help to type colors in the plot API.
