### PR TITLE
Dependencies: Removed numpy from build dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade build setuptools wheel
-          pip install --upgrade --pre numpy cython
+          pip install --upgrade --pre cython
 
       - name: Print python info used for build
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v4
 
         # Install X server packages
         # libegl1-mesa: Required by Qt xcb platform plugin
@@ -89,9 +86,10 @@ jobs:
 
       # Runs a single command using the runners shell
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
 
       - name: Upgrade distribution modules
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,9 +124,6 @@ jobs:
 
           CIBW_ENVIRONMENT_PASS_LINUX: SILX_FORCE_CYTHON SILX_WITH_OPENMP WITH_QT_TEST WITH_GL_TEST SILX_OPENCL SILX_TEST_LOW_MEM
 
-          # Use silx wheelhouse: needed for ppc64le
-          CIBW_ENVIRONMENT_LINUX: "PIP_FIND_LINKS=https://www.silx.org/pub/wheelhouse/ PIP_TRUSTED_HOST=www.silx.org"
-
           CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-*
           # Do not build for pypy and muslinux
           CIBW_SKIP: pp* *-musllinux_*

--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -67,7 +67,6 @@ build_script:
     - "pip install %PIP_OPTIONS% --upgrade build"
     - "pip install %PIP_OPTIONS% --upgrade setuptools"
     - "pip install %PIP_OPTIONS% --upgrade wheel"
-    - "pip install %PIP_OPTIONS% --upgrade numpy"
     - "pip install %PIP_OPTIONS% --upgrade cython"
 
     # Print Python info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     "wheel",
     "setuptools",
-    "numpy",
     "Cython>=0.29.31"
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -40,14 +40,6 @@ logger = logging.getLogger("silx.setup")
 from setuptools import Extension
 from setuptools.command.build_ext import build_ext
 
-try:
-    import numpy
-except ImportError:
-    raise ImportError(
-        "To install this package, you must install numpy first\n"
-        "(See https://pypi.org/project/numpy)"
-    )
-
 
 PROJECT = "silx"
 if sys.version_info.major < 3:


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please use a Pull Request title that follows the requested syntax since it will be included in the release notes), see:
https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format
-->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

Following PR #4082, `numpy` is no longer needed to build the package, thus remove it from build dependencies