### PR TITLE
silx.gui.plot.PlotWidget: Refactored management of active items

### DIFF
--- a/doc/source/modules/gui/plot/plotsignal.rst
+++ b/doc/source/modules/gui/plot/plotsignal.rst
@@ -91,6 +91,7 @@ Both share the following keys:
 
 - 'event': 'curveClicked' or 'imageClicked'
 - 'button': the mouse button that was pressed in 'left', 'middle', 'right'
+- 'item': The plot item object that was clicked
 - 'label': The legend associated with the clicked image or curve
 - 'type': The type of item in 'curve', 'image'
 - 'x' and 'y': The clicked position in data coordinates

--- a/examples/plotCurveLegendWidget.py
+++ b/examples/plotCurveLegendWidget.py
@@ -69,7 +69,7 @@ class MyCurveLegendsWidget(CurveLegendsWidget):
         :param silx.gui.plot.items.Curve curve:
         """
         plot = curve.getPlot()
-        plot.setActiveCurve(curve.getName() if curve != plot.getActiveCurve() else None)
+        plot.setActiveCurve(curve if curve != plot.getActiveCurve() else None)
 
     def _switchCurveVisibility(self, curve):
         """Toggle the visibility of a curve

--- a/src/silx/gui/plot/CompareImages.py
+++ b/src/silx/gui/plot/CompareImages.py
@@ -110,7 +110,7 @@ class CompareImages(qt.QMainWindow):
         if silx.config.DEFAULT_PLOT_IMAGE_Y_AXIS_ORIENTATION == "downward":
             self.__plot.getYAxis().setInverted(True)
         self.__plot.addItem(self.__item)
-        self.__plot.setActiveImage("_virtual")
+        self.__plot.setActiveImage(self.__item)
 
         self.__plot.setKeepDataAspectRatio(True)
         self.__plot.sigPlotSignal.connect(self.__plotSlot)

--- a/src/silx/gui/plot/ComplexImageView.py
+++ b/src/silx/gui/plot/ComplexImageView.py
@@ -292,7 +292,7 @@ class ComplexImageView(qt.QWidget):
         self._plotImage.setName("__ComplexImageView__complex_image__")
         self._plotImage.sigItemChanged.connect(self._itemChanged)
         self._plot2D.addItem(self._plotImage)
-        self._plot2D.setActiveImage(self._plotImage.getName())
+        self._plot2D.setActiveImage(self._plotImage)
 
         toolBar = qt.QToolBar("Complex", self)
         toolBar.addWidget(_ComplexDataToolButton(parent=self, plot=self))

--- a/src/silx/gui/plot/PlotEvents.py
+++ b/src/silx/gui/plot/PlotEvents.py
@@ -139,13 +139,14 @@ def prepareMarkerSignal(
     return eventDict
 
 
-def prepareImageSignal(button, label, type_, col, row, x, y, xPixel, yPixel):
+def prepareImageSignal(button, item, col, row, x, y, xPixel, yPixel):
     """See Plot documentation for content of events"""
     return {
         "event": "imageClicked",
         "button": button,
-        "label": label,
-        "type": type_,
+        "item": item,
+        "label": item.getName(),
+        "type": "image",
         "col": col,
         "row": row,
         "x": x,
@@ -155,13 +156,14 @@ def prepareImageSignal(button, label, type_, col, row, x, y, xPixel, yPixel):
     }
 
 
-def prepareCurveSignal(button, label, type_, xData, yData, x, y, xPixel, yPixel):
+def prepareCurveSignal(button, item, xData, yData, x, y, xPixel, yPixel):
     """See Plot documentation for content of events"""
     return {
         "event": "curveClicked",
         "button": button,
-        "label": label,
-        "type": type_,
+        "item": item,
+        "label": item.getName(),
+        "type": "curve",
         "xdata": xData,
         "ydata": yData,
         "x": x,

--- a/src/silx/gui/plot/PlotInteraction.py
+++ b/src/silx/gui/plot/PlotInteraction.py
@@ -1251,8 +1251,7 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
                 indices = result.getIndices(copy=False)
                 eventDict = prepareCurveSignal(
                     "left",
-                    item.getName(),
-                    "curve",
+                    item,
                     xData[indices],
                     yData[indices],
                     dataPos[0],
@@ -1269,15 +1268,7 @@ class ItemsInteraction(ClickOrDrag, _PlotInteraction):
                 indices = result.getIndices(copy=False)
                 row, column = indices[0][0], indices[1][0]
                 eventDict = prepareImageSignal(
-                    "left",
-                    item.getName(),
-                    "image",
-                    column,
-                    row,
-                    dataPos[0],
-                    dataPos[1],
-                    x,
-                    y,
+                    "left", item, column, row, dataPos[0], dataPos[1], x, y
                 )
                 return eventDict
 

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -3135,9 +3135,9 @@ class PlotWidget(qt.QMainWindow):
             ddict = {}
         _logger.debug("Received dict keys = %s", str(ddict.keys()))
         _logger.debug(str(ddict))
-        if ddict["event"] in ["legendClicked", "curveClicked"]:
+        if ddict["event"] == "curveClicked":
             if ddict["button"] == "left":
-                self.setActiveCurve(ddict["label"])
+                self.setActiveCurve(ddict["item"])
                 qt.QToolTip.showText(self.cursor().pos(), ddict["label"])
         elif ddict["event"] == "mouseClicked" and ddict["button"] == "left":
             self.setActiveCurve(None)

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -181,7 +181,7 @@ class _PlotWidgetSelection(qt.QObject):
             if kind in plot._ACTIVE_ITEM_KINDS and item is not plot._getActiveItem(
                 kind
             ):
-                plot._setActiveItem(kind, item.getName())
+                plot._setActiveItem(kind, item)
         else:
             raise ValueError("Not an Item: %s" % str(item))
 
@@ -392,6 +392,7 @@ class PlotWidget(qt.QMainWindow):
         # Items handling
         self.__items = []
         self.__itemsToUpdate = []  # Used as an OrderedSet
+        self.__activeItems = {"curve": None, "image": None, "scatter": None}
 
         self._dataRange = None
 
@@ -406,7 +407,6 @@ class PlotWidget(qt.QMainWindow):
             color=silx.config.DEFAULT_PLOT_ACTIVE_CURVE_COLOR,
             linewidth=silx.config.DEFAULT_PLOT_ACTIVE_CURVE_LINEWIDTH,
         )
-        self._activeLegend = {"curve": None, "image": None, "scatter": None}
 
         # plot colors (updated later to sync backend)
         self._foregroundColor = 0.0, 0.0, 0.0, 1.0
@@ -1189,9 +1189,6 @@ class PlotWidget(qt.QMainWindow):
 
         legend = "Unnamed curve 1.1" if legend is None else str(legend)
 
-        # Check if curve was previously active
-        wasActive = self.getActiveCurve(just_legend=True) == legend
-
         if replace:
             self._resetColorAndStyle()
 
@@ -1266,13 +1263,13 @@ class PlotWidget(qt.QMainWindow):
         else:
             self._notifyContentChanged(curve)
 
-        if wasActive:
-            self.setActiveCurve(curve.getName())
-        elif self.getActiveCurveSelectionMode() == "legacy":
-            if self.getActiveCurve(just_legend=True) is None:
-                if len(self.getAllCurves(just_legend=True, withhidden=False)) == 1:
-                    if curve.isVisible():
-                        self.setActiveCurve(curve.getName())
+        if curve is self.getActiveCurve() or (
+            self.getActiveCurveSelectionMode() == "legacy"
+            and self.getActiveCurve() is None
+            and len(self.getAllCurves(just_legend=True, withhidden=False)) == 1
+            and curve.isVisible()
+        ):
+            self.setActiveCurve(curve)
 
         if resetzoom:
             # We ask for a zoom reset in order to handle the plot scaling
@@ -1443,9 +1440,6 @@ class PlotWidget(qt.QMainWindow):
         """
         legend = "Unnamed Image 1.1" if legend is None else str(legend)
 
-        # Check if image was previously active
-        wasActive = self.getActiveImage(just_legend=True) == legend
-
         data = numpy.array(data, copy=False)
         assert data.ndim in (2, 3)
 
@@ -1512,8 +1506,8 @@ class PlotWidget(qt.QMainWindow):
         else:
             self._notifyContentChanged(image)
 
-        if len(self.getAllImages()) == 1 or wasActive:
-            self.setActiveImage(legend)
+        if len(self.getAllImages()) == 1 or image is self.getActiveImage():
+            self.setActiveImage(image)
 
         if resetzoom:
             # We ask for a zoom reset in order to handle the plot scaling
@@ -1583,9 +1577,6 @@ class PlotWidget(qt.QMainWindow):
         """
         legend = "Unnamed scatter 1.1" if legend is None else str(legend)
 
-        # Check if scatter was previously active
-        wasActive = self._getActiveItem(kind="scatter", just_legend=True) == legend
-
         # Create/Update curve object
         scatter = self._getItem(kind="scatter", legend=legend)
         mustBeAdded = scatter is None
@@ -1634,8 +1625,8 @@ class PlotWidget(qt.QMainWindow):
             for item in self.getItems()
             if isinstance(item, items.Scatter) and item.isVisible()
         ]
-        if len(scatters) == 1 or wasActive:
-            self._setActiveItem("scatter", scatter.getName())
+        if len(scatters) == 1 or scatter is self.getActiveScatter():
+            self.setActiveScatter(scatter)
 
         return legend
 
@@ -2266,7 +2257,7 @@ class PlotWidget(qt.QMainWindow):
             )
             return
 
-        return self._setActiveItem(kind="curve", legend=legend)
+        return self._setActiveItem(kind="curve", item=legend)
 
     def setActiveCurveSelectionMode(self, mode):
         """Sets the current selection mode.
@@ -2279,7 +2270,7 @@ class PlotWidget(qt.QMainWindow):
         if mode != self._activeCurveSelectionMode:
             self._activeCurveSelectionMode = mode
             if mode == "none":  # reset active curve
-                self._setActiveItem(kind="curve", legend=None)
+                self._setActiveItem(kind="curve", item=None)
 
             elif mode == "legacy" and self.getActiveCurve() is None:
                 # Select an active curve
@@ -2317,7 +2308,7 @@ class PlotWidget(qt.QMainWindow):
         :param str legend: The legend associated to the image
                            or None to have no active image.
         """
-        return self._setActiveItem(kind="image", legend=legend)
+        return self._setActiveItem(kind="image", item=legend)
 
     def getActiveScatter(self, just_legend=False):
         """Returns the currently active scatter.
@@ -2338,80 +2329,79 @@ class PlotWidget(qt.QMainWindow):
         :param str legend: The legend associated to the scatter
                            or None to have no active scatter.
         """
-        return self._setActiveItem(kind="scatter", legend=legend)
+        return self._setActiveItem(kind="scatter", item=legend)
 
-    def _getActiveItem(self, kind, just_legend=False):
-        """Return the currently active item of that kind if any
+    def _getActiveItem(
+        self,
+        kind: str | None,
+        just_legend: bool = False,
+    ) -> items.Curve | items.Scatter | items.ImageBase | None:
+        """Return the currently active item of given kind if any.
 
