### PR TITLE
Draft: Improve line rendering

### DIFF
--- a/examples/compareBackend.py
+++ b/examples/compareBackend.py
@@ -1,0 +1,261 @@
+# /*##########################################################################
+#
+# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ###########################################################################*/
+
+"""
+Compare one to one backend rendering
+"""
+
+from __future__ import annotations
+
+__license__ = "MIT"
+
+import numpy
+import sys
+import functools
+
+from silx.gui import qt
+
+from silx.gui.plot import PlotWidget
+from silx.gui.plot import items
+from silx.gui.plot.items.marker import Marker
+from silx.gui.plot.utils.axis import SyncAxes
+
+
+_DESCRIPTIONS = {}
+
+
+class MyPlotWindow(qt.QMainWindow):
+    """QMainWindow with selected tools"""
+
+    def __init__(self, parent=None):
+        super(MyPlotWindow, self).__init__(parent)
+
+        # Create a PlotWidget
+        self._plot1 = PlotWidget(parent=self, backend="mpl")
+        self._plot1.setGraphTitle("matplotlib")
+        self._plot2 = PlotWidget(parent=self, backend="opengl")
+        self._plot2.setGraphTitle("opengl")
+
+        self.constraintX = SyncAxes(
+            [
+                self._plot1.getXAxis(),
+                self._plot2.getXAxis(),
+            ]
+        )
+        self.constraintY = SyncAxes(
+            [
+                self._plot1.getYAxis(),
+                self._plot2.getYAxis(),
+            ]
+        )
+
+        plotWidget = qt.QWidget(self)
+        plotLayout = qt.QHBoxLayout(plotWidget)
+        plotLayout.addWidget(self._plot1)
+        plotLayout.addWidget(self._plot2)
+        plotLayout.setContentsMargins(0, 0, 0, 0)
+        plotLayout.setContentsMargins(0, 0, 0, 0)
+
+        options = self.createOptions(self)
+        centralWidget = qt.QWidget(self)
+        layout = qt.QHBoxLayout(centralWidget)
+        layout.setSpacing(0)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(options)
+        layout.addWidget(plotWidget)
+
+        self.setCentralWidget(centralWidget)
+
+        self._state = {}
+
+    def clear(self):
+        self._state = {}
+
+    def createOptions(self, parent):
+        options = qt.QWidget(parent)
+        layout = qt.QVBoxLayout(options)
+        for id, description in _DESCRIPTIONS.items():
+            label, _func = description
+            button = qt.QPushButton(label, self)
+            button.clicked.connect(functools.partial(self.showUseCase, id))
+            layout.addWidget(button)
+        layout.addStretch()
+        return options
+
+    def showUseCase(self, name: str):
+        description = _DESCRIPTIONS.get(name)
+        if description is None:
+            raise ValueError(f"Unknown use case '{name}'")
+        setupFunc = description[1]
+        self.clear()
+        for p in [self._plot1, self._plot2]:
+            p.clear()
+            setupFunc(self, p)
+            p.resetZoom()
+
+    def _register(name, label):
+        def decorator(func):
+            _DESCRIPTIONS[name] = (label, func)
+            return func
+        return decorator
+
+    def _addLine(
+        self,
+        plot,
+        lineWidth: float,
+        lineStyle: str,
+        color: str,
+        gapColor: str | None,
+        curve: bool
+    ):
+        state = self._state.setdefault(plot, {})
+        x = state.get("x", 0)
+        y = state.get("y", 0)
+        x += 10
+        state["x"] = x
+        state["y"] = y
+
+        start = (x - 20, y + 0)
+        stop = (x + 40, y + 100)
+
+        def createShape():
+            shape = items.Shape("polylines")
+            shape.setPoints(numpy.array((start, stop)))
+            shape.setLineWidth(lineWidth)
+            shape.setLineStyle(lineStyle)
+            shape.setColor(color)
+            if gapColor is not None:
+                shape.setLineGapColor(gapColor)
+            return shape
+
+        def createCurve():
+            curve = items.Curve()
+            array = numpy.array((start, stop)).T
+            curve.setData(array[0], array[1])
+            curve.setLineWidth(lineWidth)
+            curve.setLineStyle(lineStyle)
+            curve.setColor(color)
+            curve.setSymbol("")
+            if gapColor is not None:
+                curve.setLineGapColor(gapColor)
+            return curve
+
+        if curve:
+            plot.addItem(createCurve())
+        else:
+            plot.addItem(createShape())
+
+    @_register("linewidth", "Line width")
+    def _setupLineStyle(self, plot: PlotWidget):
+        self._addLine(plot, 0.5, "-", "#0000FF", None, curve=False)
+        self._addLine(plot, 1.0, "-", "#0000FF", None, curve=False)
+        self._addLine(plot, 2.0, "-", "#0000FF", None, curve=False)
+        self._addLine(plot, 4.0, "-", "#0000FF", None, curve=False)
+        self._addLine(plot, 0.5, "-", "#00FFFF", None, curve=True)
+        self._addLine(plot, 1.0, "-", "#00FFFF", None, curve=True)
+        self._addLine(plot, 2.0, "-", "#00FFFF", None, curve=True)
+        self._addLine(plot, 4.0, "-", "#00FFFF", None, curve=True)
+
+    @_register("linestyle", "Line style")
+    def _setupLineStyle(self, plot: PlotWidget):
+        self._addLine(plot, 1.0, "--", "#0000FF", None, curve=False)
+        self._addLine(plot, 1.0, "-.", "#0000FF", None, curve=False)
+        self._addLine(plot, 1.0, ":", "#0000FF", None, curve=False)
+        self._addLine(plot, 2.0, "--", "#00FFFF", None, curve=True)
+        self._addLine(plot, 2.0, "-.", "#00FFFF", None, curve=True)
+        self._addLine(plot, 2.0, ":", "#00FFFF", None, curve=True)
+
+    @_register("gapcolor", "LineStyle Gap Color")
+    def _setupLineStyleGapColor(self, plot):
+        self._addLine(plot, 1.0, "-", "#FF00FF", "black", curve=False)
+        self._addLine(plot, 1.0, "-.", "#FF00FF", "black", curve=False)
+        self._addLine(plot, 1.0, "--", "#FF00FF", "black", curve=False)
+        self._addLine(plot, 0.5, "--", "#FF00FF", "black", curve=False)
+        self._addLine(plot, 1.5, "--", "#FF00FF", "black", curve=False)
+        self._addLine(plot, 2.0, "--", "#FF00FF", "black", curve=False)
+        plot.setGraphXLimits(0, 100)
+        plot.setGraphYLimits(0, 100)
+
+    @_register("curveshape", "Curve vs Shape")
+    def _setupLineStyleCurveShape(self, plot):
+        self._addLine(plot, 1.0, (0, (5, 5)), "#00FF00", None, curve=False)
+        self._addLine(plot, 4.0, (0, (3, 3)), "#00FF00", None, curve=False)
+        self._addLine(plot, 4.0, (0, (5, 5)), "#00FF00", None, curve=False)
+        self._addLine(plot, 4.0, (0, (7, 7)), "#00FF00", None, curve=False)
+        self._addLine(plot, 1.0, (0, (5, 5)), "#00FFFF", None, curve=True)
+        self._addLine(plot, 4.0, (0, (3, 3)), "#00FFFF", None, curve=True)
+        self._addLine(plot, 4.0, (0, (5, 5)), "#00FFFF", None, curve=True)
+        self._addLine(plot, 4.0, (0, (7, 7)), "#00FFFF", None, curve=True)
+        plot.setGraphXLimits(0, 100)
+        plot.setGraphYLimits(0, 100)
+
+    @_register("text", "Text")
+    def _setupText(self, plot):
+        plot.clear()
+        plot.getDefaultColormap().setName("viridis")
+
+        # Add an image to the plot
+        x = numpy.outer(numpy.linspace(-10, 10, 200), numpy.linspace(-10, 5, 150))
+        image = numpy.sin(x) / x
+        plot.addImage(image)
+
+        label = Marker()
+        label.setPosition(50, 50)
+        label.setText("Foo bar\nmmmmmmmmmmmmmmmmmmmm")
+        label.setBackgroundColor("#FFFFFF44")
+        plot.addItem(label)
+
+        label2 = Marker()
+        label2.setPosition(70, 70)
+        label2.setText("Foo bar")
+        label2.setColor("red")
+        label2.setBackgroundColor("#00000044")
+        plot.addItem(label2)
+
+        label3 = Marker()
+        label3.setPosition(10, 70)
+        label3.setText("Pioupiou")
+        label3.setColor("yellow")
+        label3.setBackgroundColor("#000000")
+        plot.addItem(label3)
+
+
+def main():
+    global app
+    app = qt.QApplication([])
+
+    # Create the ad hoc window containing a PlotWidget and associated tools
+    window = MyPlotWindow()
+    window.setAttribute(qt.Qt.WA_DeleteOnClose)
+    window.show()
+    if len(sys.argv) == 1:
+        useCase = "linestyle"
+    else:
+        useCase = sys.argv[1]
+    window.showUseCase(useCase)
+    app.exec()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/silx/gui/plot/ColorBar.py
+++ b/src/silx/gui/plot/ColorBar.py
@@ -595,7 +595,10 @@ class _ColorScale(qt.QWidget):
     def _getRelativePosition(self, yPixel):
         """yPixel : pixel position into _ColorScale widget reference"""
         # widgets are bottom-top referencial but we display in top-bottom referential
