### PR TITLE
silx.gui.plot: Use `PlotWidget.get|setActiveScatter` instead of `PlotWidget._get|setActiveItem(kind="scatter"..)`

### DIFF
--- a/examples/scatterMask.py
+++ b/examples/scatterMask.py
@@ -126,8 +126,7 @@ class MaskScatterWidget(qt.QMainWindow):
         self._plot.addScatter(x, y, v, legend=self._activeScatterLegend,
                               info=info, colormap=colormap)
         # the mask is associated with the active scatter
-        self._plot._setActiveItem(kind="scatter",
-                                  legend=self._activeScatterLegend)
+        self._plot.setActiveScatter(self._activeScatterLegend)
 
         self._alphaSlider.setLegend(self._activeScatterLegend)
 

--- a/src/silx/gui/plot/ColorBar.py
+++ b/src/silx/gui/plot/ColorBar.py
@@ -129,8 +129,7 @@ class ColorBarWidget(qt.QWidget):
         plot = self.getPlot()
         if plot is not None and not self._isConnected:
             activeImageLegend = plot.getActiveImage(just_legend=True)
-            activeScatterLegend = plot._getActiveItem(
-                kind='scatter', just_legend=True)
+            activeScatterLegend = plot.getActiveScatter(just_legend=True)
             if activeImageLegend is None and activeScatterLegend is None:
                 # Show plot default colormap
                 self._syncWithDefaultColormap()
@@ -220,7 +219,7 @@ class ColorBarWidget(qt.QWidget):
             return
 
         # Sync with active scatter
-        scatter = plot._getActiveItem(kind='scatter')
+        scatter = plot.getActiveScatter()
 
         self.setColormap(colormap=scatter.getColormap(),
                          data=scatter)
@@ -230,8 +229,7 @@ class ColorBarWidget(qt.QWidget):
         plot = self.getPlot()
 
         if legend is None:  # No active image, try with active scatter
-            activeScatterLegend = plot._getActiveItem(
-                kind='scatter', just_legend=True)
+            activeScatterLegend = plot.getActiveScatter(just_legend=True)
             # No more active image, use active scatter if any
             self._activeScatterChanged(None, activeScatterLegend)
         else:
@@ -255,7 +253,7 @@ class ColorBarWidget(qt.QWidget):
             plot = self.getPlot()
             if (plot is not None and
                     plot.getActiveImage() is None and
-                    plot._getActiveItem(kind='scatter') is None):
+                    plot.getActiveScatter() is None):
                 # No active item, take default colormap update into account
                 self._syncWithDefaultColormap()
 

--- a/src/silx/gui/plot/ScatterMaskToolsWidget.py
+++ b/src/silx/gui/plot/ScatterMaskToolsWidget.py
@@ -223,7 +223,7 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
         """
         if self._data_scatter is None:
             # this can happen if the mask tools widget has never been shown
-            self._data_scatter = self.plot._getActiveItem(kind="scatter")
+            self._data_scatter = self.plot.getActiveScatter()
             if self._data_scatter is None:
                 return None
             self._adjustColorAndBrushSize(self._data_scatter)
@@ -323,7 +323,7 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
         removed, otherwise it is adjusted to z.
         """
         # check that content changed was the active scatter
-        activeScatter = self.plot._getActiveItem(kind="scatter")
+        activeScatter = self.plot.getActiveScatter()
 
         if activeScatter is None or activeScatter.getName() == self._maskName:
             # No active scatter or active scatter is the mask...
@@ -352,7 +352,7 @@ class ScatterMaskToolsWidget(BaseMaskToolsWidget):
 
     def _activeScatterChanged(self, previous, next):
         """Update widget and mask according to active scatter changes"""
-        activeScatter = self.plot._getActiveItem(kind="scatter")
+        activeScatter = self.plot.getActiveScatter()
 
         if activeScatter is None or activeScatter.getName() == self._maskName:
             # No active scatter or active scatter is the mask...

