### PR TITLE
`silx.math.fit.peaks`: Fixed `-Wuse-after-free` warning

### DIFF
--- a/src/silx/math/fit/peaks/src/peaks.c
+++ b/src/silx/math/fit/peaks/src/peaks.c
@@ -206,22 +206,20 @@ long seek(long begin_index,
                         realloc_peaks = realloc(peaks0, max_npeaks * sizeof(double));
                         if (realloc_peaks == NULL) {
                             printf("Error: failed to extend memory for peaks array.");
-                            *peaks = peaks0;
-                            *relevances = relevances0;
                             return(-n_peaks);
                         } else {
                             peaks0 = realloc_peaks;
+                            *peaks = peaks0;
                         }
 
                         realloc_relevances = realloc(relevances0, max_npeaks * sizeof(double));
                         if (realloc_relevances == NULL) {
                             printf("Error: failed to extend memory for peak relevances array.");
-                            *peaks = peaks0;
-                            *relevances = relevances0;
                             return(-n_peaks);
                         }
                         else {
                             relevances0 = realloc_relevances;
+                            *relevances = relevances0;
                         }
                     }
                     peaks0[n_peaks] = cch-1;
@@ -257,7 +255,5 @@ long seek(long begin_index,
         printf("index %g with y = %g\n", peaks0[i],data[(long ) peaks0[i]]);
       }
     }
-    *peaks = peaks0;
-    *relevances = relevances0;
     return (n_peaks);
 }

--- a/src/silx/math/fit/peaks/src/peaks.c
+++ b/src/silx/math/fit/peaks/src/peaks.c
@@ -1,5 +1,5 @@
 #/*##########################################################################
-# Copyright (c) 2004-2016 European Synchrotron Radiation Facility
+# Copyright (c) 2004-2024 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -204,15 +204,23 @@ long seek(long begin_index,
                     if (n_peaks == max_npeaks) {
                         max_npeaks = max_npeaks + 100;
                         realloc_peaks = realloc(peaks0, max_npeaks * sizeof(double));
-                        realloc_relevances = realloc(relevances0, max_npeaks * sizeof(double));
-                        if (realloc_peaks == NULL || realloc_relevances == NULL) {
+                        if (realloc_peaks == NULL) {
                             printf("Error: failed to extend memory for peaks array.");
+                            *peaks = peaks0;
+                            *relevances = relevances0;
+                            return(-n_peaks);
+                        } else {
+                            peaks0 = realloc_peaks;
+                        }
+
+                        realloc_relevances = realloc(relevances0, max_npeaks * sizeof(double));
+                        if (realloc_relevances == NULL) {
+                            printf("Error: failed to extend memory for peak relevances array.");
                             *peaks = peaks0;
                             *relevances = relevances0;
                             return(-n_peaks);
                         }
                         else {
-                            peaks0 = realloc_peaks;
                             relevances0 = realloc_relevances;
                         }
                     }


### PR DESCRIPTION
Checklist:
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))
<hr>
<!-- provide a description of the changes below -->

This PR aims at fixing `Wuse-after-free` warning with recent gcc (12 or 14?) reported in #4139.
At least, it fixes the case of a first successful realloc for `peaks0` and a failed second realloc for `relevances0` (in which case `peaks0` points to freed memory).


closes #4139