### PR TITLE
silx.io.open: Added basic support for tiled URLs

### DIFF
--- a/src/silx/io/tiledh5.py
+++ b/src/silx/io/tiledh5.py
@@ -44,7 +44,7 @@ def _get_children(
     container: tiled.client.container.Container,
     max_children: int | None = None,
 ):
-    """Return first max_children entries of given container as commonh5 wrappers.
+    """Return first max_children entries of given container as a dict of commonh5 wrappers.
 
     :param parent: The commonh5 wrapper for which to retrieve children.
     :param container: The tiled container from which to retrieve the entries.
@@ -77,7 +77,7 @@ def _get_children(
 class TiledH5(commonh5.File):
     """tiled client wrapper"""
 
-    MAX_CHILDREN: int | None = None
+    MAX_CHILDREN_PER_GROUP: int | None = None
     """Maximum number of children to instantiate for each group.
 
     Set to None for allowing an unbound number of children per group.
@@ -102,7 +102,7 @@ class TiledH5(commonh5.File):
 
     @lru_cache
     def _get_items(self):
-        return _get_children(self, self.__container, self.MAX_CHILDREN)
+        return _get_children(self, self.__container, self.MAX_CHILDREN_PER_GROUP)
 
 
 class TiledGroup(commonh5.Group):
@@ -120,7 +120,7 @@ class TiledGroup(commonh5.Group):
 
     @lru_cache
     def _get_items(self):
-        return _get_children(self, self.__container, self.file.MAX_CHILDREN)
+        return _get_children(self, self.__container, self.file.MAX_CHILDREN_PER_GROUP)
 
 
 class TiledDataset(commonh5.LazyLoadableDataset):

--- a/src/silx/io/tiledh5.py
+++ b/src/silx/io/tiledh5.py
@@ -121,7 +121,7 @@ class TiledGroup(commonh5.Group):
         return _get_children(self, self.__container, self.file.MAX_CHILDREN_PER_GROUP)
 
 
-class TiledDataset(commonh5.LazyLoadableDataset):
+class TiledDataset(commonh5.Dataset):
     """tiled ArrayClient wrapper"""
 
     def __init__(
@@ -131,36 +131,22 @@ class TiledDataset(commonh5.LazyLoadableDataset):
         parent: TiledH5 | TiledGroup | None = None,
         attrs: dict | None = None,
     ):
-        super().__init__(name, parent, attrs)
-        self.__client = client
-
-    def _create_data(self) -> numpy.ndarray:
-        return self.__client[()]
-
-    @property
-    def dtype(self):
-        return self.__client.dtype
+        super().__init__(name, client, parent, attrs)
 
     @property
     def shape(self):
-        return self.__client.shape
+        return self._get_data().shape
 
     @property
     def size(self):
-        return self.__client.size
+        return self._get_data().size
 
     def __len__(self):
         return len(self.__client)
 
     def __getitem__(self, item):
-        return self.__client[item]
+        return self._get_data()[item]
 
     @property
     def value(self):
-        return self.__client[()]
-
-    def __iter__(self):
-        return self.__client.__iter__()
-
-    def __getattr__(self, item):
-        return getattr(self.__client, item)
+        return self._get_data()[()]

--- a/src/silx/io/tiledh5.py
+++ b/src/silx/io/tiledh5.py
@@ -1,4 +1,30 @@
-"""Provides a wrapper to expose `Tiled <https://blueskyproject.io/tiled/>`_"""
+# /*##########################################################################
+# Copyright (C) 2024 European Synchrotron Radiation Facility
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# ############################################################################*/
+"""
+Provides a wrapper to expose `Tiled <https://blueskyproject.io/tiled/>`_
+
+This is a preview feature.
+"""
 from __future__ import annotations
 
 
@@ -13,9 +39,26 @@ import tiled.client
 _logger = logging.getLogger(__name__)
 
 
-def _get_children(parent, container):
+def _get_children(
+    parent: TiledH5 | TiledGroup,
+    container: tiled.client.container.Container,
+    max_children: int | None = None,
+):
+    """Return first max_children items of given container as commonh5 wrappers.
+
+    :param parent: The commonh5 wrapper for which to retrieve children.
+    :param container: The corresponding tiled container.
+    :param max_children: The maximum number of childre to retrieve.
+    """
+    items = container.items()
+
+    if max_children is not None and len(items) > max_children:
+        _logger.warning(
+            f"{container.uri} contains too many entries: Only loading first {max_children}."
+        )
+
     children = {}
-    for key, client in container.items():
+    for key, client in items.head(max_children):
         if isinstance(client, tiled.client.container.Container):
             children[key] = TiledGroup(client, name=key, parent=parent)
         elif isinstance(client, tiled.client.array.ArrayClient):
@@ -31,12 +74,25 @@ def _get_children(parent, container):
 
 
 class TiledH5(commonh5.File):
-    def __init__(self, name=None, mode=None, attrs=None):
+    """tiled client wrapper"""
+
+    MAX_CHILDREN: int | None = None
+    """Maximum number of group children to instantiate for each group.
+
+    Set to None for allowing an unbound number of children per group.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        mode: str | None = None,
+        attrs: dict | None = None,
+    ):
         assert mode in ("r", None)
         super().__init__(name, mode, attrs)
