### PR TITLE
silx.io.utils: Removed `print` statement

### DIFF
--- a/src/silx/io/utils.py
+++ b/src/silx/io/utils.py
@@ -423,7 +423,6 @@ def savespec(
     ncol = data.shape[0]
     assert len(labels) == ncol
 
-    print(xlabel, ylabel, fmt, ncol, x_array, y_array)
     if isinstance(fmt, str) and fmt.count("%") == 1:
         full_fmt_string = "  ".join([fmt] * ncol)
     elif isinstance(fmt, (list, tuple)) and len(fmt) == ncol:


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

Clean-up `print`
Related to #4178