### PR TITLE
silx.gui.plot and plot3d: Updated font management

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ fabio >= 0.9
 pyopencl; platform_machine in "i386, x86_64, AMD64"  # For silx.opencl
 Mako                      # For pyopencl reduction
 qtconsole                 # For silx.gui.console
-matplotlib >= 1.2.0       # For silx.gui.plot
+matplotlib >= 3.1.0       # For silx.gui.plot
 PyOpenGL                  # For silx.gui.plot3d
 python-dateutil           # For silx.gui.plot
 scipy                     # For silx.math.fit demo, silx.image.sift demo, silx.image.sift.test

--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,7 @@ def get_project_configuration():
         "Mako",
         # gui
         "qtconsole",
-        "matplotlib>=1.2.0",
+        "matplotlib>=3.1.0",
         "PyOpenGL",
         "python-dateutil",
         "PyQt5",

--- a/src/silx/gui/_glutils/font.py
+++ b/src/silx/gui/_glutils/font.py
@@ -49,67 +49,31 @@ def getDefaultFontFamily() -> str:
     return qt.QApplication.instance().font().family()
 
 
-# Font weights
-ULTRA_LIGHT = 0
-"""Lightest characters: Minimum font weight"""
-
-LIGHT = 25
-"""Light characters"""
-
-NORMAL = 50
-"""Normal characters"""
-
-SEMI_BOLD = 63
-"""Between normal and bold characters"""
-
-BOLD = 74
-"""Thicker characters"""
-
-BLACK = 87
-"""Really thick characters"""
-
-ULTRA_BLACK = 99
-"""Thickest characters: Maximum font weight"""
-
-
 def rasterTextQt(
     text: str,
-    font: str | qt.QFont,
-    size: int = -1,
-    weight: int = -1,
-    italic: bool = False,
-    devicePixelRatio: float = 1.0,
-) -> tuple[numpy.ndarray, int]:
+    font: qt.QFont,
+    dotsPerInch: float = 96.0,
+) -> tuple[numpy.ndarray, float]:
     """Raster text using Qt.
 
     It supports multiple lines.
 
     :param text: The text to raster
-    :param font: Font name or QFont to use
-    :param size:
-        Font size in points
-        Used only if font is given as name.
-    :param weight:
-        Font weight in [0, 99], see QFont.Weight.
-        Used only if font is given as name.
-    :param italic:
-        True for italic font (default: False).
-        Used only if font is given as name.
-    :param devicePixelRatio:
-        The current ratio between device and device-independent pixel
-        (default: 1.0)
+    :param font: Font to use
+    :param dotsPerInch: The DPI resolution of the created image
     :return: Corresponding image in gray scale and baseline offset from top
-    :rtype: (HxW numpy.ndarray of uint8, int)
     """
     if not text:
         _logger.info("Trying to raster empty text, replaced by white space")
         text = " "  # Replace empty text by white space to produce an image
 
-    if not isinstance(font, qt.QFont):
-        font = qt.QFont(font, size, weight, italic)
+    dotsPerMeter = dotsPerInch * 100 / 2.54
 
     # get text size
     image = qt.QImage(1, 1, qt.QImage.Format_Grayscale8)
+    image.setDotsPerMeterX(dotsPerMeter)
+    image.setDotsPerMeterY(dotsPerMeter)
+
     painter = qt.QPainter()
     painter.begin(image)
     painter.setPen(qt.Qt.white)
