### PR TITLE
silx.gui.dialog.ColormapDialog: Updated tests

### DIFF
--- a/src/silx/gui/conftest.py
+++ b/src/silx/gui/conftest.py
@@ -33,7 +33,8 @@ def qWidgetFactory(qapp, qapp_utils):
     qapp.processEvents()
 
     for widget in widgets:
-        widget.close()
+        if isValid(widget):
+            widget.close()
     qapp.processEvents()
 
     # Wait some time for all widgets to be deleted

--- a/src/silx/gui/dialog/test/test_colormapdialog.py
+++ b/src/silx/gui/dialog/test/test_colormapdialog.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2016-2023 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2024 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -29,383 +29,355 @@ __date__ = "09/11/2018"
 
 
 import pytest
-import weakref
 
 from silx.gui import qt
 from silx.gui.dialog import ColormapDialog
-from silx.gui.utils.testutils import TestCaseQt
 from silx.gui.colors import Colormap, preferredColormaps
-from silx.utils.testutils import ParametricTestCase
 from silx.gui.plot.items.image import ImageData
 
 import numpy
 
 
-@pytest.fixture
-def colormap():
+def testGUIEdition(qWidgetFactory):
+    """Make sure the colormap is correctly edited and also that the
+    modification are correctly updated if an other colormapdialog is
+    editing the same colormap"""
     colormap = Colormap(name="gray", vmin=10.0, vmax=20.0, normalization="linear")
-    yield colormap
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    dialog.setColormap(colormap)
+    dialog2 = qWidgetFactory(ColormapDialog.ColormapDialog)
+    dialog2.setColormap(colormap)
+
+    dialog._comboBoxColormap._setCurrentName("red")
+    dialog._comboBoxNormalization.setCurrentIndex(
+        dialog._comboBoxNormalization.findData(Colormap.LOGARITHM)
+    )
+    assert colormap.getName() == "red"
+    assert dialog.getColormap().getName() == "red"
+    assert colormap.getNormalization() == "log"
+    assert colormap.getVMin() == 10
+    assert colormap.getVMax() == 20
+    # checked second colormap dialog
+    assert dialog2._comboBoxColormap.getCurrentName() == "red"
+    assert dialog2._comboBoxNormalization.currentData() == Colormap.LOGARITHM
+    assert int(dialog2._minValue.getValue()) == 10
+    assert int(dialog2._maxValue.getValue()) == 20
 
 
-@pytest.fixture
-def colormapDialog(qapp):
-    dialog = ColormapDialog.ColormapDialog()
-    dialog.setAttribute(qt.Qt.WA_DeleteOnClose)
-    yield weakref.proxy(dialog)
+def testGUIModalOk(qapp, qapp_utils, qWidgetFactory):
+    """Make sure the colormap is modified if gone through accept"""
+    colormap = Colormap(name="gray", vmin=10.0, vmax=20.0, normalization="linear")
+    assert colormap.isAutoscale() is False
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    dialog.setModal(True)
     qapp.processEvents()
-    from silx.gui.qt import inspect
 
