### PR TITLE
silx.io.commonh5: Improved code to use built-in types

### DIFF
--- a/src/silx/io/commonh5.py
+++ b/src/silx/io/commonh5.py
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2016-2023 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2024 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,7 @@
 This module contains generic objects, emulating *h5py* groups, datasets and
 files. They are used in :mod:`spech5` and :mod:`fabioh5`.
 """
-from collections import abc
+from types import MappingProxyType
 import weakref
 
 import h5py
@@ -35,47 +35,6 @@ from . import utils
 __authors__ = ["V. Valls", "P. Knobel"]
 __license__ = "MIT"
 __date__ = "02/07/2018"
-
-
-class _MappingProxyType(abc.MutableMapping):
-    """Read-only dictionary
-
-    This class is available since Python 3.3, but not on earlyer Python
-    versions.
-    """
-
-    def __init__(self, data):
-        self._data = data
-
-    def __getitem__(self, key):
-        return self._data[key]
-
-    def __len__(self):
-        return len(self._data)
-
-    def __iter__(self):
-        return iter(self._data)
-
-    def get(self, key, default=None):
-        return self._data.get(key, default)
-
-    def __setitem__(self, key, value):
-        raise RuntimeError("Cannot modify read-only dictionary")
-
-    def __delitem__(self, key):
-        raise RuntimeError("Cannot modify read-only dictionary")
-
-    def pop(self, key):
-        raise RuntimeError("Cannot modify read-only dictionary")
-
-    def clear(self):
-        raise RuntimeError("Cannot modify read-only dictionary")
-
-    def update(self, key, value):
-        raise RuntimeError("Cannot modify read-only dictionary")
-
-    def setdefault(self, key):
-        raise RuntimeError("Cannot modify read-only dictionary")
 
 
 class Node(object):
@@ -173,7 +132,7 @@ class Node(object):
         if self._is_editable():
             return self.__attrs
         else:
-            return _MappingProxyType(self.__attrs)
+            return MappingProxyType(self.__attrs)
 
     @property
     def name(self):

--- a/src/silx/io/test/test_commonh5.py
+++ b/src/silx/io/test/test_commonh5.py
@@ -235,11 +235,8 @@ class TestSpecificCommonH5(unittest.TestCase):
         node.attrs["b"] = 8
         f.add_node(node)
         self.assertEqual(node.attrs["b"], 8)
-        try:
+        with self.assertRaises(TypeError):
             node.attrs["b"] = 1
-            self.fail()
-        except RuntimeError:
-            pass
 
     def test_create_dataset(self):
         f = commonh5.File(name="Foo", mode="w")


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please use a Pull Request title that follows the requested syntax since it will be included in the release notes), see:
https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format
-->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This PR replaces the local implementation of `_MappingProxyType` (For python 2 support) by `types.MappingProxyType`

closes #4049