### PR TITLE
silx.gui.colors: Add "percentile" mode for autoscaling

### DIFF
--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -331,10 +331,10 @@ class Colormap(qt.QObject):
     """constant for autoscale using mean +/- 3*std(data)
     with a clamp on min/max of the data"""
 
-    PERCENTILE = "percentile"
+    PERCENTILE_1_99 = "percentile_1_99"
     """constant for autoscale using 1st and 99th percentile of data"""
 
-    AUTOSCALE_MODES = (MINMAX, STDDEV3, PERCENTILE)
+    AUTOSCALE_MODES = (MINMAX, STDDEV3, PERCENTILE_1_99)
     """Tuple of managed auto scale algorithms"""
 
     sigChanged = qt.Signal()

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -331,7 +331,10 @@ class Colormap(qt.QObject):
     """constant for autoscale using mean +/- 3*std(data)
     with a clamp on min/max of the data"""
 
-    AUTOSCALE_MODES = (MINMAX, STDDEV3)
+    PERCENTILE = "percentile"
+    """constant for autoscale using 1st and 99th percentile of data"""
+
+    AUTOSCALE_MODES = (MINMAX, STDDEV3, PERCENTILE)
     """Tuple of managed auto scale algorithms"""
 
     sigChanged = qt.Signal()

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -234,7 +234,7 @@ class _AutoscaleModeComboBox(qt.QComboBox):
     DATA = {
         Colormap.MINMAX: ("Min/max", "Use the data min/max"),
         Colormap.STDDEV3: ("Mean±3std", "Use the data mean ± 3 × standard deviation"),
-        Colormap.PERCENTILE: ("Percentile", "Use 1st to 99th percentile of data"),
+        Colormap.PERCENTILE_1_99: ("Percentile 1-99", "Use 1st to 99th percentile of data"),
     }
 
     def __init__(self, parent: qt.QWidget):

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -234,6 +234,7 @@ class _AutoscaleModeComboBox(qt.QComboBox):
     DATA = {
         Colormap.MINMAX: ("Min/max", "Use the data min/max"),
         Colormap.STDDEV3: ("Mean±3std", "Use the data mean ± 3 × standard deviation"),
+        Colormap.PERCENTILE: ("Percentile", "Use 1st to 99th percentile of data"),
     }
 
     def __init__(self, parent: qt.QWidget):

--- a/src/silx/gui/test/test_colors.py
+++ b/src/silx/gui/test/test_colors.py
@@ -430,6 +430,8 @@ class TestObjectAPI(ParametricTestCase):
         self.assertEqual(colormap.getAutoscaleMode(), Colormap.STDDEV3)
         colormap.setAutoscaleMode(Colormap.MINMAX)
         self.assertEqual(colormap.getAutoscaleMode(), Colormap.MINMAX)
+        colormap.setAutoscaleMode(Colormap.PERCENTILE_1_99)
+        self.assertEqual(colormap.getAutoscaleMode(), Colormap.PERCENTILE_1_99)
 
     def testStoreRestore(self):
         colormaps = [Colormap(name="viridis"), Colormap(normalization=Colormap.SQRT)]
@@ -592,6 +594,8 @@ class TestAutoscaleRange(ParametricTestCase):
             ),
             (Colormap.LINEAR, Colormap.STDDEV3, numpy.array([10, 100]), (10, 100)),
             (Colormap.LOGARITHM, Colormap.STDDEV3, numpy.array([10, 100]), (10, 100)),
+            (Colormap.LINEAR, Colormap.PERCENTILE_1_99, numpy.array([10, 100]), (10.9, 99.1)),
+            (Colormap.LOGARITHM, Colormap.PERCENTILE_1_99, numpy.array([10, 100]), (10.9, 99.1)),
             # With nan
             (
                 Colormap.LINEAR,
@@ -617,6 +621,18 @@ class TestAutoscaleRange(ParametricTestCase):
                 data_std_inside_nan,
                 (1, 1.6733506885453602),
             ),
