### PR TITLE
silx.io.specfile, silx.math.marchingcubes: Fixed compilation warnings

### DIFF
--- a/src/silx/io/specfile/src/sfinit.c
+++ b/src/silx/io/specfile/src/sfinit.c
@@ -792,6 +792,7 @@ static void
 sfAssignScanNumbers(SpecFile *sf) {
 
   int i;
+  long bytesread;
   char *ptr;
   char buffer[50];
   char buffer2[50];
@@ -805,7 +806,10 @@ sfAssignScanNumbers(SpecFile *sf) {
         scan = (SpecScan *) object->contents;
 
         lseek(sf->fd,scan->offset,SEEK_SET);
-        read(sf->fd,buffer,sizeof(buffer));
+        bytesread = read(sf->fd,buffer,sizeof(buffer));
+        if (bytesread <= 4) {
+            continue;
+        }
         buffer[49] = '\0';
 
         for ( ptr = buffer+3,i=0; *ptr != ' ';ptr++,i++) buffer2[i] = *ptr;

--- a/src/silx/math/marchingcubes.pyx
+++ b/src/silx/math/marchingcubes.pyx
@@ -39,19 +39,6 @@ cimport cython
 cimport silx.math.mc as mc
 
 
-# From numpy_common.pxi to avoid warnings while compiling C code
-# See this thread:
-# https://mail.python.org/pipermail//cython-devel/2012-March/002137.html
-cdef extern from *:
-    bint FALSE "0"
-    void import_array()
-    void import_umath()
-
-if FALSE:
-    import_array()
-    import_umath()
-
-
 cdef class MarchingCubes:
     """Compute isosurface using marching cubes algorithm.
 


### PR DESCRIPTION
This PR fixes compilation warnings reported by debian packaging:
- Remove previous workaround in cython that was there to avoid warnings but is now causing some...
- Use read value: Now skip erroneous cases where it would have read random buffer anyway


closes #4060
