### PR TITLE
CI: Updated configuration; Dependencies: Removed `bitshuffle` from test dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
           - os: windows-2019
             cibw_archs: "auto64"
             with_sse2: true
-          - os: macos-11
+          - os: macos-12
             cibw_archs: "universal2"
             with_sse2: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,8 +176,7 @@ jobs:
           CIBW_TEST_COMMAND: python -c "import silx.test, sys; sys.exit(silx.test.run_tests(verbosity=3))"
           # Skip tests for emulated architectures and arm64 macos
           # Skip cp38 test on macos: Issue with libOpenGL
-          # Skip cp311 and cp312 on macos: bitshuffle does not build there
-          CIBW_TEST_SKIP: "*-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-macosx_universal2:arm64 cp38-macosx* cp311-macosx* cp312-macosx*"
+          CIBW_TEST_SKIP: "*-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-macosx_universal2:arm64 cp38-macosx*"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,20 @@
 Release Notes
 =============
 
+2.1.1: 2024/08/13
+-----------------
+
+* Bug fixes
+
+  * `silx.io.specfile`: Fixed `SpecFile` deallocation issue (PR #4129)
+  * `silx.gui.data.DataViewer.DataViewer`: Fixed issue with accessing views after using the removeView method (PR #4131)
+  * `silx.opencl.convolution`: Fixed separable convolution on CPU that crashed in some cases by (PR #4150)
+  * `silx.util.retry`: Fixed resetting the timeout timer when iterating (PR #4157)
+
+* Dependencies
+
+  * Removed numpy from build dependency (PR #4114)
+
 2.1.0: 2024/04/19
 -----------------
 

--- a/ci/requirements-pinned.txt
+++ b/ci/requirements-pinned.txt
@@ -1,12 +1,4 @@
-# To use pyopencl wheels on Windows
 --trusted-host www.silx.org
 --find-links http://www.silx.org/pub/wheelhouse/
 
-numpy<2; python_version <= '3.10'
-git+https://github.com/hgrecco/pint@f2e4081; python_version >= '3.10'
-
-# Pinpoint pyopencl on Windows to latest wheel available in www.silx.org
-# downloaded from https://www.lfd.uci.edu/~gohlke/pythonlibs/#pyopencl
-# Anyway, we don't test OpenCL on appveyor
-pyopencl == 2020.3.1; sys_platform == 'win32' and python_version < '3.8'
-pyopencl == 2023.1.4; sys_platform == 'win32' and python_version >= '3.8'
+# Placeholder for pinned packages used by CI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,4 +24,5 @@ filterwarnings = [
     # note the use of single quote below to denote "raw" strings in TOML
     'ignore:tostring\(\) is deprecated. Use tobytes\(\) instead\.:DeprecationWarning:OpenGL',
     'ignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning',
+    'ignore:Unable to import recommended hash:UserWarning:pytools',
 ]

--- a/setup.py
+++ b/setup.py
@@ -184,7 +184,8 @@ def get_project_configuration():
         "pytest>=6.0",
         "pytest-xvfb",
         "pytest-mock",
-        "bitshuffle",
+        # Remove bitshuffle until wheels with numpy 2 support are available
+        # "bitshuffle",
         "scipy>=1.10",
         "pooch",
     ]


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please use a Pull Request title that follows the requested syntax since it will be included in the release notes), see:
https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format
-->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This PR fixes issues in the CI that occured during v2.1.1 release by updating the CI configuration and by removing `bitshuffle` from the test dependencies since there is no wheels with numpy2 support available yet.
While this is clearly not great since it now skips the OpenCL bitshuffle implementation tests, it spares specific care and should be temporary (https://github.com/kiyo-masui/bitshuffle/pull/152).

This PR also:
- ignores warnings raised by the latest release  of `pytools` (used by `pyopencl`).
- remove requirements pinning that are no longer needed. Together with no using `bitshuffle`, this makes CI test with `numpy` v2.
- copies the v2.1.1 changelog to the `main` branch.

closes #4161 , closes #4162
