### PR TITLE
`silx.gui.plot.PlotWidget`: Changed add* methods return value to return the item instead of its legend

### DIFF
--- a/examples/plotWidget.py
+++ b/examples/plotWidget.py
@@ -160,8 +160,7 @@ class MyPlotWindow(qt.QMainWindow):
         x = numpy.random.rand(nbPoints)
         y = numpy.random.rand(nbPoints)
         value = numpy.random.rand(nbPoints)
-        legend = plot.addScatter(x=x, y=y, value=value)
-        scatter = plot.getScatter(legend)
+        scatter = plot.addScatter(x=x, y=y, value=value)
         scatter.setVisualization("solid")
         plot.resetZoom()
 

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -2474,18 +2474,21 @@ class PlotWidget(qt.QMainWindow):
         ]
         return [curve.getName() for curve in curves] if just_legend else curves
 
-    def getCurve(self, legend=None):
+    def getCurve(self, legend: str | items.Curve | None = None) -> items.Curve:
         """Get the object describing a specific curve.
 
         It returns None in case no matching curve is found.
 
-        :param str legend:
+        :param legend:
             The legend identifying the curve.
             If not provided or None (the default), the active curve is returned
             or if there is no active curve, the latest updated curve that is
             not hidden is returned if there are curves in the plot.
         :return: None or :class:`.items.Curve` object
         """
+        if isinstance(legend, items.Curve):
+            _logger.warning("getCurve call not needed: legend is already an item")
+            return legend
         return self._getItem(kind="curve", legend=legend)
 
     def getAllImages(self, just_legend=False):
@@ -2506,48 +2509,59 @@ class PlotWidget(qt.QMainWindow):
         images = [item for item in self.getItems() if isinstance(item, items.ImageBase)]
         return [image.getName() for image in images] if just_legend else images
 
-    def getImage(self, legend=None):
+    def getImage(self, legend: str | items.ImageBase | None = None) -> items.ImageBase:
         """Get the object describing a specific image.
 
         It returns None in case no matching image is found.
 
-        :param str legend:
+        :param legend:
             The legend identifying the image.
             If not provided or None (the default), the active image is returned
             or if there is no active image, the latest updated image
             is returned if there are images in the plot.
         :return: None or :class:`.items.ImageBase` object
         """
+        if isinstance(legend, items.ImageBase):
+            _logger.warning("getImage call not needed: legend is already an item")
+            return legend
         return self._getItem(kind="image", legend=legend)
 
-    def getScatter(self, legend=None):
+    def getScatter(self, legend: str | items.Scatter | None = None) -> items.Scatter:
         """Get the object describing a specific scatter.
 
         It returns None in case no matching scatter is found.
 
-        :param str legend:
+        :param legend:
             The legend identifying the scatter.
             If not provided or None (the default), the active scatter is
             returned or if there is no active scatter, the latest updated
             scatter is returned if there are scatters in the plot.
         :return: None or :class:`.items.Scatter` object
         """
+        if isinstance(legend, items.Scatter):
+            _logger.warning("getScatter call not needed: legend is already an item")
+            return legend
         return self._getItem(kind="scatter", legend=legend)
 
-    def getHistogram(self, legend=None):
+    def getHistogram(
+        self, legend: str | items.Histogram | None = None
+    ) -> items.Histogram:
         """Get the object describing a specific histogram.
 
         It returns None in case no matching histogram is found.
 
-        :param str legend:
+        :param legend:
             The legend identifying the histogram.
             If not provided or None (the default), the latest updated scatter
             is returned if there are histograms in the plot.
         :return: None or :class:`.items.Histogram` object
         """
+        if isinstance(legend, items.Histogram):
+            _logger.warning("getHistogram call not needed: legend is already an item")
+            return legend
         return self._getItem(kind="histogram", legend=legend)
 
