### PR TITLE
[2.0] silx.gui.plot: Fixed ROI initialisation with parent

### DIFF
--- a/src/silx/gui/plot/items/_roi_base.py
+++ b/src/silx/gui/plot/items/_roi_base.py
@@ -253,6 +253,8 @@ class RegionOfInterest(_RegionOfInterestBase, core.HighlightedMixIn):
         from ..tools import roi as roi_tools
 
         assert parent is None or isinstance(parent, roi_tools.RegionOfInterestManager)
+        # Must be done before _RegionOfInterestBase.__init__
+        self._child = WeakList()
         _RegionOfInterestBase.__init__(self, parent)
         core.HighlightedMixIn.__init__(self)
         self.__text = None
@@ -261,7 +263,6 @@ class RegionOfInterest(_RegionOfInterestBase, core.HighlightedMixIn):
         self._selectable = False
         self._focusProxy = None
         self._visible = True
-        self._child = WeakList()
 
     def _connectToPlot(self, plot):
         """Called after connection to a plot"""

--- a/src/silx/gui/plot/tools/test/testRoiCore.py
+++ b/src/silx/gui/plot/tools/test/testRoiCore.py
@@ -279,6 +279,14 @@ class TestRegionOfInterestManager(TestCaseQt, ParametricTestCase):
         manager.removeRoi(item1)
         self.assertIs(manager.getCurrentRoi(), None)
 
+    def testInitROIWithParent(self):
+        manager = roi.RegionOfInterestManager(self.plot)
+        item = roi_items.PointROI(manager)
+        manager.addRoi(item)
+        self.qapp.processEvents()
+        manager.removeRoi(item)
+        self.qapp.processEvents()
+
     def testMaxROI(self):
         """Test Max ROI"""
         origin1 = numpy.array([1.0, 10.0])


### PR DESCRIPTION
This PR fixes and issue with ROI when passing the manager as parent when creating the ROI and adds a test for it.

This should fix issue spotted by bliss CI: https://gitlab.esrf.fr/bliss/bliss/-/jobs/927560