### PR TITLE
Added background color for markers

### DIFF
--- a/src/silx/gui/plot/backends/BackendBase.py
+++ b/src/silx/gui/plot/backends/BackendBase.py
@@ -37,6 +37,7 @@ __date__ = "21/12/2018"
 
 from collections.abc import Callable
 import weakref
+from silx.gui.colors import RGBAColorType
 
 from ... import qt
 
@@ -218,6 +219,7 @@ class BackendBase(object):
         constraint: Callable[[float, float], tuple[float, float]] | None,
         yaxis: str,
         font: qt.QFont,
+        bgcolor: RGBAColorType | None,
     ) -> object:
         """Add a point, vertical line or horizontal line marker to the plot.
 
@@ -227,6 +229,7 @@ class BackendBase(object):
             If None, the marker is a vertical line.
         :param text: Text associated to the marker (or None for no text)
         :param color: Color to be used for instance 'blue', 'b', '#FF0000'
+        :param bgcolor: Text background color to be used for instance 'blue', 'b', '#FF0000'
         :param symbol: Symbol representing the marker.
             Only relevant for point markers where X and Y are not None.
             Value in:

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -23,6 +23,8 @@
 # ###########################################################################*/
 """Matplotlib Plot backend."""
 
+from __future__ import annotations
+
 __authors__ = ["V.A. Sole", "T. Vincent, H. Payno"]
 __license__ = "MIT"
 __date__ = "21/12/2018"
@@ -67,6 +69,7 @@ from .._utils.dtime_ticklayout import (
 )
 from ...qt import inspect as qt_inspect
 from .... import config
+from silx.gui.colors import RGBAColorType
 
 _PATCH_LINESTYLE = {
     "-": "solid",
@@ -941,7 +944,18 @@ class BackendMatplotlib(BackendBase.BackendBase):
         return item
 
     def addMarker(
-        self, x, y, text, color, symbol, linestyle, linewidth, constraint, yaxis, font
+        self,
+        x,
+        y,
+        text,
+        color,
+        symbol,
+        linestyle,
+        linewidth,
+        constraint,
+        yaxis,
+        font,
+        bgcolor: RGBAColorType | None,
     ):
         textArtist = None
         fontProperties = None if font is None else qFontToFontProperties(font)
@@ -968,6 +982,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                     y,
                     text,
                     color=color,
+                    backgroundcolor=bgcolor,
                     horizontalalignment="left",
                     fontproperties=fontProperties,
                 )
@@ -982,6 +997,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                     1.0,
                     text,
                     color=color,
+                    backgroundcolor=bgcolor,
                     horizontalalignment="left",
                     verticalalignment="top",
                     fontproperties=fontProperties,
@@ -997,6 +1013,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                     y,
                     text,
                     color=color,
+                    backgroundcolor=bgcolor,
                     horizontalalignment="right",
                     verticalalignment="top",
                     fontproperties=fontProperties,

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -23,6 +23,8 @@
 # ############################################################################*/
 """OpenGL Plot backend."""
 
+from __future__ import annotations
+
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "21/12/2018"
@@ -42,6 +44,7 @@ from ..._glutils import gl
 from ... import _glutils as glu
 from . import glutils
 from .glutils.PlotImageFile import saveImageToFile
+from silx.gui.colors import RGBAColorType
 
 _logger = logging.getLogger(__name__)
 
@@ -90,7 +93,18 @@ class _ShapeItem(dict):
 
 class _MarkerItem(dict):
     def __init__(
-        self, x, y, text, color, symbol, linestyle, linewidth, constraint, yaxis, font
+        self,
+        x,
+        y,
+        text,
+        color,
+        symbol,
+        linestyle,
+        linewidth,
+        constraint,
+        yaxis,
+        font,
+        bgcolor,
     ):
         super(_MarkerItem, self).__init__()
 
@@ -114,6 +128,7 @@ class _MarkerItem(dict):
                 "linewidth": linewidth,
                 "yaxis": yaxis,
                 "font": font,
+                "bgcolor": bgcolor,
             }
         )
 
@@ -590,10 +605,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                     continue
 
                 color = item["color"]
-                intensity = color[0] * 0.299 + color[1] * 0.587 + color[2] * 0.114
-                bgColor = (
-                    (1.0, 1.0, 1.0, 0.75) if intensity <= 0.5 else (0.0, 0.0, 0.0, 0.75)
-                )
+                bgColor = item["bgcolor"]
                 if xCoord is None or yCoord is None:
                     if xCoord is None:  # Horizontal line in data space
                         pixelPos = self._plotFrame.dataToPixel(
@@ -612,7 +624,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                                 item["font"],
                                 x,
                                 y,
-                                color=item["color"],
+                                color=color,
                                 bgColor=bgColor,
                                 align=glutils.RIGHT,
                                 valign=glutils.BOTTOM,
@@ -625,7 +637,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                             (0, width),
                             (pixelPos[1], pixelPos[1]),
                             style=item["linestyle"],
-                            color=item["color"],
+                            color=color,
                             width=item["linewidth"],
                         )
                         context.matrix = self.matScreenProj
@@ -645,7 +657,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                                 item["font"],
                                 x,
                                 y,
-                                color=item["color"],
+                                color=color,
                                 bgColor=bgColor,
                                 align=glutils.LEFT,
                                 valign=glutils.TOP,
@@ -658,7 +670,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                             (pixelPos[0], pixelPos[0]),
                             (0, height),
                             style=item["linestyle"],
-                            color=item["color"],
+                            color=color,
                             width=item["linewidth"],
                         )
                         context.matrix = self.matScreenProj
@@ -687,7 +699,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                             item["font"],
                             x,
                             y,
-                            color=item["color"],
+                            color=color,
                             bgColor=bgColor,
                             align=glutils.LEFT,
                             valign=valign,
@@ -701,7 +713,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                         (pixelPos[0],),
                         (pixelPos[1],),
                         marker=item["symbol"],
-                        color=item["color"],
+                        color=color,
                         size=11,
                     )
                     context.matrix = self.matScreenProj
@@ -1084,11 +1096,32 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         )
 
     def addMarker(
-        self, x, y, text, color, symbol, linestyle, linewidth, constraint, yaxis, font
+        self,
+        x,
+        y,
+        text,
+        color,
+        symbol,
+        linestyle,
+        linewidth,
+        constraint,
+        yaxis,
+        font,
+        bgcolor: RGBAColorType | None,
     ):
         font = qt.QApplication.instance().font() if font is None else font
         return _MarkerItem(
-            x, y, text, color, symbol, linestyle, linewidth, constraint, yaxis, font
+            x,
+            y,
+            text,
+            color,
+            symbol,
+            linestyle,
+            linewidth,
+            constraint,
+            yaxis,
+            font,
+            bgcolor,
         )
 
     # Remove methods

--- a/src/silx/gui/plot/backends/glutils/GLText.py
+++ b/src/silx/gui/plot/backends/glutils/GLText.py
@@ -41,6 +41,7 @@ import numpy
 from .... import qt
 from ...._glutils import font, gl, Context, Program, Texture
 from .GLSupport import mat4Translate
+from silx.gui.colors import RGBAColorType
 
 
 class _Cache:
@@ -140,7 +141,7 @@ class Text2D:
         x: float = 0.0,
         y: float = 0.0,
         color: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 1.0),
-        bgColor: tuple[float, float, float, float] | None = None,
+        bgColor: RGBAColorType | None = None,
         align: str = LEFT,
         valign: str = BASELINE,
         rotate: float = 0.0,

--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -154,6 +154,9 @@ class ItemChangedType(enum.Enum):
     FONT = "fontChanged"
     """Item's text font changed flag."""
 
