### PR TITLE
silx.gui.plot.PlotWidget.addCurve: Fixed progression in color, linestyle

### DIFF
--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -1192,6 +1192,11 @@ class PlotWidget(qt.QMainWindow):
         if replace:
             self._resetColorAndStyle()
 
+        if color is not None:
+            default_color, default_linestyle = color, self._getStyle()
+        else:
+            default_color, default_linestyle = self._getColorAndStyle()
+
         # Create/Update curve object
         curve = self.getCurve(legend)
         mustBeAdded = curve is None
@@ -1200,7 +1205,6 @@ class PlotWidget(qt.QMainWindow):
             curve = items.Curve() if histogram is None else items.Histogram()
             curve.setName(legend)
             # Set default color, linestyle and symbol
-            default_color, default_linestyle = self._getColorAndStyle()
             curve.setColor(default_color)
             curve.setLineStyle(default_linestyle)
             curve.setSymbol(self._defaultPlotPoints)
@@ -3105,6 +3109,16 @@ class PlotWidget(qt.QMainWindow):
             style = " "
 
         return color, style
+    
+    def _getStyle(self) -> str:
+        style = self._styleList[self._styleIndex]
+        self._styleIndex = (self._styleIndex + 1) % len(self._styleList)
+
+        if not self._plotLines:
+            style = " "
+
+        return style
+
 
     # Misc.
 

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -1192,7 +1192,9 @@ class PlotWidget(qt.QMainWindow):
         if replace:
             self._resetColorAndStyle()
 
-        if color is not None:
+        if color is not None and linestyle is not None:
+            default_color, default_linestyle = color, linestyle
+        elif color is not None:
             default_color, default_linestyle = color, self._getStyle()
         else:
             default_color, default_linestyle = self._getColorAndStyle()

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -1192,12 +1192,10 @@ class PlotWidget(qt.QMainWindow):
         if replace:
             self._resetColorAndStyle()
 
-        if color is None:
-            default_color, default_linestyle = self._getColorAndStyle()
-        elif linestyle is None:
+        if color is not None:
             default_color, default_linestyle = color, self._styleList[self._styleIndex]
         else:
-            default_color, default_linestyle = color, linestyle
+            default_color, default_linestyle = self._getColorAndStyle()
 
         # Create/Update curve object
         curve = self.getCurve(legend)

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -1341,7 +1341,6 @@ class PlotWidget(qt.QMainWindow):
             # add it to the plot
             histo = items.Histogram()
             histo.setName(legend)
-            histo.setColor(self._getColorAndStyle()[0])
 
         # Override previous/default values with provided ones
         if color is not None:
@@ -1350,6 +1349,8 @@ class PlotWidget(qt.QMainWindow):
                 if isinstance(color, str)
                 else color
             )
+        else:
+            histo.setColor(self._getColorAndStyle()[0])
         if fill is not None:
             histo.setFill(fill)
         if z is not None:

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -3112,7 +3112,7 @@ class PlotWidget(qt.QMainWindow):
 
         return color, style
 
-     # Misc.
+    # Misc.
 
     def getWidgetHandle(self):
         """Return the widget the plot is displayed in.

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -1192,10 +1192,12 @@ class PlotWidget(qt.QMainWindow):
         if replace:
             self._resetColorAndStyle()
 
-        if color is None:
+        if color is None and linestyle is None:
             default_color, default_linestyle = self._getColorAndStyle()
         elif linestyle is None:
             default_color, default_linestyle = color, self._getStyle()
+        elif color is None:
+            default_color, default_linestyle = self._getColor(), linestyle
         else:
             default_color, default_linestyle = color, linestyle
 
@@ -3111,6 +3113,25 @@ class PlotWidget(qt.QMainWindow):
             style = " "
 
         return color, style
+    
+    def _getColor(self) -> str:
+        defaultColors = self.getDefaultColors()
+        if self._colorIndex >= len(defaultColors):  # Handle list length updated
+            self._colorIndex = 0
+
+        color = defaultColors[self._colorIndex]
+
+        # Loop over color and then styles
+        self._colorIndex += 1
+        if self._colorIndex >= len(defaultColors):
+            self._colorIndex = 0
+            #self._styleIndex = (self._styleIndex + 1) % len(self._styleList)
+
+        # If color is the one of active curve, take the next one
+        if colors.rgba(color) == self.getActiveCurveStyle().getColor():
+            color = self._getColor()
+
+        return color
     
     def _getStyle(self) -> str:
         style = self._styleList[self._styleIndex]

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -1192,12 +1192,12 @@ class PlotWidget(qt.QMainWindow):
         if replace:
             self._resetColorAndStyle()
 
-        if color is not None and linestyle is not None:
-            default_color, default_linestyle = color, linestyle
-        elif color is not None:
+        if color is None:
+            default_color, default_linestyle = self._getColorAndStyle()
+        elif linestyle is None:
             default_color, default_linestyle = color, self._getStyle()
         else:
-            default_color, default_linestyle = self._getColorAndStyle()
+            default_color, default_linestyle = color, linestyle
 
         # Create/Update curve object
         curve = self.getCurve(legend)

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -1192,12 +1192,10 @@ class PlotWidget(qt.QMainWindow):
         if replace:
             self._resetColorAndStyle()
 
-        if color is None and linestyle is None:
+        if color is None:
             default_color, default_linestyle = self._getColorAndStyle()
         elif linestyle is None:
-            default_color, default_linestyle = color, self._getStyle()
-        elif color is None:
-            default_color, default_linestyle = self._getColor(), linestyle
+            default_color, default_linestyle = color, self._styleList[self._styleIndex]
         else:
             default_color, default_linestyle = color, linestyle
 
@@ -3113,37 +3111,8 @@ class PlotWidget(qt.QMainWindow):
             style = " "
 
         return color, style
-    
-    def _getColor(self) -> str:
-        defaultColors = self.getDefaultColors()
-        if self._colorIndex >= len(defaultColors):  # Handle list length updated
-            self._colorIndex = 0
 
-        color = defaultColors[self._colorIndex]
-
-        # Loop over color and then styles
-        self._colorIndex += 1
-        if self._colorIndex >= len(defaultColors):
-            self._colorIndex = 0
-            #self._styleIndex = (self._styleIndex + 1) % len(self._styleList)
-
-        # If color is the one of active curve, take the next one
-        if colors.rgba(color) == self.getActiveCurveStyle().getColor():
-            color = self._getColor()
-
-        return color
-    
-    def _getStyle(self) -> str:
-        style = self._styleList[self._styleIndex]
-        self._styleIndex = (self._styleIndex + 1) % len(self._styleList)
-
-        if not self._plotLines:
-            style = " "
-
-        return style
-
-
-    # Misc.
+     # Misc.
 
     def getWidgetHandle(self):
         """Return the widget the plot is displayed in.


