### PR TITLE
CI: Enabled OpenCL tests on Linux and OpenGL tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
 
         # Install packages:
-        # OpenCL lib and icd
+        # OpenCL lib
         # xvfb to run the GUI test headless
         # libegl1-mesa: Required by Qt xcb platform plugin
         # libgl1-mesa-glx: For OpenGL
@@ -63,7 +63,13 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install ocl-icd-opencl-dev intel-opencl-icd xvfb libegl1-mesa libgl1-mesa-glx xserver-xorg-video-dummy libxkbcommon-x11-0 libxkbcommon0 libxkbcommon-dev libxcb-icccm4 libxcb-image0 libxcb-shm0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-sync1 libxcb-xfixes0 libxcb-xinerama0 libxcb-xkb1 libxcb-cursor0 libxcb1
+          sudo apt-get install ocl-icd-opencl-dev xvfb libegl1-mesa libgl1-mesa-glx xserver-xorg-video-dummy libxkbcommon-x11-0 libxkbcommon0 libxkbcommon-dev libxcb-icccm4 libxcb-image0 libxcb-shm0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-sync1 libxcb-xfixes0 libxcb-xinerama0 libxcb-xkb1 libxcb-cursor0 libxcb1
+
+      - name: Setup Intel OpenCL ICD
+        if: runner.os == 'Linux'
+        run: |
+          wget -nv http://www.silx.org/pub/OpenCL/intel_opencl_icd-6.4.0.38.tar.gz -O - | tar -xzvf -
+          echo $(pwd)/intel_opencl_icd/icd/libintelocl.so > intel_opencl_icd/vendors/intel64.icd
 
       - uses: actions/setup-python@v5
         with:
@@ -87,6 +93,9 @@ jobs:
           pip install -r ci/requirements-pinned.txt
           pip install --pre "${{ matrix.QT_API }}"
           pip install --pre "$(ls dist/silx*.whl)[full,test]"
+          if [ ${{ runner.os }} == 'Linux' ]; then
+              export OCL_ICD_VENDORS=$(pwd)/intel_opencl_icd/vendors
+          fi
           python ./ci/info_platform.py
           pip list
 
@@ -97,5 +106,8 @@ jobs:
         run: |
           if [ ${{ runner.os }} == 'Windows' ]; then
               export WITH_GL_TEST=False
+          fi
+          if [ ${{ runner.os }} == 'Linux' ]; then
+              export OCL_ICD_VENDORS=$(pwd)/intel_opencl_icd/vendors
           fi
           python -c "import silx.test, sys; sys.exit(silx.test.run_tests(verbosity=1, args=['--qt-binding=${{ matrix.QT_API }}']));"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,49 +23,40 @@ jobs:
             python-version: "3.8"
             QT_API: PyQt5
             with_opencl: false
-            with_opengl: true
           - os: ubuntu-latest
             python-version: "3.11"
             QT_API: PyQt6
             with_opencl: true
-            with_opengl: true
           - os: ubuntu-latest
             python-version: "3.12"
             QT_API: PySide6
             with_opencl: true
-            with_opengl: true
 
           - os: macos-13
             python-version: "3.10"
             QT_API: PyQt5
             with_opencl: true
-            with_opengl: true
           - os: macos-13
             python-version: "3.12"
             QT_API: PyQt6
             with_opencl: true
-            with_opengl: true
           - os: macos-13
             python-version: "3.9"
             QT_API: PySide6
             with_opencl: true
-            with_opengl: true
 
           - os: windows-latest
             python-version: "3.9"
             QT_API: PyQt5
             with_opencl: false
-            with_opengl: false
           - os: windows-latest
             python-version: "3.12"
             QT_API: PyQt6
             with_opencl: false
-            with_opengl: false
           - os: windows-latest
             python-version: "3.10"
             QT_API: PySide6
             with_opencl: false
-            with_opengl: false
 
     steps:
       - uses: actions/checkout@v4
@@ -93,6 +84,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
+
+      - name: Setup OpenGL
+        if: runner.os == 'Windows'
+        run: |
+          C:\\msys64\\usr\\bin\\wget.exe -nv -O $(python -c 'import sys, os.path; print(os.path.dirname(sys.executable))')\\opengl32.dll http://www.silx.org/pub/silx/continuous_integration/opengl32_mingw-mesa-x86_64.dll
 
       - name: Install build dependencies
         run: |
@@ -122,7 +118,6 @@ jobs:
           QT_API: ${{ matrix.QT_API }}
           SILX_TEST_LOW_MEM: "False"
           SILX_OPENCL: ${{ matrix.with_opencl && 'True' || 'False' }}
