### PR TITLE
silx.gui: Fixed `QMouseEvent.globalPos()` not available with PyQt6

### DIFF
--- a/src/silx/gui/plot/ColorBar.py
+++ b/src/silx/gui/plot/ColorBar.py
@@ -588,7 +588,11 @@ class _ColorScale(qt.QWidget):
     def mouseMoveEvent(self, event):
         tooltip = str(self.getValueFromRelativePosition(
             self._getRelativePosition(qt.getMouseEventPosition(event)[1])))
-        qt.QToolTip.showText(event.globalPos(), tooltip, self)
+        if qt.BINDING == "PyQt5":
+            position = event.globalPos()
+        else:  # Qt6
+            position = event.globalPosition().toPoint()
+        qt.QToolTip.showText(position, tooltip, self)
         super(_ColorScale, self).mouseMoveEvent(event)
 
     def _getRelativePosition(self, yPixel):

--- a/src/silx/gui/plot/LegendSelector.py
+++ b/src/silx/gui/plot/LegendSelector.py
@@ -453,7 +453,11 @@ class LegendListItemWidget(qt.QItemDelegate):
         # Mouse events are sent to editorEvent()
         # even if they don't start editing of the item.
         if event.button() == qt.Qt.RightButton and self.contextMenu:
-            self.contextMenu.exec(event.globalPos(), modelIndex)
+            if qt.BINDING == "PyQt5":
+                position = event.globalPos()
+            else:  # Qt6
+                position = event.globalPosition().toPoint()
+            self.contextMenu.exec(position, modelIndex)
             return True
         elif event.button() == qt.Qt.LeftButton:
             # Check if checkbox was clicked


### PR DESCRIPTION
[QMouseEvent.globalPos](https://doc.qt.io/qt-6/qmouseevent-obsolete.html#globalPos) is deprecated in Qt6 and removed from PyQt6.
