### PR TITLE
silx.gui.plot.PlotWidget: Updated plot axes tick labels behavior

### DIFF
--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -42,7 +42,11 @@ _logger = logging.getLogger(__name__)
 from ... import qt
 
 # First of all init matplotlib and set its backend
-from ...utils.matplotlib import FigureCanvasQTAgg, qFontToFontProperties
+from ...utils.matplotlib import (
+    DefaultTickFormatter,
+    FigureCanvasQTAgg,
+    qFontToFontProperties,
+)
 import matplotlib
 from matplotlib.container import Container
 from matplotlib.figure import Figure
@@ -52,7 +56,7 @@ from matplotlib.backend_bases import MouseEvent
 from matplotlib.lines import Line2D
 from matplotlib.text import Text
 from matplotlib.collections import PathCollection, LineCollection
-from matplotlib.ticker import Formatter, ScalarFormatter, Locator
+from matplotlib.ticker import Formatter, Locator
 from matplotlib.tri import Triangulation
 from matplotlib.collections import TriMesh
 from matplotlib import path as mpath
@@ -543,7 +547,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
         # Configure axes tick label formatter
         for axis in (self.ax.yaxis, self.ax.xaxis, self.ax2.yaxis, self.ax2.xaxis):
-            self.__setAxisFormatter(axis)
+            axis.set_major_formatter(DefaultTickFormatter())
 
         self.ax2.set_autoscaley_on(True)
 
@@ -562,13 +566,6 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
         self._enableAxis("right", False)
         self._isXAxisTimeSeries = False
-
-    @staticmethod
-    def __setAxisFormatter(axis):
-        """Configure matplotlib Axis formatter"""
-        formatter = ScalarFormatter(useOffset=True, useMathText=True)
-        formatter.set_scientific(True)
-        axis.set_major_formatter(formatter)
 
     def getItemsFromBackToFront(self, condition=None):
         """Order as BackendBase + take into account matplotlib Axes structure"""
@@ -1262,7 +1259,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                 NiceAutoDateFormatter(locator, tz=self.getXAxisTimeZone())
             )
         else:
-            self.__setAxisFormatter(self.ax.xaxis)
+            self.ax.xaxis.set_major_formatter(DefaultTickFormatter())
 
     def setXAxisLogarithmic(self, flag):
         # Workaround for matplotlib 2.1.0 when one tries to set an axis

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -541,21 +541,9 @@ class BackendMatplotlib(BackendBase.BackendBase):
         # Set axis zorder=0.5 so grid is displayed at 0.5
         self.ax.set_axisbelow(True)
 
-        # disable the use of offsets
-        try:
-            axes = [
-                self.ax.get_yaxis().get_major_formatter(),
-                self.ax.get_xaxis().get_major_formatter(),
-                self.ax2.get_yaxis().get_major_formatter(),
-                self.ax2.get_xaxis().get_major_formatter(),
-            ]
-            for axis in axes:
-                axis.set_useOffset(False)
-                axis.set_scientific(False)
-        except:
-            _logger.warning(
-                "Cannot disabled axes offsets in %s " % matplotlib.__version__
-            )
+        # Configure axes tick label formatter
+        for axis in (self.ax.yaxis, self.ax.xaxis, self.ax2.yaxis, self.ax2.xaxis):
+            self.__setAxisFormatter(axis)
 
         self.ax2.set_autoscaley_on(True)
 
@@ -574,6 +562,13 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
         self._enableAxis("right", False)
         self._isXAxisTimeSeries = False
+
+    @staticmethod
+    def __setAxisFormatter(axis):
+        """Configure matplotlib Axis formatter"""
+        formatter = ScalarFormatter(useOffset=True, useMathText=True)
+        formatter.set_scientific(True)
+        axis.set_major_formatter(formatter)
 
     def getItemsFromBackToFront(self, condition=None):
         """Order as BackendBase + take into account matplotlib Axes structure"""
@@ -1267,14 +1262,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                 NiceAutoDateFormatter(locator, tz=self.getXAxisTimeZone())
             )
         else:
-            try:
-                scalarFormatter = ScalarFormatter(useOffset=False)
-            except:
-                _logger.warning(
-                    "Cannot disabled axes offsets in %s " % matplotlib.__version__
-                )
-                scalarFormatter = ScalarFormatter()
-            self.ax.xaxis.set_major_formatter(scalarFormatter)
+            self.__setAxisFormatter(self.ax.xaxis)
 
     def setXAxisLogarithmic(self, flag):
         # Workaround for matplotlib 2.1.0 when one tries to set an axis

--- a/src/silx/gui/utils/matplotlib.py
+++ b/src/silx/gui/utils/matplotlib.py
@@ -55,7 +55,10 @@ else:
 from matplotlib.font_manager import FontProperties
 from matplotlib.mathtext import MathTextParser
 from matplotlib.ticker import ScalarFormatter as _ScalarFormatter
-from matplotlib import figure
+from matplotlib import figure, font_manager
+from packaging.version import Version
+
+_MATPLOTLIB_VERSION = Version(matplotlib.__version__)
 
 
 class DefaultTickFormatter(_ScalarFormatter):
@@ -65,6 +68,12 @@ class DefaultTickFormatter(_ScalarFormatter):
         super().__init__(useOffset=True, useMathText=True)
         self.set_scientific(True)
         self.create_dummy_axis()
+
+    if _MATPLOTLIB_VERSION < Version("3.1.0"):
+
+        def format_ticks(self, values):
+            self.set_locs(values)
+            return [self(value, i) for i, value in enumerate(values)]
 
 
 _FONT_STYLES = {
@@ -77,8 +86,15 @@ _FONT_STYLES = {
 def qFontToFontProperties(font: qt.QFont):
     """Convert a QFont to a matplotlib FontProperties"""
     weightFactor = 10 if qt.BINDING == "PyQt5" else 1
+    families = [font.family(), font.defaultFamily()]
+    if _MATPLOTLIB_VERSION >= Version("3.6.0"):
+        # Prevent 'Font family not found warnings'
+        availableNames = font_manager.get_font_names()
+        families = [f for f in families if f in availableNames]
+        families.append(font_manager.fontManager.defaultFamily["ttf"])
+
     return FontProperties(
-        family=[font.family(), font.defaultFamily()],
+        family=families,
         style=_FONT_STYLES[font.style()],
         weight=weightFactor * font.weight(),
         size=font.pointSizeF(),

--- a/src/silx/gui/utils/matplotlib.py
+++ b/src/silx/gui/utils/matplotlib.py
@@ -54,7 +54,17 @@ else:
 
 from matplotlib.font_manager import FontProperties
 from matplotlib.mathtext import MathTextParser
+from matplotlib.ticker import ScalarFormatter as _ScalarFormatter
 from matplotlib import figure
+
+
+class DefaultTickFormatter(_ScalarFormatter):
+    """Tick label formatter"""
+
+    def __init__(self):
+        super().__init__(useOffset=True, useMathText=True)
+        self.set_scientific(True)
+        self.create_dummy_axis()
 
 
 _FONT_STYLES = {


### PR DESCRIPTION
This PR changes the configuration of matplotlib tick label `ScalarFormatter` to enable offset, scientific notation and math text to format tick labels.

The behavior of the formatter has changed over time and here are some examples of the behavior as of today: no offset/scientific notation | scientific notation only around 0 | ofset + scientific notation

<img width="471" alt="Screen Shot 2023-12-15 at 11 34 01" src="https://github.com/silx-kit/silx/assets/9449698/e13ab6e8-3c32-4fdf-a6f5-bb0632a67687">


closes #3997
