### PR TITLE
silx.gui.plot.PlotWidget: Improved text background rendering for OpenGL backend

### DIFF
--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -912,7 +912,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             pattern = ()
         if len(pattern) == 2:
             pattern = pattern * 2
-        return offset, pattern
+        return float(offset), tuple(float(v) for v in pattern)
 
     def addCurve(
         self,

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -227,6 +227,8 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
     So, the caller should not modify these arrays afterwards.
     """
 
+    _TEXT_MARKER_PADDING = 4
+
     def __init__(self, plot, parent=None, f=qt.Qt.Widget):
         glu.OpenGLWidget.__init__(
             self,
@@ -645,6 +647,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                                 align=glutils.RIGHT,
                                 valign=glutils.BOTTOM,
                                 devicePixelRatio=self.getDevicePixelRatio(),
+                                padding=self._TEXT_MARKER_PADDING,
                             )
                             labels.append(label)
 
@@ -679,6 +682,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                                 align=glutils.LEFT,
                                 valign=glutils.TOP,
                                 devicePixelRatio=self.getDevicePixelRatio(),
+                                padding=self._TEXT_MARKER_PADDING,
                             )
                             labels.append(label)
 
@@ -722,6 +726,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                             align=glutils.LEFT,
                             valign=valign,
                             devicePixelRatio=self.getDevicePixelRatio(),
+                            padding=self._TEXT_MARKER_PADDING,
                         )
                         labels.append(label)
 
@@ -1162,6 +1167,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         """Returns the default font, used by raw markers and axes labels"""
         if self._defaultFont is None:
             from matplotlib.font_manager import findfont, FontProperties
+
             font_filename = findfont(FontProperties(family=["sans-serif"]))
             _logger.debug("Load font from mpl: %s", font_filename)
             id = qt.QFontDatabase.addApplicationFont(font_filename)


### PR DESCRIPTION
Alternative implementation of PR #4011

This PR adds padding around text displayed by markers for the display of borders.
Instead of relying on 2 rendering as in PR #4011, it plays with the texture coordinates.

