### PR TITLE
silx.gui.plot.tools.profile: Fixed profile error when plot item is None

### DIFF
--- a/src/silx/gui/plot/tools/profile/core.py
+++ b/src/silx/gui/plot/tools/profile/core.py
@@ -126,7 +126,10 @@ class ProfileRoiMixIn:
         previousPlotItem = self.getPlotItem()
         if previousPlotItem is plotItem:
             return
-        self.__plotItem = weakref.ref(plotItem)
+        if plotItem is None:
+            self.__plotItem = None
+        else:
+            self.__plotItem = weakref.ref(plotItem)
         self.sigPlotItemChanged.emit()
 
     def getPlotItem(self):


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

`ProfileRoiMixIn._setPlotItem` did not support `None`, which can lead to errors:

```
ERROR:silx.app.view.main:<class 'TypeError'> cannot create weak reference to 'NoneType' object   File "silx/gui/plot/tools/profile/manager.py", line 772, in __activeImageChanged
    self.setPlotItem(item)
  File "silx/gui/plot/tools/profile/manager.py", line 942, in setPlotItem
    self.requestUpdateAllProfile()
  File "silx/gui/plot/tools/profile/manager.py", line 844, in requestUpdateAllProfile
    self.requestUpdateProfile(roi)
  File "silx/gui/plot/tools/profile/manager.py", line 870, in requestUpdateProfile
    profileRoi._setPlotItem(None)
  File "silx/gui/plot/tools/profile/core.py", line 129, in _setPlotItem
    self.__plotItem = weakref.ref(plotItem)
                      ^^^^^^^^^^^^^^^^^^^^^
```