### PR TITLE
`silx.opencl.convolution`: Fixed separable convolution on CPU that crashed in some cases

### DIFF
--- a/src/silx/opencl/convolution.py
+++ b/src/silx/opencl/convolution.py
@@ -385,7 +385,7 @@ class Convolution(OpenclProcessing):
             self.kernel_args, input_ref, output_ref
         )
         ev = opencl_kernel(*opencl_kernel_args)
-        if self.device.type == "CPU":
+        if self.queue.device.type == cl.device_type.CPU:
             ev.wait()
         if self.profile:
             self.events.append(EventDescription("batched convolution", ev))

--- a/src/silx/opencl/convolution.py
+++ b/src/silx/opencl/convolution.py
@@ -385,6 +385,8 @@ class Convolution(OpenclProcessing):
             self.kernel_args, input_ref, output_ref
         )
         ev = opencl_kernel(*opencl_kernel_args)
+        if self.device.type == "CPU":
+            ev.wait()
         if self.profile:
             self.events.append(EventDescription("batched convolution", ev))
 


### PR DESCRIPTION
Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

This MR adds a synchronization for separable convolution on CPU. For some reason [it failed](https://ci.debian.net/packages/n/nabu/testing/amd64/49560879) when used by nabu for "unsharp mask" operation.