-        :param str kind: Type of item: 'curve', 'scatter' or 'image'
-        :param bool just_legend: True to get the legend,
-                                 False (default) to get the item
-        :return: legend or item or None if no active item
+        :param kind: Type of item: 'curve', 'scatter' or 'image'
+        :param just_legend:
+            True to get the item's legend, False (the default) to get the item
+        """
+        assert kind in self._ACTIVE_ITEM_KINDS
+        item = self.__activeItems[kind]
+        if item is not None and just_legend:
+            return item.getName()
+        return item
+
+    def _setActiveItem(
+        self,
+        kind: str,
+        item: items.Curve | items.ImageBase | items.Scatter | str | None,
+    ) -> str | None:
+        """Make the given item active.
+
+        Note: There is one active item per "kind" of item.
         """
         assert kind in self._ACTIVE_ITEM_KINDS
 
-        if self._activeLegend[kind] is None:
-            return None
-
-        item = self._getItem(kind, self._activeLegend[kind])
         if item is None:
+            legend = None
+        elif isinstance(item, items.Item):
+            legend = item.getName()
+        else:
+            legend = str(item)
+            item = self._getItem(kind, legend)
+            if item is None:
+                _logger.warning("This %s does not exist: %s", kind, legend)
+
+        oldActiveItem = self._getActiveItem(kind=kind)
+
+        if oldActiveItem is None and item is None:
             return None
 
-        return item.getName() if just_legend else item
+        if oldActiveItem is not None:
+            # Stop listening previous active item
+            oldActiveItem.sigItemChanged.disconnect(self._activeItemChanged)
+            # Curve specific: Reset highlight of previous active curve
+            if kind == "curve":
+                oldActiveItem.setHighlighted(False)
 
-    def _setActiveItem(self, kind, legend):
-        """Make the curve associated to legend the active curve.
-
-        :param str kind: Type of item: 'curve' or 'image'
-        :param legend: The legend associated to the curve
-                       or None to have no active curve.
-        :type legend: str or None
-        """
-        assert kind in self._ACTIVE_ITEM_KINDS
+        self.__activeItems[kind] = item
 
         xLabel = None
         yLabel = None
         yRightLabel = None
 
-        oldActiveItem = self._getActiveItem(kind=kind)
+        if item is not None:
+            # Curve specific: handle highlight
+            if kind == "curve":
+                item.setHighlightedStyle(self.getActiveCurveStyle())
+                item.setHighlighted(True)
 
-        if oldActiveItem is not None:  # Stop listening previous active image
-            oldActiveItem.sigItemChanged.disconnect(self._activeItemChanged)
+            if isinstance(item, items.LabelsMixIn):
+                xLabel = item.getXLabel()
+                if isinstance(item, items.YAxisMixIn) and item.getYAxis() == "right":
+                    yRightLabel = item.getYLabel()
+                else:
+                    yLabel = item.getYLabel()
 
-        # Curve specific: Reset highlight of previous active curve
-        if kind == "curve" and oldActiveItem is not None:
-            oldActiveItem.setHighlighted(False)
-
-        if legend is None:
-            self._activeLegend[kind] = None
-        else:
-            legend = str(legend)
-            item = self._getItem(kind, legend)
-            if item is None:
-                _logger.warning("This %s does not exist: %s", kind, legend)
-                self._activeLegend[kind] = None
-            else:
-                self._activeLegend[kind] = legend
-
-                # Curve specific: handle highlight
-                if kind == "curve":
-                    item.setHighlightedStyle(self.getActiveCurveStyle())
-                    item.setHighlighted(True)
-
-                if isinstance(item, items.LabelsMixIn):
-                    if item.getXLabel() is not None:
-                        xLabel = item.getXLabel()
-                    if item.getYLabel() is not None:
-                        if (
-                            isinstance(item, items.YAxisMixIn)
-                            and item.getYAxis() == "right"
-                        ):
-                            yRightLabel = item.getYLabel()
-                        else:
-                            yLabel = item.getYLabel()
-
-                # Start listening new active item
-                item.sigItemChanged.connect(self._activeItemChanged)
+            # Start listening new active item
+            item.sigItemChanged.connect(self._activeItemChanged)
 
         # Store current labels and update plot
         self._xAxis._setCurrentLabel(xLabel)
@@ -2420,20 +2410,13 @@ class PlotWidget(qt.QMainWindow):
 
         self._setDirtyPlot()
 
-        activeLegend = self._activeLegend[kind]
-        if oldActiveItem is not None or activeLegend is not None:
-            if oldActiveItem is None:
-                oldActiveLegend = None
-            else:
-                oldActiveLegend = oldActiveItem.getName()
-            self.notify(
-                "active" + kind[0].upper() + kind[1:] + "Changed",
-                updated=oldActiveLegend != activeLegend,
-                previous=oldActiveLegend,
-                legend=activeLegend,
-            )
-
-        return activeLegend
+        self.notify(
+            f"active{kind.capitalize()}Changed",
+            updated=oldActiveItem is not item,
+            previous=None if oldActiveItem is None else oldActiveItem.getName(),
+            legend=legend,
+        )
+        return legend
 
     def _activeItemChanged(self, type_):
         """Listen for active item changed signal and broadcast signal

--- a/src/silx/gui/plot/StackView.py
+++ b/src/silx/gui/plot/StackView.py
@@ -593,7 +593,7 @@ class StackView(qt.QMainWindow):
         if exists is None:
             self._plot.addItem(self._stackItem)
 
-        self._plot.setActiveImage(self._stackItem.getName())
+        self._plot.setActiveImage(self._stackItem)
         self.__updatePlotLabels()
         self._updateTitle()
 

--- a/src/silx/gui/plot/StatsWidget.py
+++ b/src/silx/gui/plot/StatsWidget.py
@@ -199,7 +199,7 @@ class _PlotWidgetWrapper(_Wrapper):
             kind = self.getKind(item)
             if kind in plot._ACTIVE_ITEM_KINDS:
                 if plot._getActiveItem(kind) != item:
-                    plot._setActiveItem(kind, item.getName())
+                    plot._setActiveItem(kind, item)
 
     def getLabel(self, item):
         return item.getName()

--- a/src/silx/gui/plot/test/conftest.py
+++ b/src/silx/gui/plot/test/conftest.py
@@ -1,0 +1,43 @@
+# /*##########################################################################
+#
+# Copyright (c) 2023 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Test PlotWidget active item"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "13/12/2023"
+
+
+import pytest
+from silx.gui.plot import PlotWidget
+
+
+@pytest.fixture
+def plotWidget(qWidgetFactory, request):
+    try:
+        backend = request.param
+    except AttributeError:
+        backend = "mpl"  # Backend was not defined
+    if backend == "gl":
+        request.getfixturevalue("use_opengl")  # Skip test if OpenGL test disabled
+    yield qWidgetFactory(PlotWidget, backend=backend)

--- a/src/silx/gui/plot/test/testPlotWidget.py
+++ b/src/silx/gui/plot/test/testPlotWidget.py
@@ -29,7 +29,6 @@ __date__ = "03/01/2019"
 
 
 import unittest
-import logging
 import numpy
 import pytest
 
@@ -39,7 +38,6 @@ from silx.gui.utils.testutils import TestCaseQt
 
 from silx.gui import qt
 from silx.gui.plot import PlotWidget
-from silx.gui.plot.items.curve import CurveStyle
 from silx.gui.plot.items import BoundingRect, XAxisExtent, YAxisExtent, Axis
 from silx.gui.colors import Colormap
 
@@ -51,9 +49,6 @@ SIZE = 1024
 
 DATA_2D = numpy.arange(SIZE**2).reshape(SIZE, SIZE)
 """Image data set"""
-
-
-logger = logging.getLogger(__name__)
 
 
 class TestSpecialBackend(PlotWidgetTestCase, ParametricTestCase):
@@ -1123,190 +1118,6 @@ class TestPlotItem(PlotWidgetTestCase):
                 self.plot.resetZoom()
 
 
-class TestPlotActiveCurveImage(PlotWidgetTestCase):
-    """Basic tests for active curve and image handling"""
-
-    xData = numpy.arange(1000)
-    yData = -500 + 100 * numpy.sin(xData)
-    xData2 = xData + 1000
-    yData2 = xData - 1000 + 200 * numpy.random.random(1000)
-
-    def tearDown(self):
-        self.plot.setActiveCurveHandling(False)
-        super(TestPlotActiveCurveImage, self).tearDown()
-
-    def testActiveCurveAndLabels(self):
-        # Active curve handling off, no label change
-        self.plot.setActiveCurveHandling(False)
-        self.plot.getXAxis().setLabel("XLabel")
-        self.plot.getYAxis().setLabel("YLabel")
-        self.plot.addCurve((1, 2), (1, 2))
-        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
-
-        self.plot.addCurve((1, 2), (2, 3), xlabel="x1", ylabel="y1")
-        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
-
-        self.plot.clear()
-        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
-
-        # Active curve handling on, label changes
-        self.plot.setActiveCurveHandling(True)
-        self.plot.getXAxis().setLabel("XLabel")
-        self.plot.getYAxis().setLabel("YLabel")
-
-        # labels changed as active curve
-        self.plot.addCurve((1, 2), (1, 2), legend="1", xlabel="x1", ylabel="y1")
-        self.plot.setActiveCurve("1")
-        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
-
-        # labels not changed as not active curve
-        self.plot.addCurve((1, 2), (2, 3), legend="2")
-        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
-
-        # labels changed
-        self.plot.setActiveCurve("2")
-        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
-
-        self.plot.setActiveCurve("1")
-        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
-
-        self.plot.clear()
-        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
-
-    def testPlotActiveCurveSelectionMode(self):
-        self.plot.clear()
-        self.plot.setActiveCurveHandling(True)
-        legend = "curve 1"
-        self.plot.addCurve(self.xData, self.yData, legend=legend, color="green")
-
-        # active curve should be None
-        self.assertEqual(self.plot.getActiveCurve(just_legend=True), None)
-
-        # active curve should be None when None is set as active curve
-        self.plot.setActiveCurve(legend)
-        current = self.plot.getActiveCurve(just_legend=True)
-        self.assertEqual(current, legend)
-        self.plot.setActiveCurve(None)
-        current = self.plot.getActiveCurve(just_legend=True)
-        self.assertEqual(current, None)
-
-        # testing it automatically toggles if there is only one
-        self.plot.setActiveCurveSelectionMode("legacy")
-        current = self.plot.getActiveCurve(just_legend=True)
-        self.assertEqual(current, legend)
-
-        # active curve should not change when None set as active curve
-        self.assertEqual(self.plot.getActiveCurveSelectionMode(), "legacy")
-        self.plot.setActiveCurve(None)
-        current = self.plot.getActiveCurve(just_legend=True)
-        self.assertEqual(current, legend)
-
-        # situation where no curve is active
-        self.plot.clear()
-        self.plot.setActiveCurveHandling(True)
-        self.assertEqual(self.plot.getActiveCurveSelectionMode(), "atmostone")
-        self.plot.addCurve(self.xData, self.yData, legend=legend, color="green")
-        self.assertEqual(self.plot.getActiveCurve(just_legend=True), None)
-        self.plot.addCurve(self.xData2, self.yData2, legend="curve 2", color="red")
-        self.assertEqual(self.plot.getActiveCurve(just_legend=True), None)
-        self.plot.setActiveCurveSelectionMode("legacy")
-        self.assertEqual(self.plot.getActiveCurve(just_legend=True), None)
-
-        # the first curve added should be active
-        self.plot.clear()
-        self.plot.addCurve(self.xData, self.yData, legend=legend, color="green")
-        self.assertEqual(self.plot.getActiveCurve(just_legend=True), legend)
-        self.plot.addCurve(self.xData2, self.yData2, legend="curve 2", color="red")
-        self.assertEqual(self.plot.getActiveCurve(just_legend=True), legend)
-
-    def testActiveCurveStyle(self):
-        """Test change of active curve style"""
-        self.plot.setActiveCurveHandling(True)
-        self.plot.setActiveCurveStyle(color="black")
-        style = self.plot.getActiveCurveStyle()
-        self.assertEqual(style.getColor(), (0.0, 0.0, 0.0, 1.0))
-        self.assertIsNone(style.getLineStyle())
-        self.assertIsNone(style.getLineWidth())
-        self.assertIsNone(style.getSymbol())
-        self.assertIsNone(style.getSymbolSize())
-
-        self.plot.addCurve(x=self.xData, y=self.yData, legend="curve1")
-        curve = self.plot.getCurve("curve1")
-        curve.setColor("blue")
-        curve.setLineStyle("-")
-        curve.setLineWidth(1)
-        curve.setSymbol("o")
-        curve.setSymbolSize(5)
-
-        # Check default current style
-        defaultStyle = curve.getCurrentStyle()
-        self.assertEqual(
-            defaultStyle,
-            CurveStyle(
-                color="blue", linestyle="-", linewidth=1, symbol="o", symbolsize=5
-            ),
-        )
-
-        # Activate curve with highlight color=black
-        self.plot.setActiveCurve("curve1")
-        style = curve.getCurrentStyle()
-        self.assertEqual(style.getColor(), (0.0, 0.0, 0.0, 1.0))
-        self.assertEqual(style.getLineStyle(), "-")
-        self.assertEqual(style.getLineWidth(), 1)
-        self.assertEqual(style.getSymbol(), "o")
-        self.assertEqual(style.getSymbolSize(), 5)
-
-        # Change highlight to linewidth=2
-        self.plot.setActiveCurveStyle(linewidth=2)
-        style = curve.getCurrentStyle()
-        self.assertEqual(style.getColor(), (0.0, 0.0, 1.0, 1.0))
-        self.assertEqual(style.getLineStyle(), "-")
-        self.assertEqual(style.getLineWidth(), 2)
-        self.assertEqual(style.getSymbol(), "o")
-        self.assertEqual(style.getSymbolSize(), 5)
-
-        self.plot.setActiveCurve(None)
-        self.assertEqual(curve.getCurrentStyle(), defaultStyle)
-
-    def testActiveImageAndLabels(self):
-        # Active image handling always on, no API for toggling it
-        self.plot.getXAxis().setLabel("XLabel")
-        self.plot.getYAxis().setLabel("YLabel")
-
-        # labels changed as active curve
-        self.plot.addImage(
-            numpy.arange(100).reshape(10, 10), legend="1", xlabel="x1", ylabel="y1"
-        )
-        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
-
-        # labels not changed as not active curve
-        self.plot.addImage(numpy.arange(100).reshape(10, 10), legend="2")
-        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
-
-        # labels changed
-        self.plot.setActiveImage("2")
-        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
-
-        self.plot.setActiveImage("1")
-        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
-
-        self.plot.clear()
-        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
-
-
 ##############################################################################
 # Log
 ##############################################################################
