### PR TITLE
silx.gui.plot.ImageView: Remove deprecated `profile` method

### DIFF
--- a/src/silx/gui/plot/ImageView.py
+++ b/src/silx/gui/plot/ImageView.py
@@ -55,7 +55,6 @@ from ..colors import cursorColorForColormap
 from .tools import LimitsToolBar
 from .Profile import ProfileToolBar
 from ...utils.proxy import docstring
-from ...utils.deprecation import deprecated
 from ...utils.enum import Enum
 from .tools.RadarView import RadarView
 from .utils.axis import SyncAxes
@@ -695,11 +694,6 @@ class ImageView(PlotWindow):
         :rtype: silx.gui.plot.PlotTools.ProfileToolBar
         """
         return self.__profile
-
-    @property
-    @deprecated(replacement="getProfileToolBar()")
-    def profile(self):
-        return self.getProfileToolBar()
 
     def getHistogram(self, axis):
         """Return the histogram and corresponding row or column extent.

--- a/src/silx/gui/widgets/ElidedLabel.py
+++ b/src/silx/gui/widgets/ElidedLabel.py
@@ -28,7 +28,6 @@ __date__ = "07/12/2018"
 
 
 from packaging.version import Version
-from ...utils.deprecation import deprecated
 from silx.gui import qt
 
 


### PR DESCRIPTION
Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

`profile` was replaced with `getProfileToolBar`. This deprecation was introduced in #3457, which seems to date back to v1