### PR TITLE
silx.util.retry: Fixed resetting the timeout timer when iterating

### DIFF
--- a/src/silx/utils/retry.py
+++ b/src/silx/utils/retry.py
@@ -85,12 +85,12 @@ def _retry_loop(retry_timeout=None, retry_period=None, retry_on_error=None):
     retry_state = {"t0": t0, "exception": None, "retry_on_error": retry_on_error}
     while True:
         yield retry_state
-        if retry_period is not None:
-            time.sleep(retry_period)
-        if has_timeout and (time.time() - t0) > retry_timeout:
+        if has_timeout and (time.time() - retry_state["t0"]) > retry_timeout:
             err_msg = "%s seconds" % retry_timeout
             cause = retry_state.get("exception")
             raise RetryTimeoutError(err_msg) from cause
+        if retry_period is not None:
+            time.sleep(retry_period)
 
 
 def retry(


### PR DESCRIPTION
This fix warrants a silx release. It affects all online workflows using blissdata.