### PR TITLE
silx.gui.plot.items.Shape: Changed Shape.get|setLineBgColor to get|setLineGapColor

### DIFF
--- a/src/silx/gui/plot/PlotInteraction.py
+++ b/src/silx/gui/plot/PlotInteraction.py
@@ -134,7 +134,7 @@ class _PlotInteraction(object):
             shape=shape,
             fill=fill,
             color=color,
-            linebgcolor=color2,
+            gapcolor=color2,
             linestyle="--",
             overlay=True,
         )

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -1705,7 +1705,7 @@ class PlotWidget(qt.QMainWindow):
         item.setPoints(numpy.array((xdata, ydata)).T)
         item.setLineStyle(linestyle)
         item.setLineWidth(linewidth)
-        item.setLineBgColor(linebgcolor)
+        item.setLineGapColor(linebgcolor)
 
         self.addItem(item)
 

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -70,6 +70,7 @@ from .items.axis import TickMode  # noqa
 from .. import qt
 from ._utils.panzoom import ViewConstraints
 from ...gui.plot._utils.dtime_ticklayout import timestamp
+from ...utils.deprecation import deprecated_warning
 
 
 """
@@ -1643,7 +1644,8 @@ class PlotWidget(qt.QMainWindow):
         z=None,
         linestyle="-",
         linewidth=1.0,
-        linebgcolor=None,
+        linebgcolor="deprecated",
+        gapcolor=None,
     ):
         """Add an item (i.e. a shape) to the plot.
 
@@ -1680,7 +1682,7 @@ class PlotWidget(qt.QMainWindow):
             - ':'  dotted line
         :param float linewidth: Width of the line.
             Only relevant for line markers where X or Y is None.
-        :param str linebgcolor: Background color of the line, e.g., 'blue', 'b',
+        :param str gapcolor: Gap color of the line, e.g., 'blue', 'b',
             '#FF0000'. It is used to draw dotted line using a second color.
         :returns: The shape item
         """
@@ -1705,7 +1707,15 @@ class PlotWidget(qt.QMainWindow):
         item.setPoints(numpy.array((xdata, ydata)).T)
         item.setLineStyle(linestyle)
         item.setLineWidth(linewidth)
-        item.setLineGapColor(linebgcolor)
+        if linebgcolor != "deprecated":
+            deprecated_warning(
+                type_="Argument",
+                name="linebgcolor",
+                replacement="gapcolor",
+                since_version="2.0.0",
+            )
+            gapcolor = linebgcolor if gapcolor is None else gapcolor
+        item.setLineGapColor(gapcolor)
 
         self.addItem(item)
 

--- a/src/silx/gui/plot/backends/BackendBase.py
+++ b/src/silx/gui/plot/backends/BackendBase.py
@@ -178,7 +178,7 @@ class BackendBase(object):
         return object()
 
     def addShape(
-        self, x, y, shape, color, fill, overlay, linestyle, linewidth, linebgcolor
+        self, x, y, shape, color, fill, overlay, linestyle, linewidth, gapcolor
     ):
         """Add an item (i.e. a shape) to the plot.
 
@@ -200,7 +200,7 @@ class BackendBase(object):
             - ':'  dotted line
         :param float linewidth: Width of the line.
             Only relevant for line markers where X or Y is None.
-        :param str linebgcolor: Background color of the line, e.g., 'blue', 'b',
+        :param str gapcolor: Background color of the line, e.g., 'blue', 'b',
             '#FF0000'. It is used to draw dotted line using a second color.
         :returns: The handle used by the backend to univocally access the item
         """

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -846,15 +846,15 @@ class BackendMatplotlib(BackendBase.BackendBase):
         return collection
 
     def addShape(
-        self, x, y, shape, color, fill, overlay, linestyle, linewidth, linebgcolor
+        self, x, y, shape, color, fill, overlay, linestyle, linewidth, gapcolor
     ):
-        if linebgcolor is not None and shape not in (
+        if gapcolor is not None and shape not in (
             "rectangle",
             "polygon",
             "polylines",
         ):
             _logger.warning(
-                "linebgcolor not implemented for %s with matplotlib backend", shape
+                "gapcolor not implemented for %s with matplotlib backend", shape
             )
         xView = numpy.array(x, copy=False)
         yView = numpy.array(y, copy=False)
@@ -896,7 +896,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                 linestyle=linestyle,
                 linewidth=linewidth,
             )
-            item.set_second_edgecolor(linebgcolor)
+            item.set_second_edgecolor(gapcolor)
 
             if fill:
                 item.set_hatch(".")
@@ -917,7 +917,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                 linestyle=linestyle,
                 linewidth=linewidth,
             )
-            item.set_second_edgecolor(linebgcolor)
+            item.set_second_edgecolor(gapcolor)
 
             if fill and shape == "polygon":
                 item.set_hatch("/")

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -55,7 +55,7 @@ _logger = logging.getLogger(__name__)
 
 class _ShapeItem(dict):
     def __init__(
-        self, x, y, shape, color, fill, overlay, linestyle, linewidth, linebgcolor
+        self, x, y, shape, color, fill, overlay, linestyle, linewidth, gapcolor
     ):
         super(_ShapeItem, self).__init__()
 
@@ -83,7 +83,7 @@ class _ShapeItem(dict):
                 "y": y,
                 "linestyle": linestyle,
                 "linewidth": linewidth,
-                "linebgcolor": linebgcolor,
+                "gapcolor": gapcolor,
             }
         )
 
@@ -571,7 +571,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                             points[:, 1],
                             style=item["linestyle"],
                             color=item["color"],
-                            gapColor=item["linebgcolor"],
+                            gapColor=item["gapcolor"],
                             width=item["linewidth"],
                         )
                         context.matrix = self.matScreenProj
@@ -1067,7 +1067,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         return triangles
 
     def addShape(
-        self, x, y, shape, color, fill, overlay, linestyle, linewidth, linebgcolor
+        self, x, y, shape, color, fill, overlay, linestyle, linewidth, gapcolor
     ):
         x = numpy.array(x, copy=False)
         y = numpy.array(y, copy=False)
@@ -1079,7 +1079,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             raise RuntimeError("Cannot add item with Y <= 0 with Y axis log scale")
 
         return _ShapeItem(
-            x, y, shape, color, fill, overlay, linestyle, linewidth, linebgcolor
+            x, y, shape, color, fill, overlay, linestyle, linewidth, gapcolor
         )
 
     def addMarker(

--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -975,7 +975,7 @@ class LineGapColorMixIn(ItemMixInBase):
         :param color: line background color to be used
         :type color: Union[str, List[int], List[float], QColor, None]
         """
