### PR TITLE
`silx.resources`: Changed dependency from deprecated `pkg_resources` to `importlib_resources` for Python<3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ Cython >= 0.21.1
 packaging
 h5py
 fabio >= 0.9
+importlib_resources; python_version < '3.9'
 
 # Extra dependencies (from setup.py extra_requires 'full' target)
 pyopencl; platform_machine in "i386, x86_64, AMD64"  # For silx.opencl

--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,7 @@ def get_project_configuration():
         "fabio>=0.9",
     ]
     if sys.version_info < (3, 9):
-        install_requires.append("setuptools")  # For pkg_resources
+        install_requires.append("importlib_resources")
 
     # extras requirements: target 'full' to install all dependencies at once
     full_requires = [

--- a/src/silx/resources/__init__.py
+++ b/src/silx/resources/__init__.py
@@ -62,15 +62,15 @@ __date__ = "08/03/2019"
 import atexit
 import contextlib
 import functools
-import importlib
-import importlib.resources
 import logging
 import os
 import sys
 from typing import NamedTuple, Optional
 
 if sys.version_info < (3, 9):
-    import pkg_resources
+    import importlib_resources
+else:
+    import importlib.resources as importlib_resources
 
 
 logger = logging.getLogger(__name__)
@@ -155,12 +155,7 @@ def list_dir(resource: str) -> list[str]:
         path = resource_filename(resource)
         return os.listdir(path)
 
-    if sys.version_info < (3, 9):
-        return pkg_resources.resource_listdir(
-            resource_directory.package_name, resource_name
-        )
-
-    path = importlib.resources.files(resource_directory.package_name) / resource_name
+    path = importlib_resources.files(resource_directory.package_name) / resource_name
     return [entry.name for entry in path.iterdir()]
 
 
@@ -244,12 +239,9 @@ def _get_resource_filename(package: str, resource: str) -> str:
     :param resource: Resource path relative to package using '/' path separator
     :return: Abolute resource path in the file system
     """
-    if sys.version_info < (3, 9):
-        return pkg_resources.resource_filename(package, resource)
-
     # Caching prevents extracting the resource twice
-    file_context = importlib.resources.as_file(
-        importlib.resources.files(package) / resource
+    file_context = importlib_resources.as_file(
+        importlib_resources.files(package) / resource
     )
     path = _file_manager.enter_context(file_context)
     return str(path.absolute())


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please use a Pull Request title that follows the requested syntax since it will be included in the release notes), see:
https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format
-->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->
This PR replaces usage of `pkg_resources` with `importlib_resources` backport package for Python<3.9

Closes #4075 