### PR TITLE
`silx.gui.plot.PlotWidget`: Fixed support of negative error values for curves and scatter plot 

### DIFF
--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -1555,11 +1555,11 @@ class PointsBase(DataItem, SymbolMixIn, AlphaMixIn):
                 y = numpy.array(y, copy=True, dtype=numpy.float64)
                 y[clipped] = numpy.nan
 
-                if xPositive and xerror is not None:
-                    xerror = self._logFilterError(x, xerror)
+            if xPositive and xerror is not None:
+                xerror = self._logFilterError(x, xerror)
 
-                if yPositive and yerror is not None:
-                    yerror = self._logFilterError(y, yerror)
+            if yPositive and yerror is not None:
+                yerror = self._logFilterError(y, yerror)
 
         return x, y, xerror, yerror
 

--- a/src/silx/gui/plot/items/scatter.py
+++ b/src/silx/gui/plot/items/scatter.py
@@ -930,8 +930,8 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
             )
         return self.__interpolatorFuture
 
-    def _logFilterData(self, xPositive, yPositive):
-        """Filter out values with x or y <= 0 on log axes
+    def _filterData(self, xPositive: bool, yPositive: bool):
+        """Filter out errors<0 and values with x or y <= 0 on log axes
 
         :param bool xPositive: True to filter arrays according to X coords.
         :param bool yPositive: True to filter arrays according to Y coords.
@@ -949,7 +949,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
                 value = numpy.array(value, copy=True, dtype=numpy.float64)
                 value[clipped] = numpy.nan
 
-        x, y, xerror, yerror = PointsBase._logFilterData(self, xPositive, yPositive)
+        x, y, xerror, yerror = PointsBase._filterData(self, xPositive, yPositive)
 
         return x, y, value, xerror, yerror
 

--- a/src/silx/gui/plot/test/testPlotWidget.py
+++ b/src/silx/gui/plot/test/testPlotWidget.py
@@ -1687,23 +1687,26 @@ class TestPlotCurveLog(PlotWidgetTestCase, ParametricTestCase):
 
                 self.qapp.processEvents()
 
-                if xError is None:
-                    dataMin, dataMax = numpy.min(self.xData), numpy.max(self.xData)
-                else:
+                dataMin, dataMax = numpy.min(self.xData), numpy.max(self.xData)
+                if xError is not None:
+                    if isinstance(xError, numpy.ndarray) and xError.shape[-1] == 1:
+                        xError = numpy.ravel(xError)
                     xMinusError = self.xData - numpy.atleast_2d(xError)[0]
-                    dataMin = numpy.min(xMinusError[xMinusError > 0])
+                    dataMin = min(dataMin, numpy.min(xMinusError[xMinusError > 0]))
                     xPlusError = self.xData + numpy.atleast_2d(xError)[-1]
-                    dataMax = numpy.max(xPlusError[xPlusError > 0])
+                    dataMax = max(dataMax, numpy.max(xPlusError[xPlusError > 0]))
                 plotMin, plotMax = self.plot.getXAxis().getLimits()
                 assert numpy.allclose((dataMin, dataMax), (plotMin, plotMax))
 
-                if yError is None:
-                    dataMin, dataMax = numpy.min(self.yData), numpy.max(self.yData)
-                else:
+                dataMin, dataMax = numpy.min(self.yData), numpy.max(self.yData)
+                if yError is not None:
+                    if isinstance(yError, numpy.ndarray) and yError.shape[-1] == 1:
+                        yError = numpy.ravel(yError)
+
                     yMinusError = self.yData - numpy.atleast_2d(yError)[0]
-                    dataMin = numpy.min(yMinusError[yMinusError > 0])
+                    dataMin = min(dataMin, numpy.min(yMinusError[yMinusError > 0]))
                     yPlusError = self.yData + numpy.atleast_2d(yError)[-1]
-                    dataMax = numpy.max(yPlusError[yPlusError > 0])
+                    dataMax = max(dataMax, numpy.max(yPlusError[yPlusError > 0]))
                 plotMin, plotMax = self.plot.getYAxis().getLimits()
                 assert numpy.allclose((dataMin, dataMax), (plotMin, plotMax))
 

--- a/src/silx/gui/plot/test/testPlotWidget.py
+++ b/src/silx/gui/plot/test/testPlotWidget.py
@@ -2047,3 +2047,28 @@ class TestPlotMarkerLog_Gl(TestPlotMarkerLog):
 
 class TestSpecial_ExplicitMplBackend(TestSpecialBackend):
     backend = "mpl"
+
+
+@pytest.mark.parametrize("plotWidget", ("mpl", "gl"), indirect=True)
+@pytest.mark.parametrize(
+    "xerror,yerror",
+    [
+        (2, 2),  # Single value
+        ((1, 2, 3), (3, 2, 1)),  # Flat array
+        (([1], [2], [3]), ([3], [2], [1])),  # Nx1 array
+        ([(1, 2, 3), (3, 2, 1)], [(3, 2, 1), (1, 2, 3)]),  # 2xN array
+        (-1, -1),  # Negative values
+        ((-1, 0, 1), (1, 0, -1)),  # Flat array with negative values
+    ],
+)
+def testCurveErrors(qapp, plotWidget, xerror, yerror):
+    """Test display of curves with different errors"""
+    item = plotWidget.addCurve(x=(1, 2, 3), y=(3, 2, 1), xerror=xerror, yerror=yerror)
+
+    assert numpy.array_equal(xerror, item.getXErrorData())
+    assert numpy.array_equal(yerror, item.getYErrorData())
+
+    plotWidget.resetZoom()
+    qapp.processEvents()
+    plotWidget.getXAxis().setScale("log")
+    plotWidget.getYAxis().setScale("log")


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please use a Pull Request title that follows the requested syntax since it will be included in the release notes), see:
https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format
-->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This PR fixes issues occurring in when negative values are passed as errors:
- In case of a negative error value, matplotlib raises an exception (issue #4066) and the OpenGL backend make the error bar go the other way...
- In case all error values lead to negative bound of the error bar, the computation of the item bounding box failed for log axes.

With this PR:
- error values are clipped to `[0, inf[` before being passed to the rendering backend
- bounds are ignoring error values leading to negative bound of the error bar.

closes #4066