### PR TITLE
silx.app.view.CustomPlotSelectionWindow : Add dataset directly from silx + drop overlay on plot

### DIFF
--- a/src/silx/app/view/CustomPlotSelectionWindow.py
+++ b/src/silx/app/view/CustomPlotSelectionWindow.py
@@ -359,23 +359,27 @@ class _DropTreeView(qt.QTreeView):
         if parentItem is None:
             parentItem = self.model().getXParent()
             index = self.model().index(0, 2)
-            button = qt.QToolButton(self)
-            button.setIcon(icons.getQIcon("remove"))
-            button.clicked.connect(
-                functools.partial(self._removeFile, None, parentItem)
-            )
+            button = self._getRemoveButton(None, parentItem)
             self.setIndexWidget(index, button)
             return
 
         # If the parentItem is not None, the remove button is for a Y dataset
         removeItem = parentItem.child(row, 2)
         if removeItem:
-            button = qt.QToolButton(self)
-            button.setIcon(icons.getQIcon("remove"))
-            button.clicked.connect(
-                functools.partial(self._removeFile, removeItem, parentItem)
-            )
+            button = self._getRemoveButton(removeItem, parentItem)
             self.setIndexWidget(removeItem.index(), button)
+
+    def _getRemoveButton(
+        self, removeItem: qt.QStandardItem | None, parentItem: qt.QStandardItem
+    ) -> qt.QToolButton:
+        """Return a remove button widget."""
+        button = qt.QToolButton(self)
+        button.setIcon(icons.getQIcon("remove"))
+        button.setStyleSheet("QToolButton { border-radius: 0px; }")
+        button.clicked.connect(
+            functools.partial(self._removeFile, removeItem, parentItem)
+        )
+        return button
 
     def _removeFile(
         self, removeItem: qt.QStandardItem | None, parentItem: qt.QStandardItem
@@ -566,6 +570,7 @@ class _DropPlot1D(plot.Plot1D):
 
 class _PlotToolBar(qt.QToolBar):
     """Toolbar widget for the plot."""
+
     def __init__(self, parent=None):
         super().__init__(parent)
 
@@ -576,8 +581,10 @@ class _PlotToolBar(qt.QToolBar):
         clearAction.triggered.connect(treeView.clear)
         self.addAction(clearAction)
 
+
 class DropOverlay(qt.QWidget):
     """Overlay widget for displaying drop zones on the plot."""
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setAttribute(qt.Qt.WA_TransparentForMouseEvents)
@@ -597,8 +604,9 @@ class DropOverlay(qt.QWidget):
         """Paint the overlay."""
         painter = qt.QPainter(self)
         painter.setRenderHint(qt.QPainter.Antialiasing)
-        painter.setPen(qt.QPen(qt.Qt.red, 3, qt.Qt.DashLine))
-        painter.setBrush(qt.QBrush(qt.Qt.transparent))
+        painter.setPen(qt.QPen(qt.Qt.black, 3, qt.Qt.DashLine))
+        brush_color = qt.QColor(0, 0, 0, 50)
+        painter.setBrush(qt.QBrush(brush_color))
         painter.drawRect(self.rect())
 
 

--- a/src/silx/app/view/CustomPlotSelectionWindow.py
+++ b/src/silx/app/view/CustomPlotSelectionWindow.py
@@ -206,14 +206,6 @@ class _FileListModel(qt.QStandardItemModel):
 
         return fileItem, iconItem, removeItem
 
-    def fileItemExists(self, filename: str) -> bool:
-        """Return if a file item with the given filename exists in the model for the Y datasets."""
-        for row in range(self.getYParent().rowCount()):
-            item = self.item(row, 1)
-            if item and item.text() == filename:
-                return True
-        return False
-
     def addUrl(self, url: silx.io.url.DataUrl, node: str = "X"):
         """Add a dataset to the model"""
         if url.file_path() is not None:
@@ -455,7 +447,6 @@ class _DropTreeView(qt.QTreeView):
                 if (
                     silx.io.is_dataset(data)
                     and data.ndim == 1
-                    and not self.model().fileItemExists(url.data_path())
                 ):
                     event.acceptProposedAction()
         else:
@@ -516,6 +507,7 @@ class _DropPlot1D(plot.Plot1D):
         self._treeView.acceptDragEvent(event)
         if event.isAccepted():
             self._showDropOverlay(event)
+            self.dropOverlay.show()
 
     def dragMoveEvent(self, event):
         super().dragMoveEvent(event)
@@ -523,11 +515,11 @@ class _DropPlot1D(plot.Plot1D):
 
     def dragLeaveEvent(self, event):
         super().dragLeaveEvent(event)
-        self.dropOverlay.hideOverlay()
+        self.dropOverlay.hide()
 
     def dropEvent(self, event):
         super().dropEvent(event)
-        self.dropOverlay.hideOverlay()
+        self.dropOverlay.hide()
         byteString = event.mimeData().data("application/x-silx-uri")
         url = silx.io.url.DataUrl(byteString.data().decode("utf-8"))
 
@@ -566,7 +558,7 @@ class _DropPlot1D(plot.Plot1D):
         else:
             rect = qt.QRect(left + offset.x(), top + offset.y(), width, height)
 
-        self.dropOverlay.showOverlay(rect)
+        self.dropOverlay.setGeometry(rect)
 
 
 class _PlotToolBar(qt.QToolBar):
@@ -596,10 +588,6 @@ class DropOverlay(qt.QWidget):
         """Show the overlay at the given rectangle."""
         self.setGeometry(rect)
         self.show()
-
-    def hideOverlay(self):
-        """Hide the overlay."""
-        self.hide()
 
     def paintEvent(self, event):
         """Paint the overlay."""

--- a/src/silx/app/view/CustomPlotSelectionWindow.py
+++ b/src/silx/app/view/CustomPlotSelectionWindow.py
@@ -94,7 +94,7 @@ class _HashDropZones(qt.QStyledItemDelegate):
             painter.drawText(
                 option.rect.adjusted(3, 3, -3, -3),
                 qt.Qt.AlignLeft | qt.Qt.AlignVCenter,
-                "Drop a 1D dataset",
+                " Drop a 1D dataset",
             )
             painter.restore()
         else:
@@ -514,7 +514,8 @@ class _DropPlot1D(plot.Plot1D):
     def dragEnterEvent(self, event):
         super().dragEnterEvent(event)
         self._treeView.acceptDragEvent(event)
-        self._showDropOverlay(event)
+        if event.isAccepted():
+            self._showDropOverlay(event)
 
     def dragMoveEvent(self, event):
         super().dragMoveEvent(event)
@@ -561,7 +562,7 @@ class _DropPlot1D(plot.Plot1D):
         yAreaTop = top + height
 
         if dropPosition.y() > yAreaTop:
-            rect = qt.QRect(left + offset.x(), yAreaTop + offset.y(), width, 20)
+            rect = qt.QRect(left + offset.x(), yAreaTop + offset.y(), width, 50)
         else:
             rect = qt.QRect(left + offset.x(), top + offset.y(), width, height)
 
@@ -604,7 +605,6 @@ class DropOverlay(qt.QWidget):
         """Paint the overlay."""
         painter = qt.QPainter(self)
         painter.setRenderHint(qt.QPainter.Antialiasing)
-        painter.setPen(qt.QPen(qt.Qt.black, 3, qt.Qt.DashLine))
         brush_color = qt.QColor(0, 0, 0, 50)
         painter.setBrush(qt.QBrush(brush_color))
         painter.drawRect(self.rect())

--- a/src/silx/app/view/CustomPlotSelectionWindow.py
+++ b/src/silx/app/view/CustomPlotSelectionWindow.py
@@ -444,10 +444,7 @@ class _DropTreeView(qt.QTreeView):
             url = silx.io.url.DataUrl(byteString.data().decode("utf-8"))
             with silx.io.open(url.file_path()) as file:
                 data = file[url.data_path()]
-                if (
-                    silx.io.is_dataset(data)
-                    and data.ndim == 1
-                ):
+                if silx.io.is_dataset(data) and data.ndim == 1:
                     event.acceptProposedAction()
         else:
             event.ignore()
@@ -600,16 +597,16 @@ class CustomPlotSelectionWindow(qt.QMainWindow):
         super().__init__(parent)
         self.setWindowTitle("Plot selection")
 
-        self.plot1D = _DropPlot1D()
-        model = _FileListModel(self.plot1D)
+        plot1D = _DropPlot1D()
+        model = _FileListModel(plot1D)
 
-        self.treeView = _DropTreeView(model, self)
-        self.plot1D.setTreeView(self.treeView)
+        self._treeView = _DropTreeView(model, self)
+        plot1D.setTreeView(self._treeView)
 
         centralWidget = qt.QSplitter()
 
-        centralWidget.addWidget(self.treeView)
-        centralWidget.addWidget(self.plot1D)
+        centralWidget.addWidget(self._treeView)
+        centralWidget.addWidget(plot1D)
 
         centralWidget.setCollapsible(0, False)
         centralWidget.setCollapsible(1, False)
@@ -617,9 +614,9 @@ class CustomPlotSelectionWindow(qt.QMainWindow):
 
         self.setCentralWidget(centralWidget)
 
-        self.toolbar = _PlotToolBar(self)
-        self.toolbar.addClearAction(self.treeView)
-        self.addToolBar(qt.Qt.TopToolBarArea, self.toolbar)
+        toolbar = _PlotToolBar(self)
+        toolbar.addClearAction(self._treeView)
+        self.addToolBar(qt.Qt.TopToolBarArea, toolbar)
 
     def showEvent(self, event):
         super().showEvent(event)
@@ -628,3 +625,11 @@ class CustomPlotSelectionWindow(qt.QMainWindow):
     def hideEvent(self, event):
         super().hideEvent(event)
         self.sigVisibilityChanged.emit(False)
+
+    def setX(self, dataUrl: silx.io.url.DataUrl):
+        """Set the X dataset in the model and the plot."""
+        self._treeView.setX(dataUrl)
+
+    def addY(self, dataUrl: silx.io.url.DataUrl):
+        """Add a Y dataset to the model and the plot."""
+        self._treeView.addY(dataUrl)

--- a/src/silx/app/view/CustomPlotSelectionWindow.py
+++ b/src/silx/app/view/CustomPlotSelectionWindow.py
@@ -584,11 +584,6 @@ class DropOverlay(qt.QWidget):
         self.setAttribute(qt.Qt.WA_NoSystemBackground)
         self.hide()
 
-    def showOverlay(self, rect):
-        """Show the overlay at the given rectangle."""
-        self.setGeometry(rect)
-        self.show()
-
     def paintEvent(self, event):
         """Paint the overlay."""
         painter = qt.QPainter(self)

--- a/src/silx/app/view/Viewer.py
+++ b/src/silx/app/view/Viewer.py
@@ -1016,11 +1016,11 @@ class Viewer(qt.QMainWindow):
                 menu.addAction(action)
 
                 if h5.ndim == 1:
-                    action = qt.QAction("Set to plot selection (X)", event.source())
+                    action = qt.QAction("Set abscissa to plot selection", event.source())
                     action.triggered.connect(lambda: self.setToPlotSelection(obj.data_url))
                     menu.addAction(action)
 
-                    action = qt.QAction("Add to plot selection (Y)", event.source())
+                    action = qt.QAction("Add ordinate to plot selection (Y)", event.source())
                     action.triggered.connect(lambda: self.addToPlotSelection(obj.data_url))
                     menu.addAction(action)
 

--- a/src/silx/app/view/Viewer.py
+++ b/src/silx/app/view/Viewer.py
@@ -998,7 +998,6 @@ class Viewer(qt.QMainWindow):
 
         for obj in selectedObjects:
             h5 = obj.h5py_object
-        
             name = obj.name
             if name.startswith("/"):
                 name = name[1:]

--- a/src/silx/app/view/Viewer.py
+++ b/src/silx/app/view/Viewer.py
@@ -1020,7 +1020,7 @@ class Viewer(qt.QMainWindow):
                     action.triggered.connect(lambda: self.setToPlotSelection(obj.data_url))
                     menu.addAction(action)
 
-                    action = qt.QAction("Add ordinate to plot selection (Y)", event.source())
+                    action = qt.QAction("Add ordinate to plot selection", event.source())
                     action.triggered.connect(lambda: self.addToPlotSelection(obj.data_url))
                     menu.addAction(action)
 

--- a/src/silx/app/view/Viewer.py
+++ b/src/silx/app/view/Viewer.py
@@ -962,10 +962,23 @@ class Viewer(qt.QMainWindow):
             self.__customNxdataWindow.setVisible(True)
             self._displayCustomNxdataWindow.setChecked(True)
 
+    def __makeSureCustomPlotSelectionWindowIsVisible(self):
+        if not self._customPlotSelectionWindow.isVisible():
+            self._customPlotSelectionWindow.setVisible(True)
+            self._displayCustomPlotSelectionWindow.setChecked(True)
+
     def useAsNewCustomSignal(self, h5dataset):
         self.__makeSureCustomNxDataWindowIsVisible()
         model = self.__customNxdata.model()
         model.createFromSignal(h5dataset)
+
+    def setToPlotSelection(self, h5dataset):
+        self.__makeSureCustomPlotSelectionWindowIsVisible()
+        self._customPlotSelectionWindow.treeView.setX(h5dataset)
+
+    def addToPlotSelection(self, h5dataset):
+        self.__makeSureCustomPlotSelectionWindowIsVisible()
+        self._customPlotSelectionWindow.treeView.addY(h5dataset)
 
     def useAsNewCustomNxdata(self, h5nxdata):
         self.__makeSureCustomNxDataWindowIsVisible()
@@ -986,7 +999,7 @@ class Viewer(qt.QMainWindow):
 
         for obj in selectedObjects:
             h5 = obj.h5py_object
-
+        
             name = obj.name
             if name.startswith("/"):
                 name = name[1:]
@@ -1001,6 +1014,15 @@ class Viewer(qt.QMainWindow):
                 action = qt.QAction("Use as a new custom signal", event.source())
                 action.triggered.connect(lambda: self.useAsNewCustomSignal(h5))
                 menu.addAction(action)
+
+                if h5.ndim == 1:
+                    action = qt.QAction("Set to plot selection (X)", event.source())
+                    action.triggered.connect(lambda: self.setToPlotSelection(obj.data_url))
+                    menu.addAction(action)
+
+                    action = qt.QAction("Add to plot selection (Y)", event.source())
+                    action.triggered.connect(lambda: self.addToPlotSelection(obj.data_url))
+                    menu.addAction(action)
 
             if silx.io.is_group(h5) and silx.io.nxdata.is_valid_nxdata(h5):
                 action = qt.QAction("Use as a new custom NXdata", event.source())

--- a/src/silx/app/view/Viewer.py
+++ b/src/silx/app/view/Viewer.py
@@ -965,18 +965,17 @@ class Viewer(qt.QMainWindow):
     def __makeSureCustomPlotSelectionWindowIsVisible(self):
         if not self._customPlotSelectionWindow.isVisible():
             self._customPlotSelectionWindow.setVisible(True)
-            self._displayCustomPlotSelectionWindow.setChecked(True)
 
     def useAsNewCustomSignal(self, h5dataset):
         self.__makeSureCustomNxDataWindowIsVisible()
         model = self.__customNxdata.model()
         model.createFromSignal(h5dataset)
 
-    def setToPlotSelection(self, h5dataset):
+    def setToPlotSelectionAbscissaValues(self, h5dataset):
         self.__makeSureCustomPlotSelectionWindowIsVisible()
         self._customPlotSelectionWindow.treeView.setX(h5dataset)
 
-    def addToPlotSelection(self, h5dataset):
+    def addAsPlotSelectionOrdinateValues(self, h5dataset):
         self.__makeSureCustomPlotSelectionWindowIsVisible()
         self._customPlotSelectionWindow.treeView.addY(h5dataset)
 
@@ -1016,12 +1015,12 @@ class Viewer(qt.QMainWindow):
                 menu.addAction(action)
 
                 if h5.ndim == 1:
-                    action = qt.QAction("Set abscissa to plot selection", event.source())
-                    action.triggered.connect(lambda: self.setToPlotSelection(obj.data_url))
+                    action = qt.QAction("Set X value to plot selection", event.source())
+                    action.triggered.connect(lambda: self.setToPlotSelectionAbscissaValues(obj.data_url))
                     menu.addAction(action)
 
-                    action = qt.QAction("Add ordinate to plot selection", event.source())
-                    action.triggered.connect(lambda: self.addToPlotSelection(obj.data_url))
+                    action = qt.QAction("Add Y values to plot selection", event.source())
+                    action.triggered.connect(lambda: self.addAsPlotSelectionOrdinateValues(obj.data_url))
                     menu.addAction(action)
 
             if silx.io.is_group(h5) and silx.io.nxdata.is_valid_nxdata(h5):

--- a/src/silx/app/view/Viewer.py
+++ b/src/silx/app/view/Viewer.py
@@ -1014,7 +1014,7 @@ class Viewer(qt.QMainWindow):
                 menu.addAction(action)
 
                 if h5.ndim == 1:
-                    action = qt.QAction("Set X value to plot selection", event.source())
+                    action = qt.QAction("Set X values of plot selection", event.source())
                     action.triggered.connect(lambda: self.setToPlotSelectionAbscissaValues(obj.data_url))
                     menu.addAction(action)
 

--- a/src/silx/app/view/Viewer.py
+++ b/src/silx/app/view/Viewer.py
@@ -973,11 +973,11 @@ class Viewer(qt.QMainWindow):
 
     def setToPlotSelectionAbscissaValues(self, h5dataset):
         self.__makeSureCustomPlotSelectionWindowIsVisible()
-        self._customPlotSelectionWindow.treeView.setX(h5dataset)
+        self._customPlotSelectionWindow.setX(h5dataset)
 
     def addAsPlotSelectionOrdinateValues(self, h5dataset):
         self.__makeSureCustomPlotSelectionWindowIsVisible()
-        self._customPlotSelectionWindow.treeView.addY(h5dataset)
+        self._customPlotSelectionWindow.addY(h5dataset)
 
     def useAsNewCustomNxdata(self, h5nxdata):
         self.__makeSureCustomNxDataWindowIsVisible()


### PR DESCRIPTION
Added functionality to enhance the user experience.

**1. Added functionality for adding X or Y datasets directly from the main page**

To do this, simply : 
-  Open silx view
- Select a file
- Right-click on the dataset and choose one of the 2 options (see image)
             - Set abscissa to plot selection
             - Add ordinate to plot selection
 - The "Plot Selection" page will open

![image](https://github.com/silx-kit/silx/assets/102356226/526b561c-5f3d-4979-8427-0e18dbdbc6b8)

**2. Add user feedback when dropping on the plot** 

![image](https://github.com/silx-kit/silx/assets/102356226/51d357bb-6084-43cf-a02f-b322a49b5552)