### PR TITLE
Documentation: Updated landing page

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,7 +11,7 @@ include requirements-dev.txt
 include pyproject.toml
 recursive-include src/silx *.pyx *.pxd *.pxi
 recursive-include src/silx *.h *.c *.hpp *.cpp
-recursive-include doc/source *.py *.rst *.png *.ico *.ipynb *.html *.svg
+recursive-include doc/source *.py *.rst *.png *.ico *.ipynb *.html *.svg *.gif
 global-exclude .ipynb_checkpoints/*
 recursive-include qtdesigner_plugins *.py *.rst
 recursive-include src/silx/resources *

--- a/doc/source/applications/index.rst
+++ b/doc/source/applications/index.rst
@@ -1,6 +1,7 @@
+.. _Applications:
 
-Application
-===========
+Applications
+============
 
 While *silx* is first and foremost a Python library to be used by developers,
 a set of command line applications is provided to use some key features of

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2015-2022 European Synchrotron Radiation Facility
+# Copyright (C) 2015-2023 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -67,6 +67,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.doctest",
     "sphinx.ext.inheritance_diagram",
+    "sphinx_tabs.tabs",
     "sphinxext-archive",
     "snapshotqt_directive",
     "nbsphinx",
@@ -78,6 +79,8 @@ if importlib.util.find_spec("sphinx_autodoc_typehints"):
     always_document_param_types = True
 
 autodoc_member_order = "bysource"
+
+sphinx_tabs_disable_tab_closing = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -67,7 +67,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.doctest",
     "sphinx.ext.inheritance_diagram",
-    "sphinx_tabs.tabs",
+    "sphinx_panels",
     "sphinxext-archive",
     "snapshotqt_directive",
     "nbsphinx",
@@ -79,8 +79,6 @@ if importlib.util.find_spec("sphinx_autodoc_typehints"):
     always_document_param_types = True
 
 autodoc_member_order = "bysource"
-
-sphinx_tabs_disable_tab_closing = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -10,70 +10,122 @@ silx |version|
    modules/index.rst
    changelog.rst
 
-.. |silxView| image:: http://www.silx.org/doc/silx/img/silx-view-v1-0.gif
-   :width: 480px
-
 silx provides applications and Python modules to support the
 development of data assessment, reduction and analysis at synchrotron radiation
 facilities.
 It provides reading/writing tools for different file formats, data
 reduction routines and a set of Qt widgets to browse and visualise data.
 
-:doc:`install`
---------------
+:ref:`Installation`
+-------------------
 
 You can install ``silx`` via `pip <https://pypi.org/project/pip>`_, `conda <https://docs.conda.io>`_ or on Linux with the following commands:
 
-.. tabs::
+.. tabbed:: pip
 
-   .. tab:: pip
+   .. code-block:: bash
 
-      .. code-block:: bash
+      pip install silx[full]
 
-         pip install silx[full]
+.. tabbed:: conda
 
-   .. tab:: conda
+   .. code-block:: bash
 
-      .. code-block:: bash
+      conda install -c conda-forge silx
 
-         conda install -c conda-forge silx
+.. tabbed:: Debian & Ubuntu
 
-   .. tab:: Debian & Ubuntu
+   .. code-block:: bash
 
-      .. code-block:: bash
+      sudo apt-get install silx
 
-         sudo apt-get install silx
+:ref:`Applications`
+-------------------
 
-:doc:`applications/index`
--------------------------
+.. panels::
 
-The :ref:`silx view` unified viewer supports HDF5, SPEC and image file formats:
+   :column: col-lg-12
+   :body: text-center
 
-|silxView|
+   **silx view**
+   ^^^^^^^^^^^^^
 
+   .. image:: img/silx-view.gif
 
-Python package
---------------
+   .. link-button:: applications/view
+      :type: ref
+      :text: Unified viewer supporting HDF5, SPEC and image file formats
+      :classes: stretched-link
 
-Features:
+   ---
 
-* Supporting `HDF5 <https://www.hdfgroup.org/HDF5/>`_,
-  `SPEC <https://certif.com/spec.html>`_ and
-  `FabIO <http://www.silx.org/doc/fabio/dev/getting_started.html#list-of-file-formats-that-fabio-can-read-and-write>`_
-  images file formats.
-* OpenCL-based data processing: image alignment (SIFT),
-  image processing (median filter, histogram),
-  filtered backprojection for tomography
-* Data reduction: histogramming, fitting, median filter
-* A set of Qt widgets, including:
+   **silx compare**
+   ^^^^^^^^^^^^^^^^
 
-  * 1D and 2D visualization widgets with a set of associated tools using multiple backends (matplotlib or OpenGL)
-  * OpenGL-based widgets to visualize data in 3D (scalar field with isosurface and cut plane, scatter plot)
-  * a unified browser for HDF5, SPEC and image file formats supporting inspection and
-    visualization of n-dimensional datasets.
+   .. image:: applications/img/silx-compare.png
 
-Resources:
+   .. link-button:: applications/compare
+      :type: ref
+      :text: User interface to compare 2D data from files
+      :classes: stretched-link
 
-- :doc:`tutorials`
-- :doc:`modules/gui/gallery`
-- :doc:`modules/index`
+   ---
+
+   **silx convert**
+   ^^^^^^^^^^^^^^^^
+
+   .. link-button:: applications/convert
+      :type: ref
+      :text: Converter of legacy file formats into HDF5 file
+      :classes: stretched-link
+
+:ref:`Python modules<API Reference>`
+------------------------------------
+
+.. panels::
+
+   **silx.gui**
+   ^^^^^^^^^^^^
+
+   .. link-button:: modules/gui/index
+      :type: ref
+      :text: Qt widgets:
+      :classes: stretched-link
+
+   * 1D and 2D visualization widgets and associated tools
+   * OpenGL-based 3D visualization widgets
+   * a unified HDF5, SPEC and image data file browser and n-dimensional dataset viewer
+
+   ---
+
+   **silx.opencl**
+   ^^^^^^^^^^^^^^^
+
+   .. link-button:: modules/opencl/index
+      :type: ref
+      :text: OpenCL-based data processing:
+      :classes: stretched-link
+
+   * Image alignment (SIFT)
+   * Image processing (median filter, histogram)
+   * Filtered backprojection for tomography
+
+   ---
+
+   **silx.io**
+   ^^^^^^^^^^^
+
+   .. link-button:: modules/io/index
+      :type: ref
+      :text: Supporting HDF5, SPEC and FabIO images file formats
+      :classes: stretched-link
+
+   ---
+
+   **silx.math**
+   ^^^^^^^^^^^^^
+
+   .. link-button:: modules/math/index
+      :type: ref
+      :text: Data reduction: histogramming, fitting, median filter
+      :classes: stretched-link

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -22,17 +22,27 @@ reduction routines and a set of Qt widgets to browse and visualise data.
 :doc:`install`
 --------------
 
-You can install ``silx`` using `pip <https://pypi.org/project/pip>`_::
+You can install ``silx`` via `pip <https://pypi.org/project/pip>`_, `conda <https://docs.conda.io>`_ or on Linux with the following commands:
 
-    pip install silx[full]
+.. tabs::
 
-Using `conda <https://docs.conda.io>`_::
+   .. tab:: pip
 
-    conda install -c conda-forge silx
+      .. code-block:: bash
 
-And on Debian and Ubuntu with::
+         pip install silx[full]
 
-    sudo apt-get install silx
+   .. tab:: conda
+
+      .. code-block:: bash
+
+         conda install -c conda-forge silx
+
+   .. tab:: Debian & Ubuntu
+
+      .. code-block:: bash
+
+         sudo apt-get install silx
 
 :doc:`applications/index`
 -------------------------

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -1,3 +1,4 @@
+.. _Installation:
 
 Installation
 ============

--- a/doc/source/modules/index.rst
+++ b/doc/source/modules/index.rst
@@ -1,3 +1,5 @@
+.. _API Reference:
+
 API Reference
 =============
 

--- a/package/debian12/control
+++ b/package/debian12/control
@@ -33,6 +33,7 @@ Build-Depends: cython3 (>= 0.23.2),
                python3-scipy,
                python3-setuptools,
                python3-sphinx,
+               python3-sphinx-tabs,
                python3-sphinxcontrib.programoutput,
                xauth,
                xvfb

--- a/package/debian12/control
+++ b/package/debian12/control
@@ -33,7 +33,7 @@ Build-Depends: cython3 (>= 0.23.2),
                python3-scipy,
                python3-setuptools,
                python3-sphinx,
-               python3-sphinx-tabs,
+               python3-sphinx-panels,
                python3-sphinxcontrib.programoutput,
                xauth,
                xvfb

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,6 +6,7 @@ build             # To build the project
 wheel             # To build wheels
 Sphinx            # To build the documentation in doc/
 sphinx-autodoc-typehints  # For leveraging Python type hints from Sphinx
+sphinx-tabs       # For tabs in documentation
 pillow            # For loading images in documentation generation
 pydata_sphinx_theme  # Sphinx theme
 nbsphinx          # For converting ipynb in documentation

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ build             # To build the project
 wheel             # To build wheels
 Sphinx            # To build the documentation in doc/
 sphinx-autodoc-typehints  # For leveraging Python type hints from Sphinx
-sphinx-tabs       # For tabs in documentation
+sphinx-panels     # For tabs and grid in documentation
 pillow            # For loading images in documentation generation
 pydata_sphinx_theme  # Sphinx theme
 nbsphinx          # For converting ipynb in documentation

--- a/setup.py
+++ b/setup.py
@@ -203,6 +203,7 @@ def get_project_configuration():
         "pydata_sphinx_theme",
         "sphinx",
         "sphinx-autodoc-typehints",
+        "sphinx-tabs",
     }
 
     extras_require = {

--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ def get_project_configuration():
         "pydata_sphinx_theme",
         "sphinx",
         "sphinx-autodoc-typehints",
-        "sphinx-tabs",
+        "sphinx-panels",
     }
 
     extras_require = {


### PR DESCRIPTION
This PR reworks the documentation landing page to use `sphinx-panels` tabs and grid.

I used the `sphinx-panels` package which is deprecated rather than `sphinx-design` (its successor) to be compatible with debian 12 which do not provide `sphinx-design`.


![Screenshot from 2024-01-09 15-13-39](https://github.com/silx-kit/silx/assets/9449698/12bc1de8-117c-4c06-bdac-4ca524d71f5b)
