### PR TITLE
silx view: improve NXdata signal selection

### DIFF
--- a/src/silx/gui/data/NXdataWidgets.py
+++ b/src/silx/gui/data/NXdataWidgets.py
@@ -989,7 +989,6 @@ class ArrayStackPlot(qt.QWidget):
         """Update displayed stack according to the current axes selector
         data."""
         stack = self._axesSelector.selectedData()
-        stack_name = self.__signal_name
         x_axis = self.__x_axis
         y_axis = self.__y_axis
         z_axis = self.__z_axis
@@ -1014,9 +1013,8 @@ class ArrayStackPlot(qt.QWidget):
         legend = legend[:-2] + "]"
         self._legend.setText("Displayed data: " + legend)
 
-        self._stack_view.setStack(
-            stack, stack_name=stack_name, calibrations=calibrations
-        )
+        self._stack_view.setStack(stack, calibrations=calibrations)
+        self._stack_view.setStackName(self.__signal_name)
         self._stack_view.setLabels(
             labels=[self.__z_axis_name, self.__y_axis_name, self.__x_axis_name]
         )

--- a/src/silx/gui/data/NXdataWidgets.py
+++ b/src/silx/gui/data/NXdataWidgets.py
@@ -79,16 +79,16 @@ class ArrayCurvePlot(qt.QWidget):
         self._plot = Plot1D(self)
         self._plot.setGraphGrid(True)
 
-        self._selector = NumpyAxesSelector(self)
-        self._selector.setNamedAxesSelectorVisibility(False)
-        self.__selector_is_connected = False
+        self._axesSelector = NumpyAxesSelector(self)
+        self._axesSelector.setNamedAxesSelectorVisibility(False)
+        self.__axes_selector_is_connected = False
 
         self._plot.sigActiveCurveChanged.connect(self._setYLabelFromActiveLegend)
 
         layout = qt.QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self._plot)
-        layout.addWidget(self._selector)
+        layout.addWidget(self._axesSelector)
 
         self.setLayout(layout)
 
@@ -136,16 +136,16 @@ class ArrayCurvePlot(qt.QWidget):
         self.__axis_name = xlabel
         self.__x_axis_errors = xerror
 
-        if self.__selector_is_connected:
-            self._selector.selectionChanged.disconnect(self._updateCurve)
-            self.__selector_is_connected = False
-        self._selector.setData(ys[0])
-        self._selector.setAxisNames(["Y"])
+        if self.__axes_selector_is_connected:
+            self._axesSelector.selectionChanged.disconnect(self._updateCurve)
+            self.__axes_selector_is_connected = False
+        self._axesSelector.setData(ys[0])
+        self._axesSelector.setAxisNames(["Y"])
 
         if len(ys[0].shape) < 2:
-            self._selector.hide()
+            self._axesSelector.hide()
         else:
-            self._selector.show()
+            self._axesSelector.show()
 
         self._plot.setGraphTitle(title or "")
         if xscale is not None:
@@ -154,12 +154,12 @@ class ArrayCurvePlot(qt.QWidget):
             self._plot.getYAxis().setScale("log" if yscale == "log" else "linear")
         self._updateCurve()
 
-        if not self.__selector_is_connected:
-            self._selector.selectionChanged.connect(self._updateCurve)
-            self.__selector_is_connected = True
+        if not self.__axes_selector_is_connected:
+            self._axesSelector.selectionChanged.connect(self._updateCurve)
+            self.__axes_selector_is_connected = True
 
     def _updateCurve(self):
-        selection = self._selector.selection()
+        selection = self._axesSelector.selection()
         ys = [sig[selection] for sig in self.__signals]
         y0 = ys[0]
         len_y = len(y0)
@@ -188,7 +188,7 @@ class ArrayCurvePlot(qt.QWidget):
             # errors only supported for primary signal in NXdata
             y_errors = None
             if i == 0 and self.__signal_errors is not None:
-                y_errors = self.__signal_errors[self._selector.selection()]
+                y_errors = self.__signal_errors[self._axesSelector.selection()]
             self._plot.addCurve(
                 x, ys[i], legend=legend, xerror=self.__x_axis_errors, yerror=y_errors
             )
@@ -206,9 +206,9 @@ class ArrayCurvePlot(qt.QWidget):
                 break
 
     def clear(self):
