### PR TITLE
[2.0] silx.io.utils.h5py_read_dataset: Fixed support of empty arrays

### DIFF
--- a/src/silx/io/test/test_utils.py
+++ b/src/silx/io/test/test_utils.py
@@ -900,6 +900,12 @@ class TestH5Strings(unittest.TestCase):
         if charset is not None:
             assert self.file["vlen_data"].id.get_type().get_cset() == charset
 
+        self.file["vlen_empty_array"] = self._make_array(value, 0)
+        data = utils.h5py_read_dataset(
+            self.file["vlen_empty_array"], decode_ascii=decode_ascii
+        )
+        assert data.shape == (0,)
+
         # Write+read fixed length
         self.file["flen_data"] = self._make_array(value, 2, vlen=False)
         data = utils.h5py_read_dataset(

--- a/src/silx/io/utils.py
+++ b/src/silx/io/utils.py
@@ -1223,7 +1223,10 @@ def h5py_value_isinstance(value, vtype):
         except AttributeError:
             pass
     else:
-        value = value[0]
+        try:
+            value = value[0]
+        except IndexError:
+            pass
     return isinstance(value, vtype)
 
 


### PR DESCRIPTION
This PR fixes support of `h5py_read_dataset` with empty arrays (It was raising an exception) and updates tests to check it (related to PR #3748).


<!--
You are encouraged to write a PR title that is meaningful by itself.
It will be used to auto-generate the complete changelog.

To highlight a change in the changelog, please add a line starting with `Changelog: ` in the PR description.
It will be used to generate the changelog's summary.

E.g., Changelog: Added new wonderful feature
-->


Changelog: 
