### PR TITLE
gui matplotlib backend warning: fix conflict between y limits and autoscale

### DIFF
--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1351,8 +1351,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
     def setKeepDataAspectRatio(self, flag):
         self.ax.set_aspect(1.0 if flag else "auto")
         self.ax2.set_aspect(1.0 if flag else "auto")
-        # self.ax.set_autoscaley_on(flag)
-        # self.ax2.set_autoscaley_on(flag)
+        self.ax.set_autoscaley_on(flag)
+        self.ax2.set_autoscaley_on(flag)
 
     def setGraphGrid(self, which):
         self.ax.grid(False, which="both")  # Disable all grid first

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1193,12 +1193,16 @@ class BackendMatplotlib(BackendBase.BackendBase):
         self.ax.set_xlim(min(xmin, xmax), max(xmin, xmax))
 
         if y2min is not None and y2max is not None:
-            if not self.isYAxisInverted():
+            if self.ax2.get_autoscaley_on():
+                pass
+            elif not self.isYAxisInverted():
                 self.ax2.set_ylim(min(y2min, y2max), max(y2min, y2max))
             else:
                 self.ax2.set_ylim(max(y2min, y2max), min(y2min, y2max))
 
-        if not self.isYAxisInverted():
+        if self.ax.get_autoscaley_on():
+            pass
+        elif not self.isYAxisInverted():
             self.ax.set_ylim(min(ymin, ymax), max(ymin, ymax))
         else:
             self.ax.set_ylim(max(ymin, ymax), min(ymin, ymax))
@@ -1347,6 +1351,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
     def setKeepDataAspectRatio(self, flag):
         self.ax.set_aspect(1.0 if flag else "auto")
         self.ax2.set_aspect(1.0 if flag else "auto")
+        # self.ax.set_autoscaley_on(flag)
+        # self.ax2.set_autoscaley_on(flag)
 
     def setGraphGrid(self, which):
         self.ax.grid(False, which="both")  # Disable all grid first

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1192,20 +1192,17 @@ class BackendMatplotlib(BackendBase.BackendBase):
         self._dirtyLimits = True
         self.ax.set_xlim(min(xmin, xmax), max(xmin, xmax))
 
+        keepRatio = self.isKeepDataAspectRatio()
         if y2min is not None and y2max is not None:
-            if self.ax2.get_autoscaley_on():
-                pass
-            elif not self.isYAxisInverted():
-                self.ax2.set_ylim(min(y2min, y2max), max(y2min, y2max))
+            if not self.isYAxisInverted():
+                self.ax2.set_ylim(min(y2min, y2max), max(y2min, y2max), auto=keepRatio)
             else:
-                self.ax2.set_ylim(max(y2min, y2max), min(y2min, y2max))
+                self.ax2.set_ylim(max(y2min, y2max), min(y2min, y2max), auto=keepRatio)
 
-        if self.ax.get_autoscaley_on():
-            pass
-        elif not self.isYAxisInverted():
-            self.ax.set_ylim(min(ymin, ymax), max(ymin, ymax))
+        if not self.isYAxisInverted():
+            self.ax.set_ylim(min(ymin, ymax), max(ymin, ymax), auto=keepRatio)
         else:
-            self.ax.set_ylim(max(ymin, ymax), min(ymin, ymax))
+            self.ax.set_ylim(max(ymin, ymax), min(ymin, ymax), auto=keepRatio)
 
         self._updateMarkers()
 
@@ -1254,10 +1251,11 @@ class BackendMatplotlib(BackendBase.BackendBase):
             xcenter = 0.5 * (xmin + xmax)
             ax.set_xlim(xcenter - 0.5 * newXRange, xcenter + 0.5 * newXRange)
 
+        keepRatio = self.isKeepDataAspectRatio()
         if not self.isYAxisInverted():
-            ax.set_ylim(ymin, ymax)
+            ax.set_ylim(ymin, ymax, auto=keepRatio)
         else:
-            ax.set_ylim(ymax, ymin)
+            ax.set_ylim(ymax, ymin, auto=keepRatio)
 
         self._updateMarkers()
 
@@ -1319,7 +1317,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
                     dataRange = self._plot.getDataRange()[dataRangeIndex]
                     if dataRange is None:
                         dataRange = 1, 100  # Fallback
-                    axis.set_ylim(*dataRange)
+                    axis.set_ylim(*dataRange, auto=self.isKeepDataAspectRatio())
                     redraw = True
             if redraw:
                 self.draw()
@@ -1351,8 +1349,6 @@ class BackendMatplotlib(BackendBase.BackendBase):
     def setKeepDataAspectRatio(self, flag):
         self.ax.set_aspect(1.0 if flag else "auto")
         self.ax2.set_aspect(1.0 if flag else "auto")
-        self.ax.set_autoscaley_on(flag)
-        self.ax2.set_autoscaley_on(flag)
 
     def setGraphGrid(self, which):
         self.ax.grid(False, which="both")  # Disable all grid first


### PR DESCRIPTION
This PR is an attempt to fix a warning appearing with matplotlib 3.10

See details in #4203 

close #4203 
