### PR TITLE
silx.gui: improved `qWidgetFactory` test fixture

### DIFF
--- a/src/silx/gui/conftest.py
+++ b/src/silx/gui/conftest.py
@@ -1,4 +1,3 @@
-import weakref
 import pytest
 
 from silx.gui import qt
@@ -27,7 +26,7 @@ def qWidgetFactory(qapp, qapp_utils):
         qapp_utils.qWaitForWindowExposed(widget)
         widgets.append(widget)
 
-        return weakref.proxy(widget)
+        return widget
 
     yield createWidget
 

--- a/src/silx/gui/widgets/test/test_floatedit.py
+++ b/src/silx/gui/widgets/test/test_floatedit.py
@@ -32,21 +32,20 @@ from silx.gui.widgets.FloatEdit import FloatEdit
 
 @pytest.fixture
 def floatEdit(qWidgetFactory):
-    proxy = qWidgetFactory(FloatEdit)
-    yield proxy
+    widget = qWidgetFactory(FloatEdit)
+    yield widget
 
 
 @pytest.fixture
-def floatEditHolder(qapp, qapp_utils, qWidgetFactory, floatEdit):
-    proxy = qWidgetFactory(qt.QWidget)
-    holder = proxy.__repr__.__self__
-    layout = qt.QHBoxLayout(holder)
+def floatEditHolder(qWidgetFactory, floatEdit):
+    widget = qWidgetFactory(qt.QWidget)
+    layout = qt.QHBoxLayout(widget)
     layout.addStretch()
-    layout.addWidget(floatEdit.__repr__.__self__)
-    yield proxy
+    layout.addWidget(floatEdit)
+    yield widget
 
 
-def test_show(qapp_utils, floatEdit):
+def test_show(floatEdit):
     pass
 
 
@@ -55,7 +54,7 @@ def test_value(floatEdit):
     assert floatEdit.value() == 1.5
 
 
-def test_no_widgetresize(qapp_utils, floatEditHolder, floatEdit):
+def test_no_widgetresize(floatEditHolder, floatEdit):
     floatEditHolder.resize(50, 50)
     floatEdit.setValue(123)
     a = floatEdit.width()


### PR DESCRIPTION
Do not return a weakref proxy but the widget itself so it can be added e.g. to a Qt layout.
