### PR TITLE
silx.gui.data.DataViewer.DataViewer: Fixed issue with accessing views after using the removeView method.

### DIFF
--- a/src/silx/gui/data/DataViewer.py
+++ b/src/silx/gui/data/DataViewer.py
@@ -195,7 +195,9 @@ class DataViewer(qt.QFrame):
         """
         if view not in self.__index:
             widget = view.getWidget()
-            index = self.__stack.addWidget(widget)
+            index = self.__stack.indexOf(widget)
+            if index == -1:
+                index = self.__stack.addWidget(widget)
             self.__index[view] = index
         else:
             index = self.__index[view]


### PR DESCRIPTION
Fixed issue #4130 which occured after using the ``silx.gui.data.DataViewer.DataViewer.removeView`` method which invalidated the ``index`` dictionary for accessing widgets.
Switching between views modified the referenced ``__stack`` without updating the ``__index``.