### PR TITLE
silx.gui.plot.PlotWidged: Fixed tick display of timeseries

### DIFF
--- a/src/silx/gui/plot/_utils/dtime_ticklayout.py
+++ b/src/silx/gui/plot/_utils/dtime_ticklayout.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2014-2022 European Synchrotron Radiation Facility
+# Copyright (c) 2014-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -21,6 +21,8 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
+from __future__ import annotations
+
 """This module implements date-time labels layout on graph axes."""
 
 __authors__ = ["P. Kenter"]
@@ -28,6 +30,7 @@ __license__ = "MIT"
 __date__ = "04/04/2018"
 
 
+from collections.abc import Sequence
 import datetime as dt
 import enum
 import logging
@@ -326,6 +329,29 @@ def bestFormatString(spacing, unit):
         return "%S.%f"
     else:
         raise ValueError("Unexpected DtUnit: {}".format(unit))
+
+
+def formatDatetimes(
+    datetimes: Sequence[dt.datetime], spacing: int | None, unit: DtUnit | None
+) -> dict[dt.datetime, str]:
+    """Returns formatted string for each datetime according to tick spacing and time unit"""
+    if spacing is None or unit is None:
+        # Locator has no spacing or units yet: Use elaborate fmtString
+        return {
+            datetime: datetime.strftime("Y-%m-%d %H:%M:%S") for datetime in datetimes
+        }
+
+    formatString = bestFormatString(spacing, unit)
+    if unit != DtUnit.MICRO_SECONDS:
+        return {datetime: datetime.strftime(formatString) for datetime in datetimes}
+
+    # For microseconds: Strip leading/trailing zeros
+    texts = tuple(datetime.strftime(formatString) for datetime in datetimes)
+    nzeros = min(len(text) - len(text.rstrip("0")) for text in texts)
+    return {
+        datetime: text[0 if text[0] != "0" else 1 : -min(nzeros, 5)]
+        for datetime, text in zip(datetimes, texts)
+    }
 
 
 def niceDateTimeElement(value, unit, isRound=False):

--- a/src/silx/gui/plot/_utils/dtime_ticklayout.py
+++ b/src/silx/gui/plot/_utils/dtime_ticklayout.py
@@ -293,7 +293,7 @@ NICE_DATE_VALUES = {
     DtUnit.HOURS: [1, 2, 3, 4, 6, 12],
     DtUnit.MINUTES: [1, 2, 3, 5, 10, 15, 30],
     DtUnit.SECONDS: [1, 2, 3, 5, 10, 15, 30],
-    DtUnit.MICRO_SECONDS: [1.0, 2.0, 5.0, 10.0],  # floats for microsec
+    DtUnit.MICRO_SECONDS: [1.0, 2.0, 3.0, 4.0, 5.0, 10.0],  # floats for microsec
 }
 
 

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -427,6 +427,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
                 # Sync plot frame with window
                 self._plotFrame.devicePixelRatio = self.getDevicePixelRatio()
+                self._plotFrame.dotsPerInch = self.getDotsPerInch()
                 # self._paintDirectGL()
                 self._paintFBOGL()
 

--- a/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -50,7 +50,12 @@ from ..._utils import checkAxisLimits, FLOAT32_MINPOS
 from .GLSupport import mat4Ortho
 from .GLText import Text2D, CENTER, BOTTOM, TOP, LEFT, RIGHT, ROTATE_270
 from ..._utils.ticklayout import niceNumbersAdaptative, niceNumbersForLog10
-from ..._utils.dtime_ticklayout import calcTicksAdaptive, bestFormatString
+from ..._utils.dtime_ticklayout import (
+    bestUnit,
+    calcTicksAdaptive,
+    bestFormatString,
+    DtUnit,
+)
 from ..._utils.dtime_ticklayout import timestamp
 
 _logger = logging.getLogger(__name__)
@@ -390,6 +395,12 @@ class PlotAxis(object):
                     except ValueError:
                         _logger.warning("Data range cannot be displayed with time axis")
                         return  # Range is out of bound of the datetime
