### PR TITLE
silx.gui.plot.PlotWidget: Refactored item management

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
           - name-suffix: "PyQt6 wheel"
             os: ubuntu-latest
-            python-version: '3.7'
+            python-version: '3.11'
             BUILD_OPTION: --wheel
             QT_BINDING: PyQt6
             RUN_TESTS_OPTIONS: --qt-binding=PyQt6 --no-opengl --low-mem

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -386,7 +386,7 @@ class PlotWidget(qt.QMainWindow):
 
         # Items handling
         self.__items = []
-        self._contentToUpdate = []  # Used as an OrderedSet
+        self.__itemsToUpdate = []  # Used as an OrderedSet
 
         self._dataRange = None
 
@@ -929,9 +929,9 @@ class PlotWidget(qt.QMainWindow):
         """
         assert item.getPlot() == self
         # Put item at the end of the list
-        if item in self._contentToUpdate:
-            self._contentToUpdate.remove(item)
-        self._contentToUpdate.append(item)
+        if item in self.__itemsToUpdate:
+            self.__itemsToUpdate.remove(item)
+        self.__itemsToUpdate.append(item)
         self._setDirtyPlot(overlayOnly=item.isOverlay())
 
     def addItem(self, item):
@@ -979,8 +979,8 @@ class PlotWidget(qt.QMainWindow):
 
         # Remove item from plot
         self.__items.remove(item)
-        if item in self._contentToUpdate:
-            self._contentToUpdate.remove(item)
+        if item in self.__itemsToUpdate:
+            self.__itemsToUpdate.remove(item)
         if item.isVisible():
             self._setDirtyPlot(overlayOnly=item.isOverlay())
         if item.getBounds() is not None:
@@ -3126,10 +3126,10 @@ class PlotWidget(qt.QMainWindow):
 
         It is in charge of performing required PlotWidget operations
         """
-        for item in self._contentToUpdate:
+        for item in self.__itemsToUpdate:
             item._update(self._backend)
 
-        self._contentToUpdate = []
+        self.__itemsToUpdate = []
         yield
         self._dirty = False  # reset dirty flag
 

--- a/src/silx/gui/plot/test/testItem.py
+++ b/src/silx/gui/plot/test/testItem.py
@@ -33,7 +33,7 @@ import numpy
 from silx.gui.utils.testutils import SignalListener
 from silx.gui.plot.items.roi import RegionOfInterest
 from silx.gui.plot.items import ItemChangedType
-from silx.gui.plot import items
+from silx.gui.plot import items, PlotWidget
 from .utils import PlotWidgetTestCase
 
 
@@ -386,3 +386,25 @@ def testRegionOfInterestText():
         ItemChangedType.NAME, ItemChangedType.TEXT
     ]
     assert roi.getText() == "even_newer_name"
+
+
+def testPlotAddItemsWithoutLegend(qWidgetFactory):
+    plotWidget = qWidgetFactory(PlotWidget)
+
+    curve1 = items.Curve()
+    curve1.setData([0, 10], [0, 20])
+    plotWidget.addItem(curve1)
+
+    curve2 = items.Curve()
+    curve2.setData([0, -10], [0, -20])
+    plotWidget.addItem(curve2)
+
+    assert plotWidget.getItems() == (curve1, curve2)
+
+    datarange = plotWidget.getDataRange()
+    assert datarange.x == (-10, 10)
+    assert datarange.y == (-20, 20)
+
+    plotWidget.resetZoom()
+    assert plotWidget.getXAxis().getLimits() == (-10, 10)
+    assert plotWidget.getYAxis().getLimits() == (-20, 20)


### PR DESCRIPTION
This PR is changing the way items are stored inside a `PlotWidget`. This aims at making it simpler and solves issues like #3896. On the down side, it might change the behaviour of item management when not using the `PlotWidget.add*` methods...

Still needs testing


closes #3896