### PR TITLE
silx.gui.widgets.ElidedLabel: Fixed deprecation warning with Qt5>=511

### DIFF
--- a/src/silx/gui/widgets/ElidedLabel.py
+++ b/src/silx/gui/widgets/ElidedLabel.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2004-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2024 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -27,6 +27,8 @@
 __license__ = "MIT"
 __date__ = "07/12/2018"
 
+
+from packaging.version import Version
 from ...utils.deprecation import deprecated
 from silx.gui import qt
 
@@ -62,7 +64,7 @@ class ElidedLabel(qt.QLabel):
 
     def __updateMinimumSize(self):
         metrics = self.fontMetrics()
-        if qt.BINDING == "PyQt5":
+        if Version(qt.qVersion()) < Version("5.11"):  # PyQt5
             width = metrics.width("...")
         else:  # Qt6
             width = metrics.horizontalAdvance("...")


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please use a Pull Request title that follows the requested syntax since it will be included in the release notes), see:
https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format
-->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This PR avoids a deprecation warning with Qt5 >= 5.11

closes #4085