-        old = self._selector.blockSignals(True)
-        self._selector.clear()
-        self._selector.blockSignals(old)
+        old = self._axesSelector.blockSignals(True)
+        self._axesSelector.clear()
+        self._axesSelector.blockSignals(old)
         self._plot.clear()
 
 
@@ -407,9 +407,9 @@ class ArrayImagePlot(qt.QWidget):
         maskToolWidget.setItemMaskUpdated(True)
 
         # not closable
-        self._selector = NumpyAxesSelector(self)
-        self._selector.setNamedAxesSelectorVisibility(False)
-        self._selector.selectionChanged.connect(self._updateImage)
+        self._axesSelector = NumpyAxesSelector(self)
+        self._axesSelector.setNamedAxesSelectorVisibility(False)
+        self._axesSelector.selectionChanged.connect(self._updateImage)
 
         self._auxSigSlider = HorizontalSliderWithBrowser(parent=self)
         self._auxSigSlider.setMinimum(0)
@@ -419,7 +419,7 @@ class ArrayImagePlot(qt.QWidget):
 
         layout = qt.QVBoxLayout()
         layout.addWidget(self._plot)
-        layout.addWidget(self._selector)
+        layout.addWidget(self._axesSelector)
         layout.addWidget(self._auxSigSlider)
 
         self.setLayout(layout)
@@ -488,7 +488,7 @@ class ArrayImagePlot(qt.QWidget):
         :param str yscale: Scale of Y axis in (None, 'linear', 'log')
         :param keep_ratio: Toggle plot keep aspect ratio
         """
-        self._selector.selectionChanged.disconnect(self._updateImage)
+        self._axesSelector.selectionChanged.disconnect(self._updateImage)
         self._auxSigSlider.valueChanged.disconnect(self._sliderIdxChanged)
 
         self.__signals = signals
@@ -499,19 +499,19 @@ class ArrayImagePlot(qt.QWidget):
         self.__y_axis_name = ylabel
         self.__title = title
 
-        self._selector.clear()
+        self._axesSelector.clear()
         if not isRgba:
-            self._selector.setAxisNames(["Y", "X"])
+            self._axesSelector.setAxisNames(["Y", "X"])
             img_ndim = 2
         else:
-            self._selector.setAxisNames(["Y", "X", "RGB(A) channel"])
+            self._axesSelector.setAxisNames(["Y", "X", "RGB(A) channel"])
             img_ndim = 3
-        self._selector.setData(signals[0])
+        self._axesSelector.setData(signals[0])
 
         if len(signals[0].shape) <= img_ndim:
-            self._selector.hide()
+            self._axesSelector.hide()
         else:
-            self._selector.show()
+            self._axesSelector.show()
 
         self._auxSigSlider.setMaximum(len(signals) - 1)
         if len(signals) > 1:
@@ -522,7 +522,7 @@ class ArrayImagePlot(qt.QWidget):
 
         self._axis_scales = xscale, yscale
 
-        self._selector.selectionChanged.connect(self._updateImage)
+        self._axesSelector.selectionChanged.connect(self._updateImage)
         self._auxSigSlider.valueChanged.connect(self._sliderIdxChanged)
 
         self._updateImage()
@@ -530,7 +530,7 @@ class ArrayImagePlot(qt.QWidget):
         self._plot.resetZoom()
 
     def _updateImage(self):
-        selection = self._selector.selection()
+        selection = self._axesSelector.selection()
         auxSigIdx = self._auxSigSlider.value()
 
         legend = self.__signals_names[auxSigIdx]
@@ -632,9 +632,9 @@ class ArrayImagePlot(qt.QWidget):
         self._plot.getYAxis().setLabel(self.__y_axis_name)
 
     def clear(self):
-        old = self._selector.blockSignals(True)
-        self._selector.clear()
-        self._selector.blockSignals(old)
+        old = self._axesSelector.blockSignals(True)
+        self._axesSelector.clear()
+        self._axesSelector.blockSignals(old)
         self._plot.clear()
 
 
@@ -685,9 +685,9 @@ class ArrayComplexImagePlot(qt.QWidget):
         maskToolWidget.setItemMaskUpdated(True)
 
         # not closable
-        self._selector = NumpyAxesSelector(self)
-        self._selector.setNamedAxesSelectorVisibility(False)
-        self._selector.selectionChanged.connect(self._updateImage)
+        self._axesSelector = NumpyAxesSelector(self)
+        self._axesSelector.setNamedAxesSelectorVisibility(False)
+        self._axesSelector.selectionChanged.connect(self._updateImage)
 
         self._auxSigSlider = HorizontalSliderWithBrowser(parent=self)
         self._auxSigSlider.setMinimum(0)
@@ -697,7 +697,7 @@ class ArrayComplexImagePlot(qt.QWidget):
 
         layout = qt.QVBoxLayout()
         layout.addWidget(self._plot)
-        layout.addWidget(self._selector)
+        layout.addWidget(self._axesSelector)
         layout.addWidget(self._auxSigSlider)
 
         self.setLayout(layout)
@@ -739,7 +739,7 @@ class ArrayComplexImagePlot(qt.QWidget):
         :param title: Graph title
         :param keep_ratio: Toggle plot keep aspect ratio
         """