@@ -2181,153 +1992,6 @@ class TestPlotWidgetSwitchBackend(PlotWidgetTestCase):
                 self.assertEqual(self.plot.getItems(), items)
 
 
-class TestPlotWidgetSelection(PlotWidgetTestCase):
-    """Test PlotWidget.selection and active items handling"""
-
-    def _checkSelection(self, selection, current=None, selected=()):
-        """Check current item and selected items."""
-        self.assertIs(selection.getCurrentItem(), current)
-        self.assertEqual(selection.getSelectedItems(), selected)
-
-    def testSyncWithActiveItems(self):
-        """Test update of PlotWidgetSelection according to active items"""
-        listener = SignalListener()
-
-        selection = self.plot.selection()
-        selection.sigCurrentItemChanged.connect(listener)
-        self._checkSelection(selection)
-
-        # Active item is current
-        self.plot.addImage(((0, 1), (2, 3)), legend="image")
-        image = self.plot.getActiveImage()
-        self.assertEqual(listener.callCount(), 1)
-        self._checkSelection(selection, image, (image,))
-
-        # No active = no current
-        self.plot.setActiveImage(None)
-        self.assertEqual(listener.callCount(), 2)
-        self._checkSelection(selection)
-
-        # Active item is current
-        self.plot.setActiveImage("image")
-        self.assertEqual(listener.callCount(), 3)
-        self._checkSelection(selection, image, (image,))
-
-        # Mosted recently "actived" item is current
-        self.plot.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
-        scatter = self.plot.getActiveScatter()
-        self.assertEqual(listener.callCount(), 4)
-        self._checkSelection(selection, scatter, (scatter, image))
-
-        # Previously mosted recently "actived" item is current
-        self.plot.setActiveScatter(None)
-        self.assertEqual(listener.callCount(), 5)
-        self._checkSelection(selection, image, (image,))
-
-        # Mosted recently "actived" item is current
-        self.plot.setActiveScatter("scatter")
-        self.assertEqual(listener.callCount(), 6)
-        self._checkSelection(selection, scatter, (scatter, image))
-
-        # No active = no current
-        self.plot.setActiveImage(None)
-        self.plot.setActiveScatter(None)
-        self.assertEqual(listener.callCount(), 7)
-        self._checkSelection(selection)
-
-        # Mosted recently "actived" item is current
-        self.plot.setActiveScatter("scatter")
-        self.assertEqual(listener.callCount(), 8)
-        self.plot.setActiveImage("image")
-        self.assertEqual(listener.callCount(), 9)
-        self._checkSelection(selection, image, (image, scatter))
-
-        # Add a curve which is not active by default
-        self.plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
-        curve = self.plot.getCurve("curve")
-        self.assertEqual(listener.callCount(), 9)
-        self._checkSelection(selection, image, (image, scatter))
-
-        # Mosted recently "actived" item is current
-        self.plot.setActiveCurve("curve")
-        self.assertEqual(listener.callCount(), 10)
-        self._checkSelection(selection, curve, (curve, image, scatter))
-
-        # Add a curve which is not active by default
-        self.plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve2")
-        curve2 = self.plot.getCurve("curve2")
-        self.assertEqual(listener.callCount(), 10)
-        self._checkSelection(selection, curve, (curve, image, scatter))
-
-        # Mosted recently "actived" item is current, previous curve is removed
-        self.plot.setActiveCurve("curve2")
-        self.assertEqual(listener.callCount(), 11)
-        self._checkSelection(selection, curve2, (curve2, image, scatter))
-
-        # No items = no current
-        self.plot.clear()
-        self.assertEqual(listener.callCount(), 12)
-        self._checkSelection(selection)
-
-    def testPlotWidgetWithItems(self):
-        """Test init of selection on a plot with items"""
-        self.plot.addImage(((0, 1), (2, 3)), legend="image")
-        self.plot.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
-        self.plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
-        self.plot.setActiveCurve("curve")
-
-        selection = self.plot.selection()
-        self.assertIsNotNone(selection.getCurrentItem())
-        selected = selection.getSelectedItems()
-        self.assertEqual(len(selected), 3)
-        self.assertIn(self.plot.getActiveCurve(), selected)
-        self.assertIn(self.plot.getActiveImage(), selected)
-        self.assertIn(self.plot.getActiveScatter(), selected)
-
-    def testSetCurrentItem(self):
-        """Test setCurrentItem"""
-        # Add items to the plot
-        self.plot.addImage(((0, 1), (2, 3)), legend="image")
-        image = self.plot.getActiveImage()
-        self.plot.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
-        scatter = self.plot.getActiveScatter()
-        self.plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
-        self.plot.setActiveCurve("curve")
-        curve = self.plot.getActiveCurve()
-
-        selection = self.plot.selection()
-        self.assertIsNotNone(selection.getCurrentItem())
-        self.assertEqual(len(selection.getSelectedItems()), 3)
-
-        # Set current to None reset all active items
-        selection.setCurrentItem(None)
-        self._checkSelection(selection)
-        self.assertIsNone(self.plot.getActiveCurve())
-        self.assertIsNone(self.plot.getActiveImage())
-        self.assertIsNone(self.plot.getActiveScatter())
-
-        # Set current to an item makes it active
-        selection.setCurrentItem(image)
-        self._checkSelection(selection, image, (image,))
-        self.assertIsNone(self.plot.getActiveCurve())
-        self.assertIs(self.plot.getActiveImage(), image)
-        self.assertIsNone(self.plot.getActiveScatter())
-
-        # Set current to an item makes it active and keeps other active
-        selection.setCurrentItem(curve)
-        self._checkSelection(selection, curve, (curve, image))
-        self.assertIs(self.plot.getActiveCurve(), curve)
-        self.assertIs(self.plot.getActiveImage(), image)
-        self.assertIsNone(self.plot.getActiveScatter())
-
-        # Set current to an item makes it active and keeps other active
-        selection.setCurrentItem(scatter)
-        self._checkSelection(selection, scatter, (scatter, curve, image))
-        self.assertIs(self.plot.getActiveCurve(), curve)
-        self.assertIs(self.plot.getActiveImage(), image)
-        self.assertIs(self.plot.getActiveScatter(), scatter)
-
-
 @pytest.mark.usefixtures("use_opengl")
 class TestPlotWidget_Gl(TestPlotWidget):
     backend = "gl"
@@ -2369,11 +2033,6 @@ class TestPlotAxes_Gl(TestPlotAxes):
 
 
 @pytest.mark.usefixtures("use_opengl")
-class TestPlotActiveCurveImage_Gl(TestPlotActiveCurveImage):
-    backend = "gl"
-
-
-@pytest.mark.usefixtures("use_opengl")
 class TestPlotEmptyLog_Gl(TestPlotEmptyLog):
     backend = "gl"
 
@@ -2390,11 +2049,6 @@ class TestPlotImageLog_Gl(TestPlotImageLog):
 
 @pytest.mark.usefixtures("use_opengl")
 class TestPlotMarkerLog_Gl(TestPlotMarkerLog):
-    backend = "gl"
-
-
-@pytest.mark.usefixtures("use_opengl")
-class TestPlotWidgetSelection_Gl(TestPlotWidgetSelection):
     backend = "gl"
 
 

--- a/src/silx/gui/plot/test/testPlotWidgetActiveItem.py
+++ b/src/silx/gui/plot/test/testPlotWidgetActiveItem.py
@@ -34,347 +34,383 @@ import pytest
 from silx.gui.utils.testutils import SignalListener
 
 from silx.gui import qt
+from silx.gui.plot import PlotWidget
 from silx.gui.plot.items.curve import CurveStyle
 
 from .utils import PlotWidgetTestCase
 
 
-class TestPlotActiveCurveImage(PlotWidgetTestCase):
-    """Basic tests for active curve and image handling"""
+@pytest.mark.parametrize("backend", ("mpl", "gl"))
+def testActiveCurveAndLabels(qWidgetFactory, backend, request):
+    if backend == "gl":
+        request.getfixturevalue("use_opengl")  # Skip test if OpenGL test disabled
+
+    plot = qWidgetFactory(PlotWidget, backend=backend)
+
+    # Active curve handling off, no label change
+    plot.setActiveCurveHandling(False)
+    plot.getXAxis().setLabel("XLabel")
+    plot.getYAxis().setLabel("YLabel")
+    plot.addCurve((1, 2), (1, 2))
+    assert plot.getXAxis().getLabel() == "XLabel"
+    assert plot.getYAxis().getLabel() == "YLabel"
+
+    plot.addCurve((1, 2), (2, 3), xlabel="x1", ylabel="y1")
+    assert plot.getXAxis().getLabel() == "XLabel"
+    assert plot.getYAxis().getLabel() == "YLabel"
+
+    plot.clear()
+    assert plot.getXAxis().getLabel() == "XLabel"
+    assert plot.getYAxis().getLabel() == "YLabel"
+
+    # Active curve handling on, label changes
+    plot.setActiveCurveHandling(True)
+    plot.getXAxis().setLabel("XLabel")
+    plot.getYAxis().setLabel("YLabel")
+
+    # labels changed as active curve
+    plot.addCurve((1, 2), (1, 2), legend="1", xlabel="x1", ylabel="y1")
+    plot.setActiveCurve("1")
+    assert plot.getXAxis().getLabel() == "x1"
+    assert plot.getYAxis().getLabel() == "y1"
+
+    # labels not changed as not active curve
+    plot.addCurve((1, 2), (2, 3), legend="2")
+    assert plot.getXAxis().getLabel() == "x1"
+    assert plot.getYAxis().getLabel() == "y1"
+
+    # labels changed
+    plot.setActiveCurve("2")
+    assert plot.getXAxis().getLabel() == "XLabel"
+    assert plot.getYAxis().getLabel() == "YLabel"
+
+    plot.setActiveCurve("1")
+    assert plot.getXAxis().getLabel() == "x1"
+    assert plot.getYAxis().getLabel() == "y1"
+
+    plot.clear()
+    assert plot.getXAxis().getLabel() == "XLabel"
+    assert plot.getYAxis().getLabel() == "YLabel"
+
+    plot.setActiveCurveHandling(False)
+
+
+@pytest.mark.parametrize("backend", ("mpl", "gl"))
+def testPlotActiveCurveSelectionMode(qWidgetFactory, backend, request):
+    if backend == "gl":
+        request.getfixturevalue("use_opengl")  # Skip test if OpenGL test disabled
 
     xData = numpy.arange(1000)
     yData = -500 + 100 * numpy.sin(xData)
     xData2 = xData + 1000
     yData2 = xData - 1000 + 200 * numpy.random.random(1000)
 
-    def tearDown(self):
-        self.plot.setActiveCurveHandling(False)
-        super(TestPlotActiveCurveImage, self).tearDown()
+    plot = qWidgetFactory(PlotWidget)
 
-    def testActiveCurveAndLabels(self):
-        # Active curve handling off, no label change
-        self.plot.setActiveCurveHandling(False)
-        self.plot.getXAxis().setLabel("XLabel")
-        self.plot.getYAxis().setLabel("YLabel")
-        self.plot.addCurve((1, 2), (1, 2))
-        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
+    plot.clear()
+    plot.setActiveCurveHandling(True)
+    legend = "curve 1"
+    plot.addCurve(xData, yData, legend=legend, color="green")
 
-        self.plot.addCurve((1, 2), (2, 3), xlabel="x1", ylabel="y1")
-        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
+    # active curve should be None
+    assert plot.getActiveCurve(just_legend=True) is None
 
-        self.plot.clear()
-        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
+    # active curve should be None when None is set as active curve
+    plot.setActiveCurve(legend)
+    current = plot.getActiveCurve(just_legend=True)
+    assert current == legend
+    plot.setActiveCurve(None)
+    current = plot.getActiveCurve(just_legend=True)
+    assert current is None
 
-        # Active curve handling on, label changes
-        self.plot.setActiveCurveHandling(True)
-        self.plot.getXAxis().setLabel("XLabel")
-        self.plot.getYAxis().setLabel("YLabel")
+    # testing it automatically toggles if there is only one
+    plot.setActiveCurveSelectionMode("legacy")
+    current = plot.getActiveCurve(just_legend=True)
+    assert current == legend
 
-        # labels changed as active curve
-        self.plot.addCurve((1, 2), (1, 2), legend="1", xlabel="x1", ylabel="y1")
-        self.plot.setActiveCurve("1")
-        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
+    # active curve should not change when None set as active curve
+    assert plot.getActiveCurveSelectionMode() == "legacy"
+    plot.setActiveCurve(None)
+    current = plot.getActiveCurve(just_legend=True)
+    assert current == legend
 
