### PR TITLE
CI: Updated release workflow to run on `macos-13`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
           - os: windows-2019
             cibw_archs: "auto64"
             with_sse2: true
-          - os: macos-12
+          - os: macos-13
             cibw_archs: "universal2"
             with_sse2: true
 


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->


macos-12 image will be removed on 3rd of December 2024: https://github.com/actions/runner-images/issues/10721

closes #4183