-          WITH_GL_TEST: ${{ matrix.with_opengl && 'True' || 'False' }}
         run: |
           if [ ${{ runner.os }} == 'Linux' ]; then
               export OCL_ICD_VENDORS=$(pwd)/intel_opencl_icd/vendors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,32 +22,50 @@ jobs:
           - os: ubuntu-20.04
             python-version: "3.8"
             QT_API: PyQt5
+            with_opencl: false
+            with_opengl: true
           - os: ubuntu-latest
             python-version: "3.11"
             QT_API: PyQt6
+            with_opencl: true
+            with_opengl: true
           - os: ubuntu-latest
             python-version: "3.12"
             QT_API: PySide6
+            with_opencl: true
+            with_opengl: true
 
           - os: macos-13
             python-version: "3.10"
             QT_API: PyQt5
+            with_opencl: true
+            with_opengl: true
           - os: macos-13
             python-version: "3.12"
             QT_API: PyQt6
+            with_opencl: true
+            with_opengl: true
           - os: macos-13
             python-version: "3.9"
             QT_API: PySide6
+            with_opencl: true
+            with_opengl: true
 
           - os: windows-latest
             python-version: "3.9"
             QT_API: PyQt5
+            with_opencl: false
+            with_opengl: false
           - os: windows-latest
             python-version: "3.12"
             QT_API: PyQt6
+            with_opencl: false
+            with_opengl: false
           - os: windows-latest
             python-version: "3.10"
             QT_API: PySide6
+            with_opencl: false
+            with_opengl: false
 
     steps:
       - uses: actions/checkout@v4
@@ -103,10 +121,9 @@ jobs:
         env:
           QT_API: ${{ matrix.QT_API }}
           SILX_TEST_LOW_MEM: "False"
+          SILX_OPENCL: ${{ matrix.with_opencl && 'True' || 'False' }}
+          WITH_GL_TEST: ${{ matrix.with_opengl && 'True' || 'False' }}
         run: |
-          if [ ${{ runner.os }} == 'Windows' ]; then
-              export WITH_GL_TEST=False
-          fi
           if [ ${{ runner.os }} == 'Linux' ]; then
               export OCL_ICD_VENDORS=$(pwd)/intel_opencl_icd/vendors
           fi

--- a/src/silx/test/__init__.py
+++ b/src/silx/test/__init__.py
@@ -68,6 +68,7 @@ def run_tests(
         "-Wignore:tostring() is deprecated. Use tobytes() instead.:DeprecationWarning:OpenGL.GL.VERSION.GL_2_0",
         "-Wignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",
         "-Wignore:Unable to import recommended hash 'siphash24.siphash13', falling back to 'hashlib.sha256'. Run 'python3 -m pip install siphash24' to install the recommended hash.:UserWarning:pytools.persistent_dict",
+        "-Wignore:Non-empty compiler output encountered. Set the environment variable PYOPENCL_COMPILER_OUTPUT=1 to see more.:pyopencl.CompilerWarning",
         # Remove __array__ ignore once h5py v3.12 is released
         "-Wignore:__array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments.:DeprecationWarning",
     ] + list(args)

--- a/src/silx/test/__init__.py
+++ b/src/silx/test/__init__.py
@@ -68,7 +68,7 @@ def run_tests(
         "-Wignore:tostring() is deprecated. Use tobytes() instead.:DeprecationWarning:OpenGL.GL.VERSION.GL_2_0",
         "-Wignore:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",
         "-Wignore:Unable to import recommended hash 'siphash24.siphash13', falling back to 'hashlib.sha256'. Run 'python3 -m pip install siphash24' to install the recommended hash.:UserWarning:pytools.persistent_dict",
-        "-Wignore:Non-empty compiler output encountered. Set the environment variable PYOPENCL_COMPILER_OUTPUT=1 to see more.:pyopencl.CompilerWarning",
+        "-Wignore:Non-empty compiler output encountered. Set the environment variable PYOPENCL_COMPILER_OUTPUT=1 to see more.:UserWarning",
         # Remove __array__ ignore once h5py v3.12 is released
         "-Wignore:__array__ implementation doesn't accept a copy keyword, so passing copy=False failed. __array__ must implement 'dtype' and 'copy' keyword arguments.:DeprecationWarning",
     ] + list(args)


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This PR enables:
- OpenCL tests on Linux in github actions by using Intel OpenCL ICD (adapted from pyFAI config, thanks @kif !).
- OpenGL tests on Windows in github actions by a software rasterisation mesa OpenGL lib as it was done on appveyor.

It also explicitly enables/disables OpenCL tests depending on the platforms:
- Disabled on `ubuntu-20.04` because it seg fault. I used suspect the ICD to be incompatible with ubuntu 20.04.
- Disabled on Windows because installation of OpenCL is not done (yet).

OpenGL tests are now enabled on all platforms

