### PR TITLE
silx.gui.plot: Added support for non-uniform images in matplotlib backend

### DIFF
--- a/src/silx/gui/plot/backends/BackendBase.py
+++ b/src/silx/gui/plot/backends/BackendBase.py
@@ -166,6 +166,25 @@ class BackendBase(object):
         """
         return object()
 
+    def addNonUniformImage(self, x, y, data, origin, scale, colormap, alpha):
+        """
+        Add a non-uniform image to the plot.
+
+        :param numpy.ndarray x: 1D array of X coordinates of the data.
+        :param numpy.ndarray y: 1D array of Y coordinates of the data.
+        :param numpy.ndarray data: (nrows, ncolumns) data or
+            (nrows, ncolumns, RGBA) ubyte array
+        :param tuple[float] origin: (origin X, origin Y) of the data.
+            Default: (0., 0.)
+        :param tuple[float] scale: (scale X, scale Y) of the data.
+            Default: (1., 1.)
+        :param ~silx.gui.colors.Colormap colormap: Colormap object to use.
+            Ignored if data is RGB(A).
+        :param float alpha: Opacity of the image, as a float in range [0, 1].
+        :returns: The handle used by the backend to univocally access the image
+        """
+        return object()
+
     def addTriangles(self, x, y, triangles, color, alpha):
         """Add a set of triangles.
 

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -30,6 +30,7 @@ __license__ = "MIT"
 __date__ = "21/12/2018"
 
 import logging
+import warnings
 import weakref
 
 import numpy
@@ -1125,6 +1126,18 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             raise RuntimeError("Cannot add image with Y <= 0 with Y axis log scale")
 
         return image
+
+    def addNonUniformImage(self, x, y, data, origin, scale, colormap, alpha):
+        """
+        Add a non-uniform image to the plot.
+
+        This method is not yet implemented in the OpenGL backend.
+        """
+        warnings.warn(
+            "addNonUniformImage not implemented in OpenGL backend. Plotting image "
+            "with regular grid instead."
+        )
+        return self.addImage(data, origin, scale, colormap, alpha)
 
     def addTriangles(self, x, y, triangles, color, alpha):
         # Handle axes log scale: convert data


### PR DESCRIPTION
Added support for matplotlib NonUniformImages in the silx.gui.plot module.

Motivation for this change: When changing for example 2d-integration results from Q/2theta to d-spacing for analysis, the Q/2theta axis becomes non-linear and could not be displayed property for 2d-data.

A new ```addNonUniformImage(x, y, data)``` method which follows the syntax of matplotlib's ```NonUniformImage.set_data(x, y, data)``` syntax has been added to the ```PlotWidget``` with minor refactoring of the addImage to allow reusing code for both ```addImage``` and ```addNonUniformImage```.

The change has also been integrated in the Backends (and the OpenGL backend gives a warning and displays plot as "normal" images) and in the ImageData class.

Possible open issue: The ```addNonUniformImage``` is not implemented for RGB(A) data, I could not easily find out if this would really be used anywhere.