### PR DESCRIPTION
Checklist:

- [ ] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>
From #4133 

This PR fixed the way the addCurve requests color and style (examples)
Test code:

```
from silx.gui.plot import Plot2D
import numpy as np
from PyQt5.QtWidgets import QApplication, QMainWindow

if __name__ == "__main__":
    app = QApplication([])
    mw = QMainWindow()
    plot = Plot2D()

    x = np.linspace(0,10,10)

    y = [x*ii for ii in range(20)]

    for _ in range(20):
        color, style = plot._getColorAndStyle()
        print(f"color index is {plot._colorIndex}, style index is {plot._styleIndex}")
        plot.addCurve(x,y[_], legend=_ , 
                      #color='black',
                      color=color,
                      linestyle=style,
                     # linestyle='-',
                      )

    mw.setCentralWidget(plot)
    mw.show()
    app.exec_()

```

- If a color is requested before to use in the plot (and maybe other plots or markers), it completes the 10 colors of the colormap before changing the linestyle
![image](https://github.com/silx-kit/silx/assets/112327909/1a11220e-b0dd-47f6-b23e-f316aace757e)

```
color index is 1, style index is 0
color index is 2, style index is 0
color index is 3, style index is 0
color index is 4, style index is 0
color index is 5, style index is 0
color index is 6, style index is 0
color index is 7, style index is 0
color index is 8, style index is 0
color index is 9, style index is 0
color index is 0, style index is 1
color index is 1, style index is 1
color index is 2, style index is 1
color index is 3, style index is 1
color index is 4, style index is 1
color index is 5, style index is 1
color index is 6, style index is 1
color index is 7, style index is 1
color index is 8, style index is 1
color index is 9, style index is 1
color index is 0, style index is 2
```

Before the PR, addCurve request the color again (not to be used) but advances +1, so the colormap finish after 5 iterations:
![image](https://github.com/silx-kit/silx/assets/112327909/3454edf9-7d91-49a7-8705-b3100db96ee9)

```
color index is 1, style index is 0
color index is 3, style index is 0
color index is 5, style index is 0
color index is 7, style index is 0
color index is 9, style index is 0
color index is 1, style index is 1
color index is 3, style index is 1
color index is 5, style index is 1
color index is 7, style index is 1
color index is 9, style index is 1
color index is 1, style index is 2
color index is 3, style index is 2
color index is 5, style index is 2
color index is 7, style index is 2
color index is 9, style index is 2
color index is 1, style index is 3
color index is 3, style index is 3
color index is 5, style index is 3
color index is 7, style index is 3
color index is 9, style index is 3
```





- Now, since there is a method -_getStyle, decoupled from color, if a color ('black') is passed to addCurve, it will add +1 to the linestyle index.
![image](https://github.com/silx-kit/silx/assets/112327909/48bd425e-1126-4c4a-9785-07f7649a3a83)
```
color index is 0, style index is 0
color index is 0, style index is 1
color index is 0, style index is 2
color index is 0, style index is 3
color index is 0, style index is 0
color index is 0, style index is 1
color index is 0, style index is 2
color index is 0, style index is 3
color index is 0, style index is 0
color index is 0, style index is 1
color index is 0, style index is 2
color index is 0, style index is 3
color index is 0, style index is 0
color index is 0, style index is 1
color index is 0, style index is 2
color index is 0, style index is 3
color index is 0, style index is 0
color index is 0, style index is 1
color index is 0, style index is 2
color index is 0, style index is 3
```


Before the PR, it waits 10 color indexes to change the style:
![image](https://github.com/silx-kit/silx/assets/112327909/b2629711-d1b8-461f-b1f1-d7b3472437c9)

```
color index is 0, style index is 0
color index is 1, style index is 0
color index is 2, style index is 0
color index is 3, style index is 0
color index is 4, style index is 0
color index is 5, style index is 0
color index is 6, style index is 0
color index is 7, style index is 0
color index is 8, style index is 0
color index is 9, style index is 0
color index is 0, style index is 1
color index is 1, style index is 1
color index is 2, style index is 1
color index is 3, style index is 1
color index is 4, style index is 1
color index is 5, style index is 1
color index is 6, style index is 1
color index is 7, style index is 1
color index is 8, style index is 1
color index is 9, style index is 1
```


closes #4133