### PR TITLE
build: Updated build dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade build setuptools wheel
-          pip install --upgrade --pre numpy cython
+          pip install --upgrade --pre oldest-supported-numpy cython
 
       - name: Print python info used for build
         run: |
@@ -118,7 +118,7 @@ jobs:
           then
             pip install -r ci/requirements-pinned.txt;
           fi
-          pip install --pre -r requirements.txt
+          pip install --pre --upgrade -r requirements.txt
           pip uninstall -y PyQt5 PyQt6 PySide6
           if [ "${{ matrix.QT_BINDING }}" == "PyQt5" ]; then
             pip install --pre pyqt5;

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -67,7 +67,7 @@ build_script:
     - "pip install %PIP_OPTIONS% --upgrade build"
     - "pip install %PIP_OPTIONS% --upgrade setuptools"
     - "pip install %PIP_OPTIONS% --upgrade wheel"
-    - "pip install %PIP_OPTIONS% --upgrade numpy"
+    - "pip install %PIP_OPTIONS% --upgrade oldest-supported-numpy"
     - "pip install %PIP_OPTIONS% --upgrade cython"
 
     # Print Python info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 requires = [
     "wheel",
     "setuptools",
-    "numpy>=1.12",
-    "Cython>=0.21.1"
+    "oldest-supported-numpy",
+    "Cython>=0.29.31"
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Small PR following PR #4033 to update build dependencies.
Using `oldest-supported-numpy` should fix building `manylinux2010` wheels which is now broken since the build tries to build the latest numpy and fails.