### PR TITLE
silx.image.marchingsquare: Fixed cython warning

### DIFF
--- a/src/silx/image/marchingsquares/_mergeimpl.pyx
+++ b/src/silx/image/marchingsquares/_mergeimpl.pyx
@@ -5,7 +5,7 @@
 ##cython: profile=True, warn.undeclared=True, warn.unused=True, warn.unused_result=False, warn.unused_arg=True
 
 # /*##########################################################################
-# Copyright (C) 2018-2023 European Synchrotron Radiation Facility
+# Copyright (C) 2018-2024 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -85,7 +85,7 @@ cdef cppclass PolygonDescription:
     point_index_t end
     clist[point_t] points
 
-    PolygonDescription() noexcept nogil:
+    PolygonDescription() nogil:
         pass
 
 """Description of a tile context.
@@ -108,7 +108,7 @@ cdef cppclass TileContext:
     clist[coord_t] final_pixels
     cset[coord_t] pixels
 
-    TileContext() noexcept nogil:
+    TileContext() nogil:
         pass
 
 


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please use a Pull Request title that follows the requested syntax since it will be included in the release notes), see:
https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format
-->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This PR fixes a cython code generation warning with cython 3.0.10.
I checked that the generated C++ code is the same and that it's OK with a previous version of Cython (3.0.6).

closes #4105