### PR TITLE
silx.io.fioh5: Improved handling of missing data entries

### DIFF
--- a/src/silx/io/fioh5.py
+++ b/src/silx/io/fioh5.py
@@ -166,6 +166,20 @@ dtypeConverter = {
     "BOOLEAN": "?",
 }
 
+def _bytestobool (val):
+    """Convert a byte of truth to true (1) or false (0).
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+    """
+    val = val.decode().lower()
+    if val in ('y', 'yes', 't', 'true', 'on', '1'):
+        return True
+    elif val in ('n', 'no', 'f', 'false', 'off', '0'):
+        return False
+    else:
+        raise ValueError("invalid truth value %r" % (val,))
+
 
 def is_fiofile(filename):
     """Test if a file is a FIO file, by checking if three consecutive lines
@@ -256,11 +270,22 @@ class FioFile(object):
                         "Invalid fio file: Found no data "
                         "after %s lines" % ABORTLINENO
                     )
+            np_datatype = \
+                numpy.dtype([(n, t) for (n,t) in zip(self.names, self.dtypes)])
 
-            self.data = numpy.loadtxt(
+            converter = {}
+            for i, t in enumerate(self.dtypes):
+                if t == dtypeConverter['BOOLEAN']:
+                    converter[i] = _bytestobool
+
+            self.data = numpy.genfromtxt(
                 fiof,
-                dtype={"names": tuple(self.names), "formats": tuple(self.dtypes)},
+                dtype=np_datatype,
                 comments="!",
+                invalid_raise=True,
+                names=None,
+                deletechars='',
+                converters=converter
             )
 
             # ToDo: read only last line of file,
@@ -359,7 +384,7 @@ class FioH5(commonh5.File):
         try:
             fiof = FioFile(filename)  # reads complete file
         except Exception as e:
-            raise IOError("FIO file %s cannot be read.") from e
+            raise IOError("FIO file %s cannot be read." % filename) from e
 
         attrs = {
             "NX_class": to_h5py_utf8("NXroot"),

--- a/src/silx/io/fioh5.py
+++ b/src/silx/io/fioh5.py
@@ -171,7 +171,9 @@ def _bytestobool (val):
 
     Raises ValueError if 'val' is not supported.
     """
-    val = val.decode().lower()
+    if isinstance(val, bytes):
+        val = val.decode()
+    val.lower()
     if val in ('y', 'yes', 't', 'true', 'on', '1'):
         return True
     elif val in ('n', 'no', 'f', 'false', 'off', '0'):

--- a/src/silx/io/fioh5.py
+++ b/src/silx/io/fioh5.py
@@ -167,10 +167,9 @@ dtypeConverter = {
 }
 
 def _bytestobool (val):
-    """Convert a byte of truth to true (1) or false (0).
-    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
-    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
-    'val' is anything else.
+    """Convert bytes of a truth value to bool.
+
+    Raises ValueError if 'val' is not supported.
     """
     val = val.decode().lower()
     if val in ('y', 'yes', 't', 'true', 'on', '1'):
@@ -178,7 +177,7 @@ def _bytestobool (val):
     elif val in ('n', 'no', 'f', 'false', 'off', '0'):
         return False
     else:
-        raise ValueError("invalid truth value %r" % (val,))
+        raise ValueError("Invalid truth value %r" % val)
 
 
 def is_fiofile(filename):


### PR DESCRIPTION
Enables the loading of fio files with missing data entries, that can not be converted into the target data type.
Mostly uses the default behaviour of [numpy.genfromtxt](https://numpy.org/doc/stable/reference/generated/numpy.genfromtxt.html).

For example: Entries like ``<no data>`` or ``nan`` in a FLOAT data column are automatically converted to ``numpy.nan`` by ``numpy.genfromtxt``. 

Not all missing values can be handled:
Missing boolean or integer values cannot be flagged as missing (i.e. ``nan``) in a bool or integer array and thus result in a ``ValueError``.

Closes #4155 



