### PR TITLE
Hdf5TableView: use 'ScrollPerPixel' mode scrolling

### DIFF
--- a/src/silx/gui/data/Hdf5TableView.py
+++ b/src/silx/gui/data/Hdf5TableView.py
@@ -581,6 +581,7 @@ class Hdf5TableView(HierarchicalTableView.HierarchicalTableView):
         self.setModel(Hdf5TableModel(self))
         self.setItemDelegate(Hdf5TableItemDelegate(self))
         self.setSelectionMode(qt.QAbstractItemView.NoSelection)
+        self.setHorizontalScrollMode(qt.QAbstractItemView.ScrollPerPixel)
 
     def isSupportedData(self, data):
         """


### PR DESCRIPTION
This PR update the default update mode for scrolling for the HDF5TableView as this is more convenient


close #4118