### PR TITLE
silx.gui.plot.PlotWidget: Improved line dash rendering for OpenGL backend

### DIFF
--- a/src/silx/gui/plot/backends/glutils/GLPlotCurve.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotCurve.py
@@ -291,7 +291,7 @@ class GLLines2D(object):
     :param str style: Line style in: '-', '--', '-.', ':'
     :param List[float] color: RGBA color as 4 float in [0, 1]
     :param float width: Line width
-    :param float dashPeriod: Period of dashes
+    :param List[float] dashPattern: "Unscaled" dash pattern in points
     :param drawMode: OpenGL drawing mode
     :param List[float] offset: Translation of coordinates (ox, oy)
     """
@@ -387,7 +387,7 @@ class GLLines2D(object):
         color=(0.0, 0.0, 0.0, 1.0),
         gapColor=None,
         width=1,
-        dashPeriod=10.0,
+        dashPeriod=20.0,
         drawMode=None,
         offset=(0.0, 0.0),
     ):


### PR DESCRIPTION
This PR reworks the rendering of dashed lines in the OpenGL backend to make it more consistent with the matplotlib backend.
It aims at making dashes behaves the same as the matplotlib backend and the same between `Shape` and `Curve`.
There is a limitation due to OpenGL is that the available line width can be limited by the OpenGL implementation (this PR does not aim at mitigating that).
It also paves the way in the OpenGL backend to provide the line style as `(offset, dash pattern)` by centralizing the conversion of `linestyle` to dash pattern early.

<img width="832" alt="Screen Shot 2023-12-18 at 16 05 17" src="https://github.com/silx-kit/silx/assets/9449698/5307c5f7-bacb-49c5-bb71-f3e69efa32ac">


related to #4010