-        self._selector.selectionChanged.disconnect(self._updateImage)
+        self._axesSelector.selectionChanged.disconnect(self._updateImage)
         self._auxSigSlider.valueChanged.disconnect(self._sliderIdxChanged)
 
         self.__signals = signals
@@ -750,14 +750,14 @@ class ArrayComplexImagePlot(qt.QWidget):
         self.__y_axis_name = ylabel
         self.__title = title
 
-        self._selector.clear()
-        self._selector.setAxisNames(["Y", "X"])
-        self._selector.setData(signals[0])
+        self._axesSelector.clear()
+        self._axesSelector.setAxisNames(["Y", "X"])
+        self._axesSelector.setData(signals[0])
 
         if len(signals[0].shape) <= 2:
-            self._selector.hide()
+            self._axesSelector.hide()
         else:
-            self._selector.show()
+            self._axesSelector.show()
 
         self._auxSigSlider.setMaximum(len(signals) - 1)
         if len(signals) > 1:
@@ -770,11 +770,11 @@ class ArrayComplexImagePlot(qt.QWidget):
         self._plot.setKeepDataAspectRatio(keep_ratio)
         self._plot.getPlot().resetZoom()
 
-        self._selector.selectionChanged.connect(self._updateImage)
+        self._axesSelector.selectionChanged.connect(self._updateImage)
         self._auxSigSlider.valueChanged.connect(self._sliderIdxChanged)
 
     def _updateImage(self):
-        selection = self._selector.selection()
+        selection = self._axesSelector.selection()
         auxSigIdx = self._auxSigSlider.value()
 
         images = [img[selection] for img in self.__signals]
@@ -841,9 +841,9 @@ class ArrayComplexImagePlot(qt.QWidget):
         self._plot.getYAxis().setLabel(self.__y_axis_name)
 
     def clear(self):
-        old = self._selector.blockSignals(True)
-        self._selector.clear()
-        self._selector.blockSignals(old)
+        old = self._axesSelector.blockSignals(True)
+        self._axesSelector.clear()
+        self._axesSelector.blockSignals(old)
         self._plot.setData(None)
 
 
@@ -889,15 +889,15 @@ class ArrayStackPlot(qt.QWidget):
         self._hline.setFrameStyle(qt.QFrame.HLine)
         self._hline.setFrameShadow(qt.QFrame.Sunken)
         self._legend = qt.QLabel(self)
-        self._selector = NumpyAxesSelector(self)
-        self._selector.setNamedAxesSelectorVisibility(False)
-        self.__selector_is_connected = False
+        self._axesSelector = NumpyAxesSelector(self)
+        self._axesSelector.setNamedAxesSelectorVisibility(False)
+        self.__axes_selector_is_connected = False
 
         layout = qt.QVBoxLayout()
         layout.addWidget(self._stack_view)
         layout.addWidget(self._hline)
         layout.addWidget(self._legend)
-        layout.addWidget(self._selector)
+        layout.addWidget(self._axesSelector)
 
         self.setLayout(layout)
 