+            (
+                Colormap.LINEAR,
+                Colormap.PERCENTILE_1_99,
+                numpy.array([10, 20, 50, nan]),
+                (10.2, 49.4),
+            ),
+            (
+                Colormap.LOGARITHM,
+                Colormap.PERCENTILE_1_99,
+                numpy.array([10, 50, 100, nan]),
+                (10.8, 99.),
+            ),
             # With negative
             (
                 Colormap.LOGARITHM,
@@ -629,6 +645,12 @@ class TestAutoscaleRange(ParametricTestCase):
                 Colormap.STDDEV3,
                 numpy.array([10, 100, -10]),
                 (10, 100),
+            ),
+            (
+                Colormap.LOGARITHM,
+                Colormap.PERCENTILE_1_99,
+                numpy.array([10, 50, 100, -50]),
+                (10.8, 99.),
             ),
         ]
         for norm, mode, array, expectedRange in data:

--- a/src/silx/gui/test/test_colors.py
+++ b/src/silx/gui/test/test_colors.py
@@ -652,6 +652,13 @@ class TestAutoscaleRange(ParametricTestCase):
                 numpy.array([10, 50, 100, -50]),
                 (10.8, 99.),
             ),
+            # With inf
+            (
+                Colormap.LOGARITHM,
+                Colormap.PERCENTILE_1_99,
+                numpy.array([10, 50, 100, float("inf")]),
+                (10.8, 99.),
+            ),
         ]
         for norm, mode, array, expectedRange in data:
             with self.subTest(norm=norm, mode=mode, array=array):

--- a/src/silx/math/colormap.py
+++ b/src/silx/math/colormap.py
@@ -265,6 +265,9 @@ class _NormalizationMixIn:
                 vmax = dmax
             else:
                 vmax = min(dmax, stdmax)
+        elif mode == "percentile":
+            vmin = numpy.nanpercentile(data, 1)
+            vmax = numpy.nanpercentile(data, 99)
 
         else:
             raise ValueError("Unsupported mode: %s" % mode)

--- a/src/silx/math/colormap.py
+++ b/src/silx/math/colormap.py
@@ -266,7 +266,7 @@ class _NormalizationMixIn:
             else:
                 vmax = min(dmax, stdmax)
         elif mode == "percentile_1_99":
-            vmin, vmax = numpy.nanpercentile(data, (1, 99))
+            vmin, vmax = self.autoscale_percentile_1_99(data)
 
         else:
             raise ValueError("Unsupported mode: %s" % mode)
@@ -320,6 +320,15 @@ class _NormalizationMixIn:
         return self.revert(mean - 3 * std, 0.0, 1.0), self.revert(
             mean + 3 * std, 0.0, 1.0
         )
+
+    def autoscale_percentile_1_99(self, data):
+        """Autoscale using [1st, 99th] percentiles"""
+        data = data[self.is_valid(data)]
+        if data.dtype.kind == "f":  # Strip +/-inf
+            data = data[numpy.isfinite(data)]
+        if data.size == 0:
+            return None, None
+        return numpy.nanpercentile(data, (1, 99))
 
 
 class _LinearNormalizationMixIn(_NormalizationMixIn):

--- a/src/silx/math/colormap.py
+++ b/src/silx/math/colormap.py
@@ -266,8 +266,7 @@ class _NormalizationMixIn:
             else:
                 vmax = min(dmax, stdmax)
         elif mode == "percentile_1_99":
-            vmin = numpy.nanpercentile(data, 1)
-            vmax = numpy.nanpercentile(data, 99)
+            vmin, vmax = numpy.nanpercentile(data, (1, 99))
 
         else:
             raise ValueError("Unsupported mode: %s" % mode)

--- a/src/silx/math/colormap.py
+++ b/src/silx/math/colormap.py
@@ -265,7 +265,7 @@ class _NormalizationMixIn:
                 vmax = dmax
             else:
                 vmax = min(dmax, stdmax)
-        elif mode == "percentile":
+        elif mode == "percentile_1_99":
             vmin = numpy.nanpercentile(data, 1)
             vmax = numpy.nanpercentile(data, 99)
 


### PR DESCRIPTION
It autoscales from 1st to 99th (nan)percentiles of the data. In my experience this usually gives a sensible value window for realistic data. 
