### PR TITLE
`silx.gui`, silx view: Updated default Qt binding to `Pyside6`; CI: Updated config

### DIFF
--- a/.github/actions/setup-system/action.yml
+++ b/.github/actions/setup-system/action.yml
@@ -1,0 +1,33 @@
+name: 'Setup Linux'
+description: 'Install system packages and setup Intel Opencl ICD'
+
+runs:
+  using: "composite"
+  steps:
+    # Install packages:
+    # OpenCL lib
+    # xvfb to run the GUI test headless
+    # libegl1-mesa: Required by Qt xcb platform plugin
+    # libgl1-mesa-glx: For OpenGL
+    # xserver-xorg-video-dummy: For OpenGL
+    # libxkbcommon-x11-0, ..: needed for Qt plugins
+    - name: Install system packages
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install ocl-icd-opencl-dev xvfb libegl1-mesa libgl1-mesa-glx xserver-xorg-video-dummy libxkbcommon-x11-0 libxkbcommon0 libxkbcommon-dev libxcb-icccm4 libxcb-image0 libxcb-shm0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-sync1 libxcb-xfixes0 libxcb-xinerama0 libxcb-xkb1 libxcb-cursor0 libxcb1
+
+    - name: Setup Intel OpenCL ICD
+      if: runner.os == 'Linux'
+      shell: bash
+      run: |
+        wget -nv http://www.silx.org/pub/OpenCL/intel_opencl_icd-6.4.0.38.tar.gz -O - | tar -xzvf -
+        echo $(pwd)/intel_opencl_icd/icd/libintelocl.so > intel_opencl_icd/vendors/intel64.icd
+        echo "OCL_ICD_VENDORS=$(pwd)/intel_opencl_icd/vendors/intel64.icd" >> "$GITHUB_ENV"
+
+    - name: Setup OpenGL
+      if: runner.os == 'Windows'
+      shell: bash
+      run: |
+        C:\\msys64\\usr\\bin\\wget.exe -nv -O $(python -c 'import sys, os.path; print(os.path.dirname(sys.executable))')\\opengl32.dll http://www.silx.org/pub/silx/continuous_integration/opengl32_mingw-mesa-x86_64.dll

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,34 +61,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-        # Install packages:
-        # OpenCL lib
-        # xvfb to run the GUI test headless
-        # libegl1-mesa: Required by Qt xcb platform plugin
-        # libgl1-mesa-glx: For OpenGL
-        # xserver-xorg-video-dummy: For OpenGL
-        # libxkbcommon-x11-0, ..: needed for Qt plugins
-      - name: Install system packages
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install ocl-icd-opencl-dev xvfb libegl1-mesa libgl1-mesa-glx xserver-xorg-video-dummy libxkbcommon-x11-0 libxkbcommon0 libxkbcommon-dev libxcb-icccm4 libxcb-image0 libxcb-shm0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-sync1 libxcb-xfixes0 libxcb-xinerama0 libxcb-xkb1 libxcb-cursor0 libxcb1
-
-      - name: Setup Intel OpenCL ICD
-        if: runner.os == 'Linux'
-        run: |
-          wget -nv http://www.silx.org/pub/OpenCL/intel_opencl_icd-6.4.0.38.tar.gz -O - | tar -xzvf -
-          echo $(pwd)/intel_opencl_icd/icd/libintelocl.so > intel_opencl_icd/vendors/intel64.icd
-
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
 
-      - name: Setup OpenGL
-        if: runner.os == 'Windows'
-        run: |
-          C:\\msys64\\usr\\bin\\wget.exe -nv -O $(python -c 'import sys, os.path; print(os.path.dirname(sys.executable))')\\opengl32.dll http://www.silx.org/pub/silx/continuous_integration/opengl32_mingw-mesa-x86_64.dll
+      - uses: ./.github/actions/setup-system
 
       - name: Install build dependencies
         run: |
@@ -107,9 +85,6 @@ jobs:
           pip install -r ci/requirements-pinned.txt
           pip install --pre "${{ matrix.QT_API }}"
           pip install --pre "$(ls dist/silx*.whl)[full,test]"
-          if [ ${{ runner.os }} == 'Linux' ]; then
-              export OCL_ICD_VENDORS=$(pwd)/intel_opencl_icd/vendors
-          fi
           python ./ci/info_platform.py
           pip list
 
@@ -119,7 +94,4 @@ jobs:
           SILX_TEST_LOW_MEM: "False"
           SILX_OPENCL: ${{ matrix.with_opencl && 'True' || 'False' }}
         run: |