-        # labels not changed as not active curve
-        self.plot.addCurve((1, 2), (2, 3), legend="2")
-        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
+    # situation where no curve is active
+    plot.clear()
+    plot.setActiveCurveHandling(True)
+    assert plot.getActiveCurveSelectionMode() == "atmostone"
+    plot.addCurve(xData, yData, legend=legend, color="green")
+    assert plot.getActiveCurve(just_legend=True) is None
+    plot.addCurve(xData2, yData2, legend="curve 2", color="red")
+    assert plot.getActiveCurve(just_legend=True) is None
+    plot.setActiveCurveSelectionMode("legacy")
+    assert plot.getActiveCurve(just_legend=True) is None
 
-        # labels changed
-        self.plot.setActiveCurve("2")
-        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
+    # the first curve added should be active
+    plot.clear()
+    plot.addCurve(xData, yData, legend=legend, color="green")
+    assert plot.getActiveCurve(just_legend=True) == legend
+    plot.addCurve(xData2, yData2, legend="curve 2", color="red")
+    assert plot.getActiveCurve(just_legend=True) == legend
 
-        self.plot.setActiveCurve("1")
-        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
-
-        self.plot.clear()
-        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
-
-    def testPlotActiveCurveSelectionMode(self):
-        self.plot.clear()
-        self.plot.setActiveCurveHandling(True)
-        legend = "curve 1"
-        self.plot.addCurve(self.xData, self.yData, legend=legend, color="green")
-
-        # active curve should be None
-        self.assertEqual(self.plot.getActiveCurve(just_legend=True), None)
-
-        # active curve should be None when None is set as active curve
-        self.plot.setActiveCurve(legend)
-        current = self.plot.getActiveCurve(just_legend=True)
-        self.assertEqual(current, legend)
-        self.plot.setActiveCurve(None)
-        current = self.plot.getActiveCurve(just_legend=True)
-        self.assertEqual(current, None)
-
-        # testing it automatically toggles if there is only one
-        self.plot.setActiveCurveSelectionMode("legacy")
-        current = self.plot.getActiveCurve(just_legend=True)
-        self.assertEqual(current, legend)
-
-        # active curve should not change when None set as active curve
-        self.assertEqual(self.plot.getActiveCurveSelectionMode(), "legacy")
-        self.plot.setActiveCurve(None)
-        current = self.plot.getActiveCurve(just_legend=True)
-        self.assertEqual(current, legend)
-
-        # situation where no curve is active
-        self.plot.clear()
-        self.plot.setActiveCurveHandling(True)
-        self.assertEqual(self.plot.getActiveCurveSelectionMode(), "atmostone")
-        self.plot.addCurve(self.xData, self.yData, legend=legend, color="green")
-        self.assertEqual(self.plot.getActiveCurve(just_legend=True), None)
-        self.plot.addCurve(self.xData2, self.yData2, legend="curve 2", color="red")
-        self.assertEqual(self.plot.getActiveCurve(just_legend=True), None)
-        self.plot.setActiveCurveSelectionMode("legacy")
-        self.assertEqual(self.plot.getActiveCurve(just_legend=True), None)
-
-        # the first curve added should be active
-        self.plot.clear()
-        self.plot.addCurve(self.xData, self.yData, legend=legend, color="green")
-        self.assertEqual(self.plot.getActiveCurve(just_legend=True), legend)
-        self.plot.addCurve(self.xData2, self.yData2, legend="curve 2", color="red")
-        self.assertEqual(self.plot.getActiveCurve(just_legend=True), legend)
-
-    def testActiveCurveStyle(self):
-        """Test change of active curve style"""
-        self.plot.setActiveCurveHandling(True)
-        self.plot.setActiveCurveStyle(color="black")
-        style = self.plot.getActiveCurveStyle()
-        self.assertEqual(style.getColor(), (0.0, 0.0, 0.0, 1.0))
-        self.assertIsNone(style.getLineStyle())
-        self.assertIsNone(style.getLineWidth())
-        self.assertIsNone(style.getSymbol())
-        self.assertIsNone(style.getSymbolSize())
-
-        self.plot.addCurve(x=self.xData, y=self.yData, legend="curve1")
-        curve = self.plot.getCurve("curve1")
-        curve.setColor("blue")
-        curve.setLineStyle("-")
-        curve.setLineWidth(1)
-        curve.setSymbol("o")
-        curve.setSymbolSize(5)
-
-        # Check default current style
-        defaultStyle = curve.getCurrentStyle()
-        self.assertEqual(
-            defaultStyle,
-            CurveStyle(
-                color="blue", linestyle="-", linewidth=1, symbol="o", symbolsize=5
-            ),
-        )
-
-        # Activate curve with highlight color=black
-        self.plot.setActiveCurve("curve1")
-        style = curve.getCurrentStyle()
-        self.assertEqual(style.getColor(), (0.0, 0.0, 0.0, 1.0))
-        self.assertEqual(style.getLineStyle(), "-")
-        self.assertEqual(style.getLineWidth(), 1)
-        self.assertEqual(style.getSymbol(), "o")
-        self.assertEqual(style.getSymbolSize(), 5)
-
-        # Change highlight to linewidth=2
-        self.plot.setActiveCurveStyle(linewidth=2)
-        style = curve.getCurrentStyle()
-        self.assertEqual(style.getColor(), (0.0, 0.0, 1.0, 1.0))
-        self.assertEqual(style.getLineStyle(), "-")
-        self.assertEqual(style.getLineWidth(), 2)
-        self.assertEqual(style.getSymbol(), "o")
-        self.assertEqual(style.getSymbolSize(), 5)
-
-        self.plot.setActiveCurve(None)
-        self.assertEqual(curve.getCurrentStyle(), defaultStyle)
-
-    def testActiveImageAndLabels(self):
-        # Active image handling always on, no API for toggling it
-        self.plot.getXAxis().setLabel("XLabel")
-        self.plot.getYAxis().setLabel("YLabel")
-
-        # labels changed as active curve
-        self.plot.addImage(
-            numpy.arange(100).reshape(10, 10), legend="1", xlabel="x1", ylabel="y1"
-        )
-        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
-
-        # labels not changed as not active curve
-        self.plot.addImage(numpy.arange(100).reshape(10, 10), legend="2")
-        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
-
-        # labels changed
-        self.plot.setActiveImage("2")
-        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
-
-        self.plot.setActiveImage("1")
-        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
-
-        self.plot.clear()
-        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
-        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
+    plot.setActiveCurveHandling(False)
 
 
-class TestPlotWidgetSelection(PlotWidgetTestCase):
-    """Test PlotWidget.selection and active items handling"""
+@pytest.mark.parametrize("backend", ("mpl", "gl"))
+def testActiveCurveStyle(qWidgetFactory, backend, request):
+    """Test change of active curve style"""
+    if backend == "gl":
+        request.getfixturevalue("use_opengl")  # Skip test if OpenGL test disabled
 
-    def _checkSelection(self, selection, current=None, selected=()):
-        """Check current item and selected items."""
-        self.assertIs(selection.getCurrentItem(), current)
-        self.assertEqual(selection.getSelectedItems(), selected)
+    plot = qWidgetFactory(PlotWidget)
 
-    def testSyncWithActiveItems(self):
-        """Test update of PlotWidgetSelection according to active items"""
-        listener = SignalListener()
+    plot.setActiveCurveHandling(True)
+    plot.setActiveCurveStyle(color="black")
+    style = plot.getActiveCurveStyle()
+    assert style.getColor() == (0.0, 0.0, 0.0, 1.0)
+    assert style.getLineStyle() is None
+    assert style.getLineWidth() is None
+    assert style.getSymbol() is None
+    assert style.getSymbolSize() is None
 
-        selection = self.plot.selection()
-        selection.sigCurrentItemChanged.connect(listener)
-        self._checkSelection(selection)
+    xData = numpy.arange(1000)
+    yData = -500 + 100 * numpy.sin(xData)
+    plot.addCurve(x=xData, y=yData, legend="curve1")
+    curve = plot.getCurve("curve1")
+    curve.setColor("blue")
+    curve.setLineStyle("-")
+    curve.setLineWidth(1)
+    curve.setSymbol("o")
+    curve.setSymbolSize(5)
 
-        # Active item is current
-        self.plot.addImage(((0, 1), (2, 3)), legend="image")
-        image = self.plot.getActiveImage()
-        self.assertEqual(listener.callCount(), 1)
-        self._checkSelection(selection, image, (image,))
+    # Check default current style
+    defaultStyle = curve.getCurrentStyle()
+    assert defaultStyle == CurveStyle(
+        color="blue", linestyle="-", linewidth=1, symbol="o", symbolsize=5
+    )
 
-        # No active = no current
-        self.plot.setActiveImage(None)
-        self.assertEqual(listener.callCount(), 2)
-        self._checkSelection(selection)
+    # Activate curve with highlight color=black
+    plot.setActiveCurve("curve1")
+    style = curve.getCurrentStyle()
+    assert style.getColor() == (0.0, 0.0, 0.0, 1.0)
+    assert style.getLineStyle() == "-"
+    assert style.getLineWidth() == 1
+    assert style.getSymbol() == "o"
+    assert style.getSymbolSize() == 5
 
-        # Active item is current
-        self.plot.setActiveImage("image")
-        self.assertEqual(listener.callCount(), 3)
-        self._checkSelection(selection, image, (image,))
+    # Change highlight to linewidth=2
+    plot.setActiveCurveStyle(linewidth=2)
+    style = curve.getCurrentStyle()
+    assert style.getColor() == (0.0, 0.0, 1.0, 1.0)
+    assert style.getLineStyle() == "-"
+    assert style.getLineWidth() == 2
+    assert style.getSymbol() == "o"
+    assert style.getSymbolSize() == 5
 
-        # Mosted recently "actived" item is current
-        self.plot.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
-        scatter = self.plot.getActiveScatter()
-        self.assertEqual(listener.callCount(), 4)
-        self._checkSelection(selection, scatter, (scatter, image))
+    plot.setActiveCurve(None)
+    assert curve.getCurrentStyle() == defaultStyle
 