-    def _getItem(self, kind, legend=None):
+    def _getItem(self, kind, legend=None) -> items.Item:
         """Get an item from the plot: either an image or a curve.
 
         Returns None if no match found.
@@ -2558,6 +2572,10 @@ class PlotWidget(qt.QMainWindow):
                            None to get active or last item
         :return: Object describing the item or None
         """
+        if isinstance(legend, items.Item):
+            _logger.warning("_getItem call not needed: legend is already an item")
+            return legend
+
         assert kind in self.ITEM_KINDS
 
         if legend is not None:

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -2003,7 +2003,11 @@ class PlotWidget(qt.QMainWindow):
     _ACTIVE_ITEM_KINDS = "curve", "scatter", "image"
     """List of item's kind which have a active item."""
 
-    def remove(self, legend=None, kind=ITEM_KINDS):
+    def remove(
+        self,
+        legend: str | items.Item | None = None,
+        kind: str | Sequence[str] = ITEM_KINDS,
+    ):
         """Remove one or all element(s) of the given legend and kind.
 
         Examples:
@@ -2017,13 +2021,16 @@ class PlotWidget(qt.QMainWindow):
         - ``remove('myImage')`` removes elements (for instance curve, image,
           item and marker) with legend 'myImage'.
 
-        :param str legend: The legend associated to the element to remove,
-                           or None to remove
-        :param kind: The kind of elements to remove from the plot.
+        :param legend:
+            The legend of the item to remove or the item itself.
+            If None all items of given kind are removed.
+        :param kind: The kind of items to remove from the plot.
                      See :attr:`ITEM_KINDS`.
                      By default, it removes all kind of elements.
-        :type kind: str or tuple of str to specify multiple kinds.
         """
+        if isinstance(legend, items.Item):
+            return self.removeItem(legend)
+
         if kind == "all":  # Replace all by tuple of all kinds
             kind = self.ITEM_KINDS
 
@@ -2050,31 +2057,40 @@ class PlotWidget(qt.QMainWindow):
                 if item is not None:
                     self.removeItem(item)
 
-    def removeCurve(self, legend):
+    def removeCurve(self, legend: str | items.Curve | None):
         """Remove the curve associated to legend from the graph.
 
-        :param str legend: The legend associated to the curve to be deleted
+        :param legend:
+             The legend of the curve to be deleted or the curve item
         """
         if legend is None:
             return
+        if isinstance(legend, items.Item):
+            return self.removeItem(legend)
         self.remove(legend, kind="curve")
 
-    def removeImage(self, legend):
+    def removeImage(self, legend: str | items.ImageBase | None):
         """Remove the image associated to legend from the graph.
 
-        :param str legend: The legend associated to the image to be deleted
+        :param legend:
+            The legend of the image to be deleted or the image item
         """
         if legend is None:
             return
+        if isinstance(legend, items.Item):
+            return self.removeItem(legend)
         self.remove(legend, kind="image")
 
-    def removeMarker(self, legend):
+    def removeMarker(self, legend: str | items.Marker | None):
         """Remove the marker associated to legend from the graph.
 
-        :param str legend: The legend associated to the marker to be deleted
+        :param legend:
+            The legend of the marker to be deleted or the marker item
         """
         if legend is None:
             return
+        if isinstance(legend, items.Item):
+            return self.removeItem(legend)
         self.remove(legend, kind="marker")
 
     # Clear

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -1152,11 +1152,11 @@ class PlotWidget(qt.QMainWindow):
                           False to use provided arrays.
         :param baseline: curve baseline
         :type: Union[None,float,numpy.ndarray]