-        return 1.0 - (yPixel - self.margin) / float(self.height() - 2 * self.margin)
+        height = float(self.height() - 2 * self.margin)
+        if height == 0:
+            return 0.0
+        return 1.0 - (yPixel - self.margin) / height
 
     def getValueFromRelativePosition(self, value):
         """Return the value in the colorMap from a relative position in the
@@ -814,8 +817,9 @@ class _TickBar(qt.QWidget):
 
         if normMin == normMax:
             return 0.0
-        else:
-            return 1.0 - (normVal - normMin) / (normMax - normMin)
+        if not numpy.isfinite(normVal):
+            return 0.0
+        return 1.0 - (normVal - normMin) / (normMax - normMin)
 
     def _paintTick(self, val, painter, majorTick=True):
         """

--- a/src/silx/gui/plot/backends/BackendBase.py
+++ b/src/silx/gui/plot/backends/BackendBase.py
@@ -218,6 +218,7 @@ class BackendBase(object):
         constraint: Callable[[float, float], tuple[float, float]] | None,
         yaxis: str,
         font: qt.QFont,
+        bgcolor: str,
     ) -> object:
         """Add a point, vertical line or horizontal line marker to the plot.
 

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -941,7 +941,18 @@ class BackendMatplotlib(BackendBase.BackendBase):
         return item
 
     def addMarker(
-        self, x, y, text, color, symbol, linestyle, linewidth, constraint, yaxis, font
+        self,
+        x,
+        y,
+        text,
+        color,
+        symbol,
+        linestyle,
+        linewidth,
+        constraint,
+        yaxis,
+        font,
+        bgcolor: str = None,
     ):
         textArtist = None
         fontProperties = None if font is None else qFontToFontProperties(font)
@@ -968,6 +979,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                     y,
                     text,
                     color=color,
+                    backgroundcolor=bgcolor,
                     horizontalalignment="left",
                     fontproperties=fontProperties,
                 )
@@ -982,6 +994,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                     1.0,
                     text,
                     color=color,
+                    backgroundcolor=bgcolor,
                     horizontalalignment="left",
                     verticalalignment="top",
                     fontproperties=fontProperties,
@@ -997,6 +1010,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                     y,
                     text,
                     color=color,
+                    backgroundcolor=bgcolor,
                     horizontalalignment="right",
                     verticalalignment="top",
                     fontproperties=fontProperties,

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -92,7 +92,18 @@ class _ShapeItem(dict):
 
 class _MarkerItem(dict):
     def __init__(
-        self, x, y, text, color, symbol, linestyle, linewidth, constraint, yaxis, font
+        self,
+        x,
+        y,
+        text,
+        color,
+        symbol,
+        linestyle,
+        linewidth,
+        constraint,
+        yaxis,
+        font,
+        bgcolor,
     ):
         super(_MarkerItem, self).__init__()
 
@@ -116,6 +127,7 @@ class _MarkerItem(dict):
                 "linewidth": linewidth + LINE_WIDTH_OFFSET,
                 "yaxis": yaxis,
                 "font": font,
+                "bgcolor": bgcolor,
             }
         )
 
@@ -592,10 +604,9 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                     continue
 
                 color = item["color"]
-                intensity = color[0] * 0.299 + color[1] * 0.587 + color[2] * 0.114
-                bgColor = (
-                    (1.0, 1.0, 1.0, 0.75) if intensity <= 0.5 else (0.0, 0.0, 0.0, 0.75)
-                )
+                bgColor = item["bgcolor"]
+                if bgColor is None:
+                    bgColor = 1.0, 1.0, 1.0, 1.0
                 if xCoord is None or yCoord is None:
                     if xCoord is None:  # Horizontal line in data space
                         pixelPos = self._plotFrame.dataToPixel(
@@ -1086,11 +1097,32 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         )
 
     def addMarker(
-        self, x, y, text, color, symbol, linestyle, linewidth, constraint, yaxis, font
+        self,
+        x,
+        y,
+        text,
+        color,
+        symbol,
+        linestyle,
+        linewidth,
+        constraint,
+        yaxis,
+        font,
+        bgcolor: str,
     ):
         font = qt.QApplication.instance().font() if font is None else font
         return _MarkerItem(
-            x, y, text, color, symbol, linestyle, linewidth, constraint, yaxis, font
+            x,
+            y,
+            text,
+            color,
+            symbol,
+            linestyle,
+            linewidth,
+            constraint,
+            yaxis,
+            font,
+            bgcolor,
         )
 
     # Remove methods

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -52,6 +52,8 @@ _logger = logging.getLogger(__name__)
 
 # Content #####################################################################
 
+LINE_WIDTH_OFFSET = 0.33
+
 
 class _ShapeItem(dict):
     def __init__(
@@ -82,7 +84,7 @@ class _ShapeItem(dict):
                 "x": x,
                 "y": y,
                 "linestyle": linestyle,
-                "linewidth": linewidth,
+                "linewidth": linewidth + LINE_WIDTH_OFFSET,
                 "gapcolor": gapcolor,
             }
         )
@@ -111,7 +113,7 @@ class _MarkerItem(dict):
                 "constraint": constraint if isConstraint else None,
                 "symbol": symbol,
                 "linestyle": linestyle,
-                "linewidth": linewidth,
+                "linewidth": linewidth + LINE_WIDTH_OFFSET,
                 "yaxis": yaxis,
                 "font": font,
             }
@@ -573,7 +575,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                             style=item["linestyle"],
                             color=item["color"],
                             gapColor=item["gapcolor"],
-                            width=item["linewidth"],
+                            width=item["linewidth"] + LINE_WIDTH_OFFSET,
                         )
                         context.matrix = self.matScreenProj
                         lines.render(context)
@@ -626,7 +628,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                             (pixelPos[1], pixelPos[1]),
                             style=item["linestyle"],
                             color=item["color"],
-                            width=item["linewidth"],
+                            width=item["linewidth"] + LINE_WIDTH_OFFSET,
                         )
                         context.matrix = self.matScreenProj
                         lines.render(context)
@@ -659,7 +661,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                             (0, height),
                             style=item["linestyle"],
                             color=item["color"],
-                            width=item["linewidth"],
+                            width=item["linewidth"] + LINE_WIDTH_OFFSET,
                         )
                         context.matrix = self.matScreenProj
                         lines.render(context)
@@ -767,7 +769,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             gl.glVertexAttribPointer(
                 posAttrib, 2, gl.GL_FLOAT, gl.GL_FALSE, 0, vertices
             )
-            gl.glLineWidth(lineWidth)
+            gl.glLineWidth(lineWidth + LINE_WIDTH_OFFSET)
             gl.glDrawArrays(gl.GL_LINES, 0, len(vertices))
 
         gl.glDisable(gl.GL_SCISSOR_TEST)

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -1110,7 +1110,17 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         font,
         bgcolor: str,
     ):
-        font = qt.QApplication.instance().font() if font is None else font
+        if font is None:
+            from matplotlib.font_manager import findfont, FontProperties
+            font_filename = findfont(FontProperties(family=["sans-serif"]))
+            _logger.debug("Load font from mpl: %s", font_filename)
+            id = qt.QFontDatabase.addApplicationFont(font_filename)
+            family = qt.QFontDatabase.applicationFontFamilies(id)[0]
+            font = qt.QFont(family, 10, qt.QFont.Normal, False)
+            font.setStretch(110)  # Local tuning
+            font.setPointSizeF(8.5)  # Local tuning
+            font.setStyleStrategy(qt.QFont.PreferAntialias)
+
         return _MarkerItem(
             x,
             y,

--- a/src/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -25,6 +25,8 @@
 This module provides classes to render 2D lines and scatter plots
 """
 