+    BACKGROUND_COLOR = "backgroundColorChanged"
+    """Item's text background color changed flag."""
+
 
 class Item(qt.QObject):
     """Description of an item of the plot"""

--- a/src/silx/gui/plot/items/marker.py
+++ b/src/silx/gui/plot/items/marker.py
@@ -31,6 +31,7 @@ __date__ = "06/03/2017"
 
 
 import logging
+import numpy
 
 from ....utils.proxy import docstring
 from .core import (
@@ -44,6 +45,8 @@ from .core import (
 )
 from silx import config
 from silx.gui import qt
+from silx.gui import colors
+
 
 _logger = logging.getLogger(__name__)
 
@@ -75,28 +78,24 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
 
         self._x = None
         self._y = None
+        self._bgColor: colors.RGBAColorType | numpy.ndarray | None = None
         self._constraint = self._defaultConstraint
         self.__isBeingDragged = False
 
     def _addRendererCall(self, backend, symbol=None, linestyle="-", linewidth=1):
         """Perform the update of the backend renderer"""
-        color = self.getColor()
-        intensity = color[0] * 0.299 + color[1] * 0.587 + color[2] * 0.114
-        bgColor = (
-            (1.0, 1.0, 1.0, 0.75) if intensity <= 0.5 else (0.0, 0.0, 0.0, 0.75)
-        )
         return backend.addMarker(
             x=self.getXPosition(),
             y=self.getYPosition(),
             text=self.getText(),
-            color=color,
+            color=self.getColor(),
             symbol=symbol,
             linestyle=linestyle,
             linewidth=linewidth,
             constraint=self.getConstraint(),
             yaxis=self.getYAxis(),
             font=self._font,  # Do not use getFont to spare creating a new QFont
-            bgcolor=bgColor,
+            bgcolor=self.getBackgroundColor(),
         )
 
     def _addBackendRenderer(self, backend):
@@ -146,6 +145,23 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
         if font != self._font:
             self._font = None if font is None else qt.QFont(font)
             self._updated(ItemChangedType.FONT)
+
+    def getBackgroundColor(self) -> colors.RGBAColorType | None:
+        """Returns the RGBA background color of the item"""
+        return self._bgColor
+
+    def setBackgroundColor(self, color):
+        """Set item text background color
+
+        :param color: color(s) to be used as a str ("#RRGGBB") or (npoints, 4)
+                      unsigned byte array or one of the predefined color names
+                      defined in colors.py
+        """
+        if color is not None:
+            color = colors.rgba(color)
+        if self._bgColor != color:
+            self._bgColor = color
+            self._updated(ItemChangedType.BACKGROUND_COLOR)
 
     def getXPosition(self):
         """Returns the X position of the marker line in data coordinates

--- a/src/silx/gui/plot/items/marker.py
+++ b/src/silx/gui/plot/items/marker.py
@@ -80,17 +80,23 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
 
     def _addRendererCall(self, backend, symbol=None, linestyle="-", linewidth=1):
         """Perform the update of the backend renderer"""
+        color = self.getColor()
+        intensity = color[0] * 0.299 + color[1] * 0.587 + color[2] * 0.114
+        bgColor = (
+            (1.0, 1.0, 1.0, 0.75) if intensity <= 0.5 else (0.0, 0.0, 0.0, 0.75)
+        )
         return backend.addMarker(
             x=self.getXPosition(),
             y=self.getYPosition(),
             text=self.getText(),
-            color=self.getColor(),
+            color=color,
             symbol=symbol,
             linestyle=linestyle,
             linewidth=linewidth,
             constraint=self.getConstraint(),
             yaxis=self.getYAxis(),
             font=self._font,  # Do not use getFont to spare creating a new QFont
+            bgcolor=bgColor,
         )
 
     def _addBackendRenderer(self, backend):

--- a/src/silx/gui/plot/items/marker.py
+++ b/src/silx/gui/plot/items/marker.py
@@ -78,7 +78,7 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
 
         self._x = None
         self._y = None
-        self._bgColor: colors.RGBAColorType | numpy.ndarray | None = None
+        self._bgColor: colors.RGBAColorType | None = None
         self._constraint = self._defaultConstraint
         self.__isBeingDragged = False
 


### PR DESCRIPTION
Related to #4005 #4010

Previously an automatic background color was added to the marker text of the OpenGL backend to try to improve the readability of the text. That's unfortunately not enough, so better to let it open to the designer.

- Now the background is used for both backend
- And designer can specify it as `marker.setBackgroundColor("red")`
- The automatic background was dropped

```
        label = Marker()
        label.setPosition(50, 50)
        label.setText("Foo bar\nmmmmmmmmmmmmmmmmmmmm")
        label.setBackgroundColor("#FFFFFF44")
        plot.addItem(label)

        label2 = Marker()
        label2.setPosition(70, 70)
        label2.setText("Foo bar")
        label2.setColor("red")
        label2.setBackgroundColor("#00000044")
        plot.addItem(label2)

        label3 = Marker()
        label3.setPosition(10, 70)
        label3.setText("Pioupiou")
        label3.setColor("yellow")
        label3.setBackgroundColor("#000000")
        plot.addItem(label3)
```

![image](https://github.com/silx-kit/silx/assets/7579321/6c807efd-2bbb-497f-bf79-9bed1d03574a)

Changelog: 
- Markers now support a text background color
- The automatic text marker background was dropped for the opengl backend
