### PR TITLE
Documentation: Updated to use `sphinx-design` instead of `sphinx-panels`

### DIFF
--- a/doc/source/applications/compare.rst
+++ b/doc/source/applications/compare.rst
@@ -1,4 +1,4 @@
-.. _silx compare:
+.. _silx-compare:
 
 silx compare
 ============

--- a/doc/source/applications/convert.rst
+++ b/doc/source/applications/convert.rst
@@ -1,3 +1,4 @@
+.. _silx-convert:
 
 silx convert
 ============

--- a/doc/source/applications/view.rst
+++ b/doc/source/applications/view.rst
@@ -1,4 +1,4 @@
-.. _silx view:
+.. _silx-view:
 
 silx view
 =========

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -67,7 +67,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.doctest",
     "sphinx.ext.inheritance_diagram",
-    "sphinx_panels",
+    "sphinx_design",
     "sphinxext-archive",
     "snapshotqt_directive",
     "nbsphinx",
@@ -113,9 +113,10 @@ release = strictversion
 # Substitutions defined for all pages
 rst_prolog = f"""
 .. |silx_installer_btn| replace::
-   .. link-button:: https://github.com/silx-kit/silx/releases/download/v{release}/silx-{release}-windows-installer-x86_64.exe
-      :classes: btn-success
-      :text: Download Windows installer
+   .. button-link:: https://github.com/silx-kit/silx/releases/download/v{release}/silx-{release}-windows-installer-x86_64.exe
+      :color: success
+
+      **Download Windows installer**
 
 .. |silx_archive| replace:: :download:`silx ZIP archive <https://github.com/silx-kit/silx/releases/download/v{release}/silx-{release}-windows-application.zip>`
 """

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -21,113 +21,106 @@ reduction routines and a set of Qt widgets to browse and visualise data.
 
 You can install **silx** via `pip <https://pypi.org/project/pip>`_, `conda <https://docs.conda.io>`_ or on Linux with the following commands:
 
-.. tabbed:: pip
+.. tab-set::
 
-   .. code-block:: bash
+   .. tab-item:: pip
 
-      pip install silx[full]
+      .. code-block:: bash
 
-.. tabbed:: conda
+         pip install silx[full]
 
-   .. code-block:: bash
+   .. tab-item:: conda
 
-      conda install -c conda-forge silx
+      .. code-block:: bash
 
-.. tabbed:: Debian & Ubuntu
+         conda install -c conda-forge silx
 
-   .. code-block:: bash
+   .. tab-item:: Debian & Ubuntu
 
-      sudo apt-get install silx
+      .. code-block:: bash
+
+         sudo apt-get install silx
 
 |silx_installer_btn| or decompress the |silx_archive|.
 
 :ref:`Applications`
 -------------------
 
-.. panels::
+.. grid:: 1 2 2 2
+   :gutter: 2
 
-   :column: col-lg-12
-   :body: text-center
+   .. grid-item-card::
+      :columns: 12
+      :text-align: center
+      :link: silx-view
+      :link-type: ref
 
-   **silx view**
-   ^^^^^^^^^^^^^
+      silx view
+      ^^^
 
-   .. image:: img/silx-view.gif
+      .. image:: img/silx-view.gif
 
-   .. link-button:: applications/view
-      :type: ref
-      :text: Unified viewer supporting HDF5, SPEC and image file formats
-      :classes: stretched-link
+      Unified viewer supporting HDF5, SPEC and image file formats
 
-   ---
+   .. grid-item-card::
+      :text-align: center
+      :link: silx-compare
+      :link-type: ref
 
-   **silx compare**
-   ^^^^^^^^^^^^^^^^
+      silx compare
+      ^^^
 
-   .. image:: applications/img/silx-compare.png
+      .. image:: applications/img/silx-compare.png
 
-   .. link-button:: applications/compare
-      :type: ref
-      :text: User interface to compare 2D data from files
-      :classes: stretched-link
+      User interface to compare 2D data from files
 
-   ---
+   .. grid-item-card::
+      :text-align: center
+      :link: silx-convert
+      :link-type: ref
 
-   **silx convert**
-   ^^^^^^^^^^^^^^^^
+      silx convert
+      ^^^
 
-   .. link-button:: applications/convert
-      :type: ref
-      :text: Converter of legacy file formats into HDF5 file
-      :classes: stretched-link
+      Converter of legacy file formats into HDF5 file
 
 :ref:`Python modules<API Reference>`
 ------------------------------------
 
-.. panels::
+.. grid:: 1 2 2 2
+   :gutter: 2
 
-   **silx.gui**
-   ^^^^^^^^^^^^
+   .. grid-item-card:: Qt widgets
+      :link: module-silx-gui
+      :link-type: ref
 
-   .. link-button:: modules/gui/index
-      :type: ref
-      :text: Qt widgets:
-      :classes: stretched-link
+      silx.gui
+      ^^^
+      * 1D and 2D visualization widgets and associated tools
+      * OpenGL-based 3D visualization widgets
+      * A unified HDF5, SPEC and image data file browser and n-dimensional dataset viewer
 
-   * 1D and 2D visualization widgets and associated tools
-   * OpenGL-based 3D visualization widgets
-   * a unified HDF5, SPEC and image data file browser and n-dimensional dataset viewer
+   .. grid-item-card:: OpenCL-based data processing
+      :link: module-silx-opencl
+      :link-type: ref
 
