### PR TITLE
silx.gui.plot.items: Fixed Marker.setSymbolSize

### DIFF
--- a/src/silx/gui/plot/backends/BackendBase.py
+++ b/src/silx/gui/plot/backends/BackendBase.py
@@ -216,6 +216,7 @@ class BackendBase(object):
         text: str | None,
         color: str,
         symbol: str | None,
+        symbolsize: float,
         linestyle: str | tuple[float, tuple[float, ...] | None],
         linewidth: float,
         constraint: Callable[[float, float], tuple[float, float]] | None,

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -942,6 +942,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
         text,
         color,
         symbol,
+        symbolsize: float,
         linestyle,
         linewidth,
         constraint,
@@ -968,7 +969,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
         marker = self._getMarkerFromSymbol(symbol)
         if x is not None and y is not None:
             line = ax.plot(
-                x, y, linestyle=" ", color=color, marker=marker, markersize=10.0
+                x, y, linestyle=" ", color=color, marker=marker, markersize=symbolsize
             )[-1]
 
             if text is not None:

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -110,6 +110,7 @@ class _MarkerItem(dict):
         text,
         color,
         symbol,
+        symbolsize,
         linewidth,
         dashoffset,
         dashpattern,
@@ -136,6 +137,7 @@ class _MarkerItem(dict):
                 "color": colors.rgba(color),
                 "constraint": constraint if isConstraint else None,
                 "symbol": symbol,
+                "symbolsize": symbolsize,
                 "linewidth": linewidth,
                 "dashoffset": dashoffset,
                 "dashpattern": dashpattern,
@@ -737,7 +739,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
                         (pixelPos[1],),
                         marker=item["symbol"],
                         color=color,
-                        size=11,
+                        size=item["symbolsize"],
                     )
                     context.matrix = self.matScreenProj
                     marker.render(context)
@@ -1184,6 +1186,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         text,
         color,
         symbol,
+        symbolsize: float,
         linestyle,
         linewidth,
         constraint,
@@ -1201,6 +1204,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             text,
             color,
             symbol,
+            symbolsize,
             linewidth,
             dashoffset,
             dashpattern,

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -1204,7 +1204,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             text,
             color,
             symbol,
-            int(symbolsize + 0),
+            symbolsize,
             linewidth,
             dashoffset,
             dashpattern,

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -1204,7 +1204,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             text,
             color,
             symbol,
-            symbolsize,
+            int(symbolsize + 0),
             linewidth,
             dashoffset,
             dashpattern,

--- a/src/silx/gui/plot/items/marker.py
+++ b/src/silx/gui/plot/items/marker.py
@@ -83,7 +83,14 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
         self._constraint = self._defaultConstraint
         self.__isBeingDragged = False
 
-    def _addRendererCall(self, backend, symbol=None, linestyle="-", linewidth=1):
+    def _addRendererCall(
+        self,
+        backend,
+        symbol=None,
+        symbolsize=10.,
+        linestyle="-",
+        linewidth=1,
+    ):
         """Perform the update of the backend renderer"""
         return backend.addMarker(
             x=self.getXPosition(),
@@ -91,7 +98,7 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
             text=self.getText(),
             color=self.getColor(),
             symbol=symbol,
-            symbolsize=self.getSymbolSize(),
+            symbolsize=symbolsize,
             linestyle=linestyle,
             linewidth=linewidth,
             constraint=self.getConstraint(),
@@ -248,6 +255,9 @@ class Marker(MarkerBase, SymbolMixIn):
     _DEFAULT_SYMBOL = "+"
     """Default symbol of the marker"""
 
+    _DEFAULT_SYMBOL_SIZE = 10.0
+    """Default size of marker's symbol"""
+
     def __init__(self):
         MarkerBase.__init__(self)
         SymbolMixIn.__init__(self)
@@ -256,7 +266,11 @@ class Marker(MarkerBase, SymbolMixIn):
         self._y = 0.0
 
     def _addBackendRenderer(self, backend):
-        return self._addRendererCall(backend, symbol=self.getSymbol())
+        return self._addRendererCall(
+            backend,
+            symbol=self.getSymbol(),
+            symbolsize=self.getSymbolSize(),
+        )
 
     def _setConstraint(self, constraint):
         """Set the constraint function of the marker drag.

--- a/src/silx/gui/plot/items/marker.py
+++ b/src/silx/gui/plot/items/marker.py
@@ -78,6 +78,7 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
 
         self._x = None
         self._y = None
+        self._symbol_size = 10.0
         self._bgColor: colors.RGBAColorType | None = None
         self._constraint = self._defaultConstraint
         self.__isBeingDragged = False
@@ -90,6 +91,7 @@ class MarkerBase(Item, DraggableMixIn, ColorMixIn, YAxisMixIn):
             text=self.getText(),
             color=self.getColor(),
             symbol=symbol,
+            symbolsize=self.getSymbolSize(),
             linestyle=linestyle,
             linewidth=linewidth,
             constraint=self.getConstraint(),


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This is a rebase and rework of "Draft: Size for markers" #4026

Description from PR #4026:

Closes #4024

This API was exposed but not propagated the the backend.

Notice that the default marker size was not the same in mpl and opengl.
That's something which have to be checked.

Changelog:

    Markers now supports setSymbolSize
