### PR TITLE
silx.gui.widgets.ElidedLabel: Remove deprecated `getText` and `getToolTip` methods

### DIFF
--- a/src/silx/gui/widgets/ElidedLabel.py
+++ b/src/silx/gui/widgets/ElidedLabel.py
@@ -94,10 +94,6 @@ class ElidedLabel(qt.QLabel):
         """
         return self.__text
 
-    @deprecated(replacement="text", since_version="1.1.0")
-    def getText(self):
-        return self.text()
-
     def setText(self, text):
         self.__text = text
         self.__updateText()
@@ -109,10 +105,6 @@ class ElidedLabel(qt.QLabel):
         set to true.
         """
         return self.__toolTip
-
-    @deprecated(replacement="toolTip", since_version="1.1.0")
-    def getToolTip(self):
-        return self.toolTip()
 
     def setToolTip(self, toolTip):
         self.__toolTip = toolTip


### PR DESCRIPTION
Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

Part of #4236. I'll keep the last v1 deprecation for another PR so they're identified separately in the release notes.