@@ -939,9 +939,9 @@ class ArrayStackPlot(qt.QWidget):
         :param zlabel: Label for Z axis
         :param title: Graph title
         """
-        if self.__selector_is_connected:
-            self._selector.selectionChanged.disconnect(self._updateStack)
-            self.__selector_is_connected = False
+        if self.__axes_selector_is_connected:
+            self._axesSelector.selectionChanged.disconnect(self._updateStack)
+            self.__axes_selector_is_connected = False
 
         self.__signal = signal
         self.__signal_name = signal_name or ""
@@ -952,8 +952,8 @@ class ArrayStackPlot(qt.QWidget):
         self.__z_axis = z_axis
         self.__z_axis_name = zlabel
 
-        self._selector.setData(signal)
-        self._selector.setAxisNames(["Y", "X", "Z"])
+        self._axesSelector.setData(signal)
+        self._axesSelector.setAxisNames(["Y", "X", "Z"])
 
         self._stack_view.setGraphTitle(title or "")
         # by default, the z axis is the image position (dimension not plotted)
@@ -968,17 +968,17 @@ class ArrayStackPlot(qt.QWidget):
         # the legend label shows the selection slice producing the volume
         # (only interesting for ndim > 3)
         if ndims > 3:
-            self._selector.setVisible(True)
+            self._axesSelector.setVisible(True)
             self._legend.setVisible(True)
             self._hline.setVisible(True)
         else:
-            self._selector.setVisible(False)
+            self._axesSelector.setVisible(False)
             self._legend.setVisible(False)
             self._hline.setVisible(False)
 
-        if not self.__selector_is_connected:
-            self._selector.selectionChanged.connect(self._updateStack)
-            self.__selector_is_connected = True
+        if not self.__axes_selector_is_connected:
+            self._axesSelector.selectionChanged.connect(self._updateStack)
+            self.__axes_selector_is_connected = True
 
     @staticmethod
     def _get_origin_scale(axis):
@@ -994,7 +994,7 @@ class ArrayStackPlot(qt.QWidget):
     def _updateStack(self):
         """Update displayed stack according to the current axes selector
         data."""
-        stk = self._selector.selectedData()
+        stk = self._axesSelector.selectedData()
         x_axis = self.__x_axis
         y_axis = self.__y_axis
         z_axis = self.__z_axis
@@ -1011,7 +1011,7 @@ class ArrayStackPlot(qt.QWidget):
                 calibrations.append(ArrayCalibration(axis))
 
         legend = self.__signal_name + "["
-        for sl in self._selector.selection():
+        for sl in self._axesSelector.selection():
             if sl == slice(None):
                 legend += ":, "
             else:
@@ -1025,9 +1025,9 @@ class ArrayStackPlot(qt.QWidget):
         )
 
     def clear(self):
-        old = self._selector.blockSignals(True)
-        self._selector.clear()
-        self._selector.blockSignals(old)
+        old = self._axesSelector.blockSignals(True)
+        self._axesSelector.clear()
+        self._axesSelector.blockSignals(old)
         self._stack_view.clear()
 
 
@@ -1071,15 +1071,15 @@ class ArrayVolumePlot(qt.QWidget):
         self._hline.setFrameStyle(qt.QFrame.HLine)
         self._hline.setFrameShadow(qt.QFrame.Sunken)
         self._legend = qt.QLabel(self)
-        self._selector = NumpyAxesSelector(self)
-        self._selector.setNamedAxesSelectorVisibility(False)
-        self.__selector_is_connected = False
+        self._axesSelector = NumpyAxesSelector(self)
+        self._axesSelector.setNamedAxesSelectorVisibility(False)
+        self.__axes_selector_is_connected = False
 
         layout = qt.QVBoxLayout()
         layout.addWidget(self._view)
         layout.addWidget(self._hline)
         layout.addWidget(self._legend)
-        layout.addWidget(self._selector)
+        layout.addWidget(self._axesSelector)
 
         self.setLayout(layout)
 
@@ -1121,9 +1121,9 @@ class ArrayVolumePlot(qt.QWidget):
         :param zlabel: Label for Z axis
         :param title: Graph title
         """
-        if self.__selector_is_connected:
-            self._selector.selectionChanged.disconnect(self._updateVolume)
-            self.__selector_is_connected = False
+        if self.__axes_selector_is_connected:
+            self._axesSelector.selectionChanged.disconnect(self._updateVolume)
+            self.__axes_selector_is_connected = False
 
         self.__signal = signal
         self.__signal_name = signal_name or ""
