### PR TITLE
Documentation: Changed guideline to provide changelog in PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,14 @@
 <!--
-You are encouraged to write a PR title that is meaningful by itself.
-It will be used to auto-generate the complete changelog.
+Thank you for your pull request!
 
-To highlight a change in the changelog, please add a line starting with `Changelog: ` in the PR description.
-It will be used to generate the changelog's summary.
-
-E.g., Changelog: Added new wonderful feature
+Please use a Pull Request title that follows the requested syntax since it will be included in the release notes), see:
+https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format
 -->
 
+Checklist:
 
-Changelog: 
+- [ ] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))
+
+<hr>
+
+<!-- provide a description of the changes below -->

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -47,5 +47,38 @@ The process is similar to many other open-source projects like *numpy*, just lig
 
 If you encounter any problems or have any questions you can always ask on the `Issues page`_.
 
+
+Pull Request title format
+.........................
+
+To ease release notes authoring, please use the following syntax for the title of your Pull Requests (PR)::
+
+  <Subpackage/Module/Topic>: <Action> <summary of the main change affecting silx's users>
+
+
+With:
+
+- **Subpackage/Topic**: One of:
+
+  - A subpackage or a module: Use the fully qualified name of the subpackage or module of silx the PR is changing.
+    For example: ``silx.gui.qt`` or ``silx.gui.plot.PlotWidget``.
+  - A topic: If changes do not affect a particular subpackage or module, provide the topic of the change.
+    This can be for example: ``Build``, ``Documentation``, ``CI``,... or the name of a silx application (e.g., ``silx view``).
+
+- **Action**: How the changes affects the project from a silx user point of view.
+  Prefer using one of the following actions:
+
+  - **Added**: For new feature or new APIs
+  - **Deprecated**
+  - **Removed**
+  - **Changed**
+  - **Improved**
+  - **Refactored**
+  - **Fixed**
+  - More: If none of the previous actions match your changes, please use another keyword.
+
+- **Summary**: A short description of the main change as you would like to read it from release notes.
+
+
 .. _their own CONTRIBUTING guide: https://github.com/scikit-image/scikit-image/blob/3736339272b9d129f98fc723b508ac5490c171fa/CONTRIBUTING.rst
 .. _Issues page: https://github.com/silx-kit/silx/issues


### PR DESCRIPTION
<!--
Thank you for your pull request!
Please use a Pull Request title that follows the requested syntax since it will be included in the release notes, see:
https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format
-->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->


This PR proposes to change the guidelines of how to provide information in PRs for the release notes.
The goal is:

- (1) to keep it simple and easy so we are not bored to do it for each PR (e.g., adding a specific file to each PR to document the changes or filling the changelog.rst file for each PR),
- (2) to ease the authoring of release notes. It's quite long to manually sort PRs by subpackages and by kind of changes, while with a formatting convention it can be automated.

I'd take any better approach/convention for naming the kind changes/etc! and if there is something already existing, even better!
What do you think?
 

