### PR TITLE
Documentation: Updated URL of silx-related presentations

### DIFF
--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -42,6 +42,6 @@ Project
 Additional Material
 -------------------
 
-- Code Camp held before releases: `The PDFs of the talks are available for download <http://ftp.esrf.fr/pub/scisoft/silx/talks/>`_
+- Code Camp held before releases: `The PDFs of the talks are available for download <https://www.silx.org/doc/silx/talks/>`_
 
 


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This PR updates the URL for getting silx code camps presentations from deprecated ftp.esrf.fr service to www.silx.org.