@@ -1134,25 +1134,25 @@ class ArrayVolumePlot(qt.QWidget):
         self.__z_axis = z_axis
         self.__z_axis_name = zlabel
 
-        self._selector.setData(signal)
-        self._selector.setAxisNames(["Y", "X", "Z"])
+        self._axesSelector.setData(signal)
+        self._axesSelector.setAxisNames(["Y", "X", "Z"])
 
         self._updateVolume()
 
         # the legend label shows the selection slice producing the volume
         # (only interesting for ndim > 3)
         if signal.ndim > 3:
-            self._selector.setVisible(True)
+            self._axesSelector.setVisible(True)
             self._legend.setVisible(True)
             self._hline.setVisible(True)
         else:
-            self._selector.setVisible(False)
+            self._axesSelector.setVisible(False)
             self._legend.setVisible(False)
             self._hline.setVisible(False)
 
-        if not self.__selector_is_connected:
-            self._selector.selectionChanged.connect(self._updateVolume)
-            self.__selector_is_connected = True
+        if not self.__axes_selector_is_connected:
+            self._axesSelector.selectionChanged.connect(self._updateVolume)
+            self.__axes_selector_is_connected = True
 
     def _updateVolume(self):
         """Update displayed stack according to the current axes selector
@@ -1179,7 +1179,7 @@ class ArrayVolumePlot(qt.QWidget):
                 scale.append(calibration.get_slope())
 
         legend = self.__signal_name + "["
-        for sl in self._selector.selection():
+        for sl in self._axesSelector.selection():
             if sl == slice(None):
                 legend += ":, "
             else:
@@ -1188,7 +1188,7 @@ class ArrayVolumePlot(qt.QWidget):
         self._legend.setText("Displayed data: " + legend)
 
         # Update SceneWidget
-        data = self._selector.selectedData()
+        data = self._axesSelector.selectedData()
 
         volumeView = self.getVolumeView()
         volumeView.setData(data, offset=offset, scale=scale)
@@ -1197,7 +1197,7 @@ class ArrayVolumePlot(qt.QWidget):
         )
 
     def clear(self):
-        old = self._selector.blockSignals(True)
-        self._selector.clear()
-        self._selector.blockSignals(old)
+        old = self._axesSelector.blockSignals(True)
+        self._axesSelector.clear()
+        self._axesSelector.blockSignals(old)
         self.getVolumeView().clear()

--- a/src/silx/gui/data/NXdataWidgets.py
+++ b/src/silx/gui/data/NXdataWidgets.py
@@ -36,7 +36,7 @@ from silx.gui.plot.ComplexImageView import ComplexImageView
 from silx.gui.plot.items.image_aggregated import ImageDataAggregated
 from silx.gui.plot.actions.image import AggregationModeAction
 from silx.gui.colors import Colormap
-from silx.gui.widgets.SignalSelector import SignalSelector
+from silx.gui.data._SignalSelector import SignalSelector
 
 from silx.math.calibration import ArrayCalibration, NoCalibration, LinearCalibration
 

--- a/src/silx/gui/data/NXdataWidgets.py
+++ b/src/silx/gui/data/NXdataWidgets.py
@@ -246,16 +246,16 @@ class XYVScatterPlot(qt.QWidget):
             )
         )
 
-        self._slider = HorizontalSliderWithBrowser(parent=self)
-        self._slider.setMinimum(0)
-        self._slider.setValue(0)
-        self._slider.valueChanged[int].connect(self._sliderIdxChanged)
-        self._slider.setToolTip("Select auxiliary signals")
+        self._auxSigSlider = HorizontalSliderWithBrowser(parent=self)
+        self._auxSigSlider.setMinimum(0)
+        self._auxSigSlider.setValue(0)
+        self._auxSigSlider.valueChanged[int].connect(self._sliderIdxChanged)
+        self._auxSigSlider.setToolTip("Select auxiliary signals")
 
         layout = qt.QGridLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self._plot, 0, 0)
-        layout.addWidget(self._slider, 1, 0)
+        layout.addWidget(self._auxSigSlider, 1, 0)
 
         self.setLayout(layout)
 
@@ -318,14 +318,14 @@ class XYVScatterPlot(qt.QWidget):
         self.__graph_title = title or ""
         self.__scatter_titles = scatter_titles
 
-        self._slider.valueChanged[int].disconnect(self._sliderIdxChanged)
-        self._slider.setMaximum(len(values) - 1)
+        self._auxSigSlider.valueChanged[int].disconnect(self._sliderIdxChanged)
+        self._auxSigSlider.setMaximum(len(values) - 1)
         if len(values) > 1:
-            self._slider.show()
+            self._auxSigSlider.show()
         else:
-            self._slider.hide()
-        self._slider.setValue(0)
-        self._slider.valueChanged[int].connect(self._sliderIdxChanged)
+            self._auxSigSlider.hide()
+        self._auxSigSlider.setValue(0)
+        self._auxSigSlider.valueChanged[int].connect(self._sliderIdxChanged)
 
         if xscale is not None:
             self._plot.getXAxis().setScale("log" if xscale == "log" else "linear")
@@ -338,7 +338,7 @@ class XYVScatterPlot(qt.QWidget):
         x = self.__x_axis
         y = self.__y_axis
 
-        idx = self._slider.value()
+        idx = self._auxSigSlider.value()
 
         if self.__graph_title:
             title = self.__graph_title  # main NXdata @title

--- a/src/silx/gui/data/NXdataWidgets.py
+++ b/src/silx/gui/data/NXdataWidgets.py
@@ -988,7 +988,8 @@ class ArrayStackPlot(qt.QWidget):
     def _updateStack(self):
         """Update displayed stack according to the current axes selector
         data."""
-        stk = self._axesSelector.selectedData()
+        stack = self._axesSelector.selectedData()
+        stack_name = self.__signal_name
         x_axis = self.__x_axis
         y_axis = self.__y_axis
         z_axis = self.__z_axis
@@ -1013,7 +1014,9 @@ class ArrayStackPlot(qt.QWidget):
         legend = legend[:-2] + "]"
         self._legend.setText("Displayed data: " + legend)
 
-        self._stack_view.setStack(stk, calibrations=calibrations)
+        self._stack_view.setStack(
+            stack, stack_name=stack_name, calibrations=calibrations
+        )
         self._stack_view.setLabels(
             labels=[self.__z_axis_name, self.__y_axis_name, self.__x_axis_name]
         )

--- a/src/silx/gui/data/NXdataWidgets.py
+++ b/src/silx/gui/data/NXdataWidgets.py
@@ -248,6 +248,7 @@ class XYVScatterPlot(qt.QWidget):
 
         self._signalSelector = SignalSelector(parent=self)
         self._signalSelector.selectionChanged.connect(self._signalChanges)
+        self._signalSelector.setToolTip("Select signal")
 
         layout = qt.QGridLayout()
         layout.setContentsMargins(0, 0, 0, 0)
@@ -410,6 +411,7 @@ class ArrayImagePlot(qt.QWidget):
 
         self._signalSelector = SignalSelector(parent=self)
         self._signalSelector.selectionChanged.connect(self._signalChanges)
+        self._signalSelector.setToolTip("Select signal")
 
         layout = qt.QVBoxLayout()
         layout.addWidget(self._plot)
@@ -685,6 +687,7 @@ class ArrayComplexImagePlot(qt.QWidget):
 
         self._signalSelector = SignalSelector(parent=self)
         self._signalSelector.selectionChanged.connect(self._signalChanges)
+        self._signalSelector.setToolTip("Select signal")
 
         layout = qt.QVBoxLayout()
         layout.addWidget(self._plot)

--- a/src/silx/gui/data/_SignalSelector.py
+++ b/src/silx/gui/data/_SignalSelector.py
@@ -1,8 +1,4 @@
-"""This module provides a :class:`SignalSelector` widget.
-
-.. image:: img/SignalSelector.png
-   :align: center
-"""
+"""This module provides a :class:`SignalSelector` widget."""
 
 from silx.gui import qt
 
@@ -10,20 +6,19 @@ from silx.gui import qt
 class SignalSelector(qt.QWidget):
     selectionChanged = qt.Signal(int)
 
-    def __init__(self, label_text: str | None = None, parent: qt.QWidget | None = None):
+    def __init__(self, parent: qt.QWidget | None = None):
         super().__init__(parent)
 
         self._layout = qt.QHBoxLayout(self)
         self._layout.setContentsMargins(0, 0, 0, 0)
         self._layout.setSpacing(2)
 
-        self._label = None
-        if label_text:
-            self._label = qt.QLabel(label_text)
-            self._layout.addWidget(self._label)
+        self._label = qt.QLabel("Select signal:")
+        self._layout.addWidget(self._label)
 
         self._combobox = qt.QComboBox()
         self._layout.addWidget(self._combobox)
+        self._layout.addStretch(1)
 
         self._combobox.currentIndexChanged.connect(self._comboboxSlot)
 

--- a/src/silx/gui/data/_SignalSelector.py
+++ b/src/silx/gui/data/_SignalSelector.py
@@ -20,10 +20,7 @@ class SignalSelector(qt.QWidget):
         self._layout.addWidget(self._combobox)
         self._layout.addStretch(1)
 
-        self._combobox.currentIndexChanged.connect(self._comboboxSlot)
-
-    def _comboboxSlot(self, index: int) -> None:
-        self.selectionChanged.emit(index)
+        self._combobox.currentIndexChanged.connect(self.selectionChanged)
 
     def setSignalNames(self, names: list[str]) -> None:
         self._combobox.clear()

--- a/src/silx/gui/data/_SignalSelector.py
+++ b/src/silx/gui/data/_SignalSelector.py
@@ -41,5 +41,5 @@ class SignalSelector(qt.QWidget):
     def setSignalIndex(self, index) -> None:
         self._combobox.setCurrentIndex(index)
 
-    def getSignalIndex(self) -> None:
+    def getSignalIndex(self) -> int:
         return self._combobox.currentIndex()

--- a/src/silx/gui/plot/StackView.py
+++ b/src/silx/gui/plot/StackView.py
@@ -545,17 +545,11 @@ class StackView(qt.QMainWindow):
         self._plot.setGraphTitle(self._titleCallback(frame_idx))
 
     def _defaultTitleCallback(self, index):
-        return f"{self._stack_name} z={self._getImageZ(index):g}"
+        title = self._stack_name or "Image"
+        return f"{title} z={self._getImageZ(index):g}"
 
     # public API, stack specific methods
-    def setStack(
-        self,
-        stack,
-        stack_name: str | None = None,
-        perspective=None,
-        reset=True,
-        calibrations=None,
-    ):
+    def setStack(self, stack, perspective=None, reset=True, calibrations=None):
         """Set the 3D stack.
 
         The perspective parameter is used to define which dimension of the 3D