-        self.__lineGapColor = colors.rgba(color)
+        self.__lineGapColor = None if color is None else colors.rgba(color)
         self._updated(ItemChangedType.LINE_GAP_COLOR)
 
 

--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -91,8 +91,7 @@ class ItemChangedType(enum.Enum):
     COLOR = "colorChanged"
     """Item's color changed flag."""
 
-    LINE_BG_COLOR = "lineBgColorChanged"
-    """Item's line background color changed flag."""
+    LINE_BG_COLOR = "lineBgColorChanged"  # Deprecated, use LINE_GAP_COLOR
 
     LINE_GAP_COLOR = "lineGapColorChanged"
     """Item's dashed line gap color changed flag."""

--- a/src/silx/gui/plot/items/shape.py
+++ b/src/silx/gui/plot/items/shape.py
@@ -141,7 +141,7 @@ class Shape(_OverlayItem, ColorMixIn, FillMixIn, _TwoColorsLineMixIn):
             overlay=self.isOverlay(),
             linestyle=self.getLineStyle(),
             linewidth=self.getLineWidth(),
-            linebgcolor=self.getLineBgColor(),
+            gapcolor=self.getLineBgColor(),
         )
 
     def getType(self):
@@ -409,5 +409,5 @@ class Line(_OverlayItem, AlphaMixIn, ColorMixIn, _TwoColorsLineMixIn):
             overlay=self.isOverlay(),
             linestyle=self.getLineStyle(),
             linewidth=self.getLineWidth(),
-            linebgcolor=self.getLineBgColor(),
+            gapcolor=self.getLineBgColor(),
         )

--- a/src/silx/gui/plot/items/shape.py
+++ b/src/silx/gui/plot/items/shape.py
@@ -33,7 +33,6 @@ import logging
 
 import numpy
 
-from ... import colors
 from .core import (
     Item,
     DataItem,
@@ -42,8 +41,10 @@ from .core import (
     FillMixIn,
     ItemChangedType,
     LineMixIn,
+    LineGapColorMixIn,
     YAxisMixIn,
 )
+from ....utils.deprecation import deprecated
 
 
 _logger = logging.getLogger(__name__)
@@ -71,41 +72,20 @@ class _OverlayItem(Item):
             self._updated(ItemChangedType.OVERLAY)
 
 
-class _TwoColorsLineMixIn(LineMixIn):
+class _TwoColorsLineMixIn(LineMixIn, LineGapColorMixIn):
     """Mix-in class for items with a background color for dashes"""
 
     def __init__(self):
         LineMixIn.__init__(self)
-        self.__backgroundColor = None
+        LineGapColorMixIn.__init__(self)
 
+    @deprecated(replacement="getLineGapColor", since_version="2.0.0")
     def getLineBgColor(self):
-        """Returns the RGBA background color of dash line
+        return self.getLineGapColor()
 
-        :rtype: 4-tuple of float in [0, 1] or array of colors
-        """
-        return self.__backgroundColor
-
+    @deprecated(replacement="setLineGapColor", since_version="2.0.0")
     def setLineBgColor(self, color, copy: bool = True):
-        """Set dash line background color
-
-        :param color: color(s) to be used
-        :type color: str ("#RRGGBB") or (npoints, 4) unsigned byte array or
-            one of the predefined color names defined in colors.py
-        :param copy: True (Default) to get a copy,
-            False to use internal representation (do not modify!)
-        """
-        if color is not None:
-            if isinstance(color, str):
-                color = colors.rgba(color)
-            else:
-                color = numpy.array(color, copy=copy)
-                # TODO more checks + improve color array support
-                if color.ndim == 1:  # Single RGBA color
-                    color = colors.rgba(color)
-                else:  # Array of colors
-                    assert color.ndim == 2
-
-        self.__backgroundColor = color
+        self.setLineGapColor(color)
         self._updated(ItemChangedType.LINE_BG_COLOR)
 
 
@@ -141,7 +121,7 @@ class Shape(_OverlayItem, ColorMixIn, FillMixIn, _TwoColorsLineMixIn):
             overlay=self.isOverlay(),
             linestyle=self.getLineStyle(),
             linewidth=self.getLineWidth(),
-            gapcolor=self.getLineBgColor(),
+            gapcolor=self.getLineGapColor(),
         )
 
     def getType(self):
@@ -409,5 +389,5 @@ class Line(_OverlayItem, AlphaMixIn, ColorMixIn, _TwoColorsLineMixIn):
             overlay=self.isOverlay(),
             linestyle=self.getLineStyle(),
             linewidth=self.getLineWidth(),
-            gapcolor=self.getLineBgColor(),
+            gapcolor=self.getLineGapColor(),
         )


### PR DESCRIPTION
This PR renames `Shape` items second color of line to use the same API as `Curve` and `Histogram`.
Previous methods, argument are kept with deprecation warnings.

closes #3998 