### PR TITLE
gui.dialog.ColormapHistogram: Remove method with typo

### DIFF
--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -86,7 +86,6 @@ from silx.gui.widgets.FormGridLayout import FormGridLayout
 from silx.math.histogram import Histogramnd
 from silx.gui.plot.items.roi import RectangleROI
 from silx.gui.plot.tools.roi import RegionOfInterestManager
-from silx.utils.deprecation import deprecated
 from silx.utils.enum import Enum as _Enum
 
 _logger = logging.getLogger(__name__)
@@ -785,10 +784,6 @@ class _ColormapHistogram(qt.QWidget):
 
     def getDisplayMode(self) -> DisplayMode:
         return self._displayMode
-
-    @deprecated(since_version="2.1.0", replacement="getDisplayMode")
-    def getDsiplayMode(self):
-        return self.getDisplayMode()
 
     def _displayModeChanged(self, action):
         mode = action.data()


### PR DESCRIPTION
Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

`getDsiplayMode` was fixed to `getDisplayMode` in v2.1.0.

I don't think it's worth keeping a deprecation through a major release for such a typo, but no worries if you prefer to keep it a while longer.

Part of #4236