### PR TITLE
docstring: Use update_wrapper to propagate the types

### DIFF
--- a/src/silx/utils/proxy.py
+++ b/src/silx/utils/proxy.py
@@ -182,7 +182,7 @@ def _docstring(dest, origin):
         except AttributeError:
             raise ValueError("origin class has no %s method" % dest.__name__)
 
-    dest.__doc__ = origin.__doc__
+    functools.update_wrapper(dest, origin)
     return dest
 
 

--- a/src/silx/utils/test/test_proxy.py
+++ b/src/silx/utils/test/test_proxy.py
@@ -322,3 +322,16 @@ class TestDocstring(unittest.TestCase):
             pass
 
         self.assertEqual(f.__doc__, g.__doc__)
+
+    def test_typed_function(self):
+        def f(a: int) -> float:
+            """Docstring"""
+            pass
+
+        @docstring(f)
+        def g():
+            pass
+
+        self.assertEqual(f.__doc__, g.__doc__)
+        self.assertEqual(g.__annotations__["a"], int)
+        self.assertEqual(g.__annotations__["return"], float)


### PR DESCRIPTION
Propagated the types when `@docstring` is used.

See update_wrapper: https://docs.python.org/3/library/functools.html#functools.update_wrapper

The downfall is that we probably can't override the types, but that's probably not a common usecase.

As the documentation is on it's own a specification, IMO there is no way to distinguish the doc and the types -> If you have to tune the type you probably should not use the `@docstring` helper because you also have to tune the documentation.

Checklist:

- [ ] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->