-        # Previously mosted recently "actived" item is current
-        self.plot.setActiveScatter(None)
-        self.assertEqual(listener.callCount(), 5)
-        self._checkSelection(selection, image, (image,))
-
-        # Mosted recently "actived" item is current
-        self.plot.setActiveScatter("scatter")
-        self.assertEqual(listener.callCount(), 6)
-        self._checkSelection(selection, scatter, (scatter, image))
-
-        # No active = no current
-        self.plot.setActiveImage(None)
-        self.plot.setActiveScatter(None)
-        self.assertEqual(listener.callCount(), 7)
-        self._checkSelection(selection)
-
-        # Mosted recently "actived" item is current
-        self.plot.setActiveScatter("scatter")
-        self.assertEqual(listener.callCount(), 8)
-        self.plot.setActiveImage("image")
-        self.assertEqual(listener.callCount(), 9)
-        self._checkSelection(selection, image, (image, scatter))
-
-        # Add a curve which is not active by default
-        self.plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
-        curve = self.plot.getCurve("curve")
-        self.assertEqual(listener.callCount(), 9)
-        self._checkSelection(selection, image, (image, scatter))
-
-        # Mosted recently "actived" item is current
-        self.plot.setActiveCurve("curve")
-        self.assertEqual(listener.callCount(), 10)
-        self._checkSelection(selection, curve, (curve, image, scatter))
-
-        # Add a curve which is not active by default
-        self.plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve2")
-        curve2 = self.plot.getCurve("curve2")
-        self.assertEqual(listener.callCount(), 10)
-        self._checkSelection(selection, curve, (curve, image, scatter))
-
-        # Mosted recently "actived" item is current, previous curve is removed
-        self.plot.setActiveCurve("curve2")
-        self.assertEqual(listener.callCount(), 11)
-        self._checkSelection(selection, curve2, (curve2, image, scatter))
-
-        # No items = no current
-        self.plot.clear()
-        self.assertEqual(listener.callCount(), 12)
-        self._checkSelection(selection)
-
-    def testPlotWidgetWithItems(self):
-        """Test init of selection on a plot with items"""
-        self.plot.addImage(((0, 1), (2, 3)), legend="image")
-        self.plot.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
-        self.plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
-        self.plot.setActiveCurve("curve")
-
-        selection = self.plot.selection()
-        self.assertIsNotNone(selection.getCurrentItem())
-        selected = selection.getSelectedItems()
-        self.assertEqual(len(selected), 3)
-        self.assertIn(self.plot.getActiveCurve(), selected)
-        self.assertIn(self.plot.getActiveImage(), selected)
-        self.assertIn(self.plot.getActiveScatter(), selected)
-
-    def testSetCurrentItem(self):
-        """Test setCurrentItem"""
-        # Add items to the plot
-        self.plot.addImage(((0, 1), (2, 3)), legend="image")
-        image = self.plot.getActiveImage()
-        self.plot.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
-        scatter = self.plot.getActiveScatter()
-        self.plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
-        self.plot.setActiveCurve("curve")
-        curve = self.plot.getActiveCurve()
-
-        selection = self.plot.selection()
-        self.assertIsNotNone(selection.getCurrentItem())
-        self.assertEqual(len(selection.getSelectedItems()), 3)
-
-        # Set current to None reset all active items
-        selection.setCurrentItem(None)
-        self._checkSelection(selection)
-        self.assertIsNone(self.plot.getActiveCurve())
-        self.assertIsNone(self.plot.getActiveImage())
-        self.assertIsNone(self.plot.getActiveScatter())
-
-        # Set current to an item makes it active
-        selection.setCurrentItem(image)
-        self._checkSelection(selection, image, (image,))
-        self.assertIsNone(self.plot.getActiveCurve())
-        self.assertIs(self.plot.getActiveImage(), image)
-        self.assertIsNone(self.plot.getActiveScatter())
-
-        # Set current to an item makes it active and keeps other active
-        selection.setCurrentItem(curve)
-        self._checkSelection(selection, curve, (curve, image))
-        self.assertIs(self.plot.getActiveCurve(), curve)
-        self.assertIs(self.plot.getActiveImage(), image)
-        self.assertIsNone(self.plot.getActiveScatter())
-
-        # Set current to an item makes it active and keeps other active
-        selection.setCurrentItem(scatter)
-        self._checkSelection(selection, scatter, (scatter, curve, image))
-        self.assertIs(self.plot.getActiveCurve(), curve)
-        self.assertIs(self.plot.getActiveImage(), image)
-        self.assertIs(self.plot.getActiveScatter(), scatter)
+    plot.setActiveCurveHandling(False)
 
 
-@pytest.mark.usefixtures("use_opengl")
-class TestPlotActiveCurveImage_Gl(TestPlotActiveCurveImage):
-    backend = "gl"
+@pytest.mark.parametrize("backend", ("mpl", "gl"))
+def testActiveImageAndLabels(qWidgetFactory, backend, request):
+    if backend == "gl":
+        request.getfixturevalue("use_opengl")  # Skip test if OpenGL test disabled
+
+    plot = qWidgetFactory(PlotWidget)
+
+    # Active image handling always on, no API for toggling it
+    plot.getXAxis().setLabel("XLabel")
+    plot.getYAxis().setLabel("YLabel")
+
+    # labels changed as active curve
+    plot.addImage(
+        numpy.arange(100).reshape(10, 10), legend="1", xlabel="x1", ylabel="y1"
+    )
+    assert plot.getXAxis().getLabel() == "x1"
+    assert plot.getYAxis().getLabel() == "y1"
+
+    # labels not changed as not active curve
+    plot.addImage(numpy.arange(100).reshape(10, 10), legend="2")
+    assert plot.getXAxis().getLabel() == "x1"
+    assert plot.getYAxis().getLabel() == "y1"
+
+    # labels changed
+    plot.setActiveImage("2")
+    assert plot.getXAxis().getLabel() == "XLabel"
+    assert plot.getYAxis().getLabel() == "YLabel"
+
+    plot.setActiveImage("1")
+    assert plot.getXAxis().getLabel() == "x1"
+    assert plot.getYAxis().getLabel() == "y1"
+
+    plot.clear()
+    assert plot.getXAxis().getLabel() == "XLabel"
+    assert plot.getYAxis().getLabel() == "YLabel"
+
+    plot.setActiveCurveHandling(False)
 
 
-@pytest.mark.usefixtures("use_opengl")
-class TestPlotWidgetSelection_Gl(TestPlotWidgetSelection):
-    backend = "gl"
+def _checkSelection(selection, current=None, selected=()):
+    """Check current item and selected items."""
+    assert selection.getCurrentItem() is current
+    assert selection.getSelectedItems() == selected
+
+
+@pytest.mark.parametrize("backend", ("mpl", "gl"))
+def testSyncWithActiveItems(qWidgetFactory, backend, request):
+    """Test update of PlotWidgetSelection according to active items"""
+    if backend == "gl":
+        request.getfixturevalue("use_opengl")  # Skip test if OpenGL test disabled
+
+    plot = qWidgetFactory(PlotWidget, backend=backend)
+
+    listener = SignalListener()
+
+    selection = plot.selection()
+    selection.sigCurrentItemChanged.connect(listener)
+    _checkSelection(selection)
+
+    # Active item is current
+    plot.addImage(((0, 1), (2, 3)), legend="image")
+    image = plot.getActiveImage()
+    assert listener.callCount() == 1
+    _checkSelection(selection, image, (image,))
+
+    # No active = no current
+    plot.setActiveImage(None)
+    assert listener.callCount() == 2
+    _checkSelection(selection)
+
+    # Active item is current
+    plot.setActiveImage("image")
+    assert listener.callCount() == 3
+    _checkSelection(selection, image, (image,))
+
+    # Mosted recently "actived" item is current
+    plot.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
+    scatter = plot.getActiveScatter()
+    assert listener.callCount() == 4
+    _checkSelection(selection, scatter, (scatter, image))
+
+    # Previously mosted recently "actived" item is current
+    plot.setActiveScatter(None)
+    assert listener.callCount() == 5
+    _checkSelection(selection, image, (image,))
+
+    # Mosted recently "actived" item is current
+    plot.setActiveScatter("scatter")
+    assert listener.callCount() == 6
+    _checkSelection(selection, scatter, (scatter, image))
+
+    # No active = no current
+    plot.setActiveImage(None)
+    plot.setActiveScatter(None)
+    assert listener.callCount() == 7
+    _checkSelection(selection)
+
+    # Mosted recently "actived" item is current
+    plot.setActiveScatter("scatter")
+    assert listener.callCount() == 8
+    plot.setActiveImage("image")
+    assert listener.callCount() == 9
+    _checkSelection(selection, image, (image, scatter))
+
+    # Add a curve which is not active by default
+    plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
+    curve = plot.getCurve("curve")
+    assert listener.callCount() == 9
+    _checkSelection(selection, image, (image, scatter))
+
+    # Mosted recently "actived" item is current
+    plot.setActiveCurve("curve")
+    assert listener.callCount() == 10
+    _checkSelection(selection, curve, (curve, image, scatter))
+
+    # Add a curve which is not active by default
+    plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve2")
+    curve2 = plot.getCurve("curve2")
+    assert listener.callCount() == 10
+    _checkSelection(selection, curve, (curve, image, scatter))
+
+    # Mosted recently "actived" item is current, previous curve is removed
+    plot.setActiveCurve("curve2")
+    assert listener.callCount() == 11
+    _checkSelection(selection, curve2, (curve2, image, scatter))
+
+    # No items = no current
+    plot.clear()
+    assert listener.callCount() == 12
+    _checkSelection(selection)
+
+
+@pytest.mark.parametrize("backend", ("mpl", "gl"))
+def testPlotWidgetWithItems(qWidgetFactory, backend, request):
+    """Test init of selection on a plot with items"""
+    if backend == "gl":
+        request.getfixturevalue("use_opengl")  # Skip test if OpenGL test disabled
+
+    plot = qWidgetFactory(PlotWidget, backend=backend)
+
+    plot.addImage(((0, 1), (2, 3)), legend="image")
+    plot.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
+    plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
+    plot.setActiveCurve("curve")
+
+    selection = plot.selection()
+    assert selection.getCurrentItem() is not None
+    selected = selection.getSelectedItems()
+    assert len(selected) == 3
+    assert plot.getActiveCurve() in selected
+    assert plot.getActiveImage() in selected
+    assert plot.getActiveScatter() in selected
+
+
+@pytest.mark.parametrize("backend", ("mpl", "gl"))
+def testSetCurrentItem(qWidgetFactory, backend, request):
+    """Test setCurrentItem"""
+    if backend == "gl":
+        request.getfixturevalue("use_opengl")  # Skip test if OpenGL test disabled
+
+    plot = qWidgetFactory(PlotWidget, backend=backend)
+
+    # Add items to the plot
+    plot.addImage(((0, 1), (2, 3)), legend="image")
+    image = plot.getActiveImage()
+    plot.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
+    scatter = plot.getActiveScatter()
+    plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
+    plot.setActiveCurve("curve")
+    curve = plot.getActiveCurve()
+
+    selection = plot.selection()
+    assert selection.getCurrentItem() is not None
+    assert len(selection.getSelectedItems()) == 3
+
+    # Set current to None reset all active items
+    selection.setCurrentItem(None)
+    _checkSelection(selection)
+    assert plot.getActiveCurve() is None
+    assert plot.getActiveImage() is None
+    assert plot.getActiveScatter() is None
+
+    # Set current to an item makes it active
+    selection.setCurrentItem(image)
+    _checkSelection(selection, image, (image,))
+    assert plot.getActiveCurve() is None
+    assert plot.getActiveImage() is image
+    assert plot.getActiveScatter() is None
+
+    # Set current to an item makes it active and keeps other active
+    selection.setCurrentItem(curve)
+    _checkSelection(selection, curve, (curve, image))
+    assert plot.getActiveCurve() is curve
+    assert plot.getActiveImage() is image
+    assert plot.getActiveScatter() is None
+
+    # Set current to an item makes it active and keeps other active
+    selection.setCurrentItem(scatter)
+    _checkSelection(selection, scatter, (scatter, curve, image))
+    assert plot.getActiveCurve() is curve
+    assert plot.getActiveImage() is image
+    assert plot.getActiveScatter() is scatter

--- a/src/silx/gui/plot/test/testPlotWidgetActiveItem.py
+++ b/src/silx/gui/plot/test/testPlotWidgetActiveItem.py
@@ -40,132 +40,125 @@ from silx.gui.plot.items.curve import CurveStyle
 from .utils import PlotWidgetTestCase
 
 
-@pytest.mark.parametrize("backend", ("mpl", "gl"))
-def testActiveCurveAndLabels(qWidgetFactory, backend, request):
+@pytest.fixture
+def plotWidget(qWidgetFactory, request):
+    backend = request.param
     if backend == "gl":
         request.getfixturevalue("use_opengl")  # Skip test if OpenGL test disabled
+    yield qWidgetFactory(PlotWidget, backend=backend)
 
-    plot = qWidgetFactory(PlotWidget, backend=backend)
 
+@pytest.mark.parametrize("plotWidget", ("mpl", "gl"), indirect=True)
+def testActiveCurveAndLabels(plotWidget):
     # Active curve handling off, no label change
-    plot.setActiveCurveHandling(False)
-    plot.getXAxis().setLabel("XLabel")
-    plot.getYAxis().setLabel("YLabel")
-    plot.addCurve((1, 2), (1, 2))
-    assert plot.getXAxis().getLabel() == "XLabel"
-    assert plot.getYAxis().getLabel() == "YLabel"
+    plotWidget.setActiveCurveHandling(False)
+    plotWidget.getXAxis().setLabel("XLabel")
+    plotWidget.getYAxis().setLabel("YLabel")
+    plotWidget.addCurve((1, 2), (1, 2))
+    assert plotWidget.getXAxis().getLabel() == "XLabel"
+    assert plotWidget.getYAxis().getLabel() == "YLabel"
 
-    plot.addCurve((1, 2), (2, 3), xlabel="x1", ylabel="y1")
-    assert plot.getXAxis().getLabel() == "XLabel"
-    assert plot.getYAxis().getLabel() == "YLabel"
+    plotWidget.addCurve((1, 2), (2, 3), xlabel="x1", ylabel="y1")
+    assert plotWidget.getXAxis().getLabel() == "XLabel"
+    assert plotWidget.getYAxis().getLabel() == "YLabel"
 
-    plot.clear()
-    assert plot.getXAxis().getLabel() == "XLabel"
-    assert plot.getYAxis().getLabel() == "YLabel"
+    plotWidget.clear()
+    assert plotWidget.getXAxis().getLabel() == "XLabel"
+    assert plotWidget.getYAxis().getLabel() == "YLabel"
 
     # Active curve handling on, label changes
-    plot.setActiveCurveHandling(True)
-    plot.getXAxis().setLabel("XLabel")
-    plot.getYAxis().setLabel("YLabel")
+    plotWidget.setActiveCurveHandling(True)
+    plotWidget.getXAxis().setLabel("XLabel")
+    plotWidget.getYAxis().setLabel("YLabel")
 
     # labels changed as active curve
-    plot.addCurve((1, 2), (1, 2), legend="1", xlabel="x1", ylabel="y1")
-    plot.setActiveCurve("1")
-    assert plot.getXAxis().getLabel() == "x1"
-    assert plot.getYAxis().getLabel() == "y1"
+    plotWidget.addCurve((1, 2), (1, 2), legend="1", xlabel="x1", ylabel="y1")
+    plotWidget.setActiveCurve("1")
+    assert plotWidget.getXAxis().getLabel() == "x1"
+    assert plotWidget.getYAxis().getLabel() == "y1"
 
     # labels not changed as not active curve