+from __future__ import annotations
+
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "03/04/2017"
@@ -383,7 +385,7 @@ class GLLines2D(object):
         yVboData=None,
         colorVboData=None,
         distVboData=None,
-        style=SOLID,
+        style: str | tuple[int, tuple[int, int]] | None=SOLID,
         color=(0.0, 0.0, 0.0, 1.0),
         gapColor=None,
         width=1,
@@ -419,7 +421,7 @@ class GLLines2D(object):
         self.color = color
         self.gapColor = gapColor
         self.width = width
-        self._style = None
+        self._style: str | tuple[int, tuple[int, int]] | None = None
         self.style = style
         self.dashPeriod = dashPeriod
         self.offset = offset
@@ -427,14 +429,16 @@ class GLLines2D(object):
         self._drawMode = drawMode if drawMode is not None else gl.GL_LINE_STRIP
 
     @property
-    def style(self):
-        """Line style (Union[str,None])"""
+    def style(self) -> str | tuple[int, tuple[int, int]] | None:
+        """Line style"""
         return self._style
 
     @style.setter
     def style(self, style):
         if style in _MPL_NONES:
             self._style = None
+        elif isinstance(style, tuple):
+            self._style = style
         else:
             assert style in self.STYLES
             self._style = style
@@ -458,6 +462,20 @@ class GLLines2D(object):
         elif style == SOLID:
             program = self._SOLID_PROGRAM
             program.use()
