### PR TITLE
silx.gui.data.Hdf5TableView uncaught exception fixed

### DIFF
--- a/src/silx/gui/data/Hdf5TableView.py
+++ b/src/silx/gui/data/Hdf5TableView.py
@@ -565,11 +565,12 @@ class Hdf5TableItemDelegate(HierarchicalTableView.HierarchicalItemDelegate):
 
     def eventFilter(self, watched, event):
         eventType = event.type()
-        if eventType == qt.QEvent.FocusIn:
-            watched.selectAll()
-            qt.QTimer.singleShot(0, watched.selectAll)
-        elif eventType == qt.QEvent.FocusOut:
-            watched.deselect()
+        if isinstance(watched, qt.QLineEdit):
+            if eventType == qt.QEvent.FocusIn:
+                watched.selectAll()
+                qt.QTimer.singleShot(0, watched.selectAll)
+            elif eventType == qt.QEvent.FocusOut:
+                watched.deselect()
         return super().eventFilter(watched, event)
 
 

--- a/src/silx/gui/data/Hdf5TableView.py
+++ b/src/silx/gui/data/Hdf5TableView.py
@@ -565,7 +565,7 @@ class Hdf5TableItemDelegate(HierarchicalTableView.HierarchicalItemDelegate):
 
     def eventFilter(self, watched, event):
         eventType = event.type()
-        if isinstance(watched, qt.QLineEdit):
+        if isinstance(watched, qt.QLineEdit): #fixes issue #4252 as it is only expect QLineEdit (but somehow one manage to have QSpinBox here)
             if eventType == qt.QEvent.FocusIn:
                 watched.selectAll()
                 qt.QTimer.singleShot(0, watched.selectAll)


### PR DESCRIPTION
close #4252
Allowing selectALL and deselect only for QLineEdit.
Actually this part of code should hit only QLineEdit but somehow QSpinBox appears there. Could not reproduce the bug.