-   ---
+      silx.opencl
+      ^^^
 
-   **silx.opencl**
-   ^^^^^^^^^^^^^^^
+      * Image alignment (SIFT)
+      * Image processing (median filter, histogram)
+      * Filtered backprojection for tomography
 
-   .. link-button:: modules/opencl/index
-      :type: ref
-      :text: OpenCL-based data processing:
-      :classes: stretched-link
+   .. grid-item-card:: Supporting HDF5, SPEC and FabIO images file formats
+      :link: module-silx-io
+      :link-type: ref
 
-   * Image alignment (SIFT)
-   * Image processing (median filter, histogram)
-   * Filtered backprojection for tomography
+      silx.io
+      ^^^
 
-   ---
+   .. grid-item-card:: Data reduction: histogramming, fitting, median filter
+      :link: module-silx-math
+      :link-type: ref
 
-   **silx.io**
-   ^^^^^^^^^^^
-
-   .. link-button:: modules/io/index
-      :type: ref
-      :text: Supporting HDF5, SPEC and FabIO images file formats
-      :classes: stretched-link
-
-   ---
-
-   **silx.math**
-   ^^^^^^^^^^^^^
-
-   .. link-button:: modules/math/index
-      :type: ref
-      :text: Data reduction: histogramming, fitting, median filter
-      :classes: stretched-link
+      silx.math
+      ^^^

--- a/doc/source/modules/gui/index.rst
+++ b/doc/source/modules/gui/index.rst
@@ -1,3 +1,4 @@
+.. _module-silx-gui:
 
 .. py:module:: silx.gui
 

--- a/doc/source/modules/io/index.rst
+++ b/doc/source/modules/io/index.rst
@@ -1,3 +1,4 @@
+.. _module-silx-io:
 
 .. py:module:: silx.io
 

--- a/doc/source/modules/math/index.rst
+++ b/doc/source/modules/math/index.rst
@@ -1,3 +1,4 @@
+.. _module-silx-math:
 
 .. py:module:: silx.math
 

--- a/doc/source/modules/opencl/index.rst
+++ b/doc/source/modules/opencl/index.rst
@@ -1,3 +1,4 @@
+.. _module-silx-opencl:
 
 .. py:module:: silx.opencl
 

--- a/doc/source/user_guide.rst
+++ b/doc/source/user_guide.rst
@@ -32,7 +32,7 @@ The current version (v\ |version|) caters for:
 
 * a set of applications:
 
-    * a unified viewer (:ref:`silx view` *filename*) for HDF5, SPEC and image file formats
+    * a unified viewer (:ref:`silx-view` *filename*) for HDF5, SPEC and image file formats
 
       |silxView|
 

--- a/package/debian12/control
+++ b/package/debian12/control
@@ -33,7 +33,6 @@ Build-Depends: cython3 (>= 0.23.2),
                python3-scipy,
                python3-setuptools,
                python3-sphinx,
-               python3-sphinx-panels,
                python3-sphinxcontrib.programoutput,
                xauth,
                xvfb
@@ -95,29 +94,3 @@ Description: Toolbox for X-Ray data analysis - Python3
     isosurface and cutting plane.
  .
  This is the Python 3 version of the package.
-
-Package: python-silx-doc
-Architecture: all
-Section: doc
-Depends: libjs-mathjax, ${misc:Depends}, ${sphinxdoc:Depends}
-Description: Toolbox for X-Ray data analysis - Documentation
- The silx project aims at providing a collection of Python packages to
- support the development of data assessment, reduction and analysis
- applications at synchrotron radiation facilities. It aims at
- providing reading/writing different file formats, data reduction
- routines and a set of Qt widgets to browse and visualize data.
- .
- The current version provides :
- .
-  * reading HDF5 file format (with support of SPEC file format)
-  * histogramming
-  * fitting
-  * 1D and 2D visualization using multiple backends (matplotlib or OpenGL)
-  * image plot widget with a set of associated tools (See changelog file).
-  * Unified browser for HDF5, SPEC and image file formats supporting inspection
-    and visualization of n-dimensional datasets.
-  * Unified viewer (silx view filename) for HDF5, SPEC and image file formats
-  * OpenGL-based widget to display 3D scalar field with
-    isosurface and cutting plane.
- .
- This is the common documentation package.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ build             # To build the project
 wheel             # To build wheels
 Sphinx            # To build the documentation in doc/
 sphinx-autodoc-typehints  # For leveraging Python type hints from Sphinx
-sphinx-panels     # For tabs and grid in documentation
+sphinx-design     # For tabs and grid in documentation
 pillow            # For loading images in documentation generation
 pydata_sphinx_theme  # Sphinx theme
 nbsphinx          # For converting ipynb in documentation

--- a/setup.py
+++ b/setup.py
@@ -203,7 +203,7 @@ def get_project_configuration():
         "pydata_sphinx_theme",
         "sphinx",
         "sphinx-autodoc-typehints",
-        "sphinx-panels",
+        "sphinx-design",
     }
 
     extras_require = {


### PR DESCRIPTION
This PR switches the documentation from `sphinx-panels`  to `sphinx-design`.
This is at the expense of no longer building the documentation with Debian12 since it does not provide `sphinx-design`.

closes #4062