-    plot.addCurve((1, 2), (2, 3), legend="2")
-    assert plot.getXAxis().getLabel() == "x1"
-    assert plot.getYAxis().getLabel() == "y1"
+    plotWidget.addCurve((1, 2), (2, 3), legend="2")
+    assert plotWidget.getXAxis().getLabel() == "x1"
+    assert plotWidget.getYAxis().getLabel() == "y1"
 
     # labels changed
-    plot.setActiveCurve("2")
-    assert plot.getXAxis().getLabel() == "XLabel"
-    assert plot.getYAxis().getLabel() == "YLabel"
+    plotWidget.setActiveCurve("2")
+    assert plotWidget.getXAxis().getLabel() == "XLabel"
+    assert plotWidget.getYAxis().getLabel() == "YLabel"
 
-    plot.setActiveCurve("1")
-    assert plot.getXAxis().getLabel() == "x1"
-    assert plot.getYAxis().getLabel() == "y1"
+    plotWidget.setActiveCurve("1")
+    assert plotWidget.getXAxis().getLabel() == "x1"
+    assert plotWidget.getYAxis().getLabel() == "y1"
 
-    plot.clear()
-    assert plot.getXAxis().getLabel() == "XLabel"
-    assert plot.getYAxis().getLabel() == "YLabel"
+    plotWidget.clear()
+    assert plotWidget.getXAxis().getLabel() == "XLabel"
+    assert plotWidget.getYAxis().getLabel() == "YLabel"
 
-    plot.setActiveCurveHandling(False)
+    plotWidget.setActiveCurveHandling(False)
 
 
-@pytest.mark.parametrize("backend", ("mpl", "gl"))
-def testPlotActiveCurveSelectionMode(qWidgetFactory, backend, request):
-    if backend == "gl":
-        request.getfixturevalue("use_opengl")  # Skip test if OpenGL test disabled
-
+@pytest.mark.parametrize("plotWidget", ("mpl", "gl"), indirect=True)
+def testPlotActiveCurveSelectionMode(plotWidget):
     xData = numpy.arange(1000)
     yData = -500 + 100 * numpy.sin(xData)
     xData2 = xData + 1000
     yData2 = xData - 1000 + 200 * numpy.random.random(1000)
 
-    plot = qWidgetFactory(PlotWidget)
-
-    plot.clear()
-    plot.setActiveCurveHandling(True)
+    plotWidget.clear()
+    plotWidget.setActiveCurveHandling(True)
     legend = "curve 1"
-    plot.addCurve(xData, yData, legend=legend, color="green")
+    plotWidget.addCurve(xData, yData, legend=legend, color="green")
 
     # active curve should be None
-    assert plot.getActiveCurve(just_legend=True) is None
+    assert plotWidget.getActiveCurve(just_legend=True) is None
 
     # active curve should be None when None is set as active curve
-    plot.setActiveCurve(legend)
-    current = plot.getActiveCurve(just_legend=True)
+    plotWidget.setActiveCurve(legend)
+    current = plotWidget.getActiveCurve(just_legend=True)
     assert current == legend
-    plot.setActiveCurve(None)
-    current = plot.getActiveCurve(just_legend=True)
+    plotWidget.setActiveCurve(None)
+    current = plotWidget.getActiveCurve(just_legend=True)
     assert current is None
 
     # testing it automatically toggles if there is only one
-    plot.setActiveCurveSelectionMode("legacy")
-    current = plot.getActiveCurve(just_legend=True)
+    plotWidget.setActiveCurveSelectionMode("legacy")
+    current = plotWidget.getActiveCurve(just_legend=True)
     assert current == legend
 
     # active curve should not change when None set as active curve
-    assert plot.getActiveCurveSelectionMode() == "legacy"
-    plot.setActiveCurve(None)
-    current = plot.getActiveCurve(just_legend=True)
+    assert plotWidget.getActiveCurveSelectionMode() == "legacy"
+    plotWidget.setActiveCurve(None)
+    current = plotWidget.getActiveCurve(just_legend=True)
     assert current == legend
 
     # situation where no curve is active
-    plot.clear()
-    plot.setActiveCurveHandling(True)
-    assert plot.getActiveCurveSelectionMode() == "atmostone"
-    plot.addCurve(xData, yData, legend=legend, color="green")
-    assert plot.getActiveCurve(just_legend=True) is None
-    plot.addCurve(xData2, yData2, legend="curve 2", color="red")
-    assert plot.getActiveCurve(just_legend=True) is None
-    plot.setActiveCurveSelectionMode("legacy")
-    assert plot.getActiveCurve(just_legend=True) is None
+    plotWidget.clear()
+    plotWidget.setActiveCurveHandling(True)
+    assert plotWidget.getActiveCurveSelectionMode() == "atmostone"
+    plotWidget.addCurve(xData, yData, legend=legend, color="green")
+    assert plotWidget.getActiveCurve(just_legend=True) is None
+    plotWidget.addCurve(xData2, yData2, legend="curve 2", color="red")
+    assert plotWidget.getActiveCurve(just_legend=True) is None
+    plotWidget.setActiveCurveSelectionMode("legacy")
+    assert plotWidget.getActiveCurve(just_legend=True) is None
 
     # the first curve added should be active
-    plot.clear()
-    plot.addCurve(xData, yData, legend=legend, color="green")
-    assert plot.getActiveCurve(just_legend=True) == legend
-    plot.addCurve(xData2, yData2, legend="curve 2", color="red")
-    assert plot.getActiveCurve(just_legend=True) == legend
+    plotWidget.clear()
+    plotWidget.addCurve(xData, yData, legend=legend, color="green")
+    assert plotWidget.getActiveCurve(just_legend=True) == legend
+    plotWidget.addCurve(xData2, yData2, legend="curve 2", color="red")
+    assert plotWidget.getActiveCurve(just_legend=True) == legend
 
-    plot.setActiveCurveHandling(False)
+    plotWidget.setActiveCurveHandling(False)
 
 
-@pytest.mark.parametrize("backend", ("mpl", "gl"))
-def testActiveCurveStyle(qWidgetFactory, backend, request):
+@pytest.mark.parametrize("plotWidget", ("mpl", "gl"), indirect=True)
+def testActiveCurveStyle(plotWidget):
     """Test change of active curve style"""
-    if backend == "gl":
-        request.getfixturevalue("use_opengl")  # Skip test if OpenGL test disabled
-
-    plot = qWidgetFactory(PlotWidget)
-
-    plot.setActiveCurveHandling(True)
-    plot.setActiveCurveStyle(color="black")
-    style = plot.getActiveCurveStyle()
+    plotWidget.setActiveCurveHandling(True)
+    plotWidget.setActiveCurveStyle(color="black")
+    style = plotWidget.getActiveCurveStyle()
     assert style.getColor() == (0.0, 0.0, 0.0, 1.0)
     assert style.getLineStyle() is None
     assert style.getLineWidth() is None
@@ -174,8 +167,8 @@ def testActiveCurveStyle(qWidgetFactory, backend, request):
 
     xData = numpy.arange(1000)
     yData = -500 + 100 * numpy.sin(xData)
-    plot.addCurve(x=xData, y=yData, legend="curve1")
-    curve = plot.getCurve("curve1")
+    plotWidget.addCurve(x=xData, y=yData, legend="curve1")
+    curve = plotWidget.getCurve("curve1")
     curve.setColor("blue")
     curve.setLineStyle("-")
     curve.setLineWidth(1)
@@ -189,7 +182,7 @@ def testActiveCurveStyle(qWidgetFactory, backend, request):
     )
 
     # Activate curve with highlight color=black
-    plot.setActiveCurve("curve1")
+    plotWidget.setActiveCurve("curve1")
     style = curve.getCurrentStyle()
     assert style.getColor() == (0.0, 0.0, 0.0, 1.0)
     assert style.getLineStyle() == "-"
@@ -198,7 +191,7 @@ def testActiveCurveStyle(qWidgetFactory, backend, request):
     assert style.getSymbolSize() == 5
 
     # Change highlight to linewidth=2
-    plot.setActiveCurveStyle(linewidth=2)
+    plotWidget.setActiveCurveStyle(linewidth=2)
     style = curve.getCurrentStyle()
     assert style.getColor() == (0.0, 0.0, 1.0, 1.0)
     assert style.getLineStyle() == "-"
@@ -206,49 +199,44 @@ def testActiveCurveStyle(qWidgetFactory, backend, request):
     assert style.getSymbol() == "o"
     assert style.getSymbolSize() == 5
 
-    plot.setActiveCurve(None)
+    plotWidget.setActiveCurve(None)
     assert curve.getCurrentStyle() == defaultStyle
 
-    plot.setActiveCurveHandling(False)
+    plotWidget.setActiveCurveHandling(False)
 
 
-@pytest.mark.parametrize("backend", ("mpl", "gl"))
-def testActiveImageAndLabels(qWidgetFactory, backend, request):
-    if backend == "gl":
-        request.getfixturevalue("use_opengl")  # Skip test if OpenGL test disabled
-
-    plot = qWidgetFactory(PlotWidget)
-
+@pytest.mark.parametrize("plotWidget", ("mpl", "gl"), indirect=True)
+def testActiveImageAndLabels(plotWidget):
     # Active image handling always on, no API for toggling it
-    plot.getXAxis().setLabel("XLabel")
-    plot.getYAxis().setLabel("YLabel")
+    plotWidget.getXAxis().setLabel("XLabel")
+    plotWidget.getYAxis().setLabel("YLabel")
 
     # labels changed as active curve
