### PR TITLE
silx.gui.plot: Fixed PlotWidget axis for OpenGL backend

### DIFF
--- a/src/silx/gui/plot/_utils/__init__.py
+++ b/src/silx/gui/plot/_utils/__init__.py
@@ -86,7 +86,11 @@ def addMarginsToLimits(
                 y2Min = pow(10.0, yMinLog - yMinMargin * yRangeLog)
                 y2Max = pow(10.0, yMaxLog + yMaxMargin * yRangeLog)
 
+    xMin, xMax = checkAxisLimits(xMin, xMax, isXLog)
+    yMin, yMax = checkAxisLimits(yMin, yMax, isYLog)
+
     if y2Min is None or y2Max is None:
         return xMin, xMax, yMin, yMax
     else:
+        y2Min, y2Max = checkAxisLimits(y2Min, y2Max, isYLog)
         return xMin, xMax, yMin, yMax, y2Min, y2Max

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -1540,13 +1540,9 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             self._ensureAspectRatio(keepDim)
 
     def setLimits(self, xmin, xmax, ymin, ymax, y2min=None, y2max=None):
-        assert xmin < xmax
-        assert ymin < ymax
-
         if y2min is None or y2max is None:
             y2Range = None
         else:
-            assert y2min < y2max
             y2Range = y2min, y2max
         self._setPlotBounds((xmin, xmax), (ymin, ymax), y2Range)
 
@@ -1554,7 +1550,6 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         return self._plotFrame.dataRanges.x
 
     def setGraphXLimits(self, xmin, xmax):
-        assert xmin < xmax
         self._setPlotBounds(xRange=(xmin, xmax), keepDim="x")
 
     def getGraphYLimits(self, axis):
@@ -1565,7 +1560,6 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             return self._plotFrame.dataRanges.y2
 
     def setGraphYLimits(self, ymin, ymax, axis):
-        assert ymin < ymax
         assert axis in ("left", "right")
 
         if axis == "left":


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This PR fixes an issue when setting the limits of the plot with some margins and log scale.

To reproduce:
```
In [1]: from silx import sx, config

In [2]: config.DEFAULT_PLOT_BACKEND='gl'

In [3]: w = sx.imshow(((0, 0), (0, 255)))
```
Then open the Colormap dialog, set to autoscale and use log scale (Related to https://gitlab.esrf.fr/bliss/bliss/-/issues/4722).
