### PR TITLE
macos-11 github runner image was removed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
           - os: windows-2019
             cibw_archs: "auto64"
             with_sse2: true
-          - os: macos-11
+          - os: macos-12
             cibw_archs: "universal2"
             with_sse2: true
 


### PR DESCRIPTION
Not sure where to find the list of available github runner images (`os` variable), but here is one:

https://docs.github.com/en/actions/writing-workflows/choosing-where-your-workflow-runs/choosing-the-runner-for-a-job#standard-github-hosted-runners-for-public-repositories

or we can check

https://github.com/actions/runner-images/tree/main/images

In any case, macos-11 was removed recently:

https://github.com/actions/runner-images/pull/10383