+
+                    if bestUnit(
+                        (dtMax - dtMin).total_seconds() == DtUnit.MICRO_SECONDS
+                    ):
+                        # Special case for micro seconds: Reduce tick density
+                        tickDensity = 1.0 * self.devicePixelRatio / self.dotsPerInch
 
                     tickDateTimes, spacing, unit = calcTicksAdaptive(
                         dtMin, dtMax, nbPixels, tickDensity

--- a/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -51,10 +51,10 @@ from .GLSupport import mat4Ortho
 from .GLText import Text2D, CENTER, BOTTOM, TOP, LEFT, RIGHT, ROTATE_270
 from ..._utils.ticklayout import niceNumbersAdaptative, niceNumbersForLog10
 from ..._utils.dtime_ticklayout import (
+    DtUnit,
     bestUnit,
     calcTicksAdaptive,
-    bestFormatString,
-    DtUnit,
+    formatDatetimes,
 )
 from ..._utils.dtime_ticklayout import timestamp
 
@@ -405,17 +405,16 @@ class PlotAxis(object):
                     tickDateTimes, spacing, unit = calcTicksAdaptive(
                         dtMin, dtMax, nbPixels, tickDensity
                     )
+                    visibleDatetimes = tuple(
+                        dt for dt in tickDateTimes if dtMin <= dt <= dtMax
+                    )
+                    ticks = formatDatetimes(visibleDatetimes, spacing, unit)
 
-                    for tickDateTime in tickDateTimes:
-                        if dtMin <= tickDateTime <= dtMax:
-                            dataPos = timestamp(tickDateTime)
-                            xPixel = x0 + (dataPos - dataMin) * xScale
-                            yPixel = y0 + (dataPos - dataMin) * yScale
-
-                            fmtStr = bestFormatString(spacing, unit)
-                            text = tickDateTime.strftime(fmtStr)
-
-                            yield ((xPixel, yPixel), dataPos, text)
+                    for tickDateTime, text in ticks.items():
+                        dataPos = timestamp(tickDateTime)
+                        xPixel = x0 + (dataPos - dataMin) * xScale
+                        yPixel = y0 + (dataPos - dataMin) * yScale
+                        yield ((xPixel, yPixel), dataPos, text)
 
 
 # GLPlotFrame #################################################################

--- a/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -172,6 +172,12 @@ class PlotAxis(object):
         return plotFrame.devicePixelRatio if plotFrame is not None else 1.0
 
     @property
+    def dotsPerInch(self):
+        """Returns the screen DPI"""
+        plotFrame = self._plotFrameRef()
+        return plotFrame.dotsPerInch if plotFrame is not None else 92
+
+    @property
     def title(self):
         """The text label associated with this axis as a str in latin-1."""
         return self._title
@@ -359,7 +365,7 @@ class PlotAxis(object):
 
                 # Density of 1.3 label per 92 pixels
                 # i.e., 1.3 label per inch on a 92 dpi screen
-                tickDensity = 1.3 / 92
+                tickDensity = 1.3 * self.devicePixelRatio / self.dotsPerInch
 
                 if not self.isTimeSeries:
                     tickMin, tickMax, step, nbFrac = niceNumbersAdaptative(
@@ -463,6 +469,7 @@ class GLPlotFrame(object):
         self._title = ""
 
         self._devicePixelRatio = 1.0
+        self._dpi = 92
 
     @property
     def isDirty(self):
@@ -547,6 +554,16 @@ class GLPlotFrame(object):
     def devicePixelRatio(self, ratio):
         if ratio != self._devicePixelRatio:
             self._devicePixelRatio = ratio
+            self._dirty()
+
+    @property
+    def dotsPerInch(self):
+        return self._dpi
+
+    @dotsPerInch.setter
+    def dotsPerInch(self, dpi):
+        if dpi != self._dpi:
+            self._dpi = dpi
             self._dirty()
 
     @property


### PR DESCRIPTION
This PR reworks the way ticks and labels are computed for timeseries when displayed as microseconds:

The "density" of ticks is adjusted in this case, the 'nice numbers' list has been extended and the formatting updated to strip leading/trailing "0".

closes #3949