+
+        elif isinstance(style, tuple):
+            program = self._DASH_PROGRAM
+            program.use()
+
+            offset, (dash1, dash2) = style
+            # FIXME: The offset is not handled
+            # FIXME: The period looks fixed
+            dash = (
+                (dash1) * width,
+                (dash1 + dash2) * width,
+                (dash1 + dash2 + dash1) * width,
+                (dash1 + dash2 + dash1 + dash2) * width,
+            )
 
         else:  # DASHED, DASHDOT, DOTTED
             program = self._DASH_PROGRAM

--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -24,6 +24,8 @@
 """This module provides the base class for items of the :class:`Plot`.
 """
 
+from __future__ import annotations
+
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "08/12/2020"
@@ -843,12 +845,12 @@ class LineMixIn(ItemMixInBase):
     """Supported line styles"""
 
     def __init__(self):
-        self._linewidth = self._DEFAULT_LINEWIDTH
-        self._linestyle = self._DEFAULT_LINESTYLE
+        self._linewidth: float = self._DEFAULT_LINEWIDTH
+        self._linestyle: str | tuple[int, tuple[int, int]] = self._DEFAULT_LINESTYLE
 
     @classmethod
     def getSupportedLineStyles(cls):
-        """Returns list of supported line styles.
+        """Returns list of supported constant line styles.
 
         :rtype: List[str,None]
         """
@@ -893,7 +895,7 @@ class LineMixIn(ItemMixInBase):
             self._linewidth = width
             self._updated(ItemChangedType.LINE_WIDTH)
 
-    def getLineStyle(self):
+    def getLineStyle(self) -> str | tuple[int, tuple[int, int]]:
         """Return the type of the line
 
         Type of line::
