### PR TITLE
Build: Fixed Debian12 packaging by removing build of documentation

### DIFF
--- a/package/debian12/rules
+++ b/package/debian12/rules
@@ -25,7 +25,7 @@ ALL_PYX := $(call rwildcard,silx/,*.pyx)
 PY3VER := $(shell py3versions -dv)
 
 %:
-	dh $@ --with python3,sphinxdoc --buildsystem=pybuild
+	dh $@ --with python3 --buildsystem=pybuild
 
 override_dh_clean:
 	dh_clean
@@ -72,12 +72,3 @@ override_dh_auto_test:
 
 override_dh_installman:
 	dh_installman -p silx build/man/*.1
-
-override_dh_sphinxdoc:
-ifeq (,$(findstring nodocs, $(DEB_BUILD_OPTIONS)))
-	#mkdir -p $(POCL_CACHE_DIR) # create POCL cachedir in order to avoid an FTBFS in sbuild
-	mkdir -p -m 700 $(XDG_RUNTIME_DIR)
-	pybuild --build -s custom -p $(PY3VER) --build-args="cd doc && env PYTHONPATH={build_dir} http_proxy='127.0.0.1:9' xvfb-run -a --server-args=\"-screen 0 1024x768x24\" {interpreter} -m sphinx -N -bhtml source build/html"
-	dh_installdocs "doc/build/html" -p python-silx-doc --doc-main-package=python3-silx
-	dh_sphinxdoc -O--buildsystem=pybuild
-endif


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please use a Pull Request title that follows the requested syntax since it will be included in the release notes), see:
https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format
-->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->


Following PR #4063, documentation no longer build on Debian12. This PR removes the build of documentation during the packaging that should have been removed in PR #4063.