-        self.__container = tiled.client.from_uri(
-            name[6:] if name.startswith("tiled:") else name
-        )
+        if name.startswith("tiled:"):
+            name = name[6:]
+        self.__container = tiled.client.from_uri(name)
         assert isinstance(self.__container, tiled.client.container.Container)
 
     def close(self):
@@ -45,25 +101,37 @@ class TiledH5(commonh5.File):
 
     @lru_cache
     def _get_items(self):
-        return _get_children(self, self.__container)
+        return _get_children(self, self.__container, self.MAX_CHILDREN)
 
 
 class TiledGroup(commonh5.Group):
     """tiled Container wrapper"""
 
-    def __init__(self, container, name, parent=None, attrs=None):
+    def __init__(
+        self,
+        container: tiled.client.container.Container,
+        name: str,
+        parent: TiledH5 | TiledGroup | None = None,
+        attrs: dict | None = None,
+    ):
         super().__init__(name, parent, attrs)
         self.__container = container
 
     @lru_cache
     def _get_items(self):
-        return _get_children(self, self.__container)
+        return _get_children(self, self.__container, self.file.MAX_CHILDREN)
 
 
 class TiledDataset(commonh5.LazyLoadableDataset):
     """tiled ArrayClient wrapper"""
 
-    def __init__(self, client, name, parent=None, attrs=None):
+    def __init__(
+        self,
+        client: tiled.client.array.ArrayClient,
+        name: str,
+        parent: TiledH5 | TiledGroup | None = None,
+        attrs: dict | None = None,
+    ):
         super().__init__(name, parent, attrs)
         self.__client = client
 

--- a/src/silx/io/tiledh5.py
+++ b/src/silx/io/tiledh5.py
@@ -34,6 +34,7 @@ import numpy
 from . import commonh5
 import h5py
 import tiled.client
+from tiled.client.cache import Cache
 
 
 _logger = logging.getLogger(__name__)
@@ -83,6 +84,9 @@ class TiledH5(commonh5.File):
     Set to None for allowing an unbound number of children per group.
     """
 
+    _cache = None
+    """Shared tiled cache with lazy initialization"""
+
     def __init__(
         self,
         name: str,
@@ -91,7 +95,9 @@ class TiledH5(commonh5.File):
     ):
         assert mode in ("r", None)
         super().__init__(name, mode, attrs)
-        self.__container = tiled.client.from_uri(name)
+        if self._cache is None:
+            TiledH5._cache = Cache()  # Use tiled cache default
+        self.__container = tiled.client.from_uri(name, cache=self._cache)
         assert isinstance(self.__container, tiled.client.container.Container)
 
     def close(self):

--- a/src/silx/io/tiledh5.py
+++ b/src/silx/io/tiledh5.py
@@ -99,6 +99,7 @@ class TiledH5(commonh5.File):
             TiledH5._cache = Cache()  # Use tiled cache default
         self.__container = tiled.client.from_uri(name, cache=self._cache)
         assert isinstance(self.__container, tiled.client.container.Container)
+        _logger.warning("tiled support is a preview feature: This may change or be removed without notice.")
 
     def close(self):
         super().close()

--- a/src/silx/io/tiledh5.py
+++ b/src/silx/io/tiledh5.py
@@ -44,21 +44,22 @@ def _get_children(
     container: tiled.client.container.Container,
     max_children: int | None = None,
 ):
-    """Return first max_children items of given container as commonh5 wrappers.
+    """Return first max_children entries of given container as commonh5 wrappers.
 
     :param parent: The commonh5 wrapper for which to retrieve children.
-    :param container: The corresponding tiled container.
-    :param max_children: The maximum number of childre to retrieve.
+    :param container: The tiled container from which to retrieve the entries.
+    :param max_children: The maximum number of children to retrieve.
     """
     items = container.items()
 
     if max_children is not None and len(items) > max_children:
+        items = items.head(max_children)
         _logger.warning(
             f"{container.uri} contains too many entries: Only loading first {max_children}."
         )
 
     children = {}
-    for key, client in items.head(max_children):
+    for key, client in items:
         if isinstance(client, tiled.client.container.Container):
             children[key] = TiledGroup(client, name=key, parent=parent)
         elif isinstance(client, tiled.client.array.ArrayClient):
@@ -77,7 +78,7 @@ class TiledH5(commonh5.File):
     """tiled client wrapper"""
 
     MAX_CHILDREN: int | None = None
-    """Maximum number of group children to instantiate for each group.
+    """Maximum number of children to instantiate for each group.
 
     Set to None for allowing an unbound number of children per group.
     """

--- a/src/silx/io/tiledh5.py
+++ b/src/silx/io/tiledh5.py
@@ -34,7 +34,9 @@ class TiledH5(commonh5.File):
     def __init__(self, name=None, mode=None, attrs=None):
         assert mode in ("r", None)
         super().__init__(name, mode, attrs)
-        self.__container = tiled.client.from_uri(name)
+        self.__container = tiled.client.from_uri(
+            name[6:] if name.startswith("tiled:") else name
+        )
         assert isinstance(self.__container, tiled.client.container.Container)
 
     def close(self):

--- a/src/silx/io/tiledh5.py
+++ b/src/silx/io/tiledh5.py
@@ -91,8 +91,6 @@ class TiledH5(commonh5.File):
     ):
         assert mode in ("r", None)
         super().__init__(name, mode, attrs)
-        if name.startswith("tiled-http"):
-            name = name[6:]
         self.__container = tiled.client.from_uri(name)
         assert isinstance(self.__container, tiled.client.container.Container)
 

--- a/src/silx/io/tiledh5.py
+++ b/src/silx/io/tiledh5.py
@@ -1,0 +1,57 @@
+"""Provides a wrapper to expose `Tiled <https://blueskyproject.io/tiled/>`_"""
+from __future__ import annotations
+
+
+from functools import lru_cache
+import numpy
+from . import commonh5
+import tiled.client
+
+
+def _getChildren(parent, container):
+    children = {}
+    for key, client in container.items():
+        if isinstance(client, tiled.client.container.Container):
+            children[key] = TiledGroup(client, name=key, parent=parent)
+        elif isinstance(client, tiled.client.array.ArrayClient):
+            children[key] = TiledDataset(client, name=key, parent=parent)
+    return children
+
+
+class TiledH5(commonh5.File):
+    def __init__(self, name=None, mode=None, attrs=None):
+        assert mode in ("r", None)
+        super().__init__(name, mode, attrs)
+        self.__container = tiled.client.from_uri(name)
+        assert isinstance(self.__container, tiled.client.container.Container)
+
+    def close(self):
+        super().close()
+        self.__container = None
+
+    @lru_cache
+    def _get_items(self):
+        return _getChildren(self, self.__container)
+
+
+class TiledGroup(commonh5.Group):
+    """tiled Container wrapper"""
+
+    def __init__(self, container, name, parent=None, attrs=None):
+        super().__init__(name, parent, attrs)
+        self.__container = container
+
+    @lru_cache
+    def _get_items(self):
+        return _getChildren(self, self.__container)
+
+
+class TiledDataset(commonh5.LazyLoadableDataset):
+    """tiled ArrayClient wrapper"""
+
+    def __init__(self, client, name, parent=None, attrs=None):
+        super().__init__(name, parent, attrs)
+        self.__client = client
+
+    def _create_data(self) -> numpy.ndarray:
+        return self.__client[()]

--- a/src/silx/io/tiledh5.py
+++ b/src/silx/io/tiledh5.py
@@ -90,7 +90,7 @@ class TiledH5(commonh5.File):
     ):
         assert mode in ("r", None)
         super().__init__(name, mode, attrs)
-        if name.startswith("tiled:"):
+        if name.startswith("tiled-http"):
             name = name[6:]
         self.__container = tiled.client.from_uri(name)
         assert isinstance(self.__container, tiled.client.container.Container)

--- a/src/silx/io/utils.py
+++ b/src/silx/io/utils.py
@@ -692,9 +692,7 @@ def open(filename):  # pylint:disable=redefined-builtin
     :raises: IOError if the file can't be loaded or path can't be found
     :rtype: h5py-like node
     """
-    if filename.startswith("tiled:"):
-        from .tiledh5 import TiledH5
-
+    if filename.startswith("tiled-http") and TiledH5 is not None:
         return TiledH5(filename)
 
     url = DataUrl(filename)