-    plot.addImage(
+    plotWidget.addImage(
         numpy.arange(100).reshape(10, 10), legend="1", xlabel="x1", ylabel="y1"
     )
-    assert plot.getXAxis().getLabel() == "x1"
-    assert plot.getYAxis().getLabel() == "y1"
+    assert plotWidget.getXAxis().getLabel() == "x1"
+    assert plotWidget.getYAxis().getLabel() == "y1"
 
     # labels not changed as not active curve
-    plot.addImage(numpy.arange(100).reshape(10, 10), legend="2")
-    assert plot.getXAxis().getLabel() == "x1"
-    assert plot.getYAxis().getLabel() == "y1"
+    plotWidget.addImage(numpy.arange(100).reshape(10, 10), legend="2")
+    assert plotWidget.getXAxis().getLabel() == "x1"
+    assert plotWidget.getYAxis().getLabel() == "y1"
 
     # labels changed
-    plot.setActiveImage("2")
-    assert plot.getXAxis().getLabel() == "XLabel"
-    assert plot.getYAxis().getLabel() == "YLabel"
+    plotWidget.setActiveImage("2")
+    assert plotWidget.getXAxis().getLabel() == "XLabel"
+    assert plotWidget.getYAxis().getLabel() == "YLabel"
 
-    plot.setActiveImage("1")
-    assert plot.getXAxis().getLabel() == "x1"
-    assert plot.getYAxis().getLabel() == "y1"
+    plotWidget.setActiveImage("1")
+    assert plotWidget.getXAxis().getLabel() == "x1"
+    assert plotWidget.getYAxis().getLabel() == "y1"
 
-    plot.clear()
-    assert plot.getXAxis().getLabel() == "XLabel"
-    assert plot.getYAxis().getLabel() == "YLabel"
+    plotWidget.clear()
+    assert plotWidget.getXAxis().getLabel() == "XLabel"
+    assert plotWidget.getYAxis().getLabel() == "YLabel"
 
-    plot.setActiveCurveHandling(False)
+    plotWidget.setActiveCurveHandling(False)
 
 
 def _checkSelection(selection, current=None, selected=()):
@@ -257,160 +245,145 @@ def _checkSelection(selection, current=None, selected=()):
     assert selection.getSelectedItems() == selected
 
 
-@pytest.mark.parametrize("backend", ("mpl", "gl"))
-def testSyncWithActiveItems(qWidgetFactory, backend, request):
+@pytest.mark.parametrize("plotWidget", ("mpl", "gl"), indirect=True)
+def testSelectionSyncWithActiveItems(plotWidget):
     """Test update of PlotWidgetSelection according to active items"""
-    if backend == "gl":
-        request.getfixturevalue("use_opengl")  # Skip test if OpenGL test disabled
-
-    plot = qWidgetFactory(PlotWidget, backend=backend)
-
     listener = SignalListener()
 
-    selection = plot.selection()
+    selection = plotWidget.selection()
     selection.sigCurrentItemChanged.connect(listener)
     _checkSelection(selection)
 
     # Active item is current
-    plot.addImage(((0, 1), (2, 3)), legend="image")
-    image = plot.getActiveImage()
+    plotWidget.addImage(((0, 1), (2, 3)), legend="image")
+    image = plotWidget.getActiveImage()
     assert listener.callCount() == 1
     _checkSelection(selection, image, (image,))
 
     # No active = no current
-    plot.setActiveImage(None)
+    plotWidget.setActiveImage(None)
     assert listener.callCount() == 2
     _checkSelection(selection)
 
     # Active item is current
-    plot.setActiveImage("image")
+    plotWidget.setActiveImage("image")
     assert listener.callCount() == 3
     _checkSelection(selection, image, (image,))
 
     # Mosted recently "actived" item is current
-    plot.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
-    scatter = plot.getActiveScatter()
+    plotWidget.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
+    scatter = plotWidget.getActiveScatter()
     assert listener.callCount() == 4
     _checkSelection(selection, scatter, (scatter, image))
 
     # Previously mosted recently "actived" item is current
-    plot.setActiveScatter(None)
+    plotWidget.setActiveScatter(None)
     assert listener.callCount() == 5
     _checkSelection(selection, image, (image,))
 
     # Mosted recently "actived" item is current
-    plot.setActiveScatter("scatter")
+    plotWidget.setActiveScatter("scatter")
     assert listener.callCount() == 6
     _checkSelection(selection, scatter, (scatter, image))
 
     # No active = no current
-    plot.setActiveImage(None)
-    plot.setActiveScatter(None)
+    plotWidget.setActiveImage(None)
+    plotWidget.setActiveScatter(None)
     assert listener.callCount() == 7
     _checkSelection(selection)
 
     # Mosted recently "actived" item is current
-    plot.setActiveScatter("scatter")
+    plotWidget.setActiveScatter("scatter")
     assert listener.callCount() == 8
-    plot.setActiveImage("image")
+    plotWidget.setActiveImage("image")
     assert listener.callCount() == 9
     _checkSelection(selection, image, (image, scatter))
 
     # Add a curve which is not active by default
-    plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
-    curve = plot.getCurve("curve")
+    plotWidget.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
+    curve = plotWidget.getCurve("curve")
     assert listener.callCount() == 9
     _checkSelection(selection, image, (image, scatter))
 
     # Mosted recently "actived" item is current
-    plot.setActiveCurve("curve")
+    plotWidget.setActiveCurve("curve")
     assert listener.callCount() == 10
     _checkSelection(selection, curve, (curve, image, scatter))
 
     # Add a curve which is not active by default
-    plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve2")
-    curve2 = plot.getCurve("curve2")
+    plotWidget.addCurve((0, 1, 2), (0, 1, 2), legend="curve2")
+    curve2 = plotWidget.getCurve("curve2")
     assert listener.callCount() == 10
     _checkSelection(selection, curve, (curve, image, scatter))
 
     # Mosted recently "actived" item is current, previous curve is removed
-    plot.setActiveCurve("curve2")
+    plotWidget.setActiveCurve("curve2")
     assert listener.callCount() == 11
     _checkSelection(selection, curve2, (curve2, image, scatter))
 
     # No items = no current
-    plot.clear()
+    plotWidget.clear()
     assert listener.callCount() == 12
     _checkSelection(selection)
 
 
-@pytest.mark.parametrize("backend", ("mpl", "gl"))
-def testPlotWidgetWithItems(qWidgetFactory, backend, request):
+@pytest.mark.parametrize("plotWidget", ("mpl", "gl"), indirect=True)
+def testSelectionWithItems(plotWidget):
     """Test init of selection on a plot with items"""
-    if backend == "gl":
-        request.getfixturevalue("use_opengl")  # Skip test if OpenGL test disabled
+    plotWidget.addImage(((0, 1), (2, 3)), legend="image")
+    plotWidget.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
+    plotWidget.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
+    plotWidget.setActiveCurve("curve")
 
-    plot = qWidgetFactory(PlotWidget, backend=backend)
-
-    plot.addImage(((0, 1), (2, 3)), legend="image")
-    plot.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
-    plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
-    plot.setActiveCurve("curve")
-
-    selection = plot.selection()
+    selection = plotWidget.selection()
     assert selection.getCurrentItem() is not None
     selected = selection.getSelectedItems()
     assert len(selected) == 3
-    assert plot.getActiveCurve() in selected
-    assert plot.getActiveImage() in selected
-    assert plot.getActiveScatter() in selected
+    assert plotWidget.getActiveCurve() in selected
+    assert plotWidget.getActiveImage() in selected
+    assert plotWidget.getActiveScatter() in selected
 
 
-@pytest.mark.parametrize("backend", ("mpl", "gl"))
-def testSetCurrentItem(qWidgetFactory, backend, request):
+@pytest.mark.parametrize("plotWidget", ("mpl", "gl"), indirect=True)
+def testSelectionSetCurrentItem(plotWidget):
     """Test setCurrentItem"""
-    if backend == "gl":
-        request.getfixturevalue("use_opengl")  # Skip test if OpenGL test disabled
-
-    plot = qWidgetFactory(PlotWidget, backend=backend)
-
     # Add items to the plot
-    plot.addImage(((0, 1), (2, 3)), legend="image")
-    image = plot.getActiveImage()
-    plot.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
-    scatter = plot.getActiveScatter()
-    plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
-    plot.setActiveCurve("curve")
-    curve = plot.getActiveCurve()
+    plotWidget.addImage(((0, 1), (2, 3)), legend="image")
+    image = plotWidget.getActiveImage()
+    plotWidget.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
+    scatter = plotWidget.getActiveScatter()
+    plotWidget.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
+    plotWidget.setActiveCurve("curve")
+    curve = plotWidget.getActiveCurve()
 
-    selection = plot.selection()
+    selection = plotWidget.selection()
     assert selection.getCurrentItem() is not None
     assert len(selection.getSelectedItems()) == 3
 
     # Set current to None reset all active items
     selection.setCurrentItem(None)
     _checkSelection(selection)
-    assert plot.getActiveCurve() is None
-    assert plot.getActiveImage() is None
-    assert plot.getActiveScatter() is None
+    assert plotWidget.getActiveCurve() is None
+    assert plotWidget.getActiveImage() is None
+    assert plotWidget.getActiveScatter() is None
 
     # Set current to an item makes it active
     selection.setCurrentItem(image)
     _checkSelection(selection, image, (image,))
-    assert plot.getActiveCurve() is None
-    assert plot.getActiveImage() is image
-    assert plot.getActiveScatter() is None
+    assert plotWidget.getActiveCurve() is None
+    assert plotWidget.getActiveImage() is image
+    assert plotWidget.getActiveScatter() is None
 
     # Set current to an item makes it active and keeps other active
     selection.setCurrentItem(curve)
     _checkSelection(selection, curve, (curve, image))
-    assert plot.getActiveCurve() is curve
-    assert plot.getActiveImage() is image
-    assert plot.getActiveScatter() is None
+    assert plotWidget.getActiveCurve() is curve
+    assert plotWidget.getActiveImage() is image
+    assert plotWidget.getActiveScatter() is None
 
     # Set current to an item makes it active and keeps other active
     selection.setCurrentItem(scatter)
     _checkSelection(selection, scatter, (scatter, curve, image))
-    assert plot.getActiveCurve() is curve
-    assert plot.getActiveImage() is image
-    assert plot.getActiveScatter() is scatter
+    assert plotWidget.getActiveCurve() is curve
+    assert plotWidget.getActiveImage() is image
+    assert plotWidget.getActiveScatter() is scatter

--- a/src/silx/gui/plot/test/testPlotWidgetActiveItem.py
+++ b/src/silx/gui/plot/test/testPlotWidgetActiveItem.py
@@ -1,0 +1,380 @@
+# /*##########################################################################
+#
+# Copyright (c) 2023 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Test PlotWidget active item"""
+
+__authors__ = ["T. Vincent"]
+__license__ = "MIT"
+__date__ = "11/12/2023"
+
+
+import numpy
+import pytest
+
+from silx.gui.utils.testutils import SignalListener
+
+from silx.gui import qt
+from silx.gui.plot.items.curve import CurveStyle
+
+from .utils import PlotWidgetTestCase
+
+
+class TestPlotActiveCurveImage(PlotWidgetTestCase):
+    """Basic tests for active curve and image handling"""
+
+    xData = numpy.arange(1000)
+    yData = -500 + 100 * numpy.sin(xData)
+    xData2 = xData + 1000
+    yData2 = xData - 1000 + 200 * numpy.random.random(1000)
+
+    def tearDown(self):
+        self.plot.setActiveCurveHandling(False)
+        super(TestPlotActiveCurveImage, self).tearDown()
+
+    def testActiveCurveAndLabels(self):
+        # Active curve handling off, no label change
+        self.plot.setActiveCurveHandling(False)
+        self.plot.getXAxis().setLabel("XLabel")
+        self.plot.getYAxis().setLabel("YLabel")
+        self.plot.addCurve((1, 2), (1, 2))
+        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
+        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
+
+        self.plot.addCurve((1, 2), (2, 3), xlabel="x1", ylabel="y1")
+        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
+        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
+
+        self.plot.clear()
+        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
+        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
+
+        # Active curve handling on, label changes
+        self.plot.setActiveCurveHandling(True)
+        self.plot.getXAxis().setLabel("XLabel")
+        self.plot.getYAxis().setLabel("YLabel")
+
+        # labels changed as active curve
+        self.plot.addCurve((1, 2), (1, 2), legend="1", xlabel="x1", ylabel="y1")
+        self.plot.setActiveCurve("1")
+        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
+        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
+
+        # labels not changed as not active curve
+        self.plot.addCurve((1, 2), (2, 3), legend="2")
+        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
+        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
+
+        # labels changed
+        self.plot.setActiveCurve("2")
+        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
+        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
+
+        self.plot.setActiveCurve("1")
+        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
+        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
+
+        self.plot.clear()
+        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
+        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
+
+    def testPlotActiveCurveSelectionMode(self):
+        self.plot.clear()
+        self.plot.setActiveCurveHandling(True)
+        legend = "curve 1"
+        self.plot.addCurve(self.xData, self.yData, legend=legend, color="green")
+
+        # active curve should be None
+        self.assertEqual(self.plot.getActiveCurve(just_legend=True), None)
+
+        # active curve should be None when None is set as active curve
+        self.plot.setActiveCurve(legend)
+        current = self.plot.getActiveCurve(just_legend=True)
+        self.assertEqual(current, legend)
+        self.plot.setActiveCurve(None)
+        current = self.plot.getActiveCurve(just_legend=True)
+        self.assertEqual(current, None)
+
+        # testing it automatically toggles if there is only one
+        self.plot.setActiveCurveSelectionMode("legacy")
+        current = self.plot.getActiveCurve(just_legend=True)
+        self.assertEqual(current, legend)
+
+        # active curve should not change when None set as active curve
+        self.assertEqual(self.plot.getActiveCurveSelectionMode(), "legacy")
+        self.plot.setActiveCurve(None)
+        current = self.plot.getActiveCurve(just_legend=True)
+        self.assertEqual(current, legend)
+
+        # situation where no curve is active
+        self.plot.clear()
+        self.plot.setActiveCurveHandling(True)
+        self.assertEqual(self.plot.getActiveCurveSelectionMode(), "atmostone")
+        self.plot.addCurve(self.xData, self.yData, legend=legend, color="green")
+        self.assertEqual(self.plot.getActiveCurve(just_legend=True), None)
+        self.plot.addCurve(self.xData2, self.yData2, legend="curve 2", color="red")
+        self.assertEqual(self.plot.getActiveCurve(just_legend=True), None)
+        self.plot.setActiveCurveSelectionMode("legacy")
+        self.assertEqual(self.plot.getActiveCurve(just_legend=True), None)
+
+        # the first curve added should be active
+        self.plot.clear()
+        self.plot.addCurve(self.xData, self.yData, legend=legend, color="green")
+        self.assertEqual(self.plot.getActiveCurve(just_legend=True), legend)
+        self.plot.addCurve(self.xData2, self.yData2, legend="curve 2", color="red")
+        self.assertEqual(self.plot.getActiveCurve(just_legend=True), legend)
+
+    def testActiveCurveStyle(self):
+        """Test change of active curve style"""
+        self.plot.setActiveCurveHandling(True)
+        self.plot.setActiveCurveStyle(color="black")
+        style = self.plot.getActiveCurveStyle()
+        self.assertEqual(style.getColor(), (0.0, 0.0, 0.0, 1.0))
+        self.assertIsNone(style.getLineStyle())
+        self.assertIsNone(style.getLineWidth())
+        self.assertIsNone(style.getSymbol())
+        self.assertIsNone(style.getSymbolSize())
+
+        self.plot.addCurve(x=self.xData, y=self.yData, legend="curve1")
+        curve = self.plot.getCurve("curve1")
+        curve.setColor("blue")
+        curve.setLineStyle("-")
+        curve.setLineWidth(1)
+        curve.setSymbol("o")
+        curve.setSymbolSize(5)
+
+        # Check default current style
+        defaultStyle = curve.getCurrentStyle()
+        self.assertEqual(
+            defaultStyle,
+            CurveStyle(
+                color="blue", linestyle="-", linewidth=1, symbol="o", symbolsize=5
+            ),
+        )
+
+        # Activate curve with highlight color=black
+        self.plot.setActiveCurve("curve1")
+        style = curve.getCurrentStyle()
+        self.assertEqual(style.getColor(), (0.0, 0.0, 0.0, 1.0))
+        self.assertEqual(style.getLineStyle(), "-")
+        self.assertEqual(style.getLineWidth(), 1)
+        self.assertEqual(style.getSymbol(), "o")
+        self.assertEqual(style.getSymbolSize(), 5)
+
+        # Change highlight to linewidth=2
+        self.plot.setActiveCurveStyle(linewidth=2)
+        style = curve.getCurrentStyle()
+        self.assertEqual(style.getColor(), (0.0, 0.0, 1.0, 1.0))
+        self.assertEqual(style.getLineStyle(), "-")
+        self.assertEqual(style.getLineWidth(), 2)
+        self.assertEqual(style.getSymbol(), "o")
+        self.assertEqual(style.getSymbolSize(), 5)
+
+        self.plot.setActiveCurve(None)
+        self.assertEqual(curve.getCurrentStyle(), defaultStyle)
+
+    def testActiveImageAndLabels(self):
+        # Active image handling always on, no API for toggling it
+        self.plot.getXAxis().setLabel("XLabel")
+        self.plot.getYAxis().setLabel("YLabel")
+
+        # labels changed as active curve
+        self.plot.addImage(
+            numpy.arange(100).reshape(10, 10), legend="1", xlabel="x1", ylabel="y1"
+        )
+        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
+        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
+
+        # labels not changed as not active curve
+        self.plot.addImage(numpy.arange(100).reshape(10, 10), legend="2")
+        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
+        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
+
+        # labels changed
+        self.plot.setActiveImage("2")
+        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
+        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
+
+        self.plot.setActiveImage("1")
+        self.assertEqual(self.plot.getXAxis().getLabel(), "x1")
+        self.assertEqual(self.plot.getYAxis().getLabel(), "y1")
+
+        self.plot.clear()
+        self.assertEqual(self.plot.getXAxis().getLabel(), "XLabel")
+        self.assertEqual(self.plot.getYAxis().getLabel(), "YLabel")
+
+
+class TestPlotWidgetSelection(PlotWidgetTestCase):
+    """Test PlotWidget.selection and active items handling"""
+
+    def _checkSelection(self, selection, current=None, selected=()):
+        """Check current item and selected items."""
+        self.assertIs(selection.getCurrentItem(), current)
+        self.assertEqual(selection.getSelectedItems(), selected)
+
+    def testSyncWithActiveItems(self):
+        """Test update of PlotWidgetSelection according to active items"""
+        listener = SignalListener()
+
+        selection = self.plot.selection()
+        selection.sigCurrentItemChanged.connect(listener)
+        self._checkSelection(selection)
+
+        # Active item is current
+        self.plot.addImage(((0, 1), (2, 3)), legend="image")
+        image = self.plot.getActiveImage()
+        self.assertEqual(listener.callCount(), 1)
+        self._checkSelection(selection, image, (image,))
+
+        # No active = no current
+        self.plot.setActiveImage(None)
+        self.assertEqual(listener.callCount(), 2)
+        self._checkSelection(selection)
+
+        # Active item is current
+        self.plot.setActiveImage("image")
+        self.assertEqual(listener.callCount(), 3)
+        self._checkSelection(selection, image, (image,))
+
+        # Mosted recently "actived" item is current
+        self.plot.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
+        scatter = self.plot.getActiveScatter()
+        self.assertEqual(listener.callCount(), 4)
+        self._checkSelection(selection, scatter, (scatter, image))
+
+        # Previously mosted recently "actived" item is current
+        self.plot.setActiveScatter(None)
+        self.assertEqual(listener.callCount(), 5)
+        self._checkSelection(selection, image, (image,))
+
+        # Mosted recently "actived" item is current
+        self.plot.setActiveScatter("scatter")
+        self.assertEqual(listener.callCount(), 6)
+        self._checkSelection(selection, scatter, (scatter, image))
+
+        # No active = no current
+        self.plot.setActiveImage(None)
+        self.plot.setActiveScatter(None)
+        self.assertEqual(listener.callCount(), 7)
+        self._checkSelection(selection)
+
+        # Mosted recently "actived" item is current
+        self.plot.setActiveScatter("scatter")
+        self.assertEqual(listener.callCount(), 8)
+        self.plot.setActiveImage("image")
+        self.assertEqual(listener.callCount(), 9)
+        self._checkSelection(selection, image, (image, scatter))
+
+        # Add a curve which is not active by default
+        self.plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
+        curve = self.plot.getCurve("curve")
+        self.assertEqual(listener.callCount(), 9)
+        self._checkSelection(selection, image, (image, scatter))
+
+        # Mosted recently "actived" item is current
+        self.plot.setActiveCurve("curve")
+        self.assertEqual(listener.callCount(), 10)
+        self._checkSelection(selection, curve, (curve, image, scatter))
+
+        # Add a curve which is not active by default
+        self.plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve2")
+        curve2 = self.plot.getCurve("curve2")
+        self.assertEqual(listener.callCount(), 10)
+        self._checkSelection(selection, curve, (curve, image, scatter))
+
+        # Mosted recently "actived" item is current, previous curve is removed
+        self.plot.setActiveCurve("curve2")
+        self.assertEqual(listener.callCount(), 11)
+        self._checkSelection(selection, curve2, (curve2, image, scatter))
+
+        # No items = no current
+        self.plot.clear()
+        self.assertEqual(listener.callCount(), 12)
+        self._checkSelection(selection)
+
+    def testPlotWidgetWithItems(self):
+        """Test init of selection on a plot with items"""
+        self.plot.addImage(((0, 1), (2, 3)), legend="image")
+        self.plot.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
+        self.plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
+        self.plot.setActiveCurve("curve")
+
+        selection = self.plot.selection()
+        self.assertIsNotNone(selection.getCurrentItem())
+        selected = selection.getSelectedItems()
+        self.assertEqual(len(selected), 3)
+        self.assertIn(self.plot.getActiveCurve(), selected)
+        self.assertIn(self.plot.getActiveImage(), selected)
+        self.assertIn(self.plot.getActiveScatter(), selected)
+
+    def testSetCurrentItem(self):
+        """Test setCurrentItem"""
+        # Add items to the plot
+        self.plot.addImage(((0, 1), (2, 3)), legend="image")
+        image = self.plot.getActiveImage()
+        self.plot.addScatter((3, 2, 1), (0, 1, 2), (0, 1, 2), legend="scatter")
+        scatter = self.plot.getActiveScatter()
+        self.plot.addCurve((0, 1, 2), (0, 1, 2), legend="curve")
+        self.plot.setActiveCurve("curve")
+        curve = self.plot.getActiveCurve()
+
+        selection = self.plot.selection()
+        self.assertIsNotNone(selection.getCurrentItem())
+        self.assertEqual(len(selection.getSelectedItems()), 3)
+
+        # Set current to None reset all active items
+        selection.setCurrentItem(None)
+        self._checkSelection(selection)
+        self.assertIsNone(self.plot.getActiveCurve())
+        self.assertIsNone(self.plot.getActiveImage())
+        self.assertIsNone(self.plot.getActiveScatter())
+
+        # Set current to an item makes it active
+        selection.setCurrentItem(image)
+        self._checkSelection(selection, image, (image,))
+        self.assertIsNone(self.plot.getActiveCurve())
+        self.assertIs(self.plot.getActiveImage(), image)
+        self.assertIsNone(self.plot.getActiveScatter())
+
+        # Set current to an item makes it active and keeps other active
+        selection.setCurrentItem(curve)
+        self._checkSelection(selection, curve, (curve, image))
+        self.assertIs(self.plot.getActiveCurve(), curve)
+        self.assertIs(self.plot.getActiveImage(), image)
+        self.assertIsNone(self.plot.getActiveScatter())
+
+        # Set current to an item makes it active and keeps other active
+        selection.setCurrentItem(scatter)
+        self._checkSelection(selection, scatter, (scatter, curve, image))
+        self.assertIs(self.plot.getActiveCurve(), curve)
+        self.assertIs(self.plot.getActiveImage(), image)
+        self.assertIs(self.plot.getActiveScatter(), scatter)
+
+
+@pytest.mark.usefixtures("use_opengl")
+class TestPlotActiveCurveImage_Gl(TestPlotActiveCurveImage):
+    backend = "gl"
+
+
+@pytest.mark.usefixtures("use_opengl")
+class TestPlotWidgetSelection_Gl(TestPlotWidgetSelection):
+    backend = "gl"

--- a/src/silx/gui/plot/test/testPlotWidgetActiveItem.py
+++ b/src/silx/gui/plot/test/testPlotWidgetActiveItem.py
@@ -33,16 +33,16 @@ import pytest
 
 from silx.gui.utils.testutils import SignalListener
 
-from silx.gui import qt
 from silx.gui.plot import PlotWidget
 from silx.gui.plot.items.curve import CurveStyle
-
-from .utils import PlotWidgetTestCase
 
 
 @pytest.fixture
 def plotWidget(qWidgetFactory, request):
-    backend = request.param
+    try:
+        backend = request.param
+    except AttributeError:
+        backend = "mpl"  # Backend was not defined
     if backend == "gl":
         request.getfixturevalue("use_opengl")  # Skip test if OpenGL test disabled
     yield qWidgetFactory(PlotWidget, backend=backend)
@@ -386,4 +386,44 @@ def testSelectionSetCurrentItem(plotWidget):
     _checkSelection(selection, scatter, (scatter, curve, image))
     assert plotWidget.getActiveCurve() is curve
     assert plotWidget.getActiveImage() is image
+    assert plotWidget.getActiveScatter() is scatter
+
+
+def testSetActiveCurveWithInstance(plotWidget):
+    """Test setting the active curve with a curve item instance"""
+    plotWidget.addCurve((0, 1), (0, 1), legend="curve0")
+    plotWidget.addCurve((0, 1), (1, 0), legend="curve1")
+    curve0, curve1 = plotWidget.getItems()
+
+    plotWidget.setActiveCurve(curve0)
+    assert plotWidget.getActiveCurve() is curve0
+
+    plotWidget.setActiveCurve(curve1)
+    assert plotWidget.getActiveCurve() is curve1
+
+    plotWidget.setActiveCurve(None)
+    assert plotWidget.getActiveCurve() is None
+
+
+def testSetActiveImageWithInstance(plotWidget):
+    """Test setting the active image with an image item instance"""
+    plotWidget.addImage(((0, 1), (2, 3)), legend="image")
+    image = plotWidget.getItems()[0]
+
+    plotWidget.setActiveImage(None)
+    assert plotWidget.getActiveImage() is None
+
+    plotWidget.setActiveImage(image)
+    assert plotWidget.getActiveImage() is image
+
+
+def testSetActiveScatterWithInstance(plotWidget):
+    """Test setting the active scatter with a scatter item instance"""
+    plotWidget.addScatter((0, 1), (0, 1), (0, 1), legend="scatter")
+    scatter = plotWidget.getItems()[0]
+
+    plotWidget.setActiveScatter(None)
+    assert plotWidget.getActiveScatter() is None
+
+    plotWidget.setActiveScatter(scatter)
     assert plotWidget.getActiveScatter() is scatter

--- a/src/silx/gui/plot/test/testPlotWidgetActiveItem.py
+++ b/src/silx/gui/plot/test/testPlotWidgetActiveItem.py
@@ -32,20 +32,7 @@ import numpy
 import pytest
 
 from silx.gui.utils.testutils import SignalListener
-
-from silx.gui.plot import PlotWidget
 from silx.gui.plot.items.curve import CurveStyle
-
-
-@pytest.fixture
-def plotWidget(qWidgetFactory, request):
-    try:
-        backend = request.param
-    except AttributeError:
-        backend = "mpl"  # Backend was not defined
-    if backend == "gl":
-        request.getfixturevalue("use_opengl")  # Skip test if OpenGL test disabled
-    yield qWidgetFactory(PlotWidget, backend=backend)
 
 
 @pytest.mark.parametrize("plotWidget", ("mpl", "gl"), indirect=True)

--- a/src/silx/gui/plot/test/testPlotWidgetDataMargins.py
+++ b/src/silx/gui/plot/test/testPlotWidgetDataMargins.py
@@ -30,14 +30,6 @@ __date__ = "11/05/2023"
 import numpy
 import pytest
 
-from silx.gui.plot import PlotWidget
-
-
-@pytest.fixture
-def plotWidget(qWidgetFactory):
-    """Fixture providing a PlotWidget"""
-    yield qWidgetFactory(PlotWidget)
-
 
 def testDefaultDataMargins(plotWidget):
     """Test default PlotWidget data margins: No margins"""


### PR DESCRIPTION
~~Merge PR #3987 first!~~

This PR follows PR #3986 and enable passing items rather than only their legend to `PlotWidget.setActiveCurve|Image|Scatter`.