@@ -120,6 +84,7 @@ def rasterTextQt(
     painter.end()
 
     metrics = qt.QFontMetrics(font)
+    offset = metrics.ascent() / 72.0 * dotsPerInch
 
     # This does not provide the correct text bbox on macOS
     # size = metrics.size(qt.Qt.TextExpandTabs, text)
@@ -128,16 +93,17 @@ def rasterTextQt(
     #     qt.Qt.TextExpandTabs,
     #     text)
 
-    # Add extra border and handle devicePixelRatio
-    width = bounds.width() * devicePixelRatio + 2
+    # Add extra border
+    width = bounds.width() + 2
     # align line size to 32 bits to ease conversion to numpy array
     width = 4 * ((width + 3) // 4)
     image = qt.QImage(
         int(width),
-        int(bounds.height() * devicePixelRatio + 2),
+        int(bounds.height() + 2),
         qt.QImage.Format_Grayscale8,
     )
-    image.setDevicePixelRatio(devicePixelRatio)
+    image.setDotsPerMeterX(dotsPerMeter)
+    image.setDotsPerMeterY(dotsPerMeter)
     image.fill(0)
 
     # Raster text
@@ -153,48 +119,35 @@ def rasterTextQt(
     # Remove leading and trailing empty columns/rows but one on each side
     filled_rows = numpy.nonzero(numpy.sum(array, axis=1))[0]
     filled_columns = numpy.nonzero(numpy.sum(array, axis=0))[0]
+
     if len(filled_rows) == 0 or len(filled_columns) == 0:
-        return array, metrics.ascent()
-
-    min_row = max(0, filled_rows[0] - 1)
-    array = array[
-        min_row : filled_rows[-1] + 2,
-        max(0, filled_columns[0] - 1) : filled_columns[-1] + 2,
-    ]
-
-    return array, metrics.ascent() - min_row
+        return array, offset
+    return (
+        numpy.ascontiguousarray(
+            array[
+                0 : filled_rows[-1] + 2,
+                max(0, filled_columns[0] - 1) : filled_columns[-1] + 2,
+            ]
+        ),
+        offset,
+    )
 
 
 def rasterText(
     text: str,
-    font: str | qt.QFont,
-    size: int = -1,
-    weight=-1,
-    italic: bool = False,
-    devicePixelRatio=1.0,
-) -> tuple[numpy.ndarray, int]:
+    font: qt.QFont,
+    dotsPerInch: float = 96.0,
+) -> tuple[numpy.ndarray, float]:
     """Raster text using Qt or matplotlib if there may be math syntax.
 
     It supports multiple lines.
 
     :param text: The text to raster
     :param font: Font name or QFont to use
-    :param size:
-        Font size in points
-        Used only if font is given as name.
-    :param weight:
-        Font weight in [0, 99], see QFont.Weight.
-        Used only if font is given as name.
-    :param italic:
-        True for italic font (default: False).
-        Used only if font is given as name.
-    :param devicePixelRatio:
-        The current ratio between device and device-independent pixel
-        (default: 1.0)
+    :param dotsPerInch: Created image resolution
     :return: Corresponding image in gray scale and baseline offset from top
-    :rtype: (HxW numpy.ndarray of uint8, int)
     """
+
     if rasterMathText is not None and text.count("$") >= 2:
-        return rasterMathText(text, font, size, weight, italic, devicePixelRatio)
-    else:
-        return rasterTextQt(text, font, size, weight, italic, devicePixelRatio)
+        return rasterMathText(text, font, dotsPerInch)
+    return rasterTextQt(text, font, dotsPerInch)

--- a/src/silx/gui/_glutils/font.py
+++ b/src/silx/gui/_glutils/font.py
@@ -35,11 +35,8 @@ import numpy
 
 from .. import qt
 from ..utils.image import convertQImageToArray
+from ..utils.matplotlib import rasterMathText
 
-try:
-    from ..utils.matplotlib import rasterMathText
-except ImportError:
-    rasterMathText = None
 
 _logger = logging.getLogger(__name__)
 
@@ -148,6 +145,6 @@ def rasterText(
     :return: Corresponding image in gray scale and baseline offset from top
     """
 
-    if rasterMathText is not None and text.count("$") >= 2:
+    if text.count("$") >= 2:
         return rasterMathText(text, font, dotsPerInch)
     return rasterTextQt(text, font, dotsPerInch)

--- a/src/silx/gui/_glutils/font.py
+++ b/src/silx/gui/_glutils/font.py
@@ -23,128 +23,17 @@
 # ###########################################################################*/
 """Text rasterisation feature leveraging Qt font and text layout support."""
 
-from __future__ import annotations
-
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "13/10/2016"
 
 
-import logging
-import numpy
-
 from .. import qt
-from ..utils.image import convertQImageToArray
-from ..utils.matplotlib import rasterMathText
 
-
-_logger = logging.getLogger(__name__)
+# Expose rasterMathText as part of this module
+from ..utils.matplotlib import rasterMathText as rasterText  # noqa
 
 
 def getDefaultFontFamily() -> str:
     """Returns the default font family of the application"""
     return qt.QApplication.instance().font().family()
-
-
-def rasterTextQt(
-    text: str,
-    font: qt.QFont,
-    dotsPerInch: float = 96.0,
-) -> tuple[numpy.ndarray, float]:
-    """Raster text using Qt.
-
-    It supports multiple lines.
-
-    :param text: The text to raster
-    :param font: Font to use
-    :param dotsPerInch: The DPI resolution of the created image
-    :return: Corresponding image in gray scale and baseline offset from top
-    """
-    if not text:
-        _logger.info("Trying to raster empty text, replaced by white space")
-        text = " "  # Replace empty text by white space to produce an image
-
-    dotsPerMeter = dotsPerInch * 100 / 2.54
-
-    # get text size
-    image = qt.QImage(1, 1, qt.QImage.Format_Grayscale8)
-    image.setDotsPerMeterX(dotsPerMeter)
-    image.setDotsPerMeterY(dotsPerMeter)
-
-    painter = qt.QPainter()
-    painter.begin(image)
-    painter.setPen(qt.Qt.white)
-    painter.setFont(font)
-    bounds = painter.boundingRect(
-        qt.QRect(0, 0, 4096, 4096), qt.Qt.TextExpandTabs, text
-    )
-    painter.end()
-
-    metrics = qt.QFontMetrics(font)
-    offset = metrics.ascent() / 72.0 * dotsPerInch
-
-    # This does not provide the correct text bbox on macOS
-    # size = metrics.size(qt.Qt.TextExpandTabs, text)
-    # bounds = metrics.boundingRect(
-    #     qt.QRect(0, 0, size.width(), size.height()),
-    #     qt.Qt.TextExpandTabs,
-    #     text)
-
-    # Add extra border
-    width = bounds.width() + 2
-    # align line size to 32 bits to ease conversion to numpy array
-    width = 4 * ((width + 3) // 4)
-    image = qt.QImage(
-        int(width),
-        int(bounds.height() + 2),
-        qt.QImage.Format_Grayscale8,
-    )
-    image.setDotsPerMeterX(dotsPerMeter)
-    image.setDotsPerMeterY(dotsPerMeter)
-    image.fill(0)
-
-    # Raster text
-    painter = qt.QPainter()
-    painter.begin(image)
-    painter.setPen(qt.Qt.white)
-    painter.setFont(font)
-    painter.drawText(bounds, qt.Qt.TextExpandTabs, text)
-    painter.end()
-
-    array = convertQImageToArray(image)
-
-    # Remove leading and trailing empty columns/rows but one on each side
-    filled_rows = numpy.nonzero(numpy.sum(array, axis=1))[0]
-    filled_columns = numpy.nonzero(numpy.sum(array, axis=0))[0]
-
-    if len(filled_rows) == 0 or len(filled_columns) == 0:
-        return array, offset
-    return (
-        numpy.ascontiguousarray(
-            array[
-                0 : filled_rows[-1] + 2,
-                max(0, filled_columns[0] - 1) : filled_columns[-1] + 2,
-            ]
-        ),
-        offset,
-    )
-
-
-def rasterText(
-    text: str,
-    font: qt.QFont,
-    dotsPerInch: float = 96.0,
-) -> tuple[numpy.ndarray, float]:
-    """Raster text using Qt or matplotlib if there may be math syntax.
-
-    It supports multiple lines.
-
-    :param text: The text to raster
-    :param font: Font name or QFont to use
-    :param dotsPerInch: Created image resolution
-    :return: Corresponding image in gray scale and baseline offset from top
-    """
-
-    if text.count("$") >= 2:
-        return rasterMathText(text, font, dotsPerInch)
-    return rasterTextQt(text, font, dotsPerInch)

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -749,7 +749,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         # Render marker labels
         gl.glViewport(0, 0, self._plotFrame.size[0], self._plotFrame.size[1])
         for label in labels:
-            label.render(self.matScreenProj)
+            label.render(self.matScreenProj, self._plotFrame.dotsPerInch)
 
     def _renderOverlayGL(self):
         """Render overlay layer: overlay items and crosshair."""

--- a/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -85,6 +85,7 @@ class PlotAxis(object):
         orderOffsetVAlign=CENTER,
         titleRotate=0,
         titleOffset=(0.0, 0.0),
+        font: qt.QFont | None = None,
     ):
         self._tickFormatter = DefaultTickFormatter()
         self._ticks = None
@@ -110,12 +111,19 @@ class PlotAxis(object):
         self._titleVAlign = titleVAlign
         self._titleRotate = titleRotate
         self._titleOffset = titleOffset
+        self._font = font
 
     @property
     def dataRange(self):
         """The range of the data represented on the axis as a tuple
         of 2 floats: (min, max)."""
         return self._dataRange
+
+    @property
+    def font(self) -> qt.QFont:
+        if self._font is None:
+            return qt.QApplication.instance().font()
+        return self._font
 
     @dataRange.setter
     def dataRange(self, dataRange):
@@ -254,9 +262,6 @@ class PlotAxis(object):
         """
         vertices = list(self.displayCoords)  # Add start and end points
         labels = []
-        tickLabelsSize = [0.0, 0.0]
-
-        font = qt.QApplication.instance().font()
 
         xTickLength, yTickLength = self._tickLength
         xTickLength *= self.devicePixelRatio
@@ -269,7 +274,7 @@ class PlotAxis(object):
 
                 label = Text2D(
                     text=text,
-                    font=font,
+                    font=self.font,
                     color=self._foregroundColor,
                     x=xPixel - xTickLength,
                     y=yPixel - yTickLength,
@@ -277,13 +282,6 @@ class PlotAxis(object):
                     valign=self._labelVAlign,
                     devicePixelRatio=self.devicePixelRatio,
                 )
-
-                width, height = label.size
-                if width > tickLabelsSize[0]:
-                    tickLabelsSize[0] = width
-                if height > tickLabelsSize[1]:
-                    tickLabelsSize[1] = height
-
                 labels.append(label)
 
             vertices.append((xPixel, yPixel))
@@ -306,7 +304,7 @@ class PlotAxis(object):
 
         axisTitle = Text2D(
             text=self.title,
-            font=font,
+            font=self.font,
             color=self._foregroundColor,
             x=xAxisCenter + xOffset,
             y=yAxisCenter + yOffset,
@@ -322,7 +320,7 @@ class PlotAxis(object):
             labels.append(
                 Text2D(
                     text=self._orderAndOffsetText,
-                    font=font,
+                    font=self.font,
                     color=self._foregroundColor,
                     x=xOrderOffset,
                     y=yOrderOffet,
@@ -783,7 +781,7 @@ class GLPlotFrame(object):
         gl.glDrawArrays(gl.GL_LINES, 0, len(vertices))
 
         for label in labels:
-            label.render(matProj)
+            label.render(matProj, self.dotsPerInch)
 
     def renderGrid(self):
         if self._grid == self.GRID_NONE:
@@ -831,7 +829,11 @@ class GLPlotFrame2D(GLPlotFrame):
         :type gridColor: tuple RGBA with RGBA values ranging from 0.0 to 1.0
         :param font: Font used by the axes label
         """
-        super(GLPlotFrame2D, self).__init__(marginRatios, foregroundColor, gridColor, font)
+        super(GLPlotFrame2D, self).__init__(
+            marginRatios, foregroundColor, gridColor, font
+        )
+        self._font = font
+
         self.axes.append(
             PlotAxis(
                 self,
@@ -844,6 +846,7 @@ class GLPlotFrame2D(GLPlotFrame):
                 titleAlign=CENTER,
                 titleVAlign=TOP,
                 titleRotate=0,
+                font=self._font,
             )
         )
 
@@ -861,6 +864,7 @@ class GLPlotFrame2D(GLPlotFrame):
                 titleAlign=CENTER,
                 titleVAlign=BOTTOM,
                 titleRotate=ROTATE_270,
+                font=self._font,
             )
         )
 
@@ -875,6 +879,7 @@ class GLPlotFrame2D(GLPlotFrame):
             titleAlign=CENTER,
             titleVAlign=TOP,
             titleRotate=ROTATE_270,
+            font=self._font,
         )
 
         self._isYAxisInverted = False
@@ -1332,10 +1337,9 @@ class GLPlotFrame2D(GLPlotFrame):
         self._x2AxisCoords = ((xCoords[0], yCoords[1]), (xCoords[1], yCoords[1]))
 
         # Set order&offset anchor **before** handling Y axis inversion
-        font = qt.QApplication.instance().font()
-        fontPixelSize = font.pixelSize()
+        fontPixelSize = self._font.pixelSize()
         if fontPixelSize == -1:
-            fontPixelSize = font.pointSizeF() / 72.0 * self.dotsPerInch
+            fontPixelSize = self._font.pointSizeF() / 72.0 * self.dotsPerInch
 
         self.axes[0].orderOffetAnchor = (
             xCoords[1],

--- a/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -25,6 +25,8 @@
 This modules provides the rendering of plot titles, axes and grid.
 """
 
+from __future__ import annotations
+
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "03/04/2017"

--- a/src/silx/gui/plot3d/Plot3DWidget.py
+++ b/src/silx/gui/plot3d/Plot3DWidget.py
@@ -350,7 +350,9 @@ class Plot3DWidget(glu.OpenGLWidget):
         if self.viewport.dirty:
             self.viewport.adjustCameraDepthExtent()
 
-        self._window.render(self.context(), self.getDevicePixelRatio())
+        self._window.render(
+            self.context(), self.getDotsPerInch(), self.getDevicePixelRatio()
+        )
 
         if self._firstRender:  # TODO remove this ugly hack
             self._firstRender = False

--- a/src/silx/gui/plot3d/scene/axes.py
+++ b/src/silx/gui/plot3d/scene/axes.py
@@ -46,7 +46,7 @@ class LabelledAxes(primitives.GroupBBox):
         super(LabelledAxes, self).__init__()
         self._ticksForBounds = None
 
-        self._font = text.Font()
+        self._font = text.Font(size=10)
 
         self._boxVisibility = True
 
@@ -225,6 +225,7 @@ class LabelledAxes(primitives.GroupBBox):
             for tick, label in zip(xticks, xlabels):
                 text2d = text.Text2D(text=label, font=self.font)
                 text2d.align = "center"
+                text2d.valign = "center"
                 text2d.foreground = color
                 text2d.transforms = [
                     transform.Translate(tx=tick, ty=offsets[1], tz=offsets[2])
@@ -234,6 +235,7 @@ class LabelledAxes(primitives.GroupBBox):
             for tick, label in zip(yticks, ylabels):
                 text2d = text.Text2D(text=label, font=self.font)
                 text2d.align = "center"
+                text2d.valign = "center"
                 text2d.foreground = color
                 text2d.transforms = [
                     transform.Translate(tx=offsets[0], ty=tick, tz=offsets[2])
@@ -243,6 +245,7 @@ class LabelledAxes(primitives.GroupBBox):
             for tick, label in zip(zticks, zlabels):
                 text2d = text.Text2D(text=label, font=self.font)
                 text2d.align = "center"
+                text2d.valign = "center"
                 text2d.foreground = color
                 text2d.transforms = [
                     transform.Translate(tx=offsets[0], ty=offsets[1], tz=tick)

--- a/src/silx/gui/plot3d/scene/text.py
+++ b/src/silx/gui/plot3d/scene/text.py
@@ -69,9 +69,7 @@ class Font(event.Notifier):
         "_size", doc="""Font size in points (int)""", converter=int
     )
 
-    weight = event.notifyProperty(
-        "_weight", doc="""Font size in points (int)""", converter=int
-    )
+    weight = event.notifyProperty("_weight", doc="""Font weight (int)""", converter=int)
 
     italic = event.notifyProperty(
         "_italic", doc="""True for italic (bool)""", converter=bool

--- a/src/silx/gui/plot3d/scene/window.py
+++ b/src/silx/gui/plot3d/scene/window.py
@@ -58,6 +58,7 @@ class Context(object):
         self._context = glContextHandle
         self._isCurrent = False
         self._devicePixelRatio = 1.0
+        self._dotsPerInch = 96.0
 
     @property
     def isCurrent(self):
@@ -73,6 +74,16 @@ class Context(object):
         :param bool isCurrent: The state of the system OpenGL context.
         """
         self._isCurrent = bool(isCurrent)
+
+    @property
+    def dotsPerInch(self) -> float:
+        """Number of physical dots per inch on the screen"""
+        return self._dotsPerInch
+
+    @dotsPerInch.setter
+    def dotsPerInch(self, dpi: float):
+        assert dpi > 0.0
+        self._dotsPerInch = float(dpi)
 
     @property
     def devicePixelRatio(self):
@@ -350,11 +361,12 @@ class Window(event.Notifier):
 
         return numpy.array(image, copy=False, order="C")
 
-    def render(self, glcontext, devicePixelRatio):
+    def render(self, glcontext, dotsPerInch: float, devicePixelRatio: float):
         """Perform the rendering of attached viewports
 
         :param glcontext: System identifier of the OpenGL context
-        :param float devicePixelRatio:
+        :param dotsPerInch: Screen physical resolution in pixels per inch
+        :param devicePixelRatio:
             Ratio between device and device-independent pixels
         """
         if self.size == (0, 0):
@@ -364,6 +376,7 @@ class Window(event.Notifier):
             self._contexts[glcontext] = ContextGL2(glcontext)  # New context
 
         with self._contexts[glcontext] as context:
+            context.dotsPerInch = dotsPerInch
             context.devicePixelRatio = devicePixelRatio
             if self._isframebuffer:
                 self._renderWithOffscreenFramebuffer(context)

--- a/src/silx/gui/utils/matplotlib.py
+++ b/src/silx/gui/utils/matplotlib.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2016-2023 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2024 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -129,15 +129,15 @@ def rasterMathText(
         parser.parse(line, prop=font_prop, dpi=dotsPerInch)
         for line in stripped_text.split("\n")
     ]
-    max_line_width = max(info.width for info in lines_info)
+    max_line_width = max(info[0] for info in lines_info)
     # Use lp string as minimum height/ascent
     ref_info = parser.parse("lp", prop=font_prop, dpi=dotsPerInch)
     line_height = max(
-        ref_info.height,
-        *(info.height for info in lines_info),
+        ref_info[1],
+        *(info[1] for info in lines_info),
     )
     first_line_ascent = max(
-        ref_info.height - ref_info.depth, lines_info[0].height - lines_info[0].depth
+        ref_info[1] - ref_info[2], lines_info[0][1] - lines_info[0][2]
     )
 
     linespacing = 1.2
@@ -160,7 +160,7 @@ def rasterMathText(
     text.set_linespacing(linespacing)
     with io.BytesIO() as buffer:
         fig.savefig(buffer, dpi=dotsPerInch, format="raw")
-        canvas_width, canvas_height = fig.canvas.get_width_height(physical=True)
+        canvas_width, canvas_height = fig.get_window_extent().max
         buffer.seek(0)
         image = numpy.frombuffer(buffer.read(), dtype=numpy.uint8).reshape(
             int(canvas_height), int(canvas_width), 4

--- a/src/silx/gui/utils/matplotlib.py
+++ b/src/silx/gui/utils/matplotlib.py
@@ -88,7 +88,7 @@ def qFontToFontProperties(font: qt.QFont):
     weightFactor = 10 if qt.BINDING == "PyQt5" else 1
     families = [font.family(), font.defaultFamily()]
     if _MATPLOTLIB_VERSION >= Version("3.6.0"):
-        # Prevent 'Font family not found warnings'
+        # Prevent 'Font family not found' warnings
         availableNames = font_manager.get_font_names()
         families = [f for f in families if f in availableNames]
         families.append(font_manager.fontManager.defaultFamily["ttf"])


### PR DESCRIPTION
This PR reworks the way to raster text in with OpenGL to (1) take into account the screen DPI and (2) use matplotlib math text parsing.
In `PlotWidget` OpenGL backend, the default font from matplotlib is used for all text in axes and title.
This requires `matplotlib>=3.1`.


It also removes a usage of `QScreen.logicalDotsPerInchY` which might returned a wrong value (this complement PR #4038)


BTW, `compareBackends.py` (PR #4031) is very useful!


Related to #4025 and #4007