--- a/src/silx/io/utils.py
+++ b/src/silx/io/utils.py
@@ -695,7 +695,7 @@ def open(filename):  # pylint:disable=redefined-builtin
     if filename.startswith("tiled:"):
         from .tiledh5 import TiledH5
 
-        return TiledH5(filename[6:])
+        return TiledH5(filename)
 
     url = DataUrl(filename)
 

--- a/src/silx/io/utils.py
+++ b/src/silx/io/utils.py
@@ -696,9 +696,6 @@ def open(filename):  # pylint:disable=redefined-builtin
     :raises: IOError if the file can't be loaded or path can't be found
     :rtype: h5py-like node
     """
-    if filename.startswith("tiled-http") and TiledH5 is not None:
-        return TiledH5(filename)
-
     url = DataUrl(filename)
     if url.scheme() in ("http", "https"):
         errors = [f"Failed to open {filename}"]

--- a/src/silx/io/utils.py
+++ b/src/silx/io/utils.py
@@ -692,6 +692,11 @@ def open(filename):  # pylint:disable=redefined-builtin
     :raises: IOError if the file can't be loaded or path can't be found
     :rtype: h5py-like node
     """
+    if filename.startswith("tiled:"):
+        from .tiledh5 import TiledH5
+
+        return TiledH5(filename[6:])
+
     url = DataUrl(filename)
 
     if url.scheme() in [None, "file", "silx"]:

--- a/src/silx/io/utils.py
+++ b/src/silx/io/utils.py
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2016-2023 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2024 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -33,13 +33,11 @@ import sys
 import time
 import logging
 from typing import Generator, Union, Optional
-import urllib.parse
 
 import numpy
 
 from silx.utils.proxy import Proxy
 from .url import DataUrl
-from . import h5py_utils
 from .._version import calc_hexversion
 
 import h5py
@@ -50,6 +48,12 @@ try:
     import h5pyd
 except ImportError as e:
     h5pyd = None
+
+try:
+    from .tiledh5 import TiledH5
+except ImportError as e:
+    TiledH5 = None
+
 
 logger = logging.getLogger(__name__)
 
@@ -696,16 +700,29 @@ def open(filename):  # pylint:disable=redefined-builtin
         return TiledH5(filename)
 
     url = DataUrl(filename)
+    if url.scheme() in ("http", "https"):
+        errors = [f"Failed to open {filename}"]
+        if h5pyd is not None:
+            try:
+                return _open_url_with_h5pyd(filename)
+            except Exception as e:
+                errors.append(f"- h5pyd failed: {type(e)} {e}")
 
-    if url.scheme() in [None, "file", "silx"]:
-        # That's a local file
-        if not url.is_valid():
-            raise IOError("URL '%s' is not valid" % filename)
-        h5_file = _open_local_file(url.file_path())
-    elif url.scheme() in ("http", "https"):
-        return _open_url_with_h5pyd(filename)
-    else:
+        if TiledH5 is not None:
+            try:
+                return TiledH5(filename)
+            except Exception as e:
+                errors.append(f"- tiled failed: {type(e)} {e}")
+
+        raise IOError("\n".join(errors))
+
+    if url.scheme() not in (None, "file", "silx"):
         raise IOError(f"Unsupported URL scheme {url.scheme}: {filename}")
+
+    # That's a local file
+    if not url.is_valid():
+        raise IOError("URL '%s' is not valid" % filename)
+    h5_file = _open_local_file(url.file_path())
 
     if url.data_path() in [None, "/", ""]:  # The full file is requested
         if url.data_slice():


### PR DESCRIPTION
<!-- Thank you for your pull request!-->
Checklist:
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))
<hr>
<!-- provide a description of the changes below -->

This PR adds minimal support for [tiled](https://blueskyproject.io/tiled/) in `silx.io.open` through a `silx.io.tiledh5` module.
As it stand, it only supports `Container` and `ArrayClient`.

There is a way to limit the number of entries retrieved for each group by setting `silx.io.tiledh5.TiledH5.MAX_CHILDREN_PER_GROUP` (default: all).

`silx.io.open` tries to open http(s) URLs with `h5pyd` and `tiled` when available and raises an `IOError` exception when both fail.
Other exceptions when accessing content (timeout, connection errors) are not catched.

There a shortcut in `silx.io.open` added in first poc when passing an URL with a `tiled-` prefix that I would prefer to remove now that the basic URL can be used. (Note: since first poc in this branch, I changed the prefix from `tiled:` to `tiled-` to avoid issues with URL parsing) attn @vasole



Related to #4106