### PR TITLE
MNT: use only int instead of long in cython code

### DIFF
--- a/src/silx/io/specfile.pyx
+++ b/src/silx/io/specfile.pyx
@@ -279,7 +279,7 @@ class MCA(object):
         if not len(self):
             raise IndexError("No MCA spectrum found in this scan")
 
-        if isinstance(key, (int, long)):
+        if isinstance(key, int):
             mca_index = key
             # allow negative index, like lists
             if mca_index < 0:


### PR DESCRIPTION
cython/cython#5830 /
d7e95912b6ed7d20e190fbf1aecb9f2a997d479 in cython removed long as a valid type in favor of int at language level 3.

<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->
