### PR TITLE
Tests: Fixed test execution

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 # /*##########################################################################
 #
-# Copyright (c) 2015-2022 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2024 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -40,6 +40,7 @@ import os
 import subprocess
 import sys
 import sysconfig
+from pathlib import Path
 
 
 # Capture all default warnings
@@ -153,15 +154,13 @@ def import_project_module(project_name, project_dir):
 
 
 if __name__ == "__main__":  # Needed for multiprocessing support on Windows
-    import pytest
-
     PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
     PROJECT_NAME = get_project_name(PROJECT_DIR)
     logger.info("Project name: %s", PROJECT_NAME)
 
     project_module = import_project_module(PROJECT_NAME, PROJECT_DIR)
     PROJECT_VERSION = getattr(project_module, "version", "")
-    PROJECT_PATH = project_module.__path__[0]
+    PROJECT_PATH = str(Path(project_module.__path__[0]).resolve())
 
     def normalize_option(option):
         option_parts = option.split(os.path.sep)
@@ -179,4 +178,14 @@ if __name__ == "__main__":  # Needed for multiprocessing support on Windows
         args += [PROJECT_PATH]
 
     argv = ["--rootdir", PROJECT_PATH] + args
-    sys.exit(pytest.main(argv))
+    sys.exit(
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+            ]
+            + argv,
+            check=False,
+        ).returncode
+    )

--- a/src/silx/test/__init__.py
+++ b/src/silx/test/__init__.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2015-2022 European Synchrotron Radiation Facility
+# Copyright (c) 2015-2024 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,8 @@
 """
 
 import logging
+import subprocess
+import sys
 
 
 try:
@@ -37,14 +39,17 @@ except ImportError:
 
 
 def run_tests(module: str = "silx", verbosity: int = 0, args=()):
-    """Run tests
+    """Run tests in a subprocess
 
     :param module: Name of the silx module to test (default: 'silx')
     :param verbosity: Requested level of verbosity
     :param args: List of extra arguments to pass to `pytest`
     """
-    return pytest.main(
+    return subprocess.run(
         [
+            sys.executable,
+            "-m",
+            "pytest",
             "--pyargs",
             module,
             "--verbosity",
@@ -53,5 +58,6 @@ def run_tests(module: str = "silx", verbosity: int = 0, args=()):
             '-o python_classes=["Test"]',
             '-o python_functions=["test"]',
         ]
-        + list(args)
-    )
+        + list(args),
+        check=False,
+    ).returncode


### PR DESCRIPTION
This PR runs `pytest` in a subprocess for both `silx.test.run_tests` and `run_tests.py`.
Previous way of running tests had issue with pytest 8.0.0rc1 apparently because of the module path. Since `pytest` is playing with the imports, it is anyway best IMO to run it separately.

Failing CI:
- https://ci.appveyor.com/project/ESRF/silx/builds/48931383/job/bgbw7jaa9wq9tjnt
- https://gitlab.esrf.fr/silx/bob/silx/-/jobs/910150