### PR TITLE
silx.io.h5py_utils: Fixed support of  libhdf5 1.14.x

### DIFF
--- a/src/silx/io/h5py_utils.py
+++ b/src/silx/io/h5py_utils.py
@@ -1,5 +1,5 @@
 # /*##########################################################################
-# Copyright (C) 2016-2024 European Synchrotron Radiation Facility
+# Copyright (C) 2016-2025 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -146,7 +146,11 @@ def retry_h5py_error(e):
         elif isinstance(e, KeyError):
             # For example this needs to be retried:
             # KeyError: 'Unable to open object (bad object header version number)'
-            return "Unable to open object" in str(e)
+            message = str(e)
+            return (
+                "Unable to open object" in message
+                or "Unable to synchronously open object" in message
+            )
     elif isinstance(e, retry_mod.RetryError):
         return True
     return False


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This PR fixes the detection of hdf5-related exceptions in `h5py_utils`'s `retry`.
The error message has changed in libhdf5 and some exceptions were no longer interpreted correctly.

closes #4241