### PR TITLE
silx.gui.plot.items: Make highlighted RegionOfInterest take priority for interactions

### DIFF
--- a/src/silx/gui/plot/items/_roi_base.py
+++ b/src/silx/gui/plot/items/_roi_base.py
@@ -574,6 +574,10 @@ class RegionOfInterest(_RegionOfInterestBase, core.HighlightedMixIn):
         if event == items.ItemChangedType.TEXT:
             self._updateText(self.getText())
         elif event == items.ItemChangedType.HIGHLIGHTED:
+            for item in self.getItems():
+                zoffset = 1000 if self.isHighlighted() else 0
+                item.setZValue(item._DEFAULT_Z_LAYER + zoffset)
+
             style = self.getCurrentStyle()
             self._updatedStyle(event, style)
         else:


### PR DESCRIPTION
This PR makes sure a highlighted ROI receives interaction first by changing the Z layer of its items.
This is a simple fix with one limitation: It does not work if ROI's item Z value is changed which is not the case so far in implemented ROIs.

A neater way to fix this woud be to have a `Group` item (see #3077).

closes #3927