### PR TITLE
silx.io: Changed `open` function behavior: lock HDF5 files when opening them

### DIFF
--- a/src/silx/gui/hdf5/test/test_hdf5.py
+++ b/src/silx/gui/hdf5/test/test_hdf5.py
@@ -39,7 +39,6 @@ from silx.gui.utils.testutils import TestCaseQt
 from silx.gui import hdf5
 from silx.gui.utils.testutils import SignalListener
 from silx.io import commonh5
-from silx.io import h5py_utils
 from silx.io.url import DataUrl
 import weakref
 
@@ -55,7 +54,7 @@ def useH5File(request, tmpdir_factory):
     tmp = tmpdir_factory.mktemp("test_hdf5")
     request.cls.filename = os.path.join(tmp, "data.h5")
     # create h5 data
-    with h5py_utils.File(request.cls.filename, "w") as f:
+    with h5py.File(request.cls.filename, "w") as f:
         g = f.create_group("arrays")
         g.create_dataset("scalar", data=10)
     yield
@@ -87,7 +86,7 @@ class TestHdf5TreeModel(TestCaseQt):
         fd, tmp_name = tempfile.mkstemp(suffix=".h5")
         os.close(fd)
         # create h5 data
-        h5file = h5py_utils.File(tmp_name, "w")
+        h5file = h5py.File(tmp_name, "w")
         g = h5file.create_group("arrays")
         g.create_dataset("scalar", data=10)
         h5file.close()
@@ -162,7 +161,7 @@ class TestHdf5TreeModel(TestCaseQt):
         self.assertEqual(model.rowCount(qt.QModelIndex()), 0)
 
     def testSynchronizeObject(self):
-        h5 = h5py_utils.File(self.filename, mode="r")
+        h5 = h5py.File(self.filename, mode="r")
         model = hdf5.Hdf5TreeModel()
         model.insertH5pyObject(h5)
         self.assertEqual(model.rowCount(qt.QModelIndex()), 1)
@@ -237,7 +236,7 @@ class TestHdf5TreeModel(TestCaseQt):
         """A file inserted as an h5py object is not open (then not closed)
         internally."""
         try:
-            h5File = h5py_utils.File(self.filename, mode="r")
+            h5File = h5py.File(self.filename, mode="r")
             model = hdf5.Hdf5TreeModel()
             self.assertEqual(model.rowCount(qt.QModelIndex()), 0)
             model.insertH5pyObject(h5File)
@@ -421,7 +420,7 @@ class TestHdf5TreeModelSignals(TestCaseQt):
     def setUp(self):
         TestCaseQt.setUp(self)
         self.model = hdf5.Hdf5TreeModel()
-        self.h5 = h5py_utils.File(self.filename, mode="r")
+        self.h5 = h5py.File(self.filename, mode="r")
         self.model.insertH5pyObject(self.h5)
 
         self.listener = SignalListener()
@@ -449,7 +448,7 @@ class TestHdf5TreeModelSignals(TestCaseQt):
             raise RuntimeError("Still waiting for a pending operation")
 
     def testInsert(self):
-        h5 = h5py_utils.File(self.filename, mode="r")
+        h5 = h5py.File(self.filename, mode="r")
         self.model.insertH5pyObject(h5)
         self.assertEqual(self.listener.callCount(), 0)
 
@@ -652,7 +651,7 @@ def useH5Model(request, tmpdir_factory):
     extH5FileName = os.path.join(tmp, "base__external.h5")
     extDatFileName = os.path.join(tmp, "base__external.dat")
 
-    externalh5 = h5py_utils.File(extH5FileName, mode="w")
+    externalh5 = h5py.File(extH5FileName, mode="w")
     externalh5["target/dataset"] = 50
     externalh5["target/link"] = h5py.SoftLink("/target/dataset")
     externalh5["/ext/vds0"] = [0, 1]
@@ -661,7 +660,7 @@ def useH5Model(request, tmpdir_factory):
 
     numpy.array([0, 1, 10, 10, 2, 3]).tofile(extDatFileName)
 
-    h5 = h5py_utils.File(filename, mode="w")
+    h5 = h5py.File(filename, mode="w")
     h5["group/dataset"] = 50
     h5["link/soft_link"] = h5py.SoftLink("/group/dataset")
     h5["link/soft_link_to_group"] = h5py.SoftLink("/group")
@@ -698,7 +697,7 @@ def useH5Model(request, tmpdir_factory):
         h5["/ext"].create_dataset("raw", shape=(2, 2), dtype=int, external=external)
         h5.close()
 
-    with h5py_utils.File(filename, mode="r") as h5File:
+    with h5py.File(filename, mode="r") as h5File:
         # Create model
         request.cls.model = hdf5.Hdf5TreeModel()
         request.cls.model.insertH5pyObject(h5File)

--- a/src/silx/io/utils.py
+++ b/src/silx/io/utils.py
@@ -555,7 +555,10 @@ def _open_local_file(filename):
                 )
 
         if h5py.is_hdf5(filename):
-            return h5py_utils.File(filename, "r")
+            try:
+                return h5py.File(filename, "r")
+            except OSError:
+                return h5py.File(filename, "r", libver='latest', swmr=True)
 
         try:
             from . import fabioh5


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please use a Pull Request title that follows the requested syntax since it will be included in the release notes), see:
https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format
-->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->


This PR reverts PR #3939 which disabled HDF5 file locking when opening a file with `silx.io.open`.
Disabling HDF5 file locking is causing trouble (see #4071) because there is an issue with external links when file locking is disabled (see https://forum.hdfgroup.org/t/external-link-and-file-locking-disabled-issue/12012).
So as of today, disabling file locking when opening a HDf5 file is not safe and IMO shouldn't be the default.

Looking at the [Larch](https://github.com/xraypy/xraylarch/blob/master/larch/io/specfile_reader.py) link in the issues PR #3939 solved(see issues #3938, #3936), it looks it is calling directly `h5py_utils.File` instead of `silx.io.open` for hdf5 file so it should not be affected.

attn @woutdenolf @maurov 