### PR TITLE
FloatEdit: Added widgetResizable

### DIFF
--- a/examples/floatedit.py
+++ b/examples/floatedit.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+# /*##########################################################################
+#
+# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""
+Test FloatEdit widgets
+"""
+
+from silx.gui import qt
+from silx.gui.widgets.FloatEdit import FloatEdit
+
+
+class Dialog(qt.QMainWindow):
+    def __init__(self, *args, **kwargs):
+        qt.QMainWindow.__init__(self, *args, **kwargs)
+
+        widget = qt.QWidget(self)
+        layout = qt.QHBoxLayout(widget)
+
+        f1 = FloatEdit(self)
+        layout.addWidget(f1)
+
+        f2 = FloatEdit(self)
+        layout.addWidget(f2)
+
+        f3 = FloatEdit(self)
+        f3.setWidgetResizable(True)
+        layout.addWidget(f3)
+
+        b = qt.QPushButton(self)
+        b.setText("f3=100")
+        b.clicked.connect(lambda: f3.setValue(100))
+        layout.addWidget(b)
+
+        self.setCentralWidget(widget)
+
+
+if __name__ == "__main__":
+    app = qt.QApplication([])
+    window = Dialog()
+    window.setVisible(True)
+    app.exec()

--- a/src/silx/gui/widgets/FloatEdit.py
+++ b/src/silx/gui/widgets/FloatEdit.py
@@ -39,9 +39,8 @@ class FloatEdit(qt.QLineEdit):
     The value can be modified with :meth:`value` and :meth:`setValue`.
 
     The property :meth:`widgetResizable` allow to change the default
-    behaviour in order to automatically resize the widhet to avoid
-    to scroll to see the whole value. You still can enforce your own
-    minimum width with :meth:`setMinimumWidth`.
+    behaviour in order to automatically resize the widget to the displayed value.
+    Use :meth:`setMinimumWidth` to enforce the minimum width.
 
     :param parent: Parent of the widget
     :param value: The value to set the QLineEdit to.
@@ -93,14 +92,15 @@ class FloatEdit(qt.QLineEdit):
 
     def widgetResizable(self) -> bool:
         """
-        Returns wether the widget auto resize itself based on it's content
+        Returns whether or not the widget auto resizes itself based on it's content
         """
         return self.__widgetResizable
 
     def setWidgetResizable(self, resizable: bool):
         """
-        If true, the widget will automatically resize itself in order to avoid
-        to scroll to see it's content where they can be avoided, or to take
+        If true, the widget will automatically resize itself to its displayed content.
+
+        This avoids to have to scroll to see the widget's content, and allow to take
         advantage of extra space.
         """
         if self.__widgetResizable == resizable:

--- a/src/silx/gui/widgets/test/test_floatedit.py
+++ b/src/silx/gui/widgets/test/test_floatedit.py
@@ -1,0 +1,88 @@
+# /*##########################################################################
+#
+# Copyright (c) 2018 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+"""Tests for FloatEdit"""
+
+__license__ = "MIT"
+
+import pytest
+import weakref
+from silx.gui import qt
+from silx.gui.widgets.FloatEdit import FloatEdit
+
+
+@pytest.fixture
+def floatEdit(qapp, qapp_utils):
+    widget = FloatEdit()
+    widget.setAttribute(qt.Qt.WA_DeleteOnClose)
+    yield widget
+    widget.close()
+    ref = weakref.ref(widget)
+    widget = None
+    qapp_utils.qWaitForDestroy(ref)
+
+
+@pytest.fixture
+def holder(qapp, qapp_utils):
+    widget = qt.QWidget()
+    qt.QHBoxLayout(widget)
+    widget.setAttribute(qt.Qt.WA_DeleteOnClose)
+    yield widget
+    widget.close()
+    ref = weakref.ref(widget)
+    widget = None
+    qapp_utils.qWaitForDestroy(ref)
+
+
+def test_show(qapp_utils, floatEdit):
+    qapp_utils.qWaitForWindowExposed(floatEdit)
+
+
+def test_value(floatEdit):
+    floatEdit.setValue(1.5)
+    assert floatEdit.value() == 1.5
+
+
+def test_no_widgetresize(qapp_utils, holder, floatEdit):
+    holder.layout().addWidget(floatEdit)
+    holder.resize(100, 100)
+    holder.show()
+    qapp_utils.qWaitForWindowExposed(holder)
+    floatEdit.setValue(123)
+    a = floatEdit.width()
+    floatEdit.setValue(123456789123456789.123456789123456789)
+    b = floatEdit.width()
+    assert b == a
+
+
+def test_widgetresize(qapp_utils, holder, floatEdit):
+    holder.layout().addWidget(floatEdit)
+    holder.resize(100, 100)
+    holder.show()
+    qapp_utils.qWaitForWindowExposed(holder)
+    floatEdit.setWidgetResizable(True)
+    floatEdit.setValue(123)
+    a = floatEdit.width()
+    floatEdit.setValue(123456789123456789.123456789123456789)
+    b = floatEdit.width()
+    assert b > a


### PR DESCRIPTION
Added a `widgetResizable`/`setWidgetResizable` to `FloatEdit` in order to always display the full value

- With this flag the widget width will grow/shrink during the user typing
- `sizeHint` is reimplemented as result the default layout also fit the content
- The implementation is based on `minimumSize` to inforce the parent layout to resize them self (windows and dialog will also grow and shrink)
- The property name `widgetResizable` was picked from `QScrollBar`

Changelog: 
- Added `widgetResizable` to `FloatEdit` (default is false)