### PR TITLE
silx.io.specfile: Fixed `SpecFile` deallocation issue

### DIFF
--- a/src/silx/io/specfile.pyx
+++ b/src/silx/io/specfile.pyx
@@ -658,8 +658,8 @@ cdef class SpecFile(object):
         else:
             self.filename = filename
 
-    def __dealloc__(self):
-        """Destructor: Calls SfClose(self.handle)"""
+    def __del__(self):
+        """Finalizer: Calls SfClose(self.handle)"""
         self.close()
 
     def close(self):


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please use a Pull Request title that follows the requested syntax since it will be included in the release notes), see:
https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format
-->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

Replaces the use of `__dealloc__` in `SpecFile` with `__del__` since the former should not call methods and the later is now supported (it was not with Python 2):

https://cython.readthedocs.io/en/latest/src/userguide/special_methods.html#finalization-methods-dealloc-and-del

> You need to be careful what you do in a `__dealloc__()` method. By the time your `__dealloc__()` method is called, the object may already have been partially destroyed and may not be in a valid state as far as Python is concerned, so you should avoid invoking any Python operations which might touch the object. In particular, don’t call any other methods of the object or do anything which might cause the object to be resurrected. It’s best if you stick to just deallocating C data.


closes #4128