@@ -566,7 +560,6 @@ class StackView(qt.QMainWindow):
         :param stack: 3D stack, or `None` to clear plot.
         :type stack: 3D numpy.ndarray, or 3D h5py.Dataset, or list/tuple of 2D
             numpy arrays, or None.
-        :param str stack_name: Name of the 3D stack.
         :param int perspective: Dimension for the frame index: 0, 1 or 2.
             Use ``None`` to keep the current perspective (default).
         :param bool reset: Whether to reset zoom or not.
@@ -599,7 +592,6 @@ class StackView(qt.QMainWindow):
         assert len(stack.shape) == 3, "data must be 3D"
 
         self._stack = stack
-        self._stack_name = stack_name or "Image"
         self.__createTransposedView()
 
         perspective_changed = False
@@ -674,6 +666,13 @@ class StackView(qt.QMainWindow):
             return self._stack.images, params
 
         return self._stack, params
+
+    def setStackName(self, name: str | None):
+        """Set the 3D stack name.
+
+        :param name: Name of the 3D stack.
+        """
+        self._stack_name = name
 
     def getCurrentView(self, copy=True, returnNumpyArray=False):
         """Get the stack, as it is currently displayed.

--- a/src/silx/gui/plot/StackView.py
+++ b/src/silx/gui/plot/StackView.py
@@ -193,6 +193,7 @@ class StackView(qt.QMainWindow):
             self.setWindowTitle("StackView")
 
         self._stack = None
+        self._stack_name = None
         """Loaded stack, as a 3D array, a 3D dataset or a list of 2D arrays."""
         self.__transposed_view = None
         """View on :attr:`_stack` with the axes sorted, to have