--- a/src/silx/gui/plot/actions/control.py
+++ b/src/silx/gui/plot/actions/control.py
@@ -390,7 +390,7 @@ class ColormapAction(PlotAction):
         else:
             # No active image or active image is RGBA,
             # Check for active scatter plot
-            scatter = self.plot._getActiveItem(kind='scatter')
+            scatter = self.plot.getActiveScatter()
             if scatter is not None:
                 colormap = scatter.getColormap()
                 self._dialog.setItem(scatter)

--- a/src/silx/gui/plot/test/testPlotWidgetNoBackend.py
+++ b/src/silx/gui/plot/test/testPlotWidgetNoBackend.py
@@ -541,10 +541,10 @@ class TestPlotAddScatter(unittest.TestCase):
         plot.addScatter(x=(0, 1), y=(0, 1), value=(0, 1), legend='scatter 0')
         plot.addScatter(x=(0, 1), y=(0, 1), value=(0, 1), legend='scatter 1')
         plot.addScatter(x=(0, 1), y=(0, 1), value=(0, 1), legend='scatter 2')
-        plot._setActiveItem('scatter', 'scatter 0')
+        plot.setActiveScatter('scatter 0')
 
         # Active scatter
-        active = plot._getActiveItem(kind='scatter')
+        active = plot.getActiveScatter()
         self.assertEqual(active.getName(), 'scatter 0')
 
         # check default values

--- a/src/silx/gui/plot/test/testScatterMaskToolsWidget.py
+++ b/src/silx/gui/plot/test/testScatterMaskToolsWidget.py
@@ -144,7 +144,7 @@ class TestScatterMaskToolsWidget(PlotWidgetTestCase, ParametricTestCase):
                 y=numpy.arange(256),
                 value=numpy.random.random(256),
                 legend='test')
-        self.plot._setActiveItem(kind="scatter", legend="test")
+        self.plot.setActiveScatter("test")
         self.qapp.processEvents()
 
         self.plot.remove('test', kind='scatter')
@@ -155,7 +155,7 @@ class TestScatterMaskToolsWidget(PlotWidgetTestCase, ParametricTestCase):
                 y=1000 * (numpy.arange(1000) % 20),
                 value=numpy.random.random(1000),
                 legend='test')
-        self.plot._setActiveItem(kind="scatter", legend="test")
+        self.plot.setActiveScatter("test")
         self.plot.resetZoom()
         self.qapp.processEvents()
 
@@ -233,7 +233,7 @@ class TestScatterMaskToolsWidget(PlotWidgetTestCase, ParametricTestCase):
                 y=25 * (numpy.arange(256) % 10),
                 value=numpy.random.random(256),
                 legend='test')
-        self.plot._setActiveItem(kind="scatter", legend="test")
+        self.plot.setActiveScatter("test")
         self.plot.resetZoom()
         self.qapp.processEvents()
 
@@ -271,7 +271,7 @@ class TestScatterMaskToolsWidget(PlotWidgetTestCase, ParametricTestCase):
                 y=1000 * (numpy.arange(1000) % 20),
                 value=numpy.ones((1000,)),
                 legend='test')
-        self.plot._setActiveItem(kind="scatter", legend="test")
+        self.plot.setActiveScatter("test")
         self.plot.resetZoom()
         self.qapp.processEvents()
 

--- a/src/silx/gui/plot/tools/PositionInfo.py
+++ b/src/silx/gui/plot/tools/PositionInfo.py
@@ -207,7 +207,7 @@ class PositionInfo(qt.QWidget):
                         selectedItems.append(activeCurve)
 
                 if snappingMode & self.SNAPPING_SCATTER:
-                    activeScatter = plot._getActiveItem(kind='scatter')
+                    activeScatter = plot.getActiveScatter()
                     if activeScatter:
                         selectedItems.append(activeScatter)
 


### PR DESCRIPTION
There is no point using a private API when there is a public one for it.
