### PR TITLE
Tests: Improved tests by converting warnings to errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,18 @@ build-backend = "setuptools.build_meta"
 required-version = 23
 target-version = ["py37", "py38", "py39", "py310", "py311", "py312"]
 safe = true
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+python_files = [
+    "test/test*.py",
+    "test/Test*.py",
+]
+python_classes = "Test"
+python_functions = "test"
+filterwarnings = [
+    "error",
+    # note the use of single quote below to denote "raw" strings in TOML
+    'ignore:tostring\(\) is deprecated. Use tobytes\(\) instead\.:DeprecationWarning:OpenGL',
+    'ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning',
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-python_files =
-    test/test*.py
-    test/Test*.py
-python_classes = Test
-python_functions = test

--- a/setup.py
+++ b/setup.py
@@ -189,7 +189,7 @@ def get_project_configuration():
     ]
 
     test_requires = [
-        "pytest",
+        "pytest>=6.0",
         "pytest-xvfb",
         "pytest-mock",
         "bitshuffle",

--- a/src/silx/gui/plot/test/testPlotWidget.py
+++ b/src/silx/gui/plot/test/testPlotWidget.py
@@ -1530,6 +1530,7 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         with self.assertRaises(Exception):
             item.setBounds((-1000, 1000, 2000, -2000))
 
+    @pytest.mark.filterwarnings("ignore:Attempting to set identical low and high ylims makes transformation singular; automatically expanding.:UserWarning")
     def testBoundingRectWithLog(self):
         item = BoundingRect()
         self.plot.addItem(item)
@@ -1549,6 +1550,7 @@ class TestPlotAxes(TestCaseQt, ParametricTestCase):
         self.plot.getYAxis()._setLogarithmic(False)
         self.assertIsNone(item.getBounds())
 
+    @pytest.mark.filterwarnings("ignore:Attempting to set identical low and high ylims makes transformation singular; automatically expanding.:UserWarning")
     def testAxisExtent(self):
         """Test XAxisExtent and yAxisExtent"""
         for cls, axis in (
@@ -2054,6 +2056,7 @@ class TestSpecial_ExplicitMplBackend(TestSpecialBackend):
     backend = "mpl"
 
 
+@pytest.mark.filterwarnings("ignore:All-NaN slice encountered:RuntimeWarning")
 @pytest.mark.parametrize("plotWidget", ("mpl", "gl"), indirect=True)
 @pytest.mark.parametrize(
     "xerror,yerror",


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please use a Pull Request title that follows the requested syntax since it will be included in the release notes), see:
https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format
-->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This PR aim at running tests with stricter rules by raising errors for warnings (e.g. deprecation warnings).
This is done by configuring pytest, adding ignores on specific tests and silenting warnings in  `silx.utils.number`

Thanks @woutdenolf for the idea!