-        :returns: The key string identify this curve
+        :returns: The curve item
         """
         # This is an histogram, use addHistogram
         if histogram is not None:
-            histoLegend = self.addHistogram(
+            histo = self.addHistogram(
                 histogram=y,
                 edges=x,
                 legend=legend,
@@ -1165,7 +1165,6 @@ class PlotWidget(qt.QMainWindow):
                 align=histogram,
                 copy=copy,
             )
-            histo = self.getHistogram(histoLegend)
 
             histo.setInfo(info)
             if linewidth is not None:
@@ -1185,7 +1184,7 @@ class PlotWidget(qt.QMainWindow):
                     "addCurve: Histogram does not support selectable argument"
                 )
 
-            return
+            return histo
 
         legend = "Unnamed curve 1.1" if legend is None else str(legend)
 
@@ -1277,7 +1276,7 @@ class PlotWidget(qt.QMainWindow):
             # axes has to be set to off.
             self.resetZoom()
 
-        return legend
+        return curve
 
     def addHistogram(
         self,
@@ -1325,7 +1324,7 @@ class PlotWidget(qt.QMainWindow):
         :param int z: Layer on which to draw the histogram
         :param baseline: histogram baseline
         :type: Union[None,float,numpy.ndarray]
-        :returns: The key string identify this histogram
+        :returns: The histogram item
         """
         legend = "Unnamed histogram" if legend is None else str(legend)
 
@@ -1367,7 +1366,7 @@ class PlotWidget(qt.QMainWindow):
             # axes has to be set to off.
             self.resetZoom()
 