@@ -544,10 +545,17 @@ class StackView(qt.QMainWindow):
         self._plot.setGraphTitle(self._titleCallback(frame_idx))
 
     def _defaultTitleCallback(self, index):
-        return "Image z=%g" % self._getImageZ(index)
+        return f"{self._stack_name} z={self._getImageZ(index):g}"
 
     # public API, stack specific methods
-    def setStack(self, stack, perspective=None, reset=True, calibrations=None):
+    def setStack(
+        self,
+        stack,
+        stack_name: str | None = None,
+        perspective=None,
+        reset=True,
+        calibrations=None,
+    ):
         """Set the 3D stack.
 
         The perspective parameter is used to define which dimension of the 3D
@@ -558,6 +566,7 @@ class StackView(qt.QMainWindow):
         :param stack: 3D stack, or `None` to clear plot.
         :type stack: 3D numpy.ndarray, or 3D h5py.Dataset, or list/tuple of 2D
             numpy arrays, or None.
+        :param str stack_name: Name of the 3D stack.
         :param int perspective: Dimension for the frame index: 0, 1 or 2.
             Use ``None`` to keep the current perspective (default).
         :param bool reset: Whether to reset zoom or not.
@@ -590,6 +599,7 @@ class StackView(qt.QMainWindow):
         assert len(stack.shape) == 3, "data must be 3D"
 
         self._stack = stack
+        self._stack_name = stack_name or "Image"
         self.__createTransposedView()
 
         perspective_changed = False
@@ -780,6 +790,7 @@ class StackView(qt.QMainWindow):
         - clear the loaded data volume
         """
         self._stack = None
