### PR TITLE
silx.gui.data.RecordTableView: Fixed cell background color in dark mode

### DIFF
--- a/src/silx/gui/data/RecordTableView.py
+++ b/src/silx/gui/data/RecordTableView.py
@@ -79,7 +79,7 @@ class _MultiLineItem(qt.QItemDelegate):
             brush = index.data(qt.Qt.BackgroundRole)
             if brush is None:
                 # default background color for a cell
-                brush = qt.Qt.white
+                brush = option.palette.base()
             painter.setBrush(brush)
         painter.drawRect(option.rect)
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please use a Pull Request title that follows the requested syntax since it will be included in the release notes), see:
https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format
-->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

The base-color for the _MultiLineItem cell is always set to white if it is not selected and there is no brush in the backgroundrole. So when viewing a string dataset with the OS set to dark mode, you can't read it anymore. For me, this happens with NULLPAD ASCII STRING.