-        return legend
+        return histo
 
     def addImage(
         self,
@@ -1436,7 +1435,7 @@ class PlotWidget(qt.QMainWindow):
         :param bool resetzoom: True (the default) to reset the zoom.
         :param bool copy: True make a copy of the data (default),
                           False to use provided arrays.
-        :returns: The key string identify this image
+        :returns: The image item
         """
         legend = "Unnamed Image 1.1" if legend is None else str(legend)
 
@@ -1515,7 +1514,7 @@ class PlotWidget(qt.QMainWindow):
             # axes has to be set to off.
             self.resetZoom()
 
-        return legend
+        return image
 
     def addScatter(
         self,
@@ -1573,7 +1572,7 @@ class PlotWidget(qt.QMainWindow):
 
         :param bool copy: True make a copy of the data (default),
                           False to use provided arrays.
-        :returns: The key string identify this scatter
+        :returns: The scatter item
         """
         legend = "Unnamed scatter 1.1" if legend is None else str(legend)
 
@@ -1628,7 +1627,7 @@ class PlotWidget(qt.QMainWindow):
         if len(scatters) == 1 or scatter is self.getActiveScatter():
             self.setActiveScatter(scatter)
 
-        return legend
+        return scatter
 
     def addShape(
         self,
@@ -1683,7 +1682,7 @@ class PlotWidget(qt.QMainWindow):
             Only relevant for line markers where X or Y is None.
         :param str linebgcolor: Background color of the line, e.g., 'blue', 'b',
             '#FF0000'. It is used to draw dotted line using a second color.
-        :returns: The key string identify this item
+        :returns: The shape item
         """
         # expected to receive the same parameters as the signal
 
@@ -1710,7 +1709,7 @@ class PlotWidget(qt.QMainWindow):
 
         self.addItem(item)
 
-        return legend
+        return item
 
     def addXMarker(
         self,
@@ -1749,7 +1748,7 @@ class PlotWidget(qt.QMainWindow):
                           the current cursor position in the plot as input
                           and that returns the filtered coordinates.
         :param str yaxis: The Y axis this marker belongs to in: 'left', 'right'
-        :return: The key string identify this marker
+        :return: The marker item
         """
         return self._addMarker(
             x=x,
@@ -1801,7 +1800,7 @@ class PlotWidget(qt.QMainWindow):
                           the current cursor position in the plot as input
                           and that returns the filtered coordinates.
         :param str yaxis: The Y axis this marker belongs to in: 'left', 'right'
-        :return: The key string identify this marker
+        :return: The marker item
         """
         return self._addMarker(
             x=None,
@@ -1867,7 +1866,7 @@ class PlotWidget(qt.QMainWindow):
                           the current cursor position in the plot as input
                           and that returns the filtered coordinates.
         :param str yaxis: The Y axis this marker belongs to in: 'left', 'right'
-        :return: The key string identify this marker
+        :return: The marker item
         """
         if x is None:
             xmin, xmax = self._xAxis.getLimits()
@@ -1966,7 +1965,7 @@ class PlotWidget(qt.QMainWindow):
         else:
             self._notifyContentChanged(marker)
 
-        return legend
+        return marker
 
     # Hide
 

--- a/src/silx/gui/plot/test/testItem.py
+++ b/src/silx/gui/plot/test/testItem.py
@@ -401,9 +401,7 @@ def testRegionOfInterestText():
     assert roi.getText() == "even_newer_name"
 
 
-def testPlotAddItemsWithoutLegend(qWidgetFactory):
-    plotWidget = qWidgetFactory(PlotWidget)
-
+def testPlotAddItemsWithoutLegend(plotWidget):
     curve1 = items.Curve()
     curve1.setData([0, 10], [0, 20])
     plotWidget.addItem(curve1)
@@ -421,3 +419,98 @@ def testPlotAddItemsWithoutLegend(qWidgetFactory):
     plotWidget.resetZoom()
     assert plotWidget.getXAxis().getLimits() == (-10, 10)
     assert plotWidget.getYAxis().getLimits() == (-20, 20)
+
+
+def testPlotWidgetAddCurve(plotWidget):
+    curve = plotWidget.addCurve(x=(0, 1), y=(1, 0), legend="test", symbol="s")
+    assert isinstance(curve, items.Curve)
+    assert numpy.array_equal(curve.getXData(copy=False), (0, 1))
+    assert numpy.array_equal(curve.getYData(copy=False), (1, 0))
+    assert curve.getName() == "test"
+    assert curve.getSymbol() == "s"
+
+    curveUpdated = plotWidget.addCurve(
+        x=(0, 1, 2), y=(1, 0, 1), legend="test", symbol="o"
+    )
+    assert curveUpdated is curve
+    assert numpy.array_equal(curveUpdated.getXData(copy=False), (0, 1, 2))
+    assert numpy.array_equal(curveUpdated.getYData(copy=False), (1, 0, 1))
+    assert curveUpdated.getName() == "test"
+    assert curveUpdated.getSymbol() == "o"
+
+
+def testPlotWidgetAddImage(plotWidget):
+    image = plotWidget.addImage(((0, 1), (2, 3)), legend="test")
+    assert isinstance(image, items.ImageData)
+    assert numpy.array_equal(image.getData(copy=False), ((0, 1), (2, 3)))
+    assert image.getName() == "test"
+
+    imageUpdated = plotWidget.addImage([(0, 1)], legend="test")
+    assert imageUpdated is image
+    assert numpy.array_equal(image.getData(copy=False), [(0, 1)])
+    assert image.getName() == "test"
+
+    # Update with a 1pixel RGB image
+    imageRgb = plotWidget.addImage([[(0.0, 0.0, 1.0)]], legend="test")
+    assert isinstance(imageRgb, items.ImageRgba)
+    assert numpy.array_equal(imageRgb.getData(copy=False), [[(0.0, 0.0, 1.0)]])
+    assert imageRgb.getName() == "test"
+
+    # Update with a 1pixel RGB image
+    imageRgbUpdated = plotWidget.addImage([[(1.0, 0.0, 0.0)]], legend="test")
+    assert imageRgbUpdated is imageRgb
+    assert numpy.array_equal(imageRgbUpdated.getData(copy=False), [[(1.0, 0.0, 0.0)]])
+    assert imageRgbUpdated.getName() == "test"
+
+
+def testPlotWidgetAddScatter(plotWidget):
+    scatter = plotWidget.addScatter(
+        x=(0, 1), y=(0, 1), value=(0, 1), legend="test", symbol="s"
+    )
+    assert isinstance(scatter, items.Scatter)
+    assert numpy.array_equal(scatter.getXData(copy=False), (0, 1))
+    assert numpy.array_equal(scatter.getYData(copy=False), (0, 1))
+    assert numpy.array_equal(scatter.getValueData(copy=False), (0, 1))
+    assert scatter.getName() == "test"
+    assert scatter.getSymbol() == "s"
+
+
+def testPlotWidgetAddHistogram(plotWidget):
+    histogram = plotWidget.addHistogram(
+        histogram=[1], edges=(0, 1), legend="test", fill=True
+    )
+    assert isinstance(histogram, items.Histogram)
+    assert numpy.array_equal(histogram.getBinEdgesData(copy=False), (0, 1))
+    assert numpy.array_equal(histogram.getValueData(copy=False), [1])
+    assert histogram.getName() == "test"
+    assert histogram.isFill()
+
+
+def testPlotWidgetAddMarker(plotWidget):
+    marker = plotWidget.addMarker(x=0, y=1, legend="test")
+    assert isinstance(marker, items.Marker)
+    assert marker.getPosition() == (0, 1)
+    assert marker.getName() == "test"
+    assert plotWidget.getItems() == (marker,)
+
+    xmarker = plotWidget.addXMarker(1, legend="test")
+    assert isinstance(xmarker, items.XMarker)
+    assert xmarker.getPosition() == (1, None)
+    assert xmarker.getName() == "test"
+    assert plotWidget.getItems() == (xmarker,)
+
+    ymarker = plotWidget.addYMarker(2, legend="test")
+    assert isinstance(ymarker, items.YMarker)
+    assert ymarker.getPosition() == (None, 2)
+    assert ymarker.getName() == "test"
+    assert plotWidget.getItems() == (ymarker,)
+
+
+def testPlotWidgetAddShape(plotWidget):
+    shape = plotWidget.addShape(
+        xdata=(0, 1), ydata=(0, 1), legend="test", shape="polygon"
+    )
+    assert isinstance(shape, items.Shape)
+    assert numpy.array_equal(shape.getPoints(copy=False), ((0, 0), (1, 1)))
+    assert shape.getName() == "test"
+    assert shape.getType() == "polygon"

--- a/src/silx/gui/plot/test/testPlotWidget.py
+++ b/src/silx/gui/plot/test/testPlotWidget.py
@@ -922,32 +922,25 @@ class TestPlotMarker(PlotWidgetTestCase):
     def testPlotMarkerYAxis(self):
         # Check only the API
 
-        legend = self.plot.addMarker(10, 10)
-        item = self.plot._getMarker(legend)
+        item = self.plot.addMarker(10, 10)
         self.assertEqual(item.getYAxis(), "left")
 
-        legend = self.plot.addMarker(10, 10, yaxis="right")
-        item = self.plot._getMarker(legend)
+        item = self.plot.addMarker(10, 10, yaxis="right")
         self.assertEqual(item.getYAxis(), "right")
 
-        legend = self.plot.addMarker(10, 10, yaxis="left")
-        item = self.plot._getMarker(legend)
+        item = self.plot.addMarker(10, 10, yaxis="left")
         self.assertEqual(item.getYAxis(), "left")
 
-        legend = self.plot.addXMarker(10, yaxis="right")
-        item = self.plot._getMarker(legend)
+        item = self.plot.addXMarker(10, yaxis="right")
         self.assertEqual(item.getYAxis(), "right")
 
-        legend = self.plot.addXMarker(10, yaxis="left")
-        item = self.plot._getMarker(legend)
+        item = self.plot.addXMarker(10, yaxis="left")
         self.assertEqual(item.getYAxis(), "left")
 
-        legend = self.plot.addYMarker(10, yaxis="right")
-        item = self.plot._getMarker(legend)
+        item = self.plot.addYMarker(10, yaxis="right")
         self.assertEqual(item.getYAxis(), "right")
 
-        legend = self.plot.addYMarker(10, yaxis="left")
-        item = self.plot._getMarker(legend)
+        item = self.plot.addYMarker(10, yaxis="left")
         self.assertEqual(item.getYAxis(), "left")
 
         self.plot.resetZoom()

--- a/src/silx/gui/plot/test/testPlotWidgetNoBackend.py
+++ b/src/silx/gui/plot/test/testPlotWidgetNoBackend.py
@@ -659,7 +659,7 @@ def testSetDefaultColorsAddCurve(qWidgetFactory):
     assert plot.getDefaultColors() == colors
 
     # Check that the color index is reset
-    curve = plot.getCurve(plot.addCurve((1, 2), (0, 1), legend="newcurve"))
+    curve = plot.addCurve((1, 2), (0, 1), legend="newcurve")
     assert curve.getColor() == rgba(colors[0])
 
 
@@ -678,7 +678,7 @@ def testDefaultColorsUpdateConfig(qWidgetFactory):
         assert plot.getDefaultColors() == colors
 
         # Check that the color index is reset
-        curve = plot.getCurve(plot.addCurve((1, 2), (0, 1), legend="newcurve"))
+        curve = plot.addCurve((1, 2), (0, 1), legend="newcurve")
         assert curve.getColor() == rgba(colors[0])
 
     finally:

--- a/src/silx/gui/plot/test/testStats.py
+++ b/src/silx/gui/plot/test/testStats.py
@@ -766,7 +766,7 @@ class TestLineWidget(TestCaseQt):
         self.plot.show()
         self.x = range(20)
         self.y0 = range(20)
-        self.curve0 = self.plot.addCurve(self.x, self.y0, legend="curve0")
+        self.plot.addCurve(self.x, self.y0, legend="curve0")
         self.y1 = range(12, 32)
         self.plot.addCurve(self.x, self.y1, legend="curve1")
         self.y2 = range(-2, 18)
@@ -821,7 +821,7 @@ class TestLineWidget(TestCaseQt):
 
     def testUpdateMode(self):
         """Make sure the update modes are well take into account"""
-        self.plot.setActiveCurve(self.curve0)
+        self.plot.setActiveCurve("curve0")
         _autoRB = self.widget._options._autoRB
         _manualRB = self.widget._options._manualRB
         # test from api
@@ -832,7 +832,7 @@ class TestLineWidget(TestCaseQt):
         # check stats change in auto mode
         curve0_min = self.widget._lineStatsWidget._statQlineEdit["min"].text()
         new_y = numpy.array(self.y0) - 2.56
-        self.plot.addCurve(x=self.x, y=new_y, legend=self.curve0)
+        self.plot.addCurve(x=self.x, y=new_y, legend="curve0")
         curve0_min2 = self.widget._lineStatsWidget._statQlineEdit["min"].text()
         self.assertTrue(curve0_min != curve0_min2)
 
@@ -842,7 +842,7 @@ class TestLineWidget(TestCaseQt):
         self.assertTrue(_manualRB.isChecked())
 
         new_y = numpy.array(self.y0) - 1.2
-        self.plot.addCurve(x=self.x, y=new_y, legend=self.curve0)
+        self.plot.addCurve(x=self.x, y=new_y, legend="curve0")
         curve0_min3 = self.widget._lineStatsWidget._statQlineEdit["min"].text()
         self.assertTrue(curve0_min3 == curve0_min2)
         self.widget._options._updateRequested()


### PR DESCRIPTION
Merge PR #3988 first!

This PR introduces a breaking API change: `PlotWidget.add*` methods (namely `addCurve`, `addImage`, `addHistogram`, `addScatter`, `addShape`, `addMarker`, `addXMarker`, `addYMarker`) now returns the created/updated PlotWidget item instead of its legend.

To mitigate this API break, `PlotWidget.remove*` methods and `PlotWidget.get*` methods were update to accept an item instance as their `legend` attribute. Together with `setActive*` methods accepting item, this should make the API change seamless for code that was using the legend as an identifier of the item in the `PlotWidget` without using it otherwise.

`PlotWidget.get*` methods log a warning when passed an item instance since this call is no longer needed.

Changes to `examples/` and tests were minimal and actually not needed to make it run.

closes #3990