-    if inspect.isValid(dialog):
-        dialog.close()
-        del dialog
-        qapp.processEvents()
+    dialog.setColormap(colormap)
+    assert colormap.getVMin() is not None
+    dialog._minValue.sigAutoScaleChanged.emit(True)
+    assert colormap.getVMin() is None
+    dialog._maxValue.sigAutoScaleChanged.emit(True)
+    qapp_utils.mouseClick(
+        widget=dialog._buttonsModal.button(qt.QDialogButtonBox.Ok),
+        button=qt.Qt.LeftButton,
+    )
+    assert colormap.getVMin() is None
+    assert colormap.getVMax() is None
+    assert colormap.isAutoscale() is True
 
 
-@pytest.fixture
-def colormap_class_attr(request, qapp_utils, colormap, colormapDialog):
-    """Provides few fixtures to a class as class attribute
+def testGUIModalCancel(qapp, qapp_utils, qWidgetFactory):
+    """Make sure the colormap is not modified if gone through reject"""
+    colormap = Colormap(name="gray", vmin=10.0, vmax=20.0, normalization="linear")
+    assert colormap.isAutoscale() is False
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    dialog.setModal(True)
+    qapp.processEvents()
 
-    Used as transition from TestCase to pytest
+    dialog.setColormap(colormap)
+    assert colormap.getVMin() is not None
+    dialog._minValue.sigAutoScaleChanged.emit(True)
+    assert colormap.getVMin() is None
+    qapp_utils.mouseClick(
+        widget=dialog._buttonsModal.button(qt.QDialogButtonBox.Cancel),
+        button=qt.Qt.LeftButton,
+    )
+    assert colormap.getVMin() is not None
+
+
+def testGUIModalClose(qapp, qapp_utils, qWidgetFactory):
+    colormap = Colormap(name="gray", vmin=10.0, vmax=20.0, normalization="linear")
+    assert colormap.isAutoscale() is False
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    dialog.setModal(False)
+    qapp.processEvents()
+
+    dialog.setColormap(colormap)
+    assert colormap.getVMin() is not None
+    dialog._minValue.sigAutoScaleChanged.emit(True)
+    assert colormap.getVMin() is None
+    qapp_utils.mouseClick(
+        widget=dialog._buttonsNonModal.button(qt.QDialogButtonBox.Close),
+        button=qt.Qt.LeftButton,
+    )
+    assert colormap.getVMin() is None
+
+
+def testGUIModalReset(qapp, qapp_utils, qWidgetFactory):
+    colormap = Colormap(name="gray", vmin=10.0, vmax=20.0, normalization="linear")
+    assert colormap.isAutoscale() is False
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    dialog.setModal(False)
+    dialog.show()
+    qapp.processEvents()
+    dialog.setColormap(colormap)
+    assert colormap.getVMin() is not None
+    dialog._minValue.sigAutoScaleChanged.emit(True)
+    assert colormap.getVMin() is None
+    qapp_utils.mouseClick(
+        widget=dialog._buttonsNonModal.button(qt.QDialogButtonBox.Reset),
+        button=qt.Qt.LeftButton,
+    )
+    assert colormap.getVMin() is not None
+    dialog.close()
+
+
+def testGUIClose(qapp, qWidgetFactory):
+    """Make sure the colormap is modify if go through reject"""
+    colormap = Colormap(name="gray", vmin=10.0, vmax=20.0, normalization="linear")
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    assert colormap.isAutoscale() is False
+    qapp.processEvents()
+
+    dialog.setColormap(colormap)
+    assert colormap.getVMin() is not None
+    dialog._minValue.sigAutoScaleChanged.emit(True)
+    assert colormap.getVMin() is None
+    dialog.close()
+    qapp.processEvents()
+    assert colormap.getVMin() is None
+
+
+@pytest.mark.parametrize("norm", Colormap.NORMALIZATIONS)
+@pytest.mark.parametrize("autoscale", (True, False))
+def testSetColormapIsCorrect(norm, autoscale, qapp, qWidgetFactory):
+    """Make sure the interface fir the colormap when set a new colormap"""
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+
+    colormap = Colormap(name="gray", vmin=10.0, vmax=20.0, normalization="linear")
+    colormap.setName("red")
+    if autoscale is True:
+        colormap.setVRange(None, None)
+    else:
+        colormap.setVRange(11, 101)
+    colormap.setNormalization(norm)
+    dialog.setColormap(colormap)
+    qapp.processEvents()
+
+    assert dialog._comboBoxNormalization.currentData() == norm
+    assert dialog._comboBoxColormap.getCurrentName() == "red"
+    assert dialog._minValue.isAutoChecked() == autoscale
+    assert dialog._maxValue.isAutoChecked() == autoscale
+    if autoscale is False:
+        assert dialog._minValue.getValue() == 11
+        assert dialog._maxValue.getValue() == 101
+        assert dialog._minValue.isEnabled()
+        assert dialog._maxValue.isEnabled()
+    else:
+        assert dialog._minValue._numVal.isReadOnly()
+        assert dialog._maxValue._numVal.isReadOnly()
+
+
+def testColormapDel(qapp, qWidgetFactory):
+    """Check behavior if the colormap has been deleted outside. For now
+    we make sure the colormap is still running and nothing more"""
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    colormap = Colormap(name="gray")
+    dialog.setColormap(colormap)
+    qapp.processEvents()
+
+    colormap = None
+    assert dialog.getColormap() is None
+    dialog._comboBoxColormap._setCurrentName("blue")
+
+
+def testColormapEditedOutside(qapp, qWidgetFactory):
+    """Make sure the GUI is still up to date if the colormap is modified
+    outside"""
+    colormap = Colormap(name="gray", vmin=10.0, vmax=20.0, normalization="linear")
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    dialog.setColormap(colormap)
+    qapp.processEvents()
+
+    colormap.setName("red")
+    assert dialog._comboBoxColormap.getCurrentName() == "red"
+    colormap.setNormalization(Colormap.LOGARITHM)
+    assert dialog._comboBoxNormalization.currentData() == Colormap.LOGARITHM
+    colormap.setVRange(11, 201)
+    assert dialog._minValue.getValue() == 11
+    assert dialog._maxValue.getValue() == 201
+    assert not (dialog._minValue._numVal.isReadOnly())
+    assert not (dialog._maxValue._numVal.isReadOnly())
+    assert not (dialog._minValue.isAutoChecked())
+    assert not (dialog._maxValue.isAutoChecked())
+    colormap.setVRange(None, None)
+    qapp.processEvents()
+
+    assert dialog._minValue._numVal.isReadOnly()
+    assert dialog._maxValue._numVal.isReadOnly()
+    assert dialog._minValue.isAutoChecked()
+    assert dialog._maxValue.isAutoChecked()
+
+
+def testSetColormapScenario(qWidgetFactory):
+    """Test of a simple scenario of a colormap dialog editing several
+    colormap"""
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    colormap = Colormap(name="gray", vmin=10.0, vmax=20.0, normalization="linear")
+    colormap1 = Colormap(name="gray", vmin=10.0, vmax=20.0, normalization="linear")
+    colormap2 = Colormap(name="red", vmin=10.0, vmax=20.0, normalization="log")
+    colormap3 = Colormap(name="blue", vmin=None, vmax=None, normalization="linear")
+
+    dialog.setColormap(colormap)
+    dialog.setColormap(colormap1)
+    del colormap1
+    dialog.setColormap(colormap2)
+    del colormap2
+    dialog.setColormap(colormap3)
+    del colormap3
+
+
+def testNotPreferredColormap(qapp, qWidgetFactory):
+    """Test that the colormapEditor is able to edit a colormap which is not
+    part of the 'prefered colormap'
     """
-    request.cls.qapp_utils = qapp_utils
-    request.cls.colormap = colormap
-    request.cls.colormapDiag = colormapDialog
-    yield
-    request.cls.qapp_utils = None
-    request.cls.colormap = None
-    request.cls.colormapDiag = None
+
+    def getFirstNotPreferredColormap():
+        cms = Colormap.getSupportedColormaps()
+        preferred = preferredColormaps()
+        for cm in cms:
+            if cm not in preferred:
+                return cm
+        return None
+
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    colormapName = getFirstNotPreferredColormap()
+    assert colormapName is not None
+    colormap = Colormap(name=colormapName)
+    dialog.setColormap(colormap)
+    qapp.processEvents()
+
+    cb = dialog._comboBoxColormap
+    assert cb.getCurrentName() == colormapName
+    cb.setCurrentIndex(0)
+    index = cb.findLutName(colormapName)
+    assert index != 0  # if 0 then the rest of the test has no sense
+    cb.setCurrentIndex(index)
+    assert cb.getCurrentName() == colormapName
 
 
-@pytest.mark.usefixtures("colormap_class_attr")
-class TestColormapDialog(TestCaseQt, ParametricTestCase):
-    def testGUIEdition(self):
-        """Make sure the colormap is correctly edited and also that the
-        modification are correctly updated if an other colormapdialog is
-        editing the same colormap"""
-        colormapDiag2 = ColormapDialog.ColormapDialog()
-        colormapDiag2.setAttribute(qt.Qt.WA_DeleteOnClose)
-        colormapDiag2.setColormap(self.colormap)
-        colormapDiag2.show()
-        self.colormapDiag.setColormap(self.colormap)
-        self.colormapDiag.show()
-        self.qapp.processEvents()
+def testColormapEditableMode(qWidgetFactory):
+    """Test that the colormapDialog is correctly updated when changing the
+    colormap editable status"""
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    colormap = Colormap(normalization="linear", vmin=1.0, vmax=10.0)
 
-        self.colormapDiag._comboBoxColormap._setCurrentName("red")
-        self.colormapDiag._comboBoxNormalization.setCurrentIndex(
-            self.colormapDiag._comboBoxNormalization.findData(Colormap.LOGARITHM)
-        )
-        self.assertTrue(self.colormap.getName() == "red")
-        self.assertTrue(self.colormapDiag.getColormap().getName() == "red")
-        self.assertTrue(self.colormap.getNormalization() == "log")
-        self.assertTrue(self.colormap.getVMin() == 10)
-        self.assertTrue(self.colormap.getVMax() == 20)
-        # checked second colormap dialog
-        self.assertTrue(colormapDiag2._comboBoxColormap.getCurrentName() == "red")
-        self.assertEqual(
-            colormapDiag2._comboBoxNormalization.currentData(), Colormap.LOGARITHM
-        )
-        self.assertTrue(int(colormapDiag2._minValue.getValue()) == 10)
-        self.assertTrue(int(colormapDiag2._maxValue.getValue()) == 20)
-        colormapDiag2.close()
-        del colormapDiag2
-        self.qapp.processEvents()
+    dialog.setColormap(colormap)
 
-    def testGUIModalOk(self):
-        """Make sure the colormap is modified if gone through accept"""
-        assert self.colormap.isAutoscale() is False
-        self.colormapDiag.setModal(True)
-        self.colormapDiag.show()
-        self.qapp.processEvents()
-        self.colormapDiag.setColormap(self.colormap)
-        self.assertTrue(self.colormap.getVMin() is not None)
-        self.colormapDiag._minValue.sigAutoScaleChanged.emit(True)
-        self.assertTrue(self.colormap.getVMin() is None)
-        self.colormapDiag._maxValue.sigAutoScaleChanged.emit(True)
-        self.mouseClick(
-            widget=self.colormapDiag._buttonsModal.button(qt.QDialogButtonBox.Ok),
-            button=qt.Qt.LeftButton,
-        )
-        self.assertTrue(self.colormap.getVMin() is None)
-        self.assertTrue(self.colormap.getVMax() is None)
-        self.assertTrue(self.colormap.isAutoscale() is True)
+    for editable in (True, False):
+        colormap.setEditable(editable)
+        assert dialog._comboBoxColormap.isEnabled() is editable
+        assert dialog._minValue.isEnabled() is editable
+        assert dialog._maxValue.isEnabled() is editable
+        assert dialog._comboBoxNormalization.isEnabled() is editable
 
-    def testGUIModalCancel(self):
-        """Make sure the colormap is not modified if gone through reject"""
-        assert self.colormap.isAutoscale() is False
-        self.colormapDiag.setModal(True)
-        self.colormapDiag.show()
-        self.qapp.processEvents()
-        self.colormapDiag.setColormap(self.colormap)
-        self.assertTrue(self.colormap.getVMin() is not None)
-        self.colormapDiag._minValue.sigAutoScaleChanged.emit(True)
-        self.assertTrue(self.colormap.getVMin() is None)
-        self.mouseClick(
-            widget=self.colormapDiag._buttonsModal.button(qt.QDialogButtonBox.Cancel),
-            button=qt.Qt.LeftButton,
-        )
-        self.assertTrue(self.colormap.getVMin() is not None)
+    # Make sure the reset button is also set to enable when edition mode is
+    # False
+    dialog.setModal(False)
+    colormap.setEditable(True)
+    dialog._comboBoxNormalization.setCurrentIndex(
+        dialog._comboBoxNormalization.findData(Colormap.LOGARITHM)
+    )
+    resetButton = dialog._buttonsNonModal.button(qt.QDialogButtonBox.Reset)
+    assert resetButton.isEnabled()
+    colormap.setEditable(False)
+    assert not (resetButton.isEnabled())
 
-    def testGUIModalClose(self):
-        assert self.colormap.isAutoscale() is False
-        self.colormapDiag.setModal(False)
-        self.colormapDiag.show()
-        self.qapp.processEvents()
-        self.colormapDiag.setColormap(self.colormap)
-        self.assertTrue(self.colormap.getVMin() is not None)
-        self.colormapDiag._minValue.sigAutoScaleChanged.emit(True)
-        self.assertTrue(self.colormap.getVMin() is None)
-        self.mouseClick(
-            widget=self.colormapDiag._buttonsNonModal.button(qt.QDialogButtonBox.Close),
-            button=qt.Qt.LeftButton,
-        )
-        self.assertTrue(self.colormap.getVMin() is None)
 
-    def testGUIModalReset(self):
-        assert self.colormap.isAutoscale() is False
-        self.colormapDiag.setModal(False)
-        self.colormapDiag.show()
-        self.qapp.processEvents()
-        self.colormapDiag.setColormap(self.colormap)
-        self.assertTrue(self.colormap.getVMin() is not None)
-        self.colormapDiag._minValue.sigAutoScaleChanged.emit(True)
-        self.assertTrue(self.colormap.getVMin() is None)
-        self.mouseClick(
-            widget=self.colormapDiag._buttonsNonModal.button(qt.QDialogButtonBox.Reset),
-            button=qt.Qt.LeftButton,
-        )
-        self.assertTrue(self.colormap.getVMin() is not None)
-        self.colormapDiag.close()
+def testImageData(qWidgetFactory):
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    data = numpy.random.rand(5, 5)
+    dialog.setData(data)
 
-    def testGUIClose(self):
-        """Make sure the colormap is modify if go through reject"""
-        assert self.colormap.isAutoscale() is False
-        self.colormapDiag.show()
-        self.qapp.processEvents()
-        self.colormapDiag.setColormap(self.colormap)
-        self.assertTrue(self.colormap.getVMin() is not None)
-        self.colormapDiag._minValue.sigAutoScaleChanged.emit(True)
-        self.assertTrue(self.colormap.getVMin() is None)
-        self.colormapDiag.close()
-        self.qapp.processEvents()
-        self.assertTrue(self.colormap.getVMin() is None)
 
-    def testSetColormapIsCorrect(self):
-        """Make sure the interface fir the colormap when set a new colormap"""
-        self.colormap.setName("red")
-        self.colormapDiag.show()
-        self.qapp.processEvents()
-        for norm in Colormap.NORMALIZATIONS:
-            for autoscale in (True, False):
-                if autoscale is True:
-                    self.colormap.setVRange(None, None)
-                else:
-                    self.colormap.setVRange(11, 101)
-                self.colormap.setNormalization(norm)
-                with self.subTest(colormap=self.colormap):
-                    self.colormapDiag.setColormap(self.colormap)
-                    self.assertEqual(
-                        self.colormapDiag._comboBoxNormalization.currentData(), norm
-                    )
-                    self.assertTrue(
-                        self.colormapDiag._comboBoxColormap.getCurrentName() == "red"
-                    )
-                    self.assertTrue(
-                        self.colormapDiag._minValue.isAutoChecked() == autoscale
-                    )
-                    self.assertTrue(
-                        self.colormapDiag._maxValue.isAutoChecked() == autoscale
-                    )
-                    if autoscale is False:
-                        self.assertTrue(self.colormapDiag._minValue.getValue() == 11)
-                        self.assertTrue(self.colormapDiag._maxValue.getValue() == 101)
-                        self.assertTrue(self.colormapDiag._minValue.isEnabled())
-                        self.assertTrue(self.colormapDiag._maxValue.isEnabled())
-                    else:
-                        self.assertTrue(
-                            self.colormapDiag._minValue._numVal.isReadOnly()
-                        )
-                        self.assertTrue(
-                            self.colormapDiag._maxValue._numVal.isReadOnly()
-                        )
+def testEmptyData(qWidgetFactory):
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    data = numpy.empty((10, 0))
+    dialog.setData(data)
 
-    def testColormapDel(self):
-        """Check behavior if the colormap has been deleted outside. For now
-        we make sure the colormap is still running and nothing more"""
-        colormap = Colormap(name="gray")
-        self.colormapDiag.setColormap(colormap)
-        self.colormapDiag.show()
-        self.qapp.processEvents()
-        colormap = None
-        self.assertTrue(self.colormapDiag.getColormap() is None)
-        self.colormapDiag._comboBoxColormap._setCurrentName("blue")
 
-    def testColormapEditedOutside(self):
-        """Make sure the GUI is still up to date if the colormap is modified
-        outside"""
-        self.colormapDiag.setColormap(self.colormap)
-        self.colormapDiag.show()
-        self.qapp.processEvents()
+def testNoneData(qWidgetFactory):
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    data = numpy.random.rand(5, 5)
+    dialog.setData(data)
+    dialog.setData(None)
 
-        self.colormap.setName("red")
-        self.assertTrue(self.colormapDiag._comboBoxColormap.getCurrentName() == "red")
-        self.colormap.setNormalization(Colormap.LOGARITHM)
-        self.assertEqual(
-            self.colormapDiag._comboBoxNormalization.currentData(), Colormap.LOGARITHM
-        )
-        self.colormap.setVRange(11, 201)
-        self.assertTrue(self.colormapDiag._minValue.getValue() == 11)
-        self.assertTrue(self.colormapDiag._maxValue.getValue() == 201)
-        self.assertFalse(self.colormapDiag._minValue._numVal.isReadOnly())
-        self.assertFalse(self.colormapDiag._maxValue._numVal.isReadOnly())
-        self.assertFalse(self.colormapDiag._minValue.isAutoChecked())
-        self.assertFalse(self.colormapDiag._maxValue.isAutoChecked())
-        self.colormap.setVRange(None, None)
-        self.qapp.processEvents()
-        self.assertTrue(self.colormapDiag._minValue._numVal.isReadOnly())
-        self.assertTrue(self.colormapDiag._maxValue._numVal.isReadOnly())
-        self.assertTrue(self.colormapDiag._minValue.isAutoChecked())
-        self.assertTrue(self.colormapDiag._maxValue.isAutoChecked())
 
-    def testSetColormapScenario(self):
-        """Test of a simple scenario of a colormap dialog editing several
-        colormap"""
-        colormap1 = Colormap(name="gray", vmin=10.0, vmax=20.0, normalization="linear")
-        colormap2 = Colormap(name="red", vmin=10.0, vmax=20.0, normalization="log")
-        colormap3 = Colormap(name="blue", vmin=None, vmax=None, normalization="linear")
-        self.colormapDiag.setColormap(self.colormap)
-        self.colormapDiag.setColormap(colormap1)
-        del colormap1
-        self.colormapDiag.setColormap(colormap2)
-        del colormap2
-        self.colormapDiag.setColormap(colormap3)
-        del colormap3
+def testImageItem(qapp, qWidgetFactory):
+    """Check that an ImageData plot item can be used"""
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    colormap = Colormap(name="gray", vmin=None, vmax=None)
+    data = numpy.arange(3**2).reshape(3, 3)
+    item = ImageData()
+    item.setData(data, copy=False)
 
-    def testNotPreferredColormap(self):
-        """Test that the colormapEditor is able to edit a colormap which is not
-        part of the 'prefered colormap'
-        """
+    dialog.setColormap(colormap)
+    qapp.processEvents()
 
-        def getFirstNotPreferredColormap():
-            cms = Colormap.getSupportedColormaps()
-            preferred = preferredColormaps()
-            for cm in cms:
-                if cm not in preferred:
-                    return cm
-            return None
+    dialog.setItem(item)
+    vrange = dialog._getFiniteColormapRange()
+    assert vrange == (0, 8)
 
-        colormapName = getFirstNotPreferredColormap()
-        assert colormapName is not None
-        colormap = Colormap(name=colormapName)
-        self.colormapDiag.setColormap(colormap)
-        self.colormapDiag.show()
-        self.qapp.processEvents()
-        cb = self.colormapDiag._comboBoxColormap
-        self.assertTrue(cb.getCurrentName() == colormapName)
-        cb.setCurrentIndex(0)
-        index = cb.findLutName(colormapName)
-        assert index != 0  # if 0 then the rest of the test has no sense
-        cb.setCurrentIndex(index)
-        self.assertTrue(cb.getCurrentName() == colormapName)
 
-    def testColormapEditableMode(self):
-        """Test that the colormapDialog is correctly updated when changing the
-        colormap editable status"""
-        colormap = Colormap(normalization="linear", vmin=1.0, vmax=10.0)
-        self.colormapDiag.show()
-        self.qapp.processEvents()
-        self.colormapDiag.setColormap(colormap)
-        for editable in (True, False):
-            with self.subTest(editable=editable):
-                colormap.setEditable(editable)
-                self.assertTrue(
-                    self.colormapDiag._comboBoxColormap.isEnabled() is editable
-                )
-                self.assertTrue(self.colormapDiag._minValue.isEnabled() is editable)
-                self.assertTrue(self.colormapDiag._maxValue.isEnabled() is editable)
-                self.assertTrue(
-                    self.colormapDiag._comboBoxNormalization.isEnabled() is editable
-                )
+def testItemDel(qapp, qWidgetFactory):
+    """Check that the plot items are not hard linked to the dialog"""
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    colormap = Colormap(name="gray", vmin=None, vmax=None)
+    data = numpy.arange(3**2).reshape(3, 3)
+    item = ImageData()
+    item.setData(data, copy=False)
 
-        # Make sure the reset button is also set to enable when edition mode is
-        # False
-        self.colormapDiag.setModal(False)
-        colormap.setEditable(True)
-        self.colormapDiag._comboBoxNormalization.setCurrentIndex(
-            self.colormapDiag._comboBoxNormalization.findData(Colormap.LOGARITHM)
-        )
-        resetButton = self.colormapDiag._buttonsNonModal.button(
-            qt.QDialogButtonBox.Reset
-        )
-        self.assertTrue(resetButton.isEnabled())
-        colormap.setEditable(False)
-        self.assertFalse(resetButton.isEnabled())
+    dialog.setColormap(colormap)
+    dialog.show()
+    qapp.processEvents()
+    dialog.setItem(item)
+    previousRange = dialog._getFiniteColormapRange()
+    del item
+    vrange = dialog._getFiniteColormapRange()
+    assert vrange != previousRange
 
-    def testImageData(self):
-        data = numpy.random.rand(5, 5)
-        self.colormapDiag.setData(data)
 
-    def testEmptyData(self):
-        data = numpy.empty((10, 0))
-        self.colormapDiag.setData(data)
+def testDataDel(qapp, qWidgetFactory):
+    """Check that the data are not hard linked to the dialog"""
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    colormap = Colormap(name="gray", vmin=None, vmax=None)
+    data = numpy.arange(5)
 
-    def testNoneData(self):
-        data = numpy.random.rand(5, 5)
-        self.colormapDiag.setData(data)
-        self.colormapDiag.setData(None)
+    dialog.setColormap(colormap)
+    qapp.processEvents()
 
-    def testImageItem(self):
-        """Check that an ImageData plot item can be used"""
-        dialog = self.colormapDiag
-        colormap = Colormap(name="gray", vmin=None, vmax=None)
-        data = numpy.arange(3**2).reshape(3, 3)
-        item = ImageData()
-        item.setData(data, copy=False)
+    dialog.setData(data)
+    previousRange = dialog._getFiniteColormapRange()
+    del data
+    vrange = dialog._getFiniteColormapRange()
+    assert vrange != previousRange
 
-        dialog.setColormap(colormap)
-        dialog.show()
-        self.qapp.processEvents()
-        dialog.setItem(item)
-        vrange = dialog._getFiniteColormapRange()
-        self.assertEqual(vrange, (0, 8))
 
-    def testItemDel(self):
-        """Check that the plot items are not hard linked to the dialog"""
-        dialog = self.colormapDiag
-        colormap = Colormap(name="gray", vmin=None, vmax=None)
-        data = numpy.arange(3**2).reshape(3, 3)
-        item = ImageData()
-        item.setData(data, copy=False)
-
-        dialog.setColormap(colormap)
-        dialog.show()
-        self.qapp.processEvents()
-        dialog.setItem(item)
-        previousRange = dialog._getFiniteColormapRange()
-        del item
-        vrange = dialog._getFiniteColormapRange()
-        self.assertNotEqual(vrange, previousRange)
-
-    def testDataDel(self):
-        """Check that the data are not hard linked to the dialog"""
-        dialog = self.colormapDiag
-        colormap = Colormap(name="gray", vmin=None, vmax=None)
-        data = numpy.arange(5)
-
-        dialog.setColormap(colormap)
-        dialog.show()
-        self.qapp.processEvents()
-        dialog.setData(data)
-        previousRange = dialog._getFiniteColormapRange()
-        del data
-        vrange = dialog._getFiniteColormapRange()
-        self.assertNotEqual(vrange, previousRange)
-
-    def testDeleteWhileExec(self):
-        colormapDiag = self.colormapDiag
-        self.colormapDiag = None
-        qt.QTimer.singleShot(1000, colormapDiag.deleteLater)
-        result = colormapDiag.exec()
-        self.assertEqual(result, 0)
+def testDeleteWhileExec(qWidgetFactory):
+    dialog = qWidgetFactory(ColormapDialog.ColormapDialog)
+    qt.QTimer.singleShot(1000, dialog.deleteLater)
+    result = dialog.exec()
+    assert result == 0
 
 
 def testUpdateImageData(qapp, qWidgetFactory):

--- a/src/silx/gui/plot3d/scene/viewport.py
+++ b/src/silx/gui/plot3d/scene/viewport.py
@@ -560,7 +560,7 @@ class Viewport(event.Notifier):
         # Bind used framebuffer to get depth
         gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, self.framebuffer)
 
-        if offset == 0:  # Fast path
+        if False:  # offset == 0:  # Fast path
             # glReadPixels is not GL|ES friendly
             depth = gl.glReadPixels(x, y, 1, 1, gl.GL_DEPTH_COMPONENT, gl.GL_FLOAT)[0]
         else:
@@ -582,7 +582,9 @@ class Viewport(event.Notifier):
 
             # Take first depth that is not 1 in the sorted values
             hits = sortedValues[sortedValues != 1.0]
+            print("XX", hits, type(hits), hits.shape)
             depth = 1.0 if len(hits) == 0 else hits[0]
+            print("YYY", depth, type(depth))
 
         gl.glBindFramebuffer(gl.GL_FRAMEBUFFER, 0)
 


### PR DESCRIPTION
This PR reworks the colormap dialog tests to make them more pytest-ish. It's an attempt to address CI failures (see #4032)

closes #4032
