### PR TITLE
silx.gui.plot.tools.roi.RegionOfInterestManager: Changed interaction mode for ROI creation

### DIFF
--- a/src/silx/gui/plot/tools/roi.py
+++ b/src/silx/gui/plot/tools/roi.py
@@ -874,7 +874,7 @@ class RegionOfInterestManager(qt.QObject):
                 color = rgba(self.getColor())
             else:
                 color = None
-            plot.setInteractiveMode(mode='select-draw',
+            plot.setInteractiveMode(mode='draw',
                                     source=self,
                                     shape=firstInteractionShapeKind,
                                     color=color,


### PR DESCRIPTION
This PR change the interaction mode used to create ROI to avoid selection of items that prevents creating ROI.

closes #3874