### PR TITLE
silx.gui.plot.ImageStack: fix `_urlIndexes` initialization. 

### DIFF
--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -242,7 +242,7 @@ class ImageStack(qt.QMainWindow):
         """Clear the plot and remove any link to url"""
         self._freeLoadingThreads()
         self._urls = None
-        self._urlIndexes = None
+        self._urlIndexes = {}
         self._urlData = {}
         self._current_url = None
         self._plot.clear()


### PR DESCRIPTION
Make sure `ImageStack._urlIndexes` is always a dict.

This can be lead to errors when calling `ImageStack.getUrls` before any url is called and better for consistency.