### PR TITLE
silx.io.h5py_utils: avoid overwriting parameters provided to h5py.Fil…

### DIFF
--- a/src/silx/io/h5py_utils.py
+++ b/src/silx/io/h5py_utils.py
@@ -388,7 +388,7 @@ class File(h5py.File):
             )
             if locking is None:
                 locking = enable_file_locking
-        locking = _hdf5_file_locking(
+        _hdf5_file_locking(
             mode=mode, locking=locking, swmr=swmr, libver=libver
         )
         if self._LOCKING_MGR is None:


### PR DESCRIPTION
`locking` is overwritten and it seems to change reading behavior (close #4069 )
Simply avoiding overwrite of this parameter seems to work. But might be too simplistic.