### PR TITLE
silx.gui.plot.PlotWidget: Fixed support of PySide6

### DIFF
--- a/src/silx/gui/dialog/test/test_datafiledialog.py
+++ b/src/silx/gui/dialog/test/test_datafiledialog.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2024 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -115,10 +115,11 @@ class _UtilsMixin(object):
             self.qWaitForDestroy(ref)
 
     def qWaitForPendingActions(self, dialog):
+        self.qapp.processEvents()
         for _ in range(20):
             if not dialog.hasPendingEvents():
                 return
-            self.qWait(10)
+            self.qWait(100)
         raise RuntimeError("Still have pending actions")
 
     def assertSamePath(self, path1, path2):

--- a/src/silx/gui/dialog/test/test_imagefiledialog.py
+++ b/src/silx/gui/dialog/test/test_imagefiledialog.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2016-2022 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2024 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -122,10 +122,11 @@ class _UtilsMixin(object):
             self.qWaitForDestroy(ref)
 
     def qWaitForPendingActions(self, dialog):
+        self.qapp.processEvents()
         for _ in range(20):
             if not dialog.hasPendingEvents():
                 return
-            self.qWait(10)
+            self.qWait(100)
         raise RuntimeError("Still have pending actions")
 
     def assertSamePath(self, path1, path2):

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2004-2023 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2024 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -828,10 +828,10 @@ class PlotWidget(qt.QMainWindow):
     def hideEvent(self, event):
         super(PlotWidget, self).hideEvent(event)
         if qt.BINDING == "PySide6":
-            # Workaround RuntimeError: The SignalInstance object was already deleted
+            # Workaround RuntimeError/AttributeError: The SignalInstance object was already deleted
             try:
                 self.sigVisibilityChanged.emit(False)
-            except RuntimeError as e:
+            except (RuntimeError, AttributeError) as e:
                 _logger.error(f"Exception occured: {e}")
         else:
             self.sigVisibilityChanged.emit(False)

--- a/src/silx/gui/plot/test/testImageView.py
+++ b/src/silx/gui/plot/test/testImageView.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2017-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2017-2024 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,30 +30,18 @@ __date__ = "24/04/2018"
 
 import numpy
 
-from silx.gui import qt
-from silx.gui.utils.testutils import TestCaseQt
 from silx.gui.plot import items
 
 from silx.gui.plot.ImageView import ImageView
 from silx.gui.colors import Colormap
+from .utils import PlotWidgetTestCase
 
 
-class TestImageView(TestCaseQt):
+class TestImageView(PlotWidgetTestCase):
     """Tests of ImageView widget."""
 
-    def setUp(self):
-        super(TestImageView, self).setUp()
-        self.plot = ImageView()
-        self.plot.show()
-        self.qWaitForWindowExposed(self.plot)
-
-    def tearDown(self):
-        self.qapp.processEvents()
-        self.plot.setAttribute(qt.Qt.WA_DeleteOnClose)
-        self.plot.close()
-        del self.plot
-        self.qapp.processEvents()
-        super(TestImageView, self).tearDown()
+    def _createPlot(self):
+        return ImageView()
 
     def testSetImage(self):
         """Test setImage"""

--- a/src/silx/gui/plot/test/testPixelIntensityHistoAction.py
+++ b/src/silx/gui/plot/test/testPixelIntensityHistoAction.py
@@ -31,32 +31,30 @@ __date__ = "02/03/2018"
 import numpy
 
 from silx.utils.testutils import ParametricTestCase
-from silx.gui.utils.testutils import TestCaseQt, getQToolButtonFromAction
+from silx.gui.utils.testutils import getQToolButtonFromAction
 from silx.gui import qt
 from silx.gui.plot import Plot2D
+from .utils import PlotWidgetTestCase
 
 
-class TestPixelIntensitiesHisto(TestCaseQt, ParametricTestCase):
+class TestPixelIntensitiesHisto(PlotWidgetTestCase, ParametricTestCase):
     """Tests for PixelIntensitiesHistoAction widget."""
+
+    def _createPlot(self):
+        return Plot2D()
 
     def setUp(self):
         super(TestPixelIntensitiesHisto, self).setUp()
         self.image = numpy.random.rand(10, 10)
-        self.plotImage = Plot2D()
-        self.plotImage.getIntensityHistogramAction().setVisible(True)
-
-    def tearDown(self):
-        del self.plotImage
-        self.qapp.processEvents()
-        super(TestPixelIntensitiesHisto, self).tearDown()
+        self.plot.getIntensityHistogramAction().setVisible(True)
 
     def testShowAndHide(self):
         """Simple test that the plot is showing and hiding when activating the
         action"""
-        self.plotImage.addImage(self.image, origin=(0, 0), legend="sino")
-        self.plotImage.show()
+        self.plot.addImage(self.image, origin=(0, 0), legend="sino")
+        self.plot.show()
 
-        histoAction = self.plotImage.getIntensityHistogramAction()
+        histoAction = self.plot.getIntensityHistogramAction()
 
         # test the pixel intensity diagram is showing
         button = getQToolButtonFromAction(histoAction)
