### PR TITLE
DataUrl: fix: allow file_path to be None

### DIFF
--- a/src/silx/io/test/test_url.py
+++ b/src/silx/io/test/test_url.py
@@ -268,3 +268,33 @@ def test_path_creation(data):
     path = url.path()
     DataUrl(path=path)
     assert path == expected_path
+
+
+def test_file_path_none():
+    """
+    make sure a file path can be None
+    """
+    url = DataUrl(scheme="silx", file_path=None, data_path="/path/to/data")
+    assert url.file_path() is None
+    assert url.scheme() == "silx"
+    assert url.data_path() == "/path/to/data"
+
+
+def test_data_path_none():
+    """
+    make sure a data path can be None
+    """
+    url = DataUrl(scheme="silx", file_path="my_file.hdf5", data_path=None)
+    assert url.file_path() == "my_file.hdf5"
+    assert url.scheme() == "silx"
+    assert url.data_path() is None
+
+
+def test_scheme_none():
+    """
+    make sure a scheme can be None
+    """
+    url = DataUrl(scheme=None, file_path="my_file.hdf5", data_path="/path/to/data")
+    assert url.file_path() == "my_file.hdf5"
+    assert url.scheme() is None
+    assert url.data_path() == "/path/to/data"

--- a/src/silx/io/url.py
+++ b/src/silx/io/url.py
@@ -140,7 +140,9 @@ class DataUrl(object):
             assert scheme is None
             self.__parse_from_path(str(path))
         else:
-            self.__file_path = str(file_path)
+            if file_path is not None:
+                file_path = str(file_path)
+            self.__file_path = file_path
             self.__data_path = data_path
             self.__data_slice = data_slice
             self.__scheme = scheme


### PR DESCRIPTION
fix some typo when dealing with `DataUrl` file_path