@@ -903,20 +905,20 @@ class LineMixIn(ItemMixInBase):
             - '--' dashed line
             - '-.' dash-dot line
             - ':'  dotted line
+            - `tuple[int, tuple[int, int]]`
 
         :rtype: str
         """
         return self._linestyle
 
-    def setLineStyle(self, style):
+    def setLineStyle(self, style: str | tuple[int, tuple[int, int]] | None):
         """Set the style of the curve line.
 
         See :meth:`getLineStyle`.
 
         :param str style: Line style
         """
-        style = str(style)
-        assert style in self.getSupportedLineStyles()
+        self.validateLineStyle(style)
         if style is None:
             style = self._DEFAULT_LINESTYLE
         if style != self._linestyle:

--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -28,7 +28,6 @@ __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "08/12/2020"
 
-import collections
 from collections import abc
 from copy import deepcopy
 import logging

--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -854,6 +854,26 @@ class LineMixIn(ItemMixInBase):
         """
         return cls._SUPPORTED_LINESTYLE
 
+    @classmethod
+    def validateLineStyle(self, style):
+        """Raises an exception if the style is not supported"""
+        if style is None:
+            return
+        elif isinstance(style, str):
+            if style in self.getSupportedLineStyles():
+                return
+        elif isinstance(style, tuple):
+            if (
+                len(style) == 2
+                and isinstance(style[0], int)
+                and isinstance(style[1], tuple)
+                and len(style[1]) == 2
+                and isinstance(style[1][0], int)
+                and isinstance(style[1][1], int)
+            ):
+                return
+        raise TypeError(f"Unsupported style '{style}' ({type(style)})")
+
     def getLineWidth(self):
         """Return the curve line width in pixels
 

--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -155,6 +155,9 @@ class ItemChangedType(enum.Enum):
     FONT = "fontChanged"
     """Item's text font changed flag."""
 
