### PR TITLE
silx.io.commonh5, silx.utils.array_like: Fixed numpy 2 deprecation warning

### DIFF
--- a/src/silx/io/commonh5.py
+++ b/src/silx/io/commonh5.py
@@ -31,6 +31,8 @@ import h5py
 import numpy
 
 from . import utils
+from .._utils import NP_OPTIONAL_COPY
+
 
 __authors__ = ["V. Valls", "P. Knobel"]
 __license__ = "MIT"
@@ -347,12 +349,16 @@ class Dataset(Node):
         :rtype: list or None"""
         return None
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         # Special case for (0,)*-shape datasets
         if numpy.prod(self.shape) == 0:
             return self[()]
         else:
-            return numpy.array(self[...], dtype=self.dtype if dtype is None else dtype)
+            return numpy.array(
+                self[...],
+                dtype=self.dtype if dtype is None else dtype,
+                copy=NP_OPTIONAL_COPY if copy is None else copy,
+            )
 
     def __iter__(self):
         """Iterate over the first axis. TypeError if scalar."""

--- a/src/silx/utils/array_like.py
+++ b/src/silx/utils/array_like.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2016-2021 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2024 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -48,6 +48,9 @@ Functions:
 
 import numpy
 import numbers
+
+from .._utils import NP_OPTIONAL_COPY
+
 
 __authors__ = ["P. Knobel"]
 __license__ = "MIT"
@@ -276,13 +279,17 @@ class ListOfImages(object):
         )
         return sorted_indices
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         """Cast the images into a numpy array, and return it.
 
         If a transposition has been done on this images, return
         a transposed view of a numpy array."""
         return numpy.transpose(
-            numpy.array(self.images, dtype=dtype), self.transposition
+            numpy.array(
+                self.images,
+                dtype=dtype,
+                copy=NP_OPTIONAL_COPY if copy is None else copy),
+            self.transposition,
         )
 
     def __len__(self):
@@ -543,13 +550,17 @@ class DatasetView(object):
 
         return numpy.transpose(output_data_not_transposed, axes=output_dimensions)
 
-    def __array__(self, dtype=None):
+    def __array__(self, dtype=None, copy=None):
         """Cast the dataset into a numpy array, and return it.
 
         If a transposition has been done on this dataset, return
         a transposed view of a numpy array."""
         return numpy.transpose(
-            numpy.array(self.dataset, dtype=dtype), self.transposition
+            numpy.array(
+                self.dataset,
+                dtype=dtype,
+                copy=NP_OPTIONAL_COPY if copy is None else copy),
+            self.transposition,
         )
 
     def __len__(self):


### PR DESCRIPTION
<!--
Thank you for your pull request!

Please use a Pull Request title that follows the requested syntax since it will be included in the release notes), see:
https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format
-->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))



<hr>

<!-- provide a description of the changes below -->

In order to avoid the following deprecation warning:
```
 DeprecationWarning: __array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments.
```
this PR adds a `copy` argument to `__array__` methods as explained in the [numpy 2 migration guide](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword):

> For any `__array__` method on a non-NumPy array-like object, dtype=None and copy=None keywords must be added to the signature - this will work with older NumPy versions as well