### PR TITLE
silx.gui: Added support for `QT_API` environment variable

### DIFF
--- a/src/silx/gui/qt/__init__.py
+++ b/src/silx/gui/qt/__init__.py
@@ -27,8 +27,10 @@
 - `PySide6 <https://pypi.org/project/PySide6/>`_
 - `PyQt6 <https://pypi.org/project/PyQt6/>`_
 
-If a Qt binding is already loaded, it will use it, otherwise the different
-Qt bindings are tried in this order: PyQt5, PySide6, PyQt6.
+If a Qt binding is already loaded, it will be used.
+If the `QT_API` environment variable is set to one of the supported Qt bindings
+(case insensitive), this binding is loaded if available, otherwise the
+different Qt bindings are tried in this order: PyQt5, PySide6, PyQt6.
 
 The name of the loaded Qt binding is stored in the BINDING variable.
 


### PR DESCRIPTION
This PR adds support for selecting the Qt binding with `QT_API` env. var. (case-insensitive) the same way as [matplotlib](https://matplotlib.org/stable/api/backend_qt_api.html#qt-bindings) and close to [qtpy](https://github.com/spyder-ide/qtpy#requirements) - which is case sensitive.