### PR TITLE
OpenCL: Fix context creation through PYOPENCL_CTX environment variable

### DIFF
--- a/src/silx/opencl/common.py
+++ b/src/silx/opencl/common.py
@@ -119,7 +119,8 @@ def get_pyopencl_ctx_tuple(pyopencl_ctx_str):
         try:
             ret = int(val)
         except ValueError:
-            return default_val
+            ret = default_val
+        return ret
 
     if pyopencl_ctx_str in ["", ":"]:
         return (0, 0)

--- a/src/silx/opencl/common.py
+++ b/src/silx/opencl/common.py
@@ -110,6 +110,28 @@ NVIDIA_FLOP_PER_CORE = {
 
 AMD_FLOP_PER_CORE = 160  # Measured on a M7820 10 core, 700MHz 1120GFlops
 
+def get_pyopencl_ctx_tuple(pyopencl_ctx_str):
+    """
+    Converts a PYOPENCL_CTX environment variable into a tuple (platform, device)
+    """
+
+    def _convert_to_int(val, default_val=0):
+        try:
+            ret = int(val)
+        except ValueError:
+            return default_val
+
+    if pyopencl_ctx_str in ["", ":"]:
+        return (0, 0)
+    if ":" in pyopencl_ctx_str:
+        platform, device = pyopencl_ctx_str.split(":")
+        platform = _convert_to_int(platform)
+        device = _convert_to_int(device)
+    else:
+        platform = _convert_to_int(pyopencl_ctx_str)
+        device = 0
+    return (platform, device)
+
 
 class Device(object):
     """

--- a/src/silx/opencl/common.py
+++ b/src/silx/opencl/common.py
@@ -627,11 +627,11 @@ class OpenCL(object):
             platformid = int(platformid)
             deviceid = int(deviceid)
         elif "PYOPENCL_CTX" in os.environ:
-            (platformid, deviceid) = get_pyopencl_ctx_tuple(os.environ["PYOPENCL_CTX"])
-
-            try_ctx = self.context_cache.get((platformid, deviceid), None)
-            if try_ctx is not None:
-                return try_ctx
+            if cached:
+                (platformid, deviceid) = get_pyopencl_ctx_tuple(os.environ["PYOPENCL_CTX"])
+                try_ctx = self.context_cache.get((platformid, deviceid), None)
+                if try_ctx is not None:
+                    return try_ctx
 
             ctx = pyopencl.create_some_context()
             # try:

--- a/src/silx/opencl/common.py
+++ b/src/silx/opencl/common.py
@@ -627,11 +627,13 @@ class OpenCL(object):
             platformid = int(platformid)
             deviceid = int(deviceid)
         elif "PYOPENCL_CTX" in os.environ:
-            #
-            #
-            #
-            ctx = pyopencl.create_some_context()
+            (platformid, deviceid) = get_pyopencl_ctx_tuple(os.environ["PYOPENCL_CTX"])
 
+            try_ctx = self.context_cache.get((platformid, deviceid), None)
+            if try_ctx is not None:
+                return try_ctx
+
+            ctx = pyopencl.create_some_context()
             # try:
             device = ctx.devices[0]
             platforms = [

--- a/src/silx/opencl/common.py
+++ b/src/silx/opencl/common.py
@@ -110,9 +110,11 @@ NVIDIA_FLOP_PER_CORE = {
 
 AMD_FLOP_PER_CORE = 160  # Measured on a M7820 10 core, 700MHz 1120GFlops
 
-def get_pyopencl_ctx_tuple(pyopencl_ctx_str):
+def get_pyopencl_ctx_tuple(pyopencl_ctx_str, cache=None):
     """
     Converts a PYOPENCL_CTX environment variable into a tuple (platform, device)
+
+    :param cache: dict with the already created contexts
     """
 
     def _convert_to_int(val, default_val=0):
@@ -126,12 +128,24 @@ def get_pyopencl_ctx_tuple(pyopencl_ctx_str):
         return (0, 0)
     if ":" in pyopencl_ctx_str:
         platform, device = pyopencl_ctx_str.split(":")
-        platform = _convert_to_int(platform)
-        device = _convert_to_int(device)
+        platform_id = _convert_to_int(platform)
+        device_id = _convert_to_int(device)
+    elif pyopencl_ctx_str.isdigit():
+        platform_id = _convert_to_int(pyopencl_ctx_str)
+        device_id = 0
     else:
-        platform = _convert_to_int(pyopencl_ctx_str)
-        device = 0
-    return (platform, device)
+        if "choose_devices" in dir(pyopencl):
+            device = pyopencl.choose_devices(interactive=False)
+            device_id = device_instance.platform.get_devices().index(device_instance)
+            platform_id = pyopencl.get_platforms().index(device.platform)
+        else:  #Fallback for elder PyOpenCL
+            ctx = pyopencl.create_some_context(interactive=False)
+            device = device_instance = ctx.devices[0]
+            device_id = device_instance.platform.get_devices().index(device_instance)
+            platform_id = pyopencl.get_platforms().index(device.platform)
+            if cache is not None:
+                cache[(platform_id, device_id)] = ctx
+    return (platform_id, device_id)
 
 
 class Device(object):
@@ -628,31 +642,8 @@ class OpenCL(object):
             platformid = int(platformid)
             deviceid = int(deviceid)
         elif "PYOPENCL_CTX" in os.environ:
-            if cached:
-                (platformid, deviceid) = get_pyopencl_ctx_tuple(os.environ["PYOPENCL_CTX"])
-                try_ctx = self.context_cache.get((platformid, deviceid), None)
-                if try_ctx is not None:
-                    return try_ctx
-
-            ctx = pyopencl.create_some_context()
-            # try:
-            device = ctx.devices[0]
-            platforms = [
-                i
-                for i, p in enumerate(self.platforms)
-                if device.platform.name == p.name
-            ]
-            if platforms:
-                platformid = platforms[0]
-                devices = [
-                    i
-                    for i, d in enumerate(self.platforms[platformid].devices)
-                    if device.name == d.name
-                ]
-                if devices:
-                    deviceid = devices[0]
-                    if cached:
-                        self.context_cache[(platformid, deviceid)] = ctx
+            platformid, deviceid = get_pyopencl_ctx_tuple(os.environ["PYOPENCL_CTX"],
+                                                          cache=self.context_cache if cached else None)
         else:
             ids = self.select_device(type=devicetype, extensions=extensions)
             if ids:
@@ -663,19 +654,11 @@ class OpenCL(object):
                 ctx = self.context_cache[(platformid, deviceid)]
             else:
                 try:
-                    ctx = pyopencl.Context(
-                        devices=[
-                            pyopencl.get_platforms()[platformid].get_devices()[deviceid]
-                        ]
-                    )
+                    device = pyopencl.get_platforms()[platformid].get_devices()[deviceid]
+                    ctx = pyopencl.Context(devices=[device])
                 except pyopencl._cl.LogicError as error:
                     self.platforms[platformid].devices[deviceid].set_unavailable()
-                    logger.warning(
-                        "Unable to create context on %s/%s: %s",
-                        platformid,
-                        deviceid,
-                        error,
-                    )
+                    logger.warning(f"Unable to create context for ({platformid}:{deviceid}): {error}")
                     ctx = None
                 else:
                     if cached:

--- a/src/silx/opencl/common.py
+++ b/src/silx/opencl/common.py
@@ -605,7 +605,11 @@ class OpenCL(object):
             platformid = int(platformid)
             deviceid = int(deviceid)
         elif "PYOPENCL_CTX" in os.environ:
+            #
+            #
+            #
             ctx = pyopencl.create_some_context()
+
             # try:
             device = ctx.devices[0]
             platforms = [

--- a/src/silx/opencl/test/test_addition.py
+++ b/src/silx/opencl/test/test_addition.py
@@ -131,12 +131,8 @@ class TestAddition(unittest.TestCase):
         for platform in ocl.platforms:
             for did, device in enumerate(platform.devices):
                 meas = _measure_workgroup_size((platform.id, device.id))
-                self.assertEqual(
-                    meas,
-                    device.max_work_group_size,
-                    "Workgroup size for %s/%s: %s == %s"
-                    % (platform, device, meas, device.max_work_group_size),
-                )
+                self.assertEqual(meas, device.max_work_group_size,
+                    f"Workgroup size for {platform}/{device}: {meas} == {device.max_work_group_size}")
 
     def test_query(self):
         """

--- a/src/silx/opencl/test/test_processing.py
+++ b/src/silx/opencl/test/test_processing.py
@@ -1,7 +1,13 @@
 import os
 import pytest
-from silx.opencl.processing import OpenclProcessing
 
+from silx.opencl.common import ocl
+
+if ocl:
+    from silx.opencl.processing import OpenclProcessing
+
+
+@pytest.mark.skipif(ocl is None, reason="PyOpenCl is missing")
 def test_context_cache():
 
     op1 = OpenclProcessing()

--- a/src/silx/opencl/test/test_processing.py
+++ b/src/silx/opencl/test/test_processing.py
@@ -1,0 +1,15 @@
+import os
+import pytest
+from silx.opencl.processing import OpenclProcessing
+
+def test_context_cache():
+
+    op1 = OpenclProcessing()
+    op2 = OpenclProcessing()
+    assert op1.ctx is op2.ctx, "Context should be the same"
+
+    os.environ["PYOPENCL_CTX"] = "0:0"
+    op3 = OpenclProcessing()
+    op4 = OpenclProcessing()
+
+    assert op3.ctx is op4.ctx, "context should be the same"


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This MR addresses an issue in `opencl/common.py` when using `PYOPENCL_CTX` variable.  

When using `PYOPENCL_CTX`, a new context is always created regardless of the cache content. This contrasts with the behavior obtained when not using `PYOPENCL_CTX` (contexts are re-used whenever possible).

```python
import os
from silx.opencl.processing import OpenclProcessing

op1 = OpenclProcessing()
op2 = OpenclProcessing()
print(op1.ctx is op2.ctx) # True

os.environ["PYOPENCL_CTX"] = "0:0"
op3 = OpenclProcessing()
op4 = OpenclProcessing()

print(op3.ctx is op4.ctx) # False
```

