### PR TITLE
Revert "silx.gui.dataviewer:added warning windows for 3D Cube plot - failing tests

### DIFF
--- a/src/silx/gui/data/_VolumeWindow.py
+++ b/src/silx/gui/data/_VolumeWindow.py
@@ -90,24 +90,6 @@ class VolumeWindow(SceneWindow):
         :param List[float] offset: (tx, ty, tz) coordinates of the origin
         :param List[float] scale: (sx, sy, sz) scale for each dimension
         """
-
-        n_elements = data.size
-        # Show a warning message box before proceeding
-        if n_elements > 512**3 :
-            warning_box = qt.QMessageBox(self)
-            warning_box.setIcon(qt.QMessageBox.Warning)
-            warning_box.setWindowTitle("Warning")
-            warning_box.setText(f"The number of elements {n_elements} is larger than {512**3}.")
-            warning_box.setInformativeText("This may take some time. Do you want to continue?")
-            warning_box.setStandardButtons(qt.QMessageBox.Yes | qt.QMessageBox.No)
-            warning_box.setDefaultButton(qt.QMessageBox.Yes)
-
-        response = warning_box.exec_()
-
-        if response == qt.QMessageBox.No:
-            # User chose not to proceed
-            return
-        
         sceneWidget = self.getSceneWidget()
         dataMaxCoords = numpy.array(list(reversed(data.shape))) - 1
 


### PR DESCRIPTION
… number of elements larger than 512**3"

<!-- Thank you for your pull request! -->

Checklist:

- [ ] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->