@@ -67,7 +65,7 @@ class TestPixelIntensitiesHisto(TestCaseQt, ParametricTestCase):
         self.assertTrue(histoAction.getHistogramWidget().isVisible())
 
         # test the pixel intensity diagram is hiding
-        self.plotImage.activateWindow()
+        self.plot.activateWindow()
         self.qapp.processEvents()
         self.mouseMove(button)
         self.mouseClick(button, qt.Qt.LeftButton)
@@ -84,15 +82,15 @@ class TestPixelIntensitiesHisto(TestCaseQt, ParametricTestCase):
             numpy.float32,
             numpy.float64,
         ]
-        self.plotImage.addImage(self.image, origin=(0, 0), legend="sino")
-        self.plotImage.show()
-        button = getQToolButtonFromAction(self.plotImage.getIntensityHistogramAction())
+        self.plot.addImage(self.image, origin=(0, 0), legend="sino")
+        self.plot.show()
+        button = getQToolButtonFromAction(self.plot.getIntensityHistogramAction())
         self.mouseMove(button)
         self.mouseClick(button, qt.Qt.LeftButton)
         self.qapp.processEvents()
         for typeToTest in typesToTest:
             with self.subTest(typeToTest=typeToTest):
-                self.plotImage.addImage(
+                self.plot.addImage(
                     self.image.astype(typeToTest), origin=(0, 0), legend="sino"
                 )
 
@@ -101,10 +99,10 @@ class TestPixelIntensitiesHisto(TestCaseQt, ParametricTestCase):
         xx = numpy.arange(10)
         yy = numpy.arange(10)
         value = numpy.sin(xx)
-        self.plotImage.addScatter(xx, yy, value)
-        self.plotImage.show()
+        self.plot.addScatter(xx, yy, value)
+        self.plot.show()
 
-        histoAction = self.plotImage.getIntensityHistogramAction()
+        histoAction = self.plot.getIntensityHistogramAction()
 
         # test the pixel intensity diagram is showing
         button = getQToolButtonFromAction(histoAction)
@@ -123,10 +121,10 @@ class TestPixelIntensitiesHisto(TestCaseQt, ParametricTestCase):
         xx = numpy.arange(10)
         yy = numpy.arange(10)
         value = numpy.sin(xx)
-        self.plotImage.addScatter(xx, yy, value)
-        self.plotImage.show()
+        self.plot.addScatter(xx, yy, value)
+        self.plot.show()
 
-        histoAction = self.plotImage.getIntensityHistogramAction()
+        histoAction = self.plot.getIntensityHistogramAction()
 
         # test the pixel intensity diagram is showing
         button = getQToolButtonFromAction(histoAction)
@@ -142,7 +140,7 @@ class TestPixelIntensitiesHisto(TestCaseQt, ParametricTestCase):
         data1 = items[0].getValueData(copy=False)
 
         # Set another item to the plot
-        self.plotImage.addImage(self.image, origin=(0, 0), legend="sino")
+        self.plot.addImage(self.image, origin=(0, 0), legend="sino")
         self.qapp.processEvents()
         data2 = items[0].getValueData(copy=False)
 

--- a/src/silx/gui/plot/test/testPixelIntensityHistoAction.py
+++ b/src/silx/gui/plot/test/testPixelIntensityHistoAction.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2016-2018 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2024 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -47,6 +47,7 @@ class TestPixelIntensitiesHisto(TestCaseQt, ParametricTestCase):
 
     def tearDown(self):
         del self.plotImage
+        self.qapp.processEvents()
         super(TestPixelIntensitiesHisto, self).tearDown()
 
     def testShowAndHide(self):


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please use a Pull Request title that follows the requested syntax since it will be included in the release notes), see:
https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format
-->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This PR adds an accepted exception type to those that can happen during `PlotWidget.hideEvent` with `PySide6`.
This aims at fixing the CI on Windows with PySide6:

```
__________________ TestPixelIntensitiesHisto.testShowAndHide __________________
self = <silx.gui.plot.test.testPixelIntensityHistoAction.TestPixelIntensitiesHisto testMethod=testShowAndHide>
    def tearDown(self):
        del self.plotImage
>       super(TestPixelIntensitiesHisto, self).tearDown()
venv_test\Lib\site-packages\silx\gui\plot\test\testPixelIntensityHistoAction.py:50: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
self = <silx.gui.plot.test.testPixelIntensityHistoAction.TestPixelIntensitiesHisto testMethod=testShowAndHide>
    def tearDown(self):
        self.qapp.processEvents()
    
        if len(self.__class__._exceptions) > 0:
            messages = "\n".join(self.__class__._exceptions)
>           raise AssertionError("Exception occured in Qt thread:\n" + messages)
E           AssertionError: Exception occured in Qt thread:
E           Traceback (most recent call last):
E           AttributeError: Slot 'FitAction::' not found.
venv_test\Lib\site-packages\silx\gui\utils\testutils.py:193: AssertionError
------------------------------ Captured log call ------------------------------
ERROR    silx.gui.plot.PlotWidget:PlotWidget.py:835 Exception occured: The SignalInstance object was already deleted
```