### PR TITLE
silx.gui.dialog.ColormapDialog: Fixed typo in method name getDisplayMode

### DIFF
--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -86,6 +86,7 @@ from silx.gui.widgets.FormGridLayout import FormGridLayout
 from silx.math.histogram import Histogramnd
 from silx.gui.plot.items.roi import RectangleROI
 from silx.gui.plot.tools.roi import RegionOfInterestManager
+from silx.utils.deprecation import deprecated
 from silx.utils.enum import Enum as _Enum
 
 _logger = logging.getLogger(__name__)
@@ -781,8 +782,9 @@ class _ColormapHistogram(qt.QWidget):
     def getDisplayMode(self) -> DisplayMode:
         return self._displayMode
 
-    getDsiplayMode = getDisplayMode
-    """Compatibility with silx <= 2.1.0"""
+    @deprecated(since_version="2.1.0", replacement="getDisplayMode")
+    def getDsiplayMode(self):
+        return self.getDisplayMode()
 
     def _displayModeChanged(self, action):
         mode = action.data()

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -778,8 +778,11 @@ class _ColormapHistogram(qt.QWidget):
         self._displayMode = mode
         self._updateDisplayMode()
 
-    def getDsiplayMode(self) -> DisplayMode:
+    def getDisplayMode(self) -> DisplayMode:
         return self._displayMode
+
+    getDsiplayMode = getDisplayMode
+    """Compatibility with silx <= 2.1.0"""
 
     def _displayModeChanged(self, action):
         mode = action.data()


### PR DESCRIPTION
There was a typo on the API.

<!--
Thank you for your pull request!

Please use a Pull Request title that follows the requested syntax since it will be included in the release notes), see:
https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format
-->

Checklist:

- [ ] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->
- `ColormapDialog`
    - Renamed method `getDsiplayMode` into `getDisplayMode`