+        self._stack_name = None
         self.__transposed_view = None
         self._perspective = 0
         self._browser.setEnabled(False)

--- a/src/silx/gui/widgets/SignalSelector.py
+++ b/src/silx/gui/widgets/SignalSelector.py
@@ -1,0 +1,53 @@
+"""This module provides a :class:`SignalSelector` widget.
+
+.. image:: img/SignalSelector.png
+   :align: center
+"""
+
+from silx.gui import qt
+
+
+class SignalSelector(qt.QWidget):
+    selectionChanged = qt.Signal(int)
+
+    def __init__(self, label_text: str | None = None, parent: qt.QWidget | None = None):
+        super().__init__(parent)
+
+        self._layout = qt.QHBoxLayout(self)
+        self._layout.setContentsMargins(0, 0, 0, 0)
+        self._layout.setSpacing(2)
+
+        self._label = None
+        if label_text:
+            self._label = qt.QLabel(label_text)
+            self._layout.addWidget(self._label)
+
+        self._combobox = qt.QComboBox()
+        self._layout.addWidget(self._combobox)
+
+        self._combobox.currentIndexChanged.connect(self._comboboxSlot)
+
+    def _comboboxSlot(self, index: int) -> None:
+        self.selectionChanged.emit(index)
+
+    def setSignalNames(self, names: list[str]) -> None:
+        self._combobox.clear()
+        self._combobox.addItems(names)
+
+    def getSignalNames(self) -> list[str]:
+        return [self._combobox.itemText(i) for i in range(self._combobox.count())]
+
+    def setSignalName(self, index, name) -> None:
+        if 0 <= index < self._combobox.count():
+            self._combobox.setItemText(index, name)
+
+    def getSignalName(self, index) -> str | None:
+        if 0 <= index < self._combobox.count():
+            return self._combobox.itemText(index)
+        return None
+
+    def setSignalIndex(self, index) -> None:
+        self._combobox.setCurrentIndex(index)
+
+    def getSignalIndex(self) -> None:
+        return self._combobox.currentIndex()


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

- Replace slider with combo-box for signal selector of "image_2d" and "scatter_2d"
- Pass NXdata signal name for "volume_3d" 

image_2d: combo-box to select signal below plot

![image](https://github.com/user-attachments/assets/d017046b-2b75-4493-bf1c-7280502c5eed)

scatter_2d: combo-box to select signal below plot

![image](https://github.com/user-attachments/assets/d90d964b-6804-44cc-97e4-2796262664f8)

volume_3d: NXdata signal name in plot title

![image](https://github.com/user-attachments/assets/68b8aa5b-df1d-488d-b684-ce3bbdf714f7)
