### PR TITLE
AbstractDataFileDialog: deleteLater models

### DIFF
--- a/src/silx/gui/dialog/AbstractDataFileDialog.py
+++ b/src/silx/gui/dialog/AbstractDataFileDialog.py
@@ -644,8 +644,12 @@ class AbstractDataFileDialog(qt.QDialog):
             self.__directory = self.directory()
         self.__browser.clear()
         self.__closeFile()
-        self.__fileModel = None
-        self.__dataModel = None
+        if self.__fileModel is not None:
+            self.__fileModel.deleteLater()
+            self.__fileModel = None
+        if self.__dataModel is not None:
+            self.__dataModel.deleteLater()
+            self.__dataModel = None
 
     def hasPendingEvents(self):
         """Returns true if the dialog have asynchronous tasks working on the

--- a/src/silx/gui/dialog/AbstractDataFileDialog.py
+++ b/src/silx/gui/dialog/AbstractDataFileDialog.py
@@ -644,9 +644,7 @@ class AbstractDataFileDialog(qt.QDialog):
             self.__directory = self.directory()
         self.__browser.clear()
         self.__closeFile()
-        if self.__fileModel is not None:
-            self.__fileModel.deleteLater()
-            self.__fileModel = None
+        self.__fileModel = None
         if self.__dataModel is not None:
             self.__dataModel.deleteLater()
             self.__dataModel = None


### PR DESCRIPTION
Addresses this bug in `pyFAI-calib2`:
https://github.com/silx-kit/pyFAI/issues/2422

<!-- Thank you for your pull request! -->

Checklist:

- [X] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->