+    BACKGROUND_COLOR = "backgroundColorChanged"
+    """Item's text background color changed flag."""
+
 
 class Item(qt.QObject):
     """Description of an item of the plot"""

--- a/src/silx/gui/plot/items/curve.py
+++ b/src/silx/gui/plot/items/curve.py
@@ -24,6 +24,8 @@
 """This module provides the :class:`Curve` item of the :class:`Plot`.
 """
 
+from __future__ import annotations
+
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "24/04/2018"
@@ -69,7 +71,7 @@ class CurveStyle(_Style):
     def __init__(
         self,
         color=None,
-        linestyle=None,
+        linestyle: str | tuple[int, tuple[int, int]] | None = None,
         linewidth=None,
         symbol=None,
         symbolsize=None,
@@ -86,8 +88,7 @@ class CurveStyle(_Style):
                     color = colors.rgba(color)
             self._color = color
 
-        if linestyle is not None:
-            assert linestyle in LineMixIn.getSupportedLineStyles()
+        LineMixIn.validateLineStyle(linestyle)
         self._linestyle = linestyle
 
         self._linewidth = None if linewidth is None else float(linewidth)
@@ -120,7 +121,7 @@ class CurveStyle(_Style):
         """
         return self._gapcolor
 
-    def getLineStyle(self):
+    def getLineStyle(self) -> str | tuple[int, tuple[int, int]] | None:
         """Return the type of the line or None if not set.
 
         Type of line::
@@ -130,6 +131,7 @@ class CurveStyle(_Style):
             - '--' dashed line
             - '-.' dash-dot line
             - ':'  dotted line
+            - `tuple[int, tuple[int, int]]`
 
         :rtype: Union[str,None]
         """

--- a/src/silx/gui/plot/items/marker.py
+++ b/src/silx/gui/plot/items/marker.py
@@ -80,17 +80,23 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
 
     def _addRendererCall(self, backend, symbol=None, linestyle="-", linewidth=1):
         """Perform the update of the backend renderer"""
+        color = self.getColor()
+        intensity = color[0] * 0.299 + color[1] * 0.587 + color[2] * 0.114
+        bgColor = (
+            (1.0, 1.0, 1.0, 0.75) if intensity <= 0.5 else (0.0, 0.0, 0.0, 0.75)
+        )
         return backend.addMarker(
             x=self.getXPosition(),
             y=self.getYPosition(),
             text=self.getText(),
-            color=self.getColor(),
+            color=color,
             symbol=symbol,
             linestyle=linestyle,
             linewidth=linewidth,
             constraint=self.getConstraint(),
             yaxis=self.getYAxis(),
             font=self._font,  # Do not use getFont to spare creating a new QFont
+            bgcolor=bgColor,
         )
 
     def _addBackendRenderer(self, backend):

--- a/src/silx/gui/plot/items/marker.py
+++ b/src/silx/gui/plot/items/marker.py
@@ -31,6 +31,7 @@ __date__ = "06/03/2017"
 
 
 import logging
+import numpy
 
 from ....utils.proxy import docstring
 from .core import (
@@ -44,6 +45,8 @@ from .core import (
 )
 from silx import config
 from silx.gui import qt
+from silx.gui import colors
+
 
 _logger = logging.getLogger(__name__)
 
@@ -75,28 +78,24 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
 
         self._x = None
         self._y = None
+        self._bgColor: colors.RGBAColorType | numpy.ndarray | None = None
         self._constraint = self._defaultConstraint
         self.__isBeingDragged = False
 
     def _addRendererCall(self, backend, symbol=None, linestyle="-", linewidth=1):
         """Perform the update of the backend renderer"""
-        color = self.getColor()
-        intensity = color[0] * 0.299 + color[1] * 0.587 + color[2] * 0.114
-        bgColor = (
-            (1.0, 1.0, 1.0, 0.75) if intensity <= 0.5 else (0.0, 0.0, 0.0, 0.75)
-        )
         return backend.addMarker(
             x=self.getXPosition(),
             y=self.getYPosition(),
             text=self.getText(),
-            color=color,
+            color=self.getColor(),
             symbol=symbol,
             linestyle=linestyle,
             linewidth=linewidth,
             constraint=self.getConstraint(),
             yaxis=self.getYAxis(),
             font=self._font,  # Do not use getFont to spare creating a new QFont
-            bgcolor=bgColor,
+            bgcolor=self.getBackgroundColor(),
         )
 
     def _addBackendRenderer(self, backend):
@@ -146,6 +145,38 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
         if font != self._font:
             self._font = None if font is None else qt.QFont(font)
             self._updated(ItemChangedType.FONT)
+
+    def getBackgroundColor(self) -> colors.RGBAColorType | numpy.ndarray | None:
+        """Returns the RGBA background color of the item
+
+        :rtype: 4-tuple of float in [0, 1] or array of colors
+        """
+        return self._bgColor
+
+    def setBackgroundColor(self, color, copy=True):
+        """Set item background  color
+
+        :param color: color(s) to be used
+        :type color: str ("#RRGGBB") or (npoints, 4) unsigned byte array or
+                     one of the predefined color names defined in colors.py
+        :param bool copy: True (Default) to get a copy,
+                         False to use internal representation (do not modify!)
+        """
+        if color is None:
+            pass
+        elif isinstance(color, (str, qt.QColor)):
+            color = colors.rgba(color)
+        else:
+            color = numpy.array(color, copy=copy)
+            # TODO more checks + improve color array support
+            if color.ndim == 1:  # Single RGBA color
+                color = colors.rgba(color)
+            else:  # Array of colors
+                assert color.ndim == 2
+
+        if self._bgColor != color:
+            self._bgColor = color
+            self._updated(ItemChangedType.BACKGROUND_COLOR)
 
     def getXPosition(self):
         """Returns the X position of the marker line in data coordinates


### PR DESCRIPTION
This PR is an intent to improve line rendering by

- Trying to have an extra `(offset, (dash1, dash2))` sypported type instead of hardcoded
- Trying to fix line width between backend
- Trying to have consistent linestyle between backend
- Trying to have consistent linestyle between curve/shape

An example was added to simplify the checks

![image](https://github.com/silx-kit/silx/assets/7579321/30464714-bb7f-458e-955c-129fee72c766)

I have tried to to do as much as i can, but i can't finalise that
- [ ] (1) In opengl the period looks hardcoded, maybe there is a missing thing in the gl program
- [ ] (2) In opengl `Curve` linestyle have twice the period of `Shape` linestyle
- [ ] The hardcoded offset +0.33 is probably not at the right location
- [ ] Was not tested with screen with different pixel densities

Changelog: 