-          if [ ${{ runner.os }} == 'Linux' ]; then
-              export OCL_ICD_VENDORS=$(pwd)/intel_opencl_icd/vendors
-          fi
           python -c "import silx.test, sys; sys.exit(silx.test.run_tests(verbosity=1, args=['--qt-binding=${{ matrix.QT_API }}']));"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install system packages
-        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install xvfb libegl1-mesa libgl1-mesa-glx xserver-xorg-video-dummy libxkbcommon-x11-0 libxkbcommon0 libxkbcommon-dev libxcb-icccm4 libxcb-image0 libxcb-shm0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-sync1 libxcb-xfixes0 libxcb-xinerama0 libxcb-xkb1 libxcb-cursor0 libxcb1
@@ -167,6 +166,9 @@ jobs:
 
           CIBW_BUILD_VERBOSITY: 1
           CIBW_BUILD: cp310-* cp311-* cp312-* cp313-*
+          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+          CIBW_MANYLINUX_PPC64LE_IMAGE: manylinux_2_28
           # Do not build for pypy and muslinux
           CIBW_SKIP: pp* *-musllinux_*
           CIBW_ARCHS: ${{ matrix.cibw_archs }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - name: Install system packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install xvfb libegl1-mesa libgl1-mesa-glx xserver-xorg-video-dummy libxkbcommon-x11-0 libxkbcommon0 libxkbcommon-dev libxcb-icccm4 libxcb-image0 libxcb-shm0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-sync1 libxcb-xfixes0 libxcb-xinerama0 libxcb-xkb1 libxcb-cursor0 libxcb1
+      - name: Setup Intel OpenCL ICD
+        run: |
+          wget -nv http://www.silx.org/pub/OpenCL/intel_opencl_icd-6.4.0.38.tar.gz -O - | tar -xzvf -
+          echo $(pwd)/intel_opencl_icd/icd/libintelocl.so > intel_opencl_icd/vendors/intel64.icd
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -69,13 +77,14 @@ jobs:
       - name: Install pandoc&graphviz
         run: sudo apt-get install pandoc graphviz
       - name: Install silx
-        run: pip install .[full,test,doc]
+        run: pip install .[full,test,doc] siphash24
       - name: Build doc
         env:
           QT_QPA_PLATFORM: "offscreen"
         run: |
+          export OCL_ICD_VENDORS=$(pwd)/intel_opencl_icd/vendors
           export SILX_VERSION="$(python -c 'import silx; print(silx.strictversion)')"
-          sphinx-build doc/source/ "silx-${SILX_VERSION}_documentation/"
+          sphinx-build --fail-on-warning doc/source/ "silx-${SILX_VERSION}_documentation/"
           zip -r "silx-${SILX_VERSION}_documentation.zip" "silx-${SILX_VERSION}_documentation/"
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
           # Install test dependencies
+          CIBW_BEFORE_TEST_LINUX: yum install -y mesa-libEGL mesa-libGL libxkbcommon-x11 libxkbcommon xcb-util-image xcb-util-keysyms libXrandr xcb-util-renderutil libXcursor libxcb
           CIBW_TEST_EXTRAS: "full,test"
           CIBW_TEST_COMMAND: python -c "import silx.test, sys; sys.exit(silx.test.run_tests(verbosity=3))"
           # Skip tests for emulated architectures and arm64 macos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,14 +35,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install system packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install xvfb libegl1-mesa libgl1-mesa-glx xserver-xorg-video-dummy libxkbcommon-x11-0 libxkbcommon0 libxkbcommon-dev libxcb-icccm4 libxcb-image0 libxcb-shm0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-sync1 libxcb-xfixes0 libxcb-xinerama0 libxcb-xkb1 libxcb-cursor0 libxcb1
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
           cache: "pip"
+      - uses: ./.github/actions/setup-system
       - uses: actions/download-artifact@v4
         with:
           name: cibw-sdist
@@ -62,18 +59,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install system packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install xvfb libegl1-mesa libgl1-mesa-glx xserver-xorg-video-dummy libxkbcommon-x11-0 libxkbcommon0 libxkbcommon-dev libxcb-icccm4 libxcb-image0 libxcb-shm0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-sync1 libxcb-xfixes0 libxcb-xinerama0 libxcb-xkb1 libxcb-cursor0 libxcb1
-      - name: Setup Intel OpenCL ICD
-        run: |
-          wget -nv http://www.silx.org/pub/OpenCL/intel_opencl_icd-6.4.0.38.tar.gz -O - | tar -xzvf -
-          echo $(pwd)/intel_opencl_icd/icd/libintelocl.so > intel_opencl_icd/vendors/intel64.icd
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
           cache: "pip"
+      - uses: ./.github/actions/setup-system
       - name: Install pandoc&graphviz
         run: sudo apt-get install pandoc graphviz
       - name: Install silx
@@ -82,7 +72,6 @@ jobs:
         env:
           QT_QPA_PLATFORM: "offscreen"
         run: |
-          export OCL_ICD_VENDORS=$(pwd)/intel_opencl_icd/vendors
           export SILX_VERSION="$(python -c 'import silx; print(silx.strictversion)')"
           sphinx-build --fail-on-warning doc/source/ "silx-${SILX_VERSION}_documentation/"
           zip -r "silx-${SILX_VERSION}_documentation.zip" "silx-${SILX_VERSION}_documentation/"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+      - name: Install system packages
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install xvfb libegl1-mesa libgl1-mesa-glx xserver-xorg-video-dummy libxkbcommon-x11-0 libxkbcommon0 libxkbcommon-dev libxcb-icccm4 libxcb-image0 libxcb-shm0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-sync1 libxcb-xfixes0 libxcb-xinerama0 libxcb-xkb1 libxcb-cursor0 libxcb1
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -144,9 +144,9 @@ The mandatory dependencies are:
 
 The GUI widgets depend on the following extra packages:
 
-* A Qt binding: either `PyQt5 <https://riverbankcomputing.com/software/pyqt/intro>`_ (>= 5.9),
-  `PySide6 <https://pypi.org/project/PySide6/>`_ (>= 6.4) or
-  `PyQt6 <https://pypi.org/project/PyQt6/>`_ (>= 6.3)
+* A Qt binding: either `PySide6 <https://pypi.org/project/PySide6/>`_ (>= 6.4),
+  `PyQt6 <https://pypi.org/project/PyQt6/>`_ (>= 6.3) or
+  `PyQt5 <https://riverbankcomputing.com/software/pyqt/intro>`_ (>= 5.9)
 * `matplotlib <http://matplotlib.org/>`_
 * `PyOpenGL <http://pyopengl.sourceforge.net/>`_
 * `qtconsole <https://pypi.org/project/qtconsole>`_

--- a/doc/source/license.rst
+++ b/doc/source/license.rst
@@ -14,8 +14,8 @@ Note:
   
   silx uses the Qt library for its graphical user interfaces.
   A word of caution is to be provided.
-  If users develop and distribute software using modules accessing Qt by means of Riverbank Computing Qt bindings PyQt4 or PyQt5, those users will be conditioned by the license of their PyQt4/5 software (GPL or commercial).
-  If the end user does not own a commercial license of PyQt4 or PyQt5 and wishes to be free of any distribution condition, (s)he should be able to use PySide6 because it uses the LGPL license.
+  If users develop and distribute software using modules accessing Qt by means of Riverbank Computing Qt bindings PyQt6 or PyQt5, those users will be conditioned by the license of their PyQt6/5 software (GPL or commercial).
+  If the end user does not own a commercial license of PyQt6 or PyQt5 and wishes to be free of any distribution condition, (s)he should be able to use PySide6 because it uses the LGPL license.
 
 The following list provides the copyright and license of the different source files of the project:
 

--- a/doc/source/modules/gui/plot/getting_started.rst
+++ b/doc/source/modules/gui/plot/getting_started.rst
@@ -38,7 +38,7 @@ Compatibility with IPython
 ++++++++++++++++++++++++++
 
 silx widgets require Qt to be initialized.
-If Qt is not yet loaded, silx tries to load PyQt5 first before trying other supported bindings.
+If Qt is not yet loaded, silx tries to load PySide6 first before trying other supported bindings.
 
 With versions of IPython lower than 3.0 (e.g., on Debian 8), there is an incompatibility between
 the way silx loads Qt and the way IPython is doing it through the ``--gui`` option,
@@ -87,13 +87,13 @@ A Qt GUI script must have a QApplication initialised before creating widgets:
        [...]
        qapp.exec()
 
-Unless a Qt binding has already been loaded, :mod:`silx.gui.qt` uses one of the supported Qt bindings (PyQt5, PySide6, PyQt6).
+Unless a Qt binding has already been loaded, :mod:`silx.gui.qt` uses one of the supported Qt bindings (PySide6, PyQt6, PyQt5).
 If you prefer to choose the Qt binding yourself, import it before importing
 a module from :mod:`silx.gui`:
 
 .. code-block:: python
 
-   import PyQt5.QtCore  # Importing PyQt5 will force silx to use it
+   import PyQt6.QtCore  # Importing PyQt6 will force silx to use it
    from silx.gui import qt
 
 

--- a/package/windows/pyinstaller.spec
+++ b/package/windows/pyinstaller.spec
@@ -108,20 +108,17 @@ silx_coll = COLLECT(
 
 # Generate license file from current Python env
 def create_license_file(filename: str):
-    import PyQt5.QtCore
+    import PySide6.QtCore
 
     with open(filename, "w") as f:
         f.write(
             f"""
 This is free software.
 
-This distribution of silx is provided under the
-GNU General Public License v3 (https://www.gnu.org/licenses/gpl-3.0.en.html) since it includes PyQt5.
-
 It includes mainy software packages with different licenses:
 
 - Python ({sys.version}): PSF license, https://www.python.org/
-- Qt ({PyQt5.QtCore.qVersion()}): GNU Lesser General Public License v3, https://www.qt.io/
+- Qt ({PySide6.QtCore.qVersion()}): GNU Lesser General Public License v3, https://www.qt.io/
 """
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,4 +27,4 @@ scipy                     # For silx.math.fit demo, silx.image.sift demo, silx.i
 pooch                     # For scipy.datasets.ascent
 Pillow                    # For silx.opencl.image.test
 pint                      # For silx.io.dictdump
-PyQt5  # PySide6, PyQt6>=6.3 # For silx.gui
+PySide6 >= 6.4  # PyQt6, PyQt5  # For silx.gui

--- a/setup.py
+++ b/setup.py
@@ -173,7 +173,7 @@ def get_project_configuration():
         "matplotlib>=3.1.0",
         "PyOpenGL",
         "python-dateutil",
-        "PyQt5",
+        "PySide6>=6.4",
         # extra
         "hdf5plugin",
         "scipy",

--- a/src/silx/gui/qt/__init__.py
+++ b/src/silx/gui/qt/__init__.py
@@ -23,14 +23,14 @@
 # ###########################################################################*/
 """Common wrapper over Python Qt bindings:
 
-- `PyQt5 <http://pyqt.sourceforge.net/Docs/PyQt5/>`_
 - `PySide6 <https://pypi.org/project/PySide6/>`_
 - `PyQt6 <https://pypi.org/project/PyQt6/>`_
+- `PyQt5 <http://pyqt.sourceforge.net/Docs/PyQt5/>`_
 
 If a Qt binding is already loaded, it will be used.
 If the `QT_API` environment variable is set to one of the supported Qt bindings
 (case insensitive), this binding is loaded if available, otherwise the
-different Qt bindings are tried in this order: PyQt5, PySide6, PyQt6.
+different Qt bindings are tried in this order: PySide6, PyQt6, PyQt5.
 
 The name of the loaded Qt binding is stored in the BINDING variable.
 

--- a/src/silx/gui/qt/_qt.py
+++ b/src/silx/gui/qt/_qt.py
@@ -41,10 +41,10 @@ _logger = logging.getLogger(__name__)
 
 
 BINDING = None
-"""The name of the Qt binding in use: PyQt5, PySide6, PyQt6."""
+"""The name of the Qt binding in use: PySide6, PyQt6, PyQt5."""
 
 QtBinding = None  # noqa
-"""The Qt binding module in use: PyQt5, PySide6, PyQt6."""
+"""The Qt binding module in use: PySide6, PyQt6, PyQt5."""
 
 HAS_SVG = False
 """True if Qt provides support for Scalable Vector Graphics (QtSVG)."""
@@ -103,7 +103,7 @@ def _select_binding() -> str:
         else:
             return binding
 
-    raise ImportError("No Qt wrapper found. Install PyQt5, PySide6, PyQt6.")
+    raise ImportError("No Qt wrapper found. Install PySide6, PyQt6, PyQt5.")
 
 
 BINDING = _select_binding()

--- a/src/silx/gui/qt/_qt.py
+++ b/src/silx/gui/qt/_qt.py
@@ -64,7 +64,7 @@ def _select_binding() -> str:
     :raises ImportError:
     :returns: Loaded binding
     """
-    bindings = "PyQt5", "PySide6", "PyQt6"
+    bindings = "PySide6", "PyQt6", "PyQt5"
 
     envvar = os.environ.get("QT_API", "").lower()
 


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This PR proposes to change the Qt binding priority list to use PySide6 as the default binding.
It also uses `PySide6` to generate the Windows executable.

This is worth a major version bump for the next release IMO.

TODO:
- [x] Test Windows application
- [x] Make sure it is OK to use `manylinux_2_28`

related to #4135, closes #4168
