### PR TITLE
silx.gui.plot.items: Added static typing

### DIFF
--- a/src/silx/gui/plot/items/_arc_roi.py
+++ b/src/silx/gui/plot/items/_arc_roi.py
@@ -30,6 +30,7 @@ __date__ = "28/06/2018"
 import logging
 import numpy
 import enum
+import typing
 
 from ... import utils
 from .. import items

--- a/src/silx/gui/plot/items/_arc_roi.py
+++ b/src/silx/gui/plot/items/_arc_roi.py
@@ -30,7 +30,6 @@ __date__ = "28/06/2018"
 import logging
 import numpy
 import enum
-import typing
 
 from ... import utils
 from .. import items

--- a/src/silx/gui/plot/items/_roi_base.py
+++ b/src/silx/gui/plot/items/_roi_base.py
@@ -72,7 +72,7 @@ class _RegionOfInterestBase(qt.QObject):
             self.setParent(parent)
         self.__name = ""
 
-    def getName(self):
+    def getName(self) -> str:
         """Returns the name of the ROI
 
         :return: name of the region of interest
@@ -80,7 +80,7 @@ class _RegionOfInterestBase(qt.QObject):
         """
         return self.__name
 
-    def setName(self, name):
+    def setName(self, name: str):
         """Set the name of the ROI
 
         :param str name: name of the region of interest
@@ -97,7 +97,7 @@ class _RegionOfInterestBase(qt.QObject):
         """
         self.sigItemChanged.emit(event)
 
-    def contains(self, position):
+    def contains(self, position: tuple[float, float]) -> bool:
         """Returns True if the `position` is in this ROI.
 
         :param tuple[float,float] position: position to check
@@ -489,26 +489,22 @@ class RegionOfInterest(_RegionOfInterestBase, core.HighlightedMixIn):
         pass
 
     @classmethod
-    def showFirstInteractionShape(cls):
+    def showFirstInteractionShape(cls) -> bool:
         """Returns True if the shape created by the first interaction and
         managed by the plot have to be visible.
-
-        :rtype: bool
         """
         return False
 
     @classmethod
-    def getFirstInteractionShape(cls):
+    def getFirstInteractionShape(cls) -> str:
         """Returns the shape kind which will be used by the very first
         interaction with the plot.
 
         This interactions are hardcoded inside the plot
-
-        :rtype: str
         """
         return cls._plotShape
 
-    def setFirstShapePoints(self, points):
+    def setFirstShapePoints(self, points: numpy.ndarray | list[tuple[float, float]]):
         """Initialize the ROI using the points from the first interaction.
 
         This interaction is constrained by the plot API and only supports few
@@ -677,20 +673,19 @@ class HandleBasedROI(RegionOfInterest):
         self._posOrigin = None
         self._posPrevious = None
 
-    def addUserHandle(self, item=None):
+    def addUserHandle(self, item: items.Marker | None = None) -> items.Marker:
         """
         Add a new free handle to the ROI.
 
         This handle do nothing. It have to be managed by the ROI
         implementing this class.
 
-        :param Union[None,silx.gui.plot.items.Marker] item: The new marker to
+        :param item: The new marker to
             add, else None to create a default marker.
-        :rtype: silx.gui.plot.items.Marker
         """
         return self.addHandle(item, role="user")
 
-    def addLabelHandle(self, item=None):
+    def addLabelHandle(self, item: items.Marker | None = None) -> items.Marker:
         """
         Add a new label handle to the ROI.
 
@@ -699,35 +694,34 @@ class HandleBasedROI(RegionOfInterest):
         It is displayed without symbol, but it is always visible anyway
         the ROI is editable, in order to display text.
 
-        :param Union[None,silx.gui.plot.items.Marker] item: The new marker to
+        :param item: The new marker to
             add, else None to create a default marker.
-        :rtype: silx.gui.plot.items.Marker
         """
         return self.addHandle(item, role="label")
 
-    def addTranslateHandle(self, item=None):
+    def addTranslateHandle(self, item: items.Marker | None = None) -> items.Marker:
         """
         Add a new translate handle to the ROI.
 
         Dragging translate handles affect the position position of the ROI
         but not the shape itself.
 
-        :param Union[None,silx.gui.plot.items.Marker] item: The new marker to
+        :param item: The new marker to
             add, else None to create a default marker.
-        :rtype: silx.gui.plot.items.Marker
         """
         return self.addHandle(item, role="translate")
 
-    def addHandle(self, item=None, role="default"):
+    def addHandle(
+        self, item: items.Marker | None = None, role: str = "default"
+    ) -> items.Marker:
         """
         Add a new handle to the ROI.
 
         Dragging handles while affect the position or the shape of the
         ROI.
 
-        :param Union[None,silx.gui.plot.items.Marker] item: The new marker to
+        :param item: The new marker to
             add, else None to create a default marker.
-        :rtype: silx.gui.plot.items.Marker
         """
         if item is None:
             item = items.Marker()
@@ -757,7 +751,7 @@ class HandleBasedROI(RegionOfInterest):
         self.addItem(item)
         return item
 
-    def removeHandle(self, handle):
+    def removeHandle(self, handle: items.Marker):
         data = [d for d in self._handles if d[0] is handle][0]
         self._handles.remove(data)
         role = data[1]
@@ -766,11 +760,8 @@ class HandleBasedROI(RegionOfInterest):
                 self.__updateEditable(handle, False)
         self.removeItem(handle)
 
-    def getHandles(self):
-        """Returns the list of handles of this HandleBasedROI.
-
-        :rtype: List[~silx.gui.plot.items.Marker]
-        """
+    def getHandles(self) -> list[items.Marker]:
+        """Returns the list of handles of this HandleBasedROI."""
         return tuple(data[0] for data in self._handles)
 
     def _updated(self, event=None, checkVisibility=True):
@@ -845,11 +836,8 @@ class HandleBasedROI(RegionOfInterest):
         self._posOrigin = None
         super()._editingFinished()
 
-    def isHandleBeingDragged(self):
-        """Returns True if one of the handles is currently being dragged.
-
-        :rtype: bool
-        """
+    def isHandleBeingDragged(self) -> bool:
+        """Returns True if one of the handles is currently being dragged."""
         return self._posOrigin is not None
 
     def handleDragStarted(self, handle, origin):

--- a/src/silx/gui/plot/items/_roi_base.py
+++ b/src/silx/gui/plot/items/_roi_base.py
@@ -76,14 +76,13 @@ class _RegionOfInterestBase(qt.QObject):
         """Returns the name of the ROI
 
         :return: name of the region of interest
-        :rtype: str
         """
         return self.__name
 
     def setName(self, name: str):
         """Set the name of the ROI
 
-        :param str name: name of the region of interest
+        :param name: name of the region of interest
         """
         name = str(name)
         if self.__name != name:
@@ -100,7 +99,7 @@ class _RegionOfInterestBase(qt.QObject):
     def contains(self, position: tuple[float, float]) -> bool:
         """Returns True if the `position` is in this ROI.
 
-        :param tuple[float,float] position: position to check
+        :param position: position to check
         :return: True if the value / point is consider to be in the region of
                  interest.
         :rtype: bool

--- a/src/silx/gui/plot/items/axis.py
+++ b/src/silx/gui/plot/items/axis.py
@@ -223,7 +223,7 @@ class Axis(qt.QObject):
     def setScale(self, scale: AxisScaleType):
         """Set the scale to be used by this axis.
 
-        :param str scale: Name of the scale ("log", or "linear")
+        :param scale: Name of the scale ("log", or "linear")
         """
         assert scale in self._SCALES
         if self._scale == scale:
@@ -264,15 +264,13 @@ class Axis(qt.QObject):
 
     def _isLogarithmic(self) -> bool:
         """Return True if this axis scale is logarithmic, False if linear.
-
-        :rtype: bool
         """
         return self._scale == self.LOGARITHMIC
 
     def _setLogarithmic(self, flag: bool):
         """Set the scale of this axes (either linear or logarithmic).
 
-        :param bool flag: True to use a logarithmic scale, False for linear.
+        :param flag: True to use a logarithmic scale, False for linear.
         """
         flag = bool(flag)
         self.setScale(self.LOGARITHMIC if flag else self.LINEAR)
@@ -522,7 +520,7 @@ class YRightAxis(Axis):
     def setInverted(self, flag: bool = True):
         """Set the Y axis orientation.
 
-        :param bool flag: True for Y axis going from top to bottom,
+        :param flag: True for Y axis going from top to bottom,
                           False for Y axis going from bottom to top
         """
         return self.__mainAxis.setInverted(flag)
@@ -542,7 +540,7 @@ class YRightAxis(Axis):
     def setScale(self, scale: AxisScaleType):
         """Set the scale to be used by this axis.
 
-        :param str scale: Name of the scale ("log", or "linear")
+        :param scale: Name of the scale ("log", or "linear")
         """
         self.__mainAxis.setScale(scale)
 

--- a/src/silx/gui/plot/items/axis.py
+++ b/src/silx/gui/plot/items/axis.py
@@ -263,8 +263,7 @@ class Axis(qt.QObject):
             self._sigLogarithmicChanged.emit(self._scale == self.LOGARITHMIC)
 
     def _isLogarithmic(self) -> bool:
-        """Return True if this axis scale is logarithmic, False if linear.
-        """
+        """Return True if this axis scale is logarithmic, False if linear."""
         return self._scale == self.LOGARITHMIC
 
     def _setLogarithmic(self, flag: bool):

--- a/src/silx/gui/plot/items/axis.py
+++ b/src/silx/gui/plot/items/axis.py
@@ -31,6 +31,7 @@ __date__ = "22/11/2018"
 
 import datetime as dt
 import enum
+import typing
 
 import dateutil.tz
 
@@ -44,6 +45,9 @@ class TickMode(enum.Enum):
 
     DEFAULT = 0  # Ticks are regular numbers
     TIME_SERIES = 1  # Ticks are datetime objects
+
+
+AxisScaleType = typing.Literal["linear", "log"]
 
 
 class Axis(qt.QObject):
@@ -112,18 +116,18 @@ class Axis(qt.QObject):
         """
         return self._getPlot()._backend
 
-    def getLimits(self):
+    def getLimits(self) -> tuple[float, float]:
         """Get the limits of this axis.
 
         :return: Minimum and maximum values of this axis as tuple
         """
         return self._internalGetLimits()
 
-    def setLimits(self, vmin, vmax):
+    def setLimits(self, vmin: float, vmax: float):
         """Set this axis limits.
 
-        :param float vmin: minimum axis value
-        :param float vmax: maximum axis value
+        :param vmin: minimum axis value
+        :param vmax: maximum axis value
         """
         vmin, vmax = self._checkLimits(vmin, vmax)
         if self.getLimits() == (vmin, vmax):
@@ -140,13 +144,12 @@ class Axis(qt.QObject):
         self.sigLimitsChanged.emit(vmin, vmax)
         self._getPlot()._notifyLimitsChanged(emitSignal=False)
 
-    def _checkLimits(self, vmin, vmax):
+    def _checkLimits(self, vmin: float, vmax: float) -> tuple[float, float]:
         """Makes sure axis range is not empty and within supported range.
 
-        :param float vmin: Min axis value
-        :param float vmax: Max axis value
+        :param vmin: Min axis value
+        :param vmax: Max axis value
         :return: (min, max) making sure min < max
-        :rtype: 2-tuple of float
         """
         return _utils.checkAxisLimits(
             vmin, vmax, isLog=self._isLogarithmic(), name=self._defaultLabel
@@ -156,7 +159,7 @@ class Axis(qt.QObject):
         """Returns the range of data items over this axis as (vmin, vmax)"""
         raise NotImplementedError()
 
-    def isInverted(self):
+    def isInverted(self) -> bool:
         """Return True if the axis is inverted (top to bottom for the y-axis),
         False otherwise. It is always False for the X axis.
 
@@ -164,13 +167,13 @@ class Axis(qt.QObject):
         """
         return False
 
-    def setInverted(self, isInverted):
+    def setInverted(self, isInverted: bool):
         """Set the axis orientation.
 
         This is only available for the Y axis.
 
-        :param bool flag: True for Y axis going from top to bottom,
-                          False for Y axis going from bottom to top
+        :param flag: True for Y axis going from top to bottom,
+                     False for Y axis going from bottom to top
         """
         if isInverted == self.isInverted():
             return
@@ -180,21 +183,20 @@ class Axis(qt.QObject):
         """Returns whether the axis is displayed or not"""
         return True
 
-    def getLabel(self):
+    def getLabel(self) -> str:
         """Return the current displayed label of this axis.
 
         :param str axis: The Y axis for which to get the label (left or right)
-        :rtype: str
         """
         return self._currentLabel
 
-    def setLabel(self, label):
+    def setLabel(self, label: str):
         """Set the label displayed on the plot for this axis.
 
         The provided label can be temporarily replaced by the label of the
         active curve if any.
 
-        :param str label: The axis label
+        :param label: The axis label
         """
         self._defaultLabel = label
         self._setCurrentLabel(label)
@@ -214,14 +216,11 @@ class Axis(qt.QObject):
         self._currentLabel = label
         self._internalSetCurrentLabel(label)
 
-    def getScale(self):
-        """Return the name of the scale used by this axis.
-
-        :rtype: str
-        """
+    def getScale(self) -> AxisScaleType:
+        """Return the name of the scale used by this axis."""
         return self._scale
 
-    def setScale(self, scale):
+    def setScale(self, scale: AxisScaleType):
         """Set the scale to be used by this axis.
 
         :param str scale: Name of the scale ("log", or "linear")
@@ -263,14 +262,14 @@ class Axis(qt.QObject):
         if emitLog:
             self._sigLogarithmicChanged.emit(self._scale == self.LOGARITHMIC)
 
-    def _isLogarithmic(self):
+    def _isLogarithmic(self) -> bool:
         """Return True if this axis scale is logarithmic, False if linear.
 
         :rtype: bool
         """
         return self._scale == self.LOGARITHMIC
 
-    def _setLogarithmic(self, flag):
+    def _setLogarithmic(self, flag: bool):
         """Set the scale of this axes (either linear or logarithmic).
 
         :param bool flag: True to use a logarithmic scale, False for linear.
@@ -278,23 +277,21 @@ class Axis(qt.QObject):
         flag = bool(flag)
         self.setScale(self.LOGARITHMIC if flag else self.LINEAR)
 
-    def getTimeZone(self):
+    def getTimeZone(self) -> datetime.tzinfo | None:
         """Sets tzinfo that is used if this axis plots date times.
 
         None means the datetimes are interpreted as local time.
-
-        :rtype: datetime.tzinfo of None.
         """
         raise NotImplementedError()
 
-    def setTimeZone(self, tz):
+    def setTimeZone(self, tz) -> datetime.tzinfo | typing.Literal["UTC"] | None:
         """Sets tzinfo that is used if this axis' tickMode is TIME_SERIES
 
         The tz must be a descendant of the datetime.tzinfo class, "UTC" or None.
         Use None to let the datetimes be interpreted as local time.
         Use the string "UTC" to let the date datetimes be in UTC time.
 
-        :param tz: datetime.tzinfo, "UTC" or None.
+        :param tz: A timezone, "UTC" or None.
         """
         raise NotImplementedError()
 
@@ -379,9 +376,11 @@ class XAxis(Axis):
     # TODO With some changes on the backend, it will be able to remove all this
     #      specialised implementations (prefixel by '_internal')
 
+    @docstring(Axis)
     def getTimeZone(self):
         return self._getBackend().getXAxisTimeZone()
 
+    @docstring(Axis)
     def setTimeZone(self, tz):
         if isinstance(tz, str) and tz.upper() == "UTC":
             tz = dateutil.tz.tzutc()
@@ -391,13 +390,13 @@ class XAxis(Axis):
         self._getBackend().setXAxisTimeZone(tz)
         self._getPlot()._setDirtyPlot()
 
-    def getTickMode(self):
+    def getTickMode(self) -> TickMode:
         if self._getBackend().isXAxisTimeSeries():
             return TickMode.TIME_SERIES
         else:
             return TickMode.DEFAULT
 
-    def setTickMode(self, tickMode):
+    def setTickMode(self, tickMode: TickMode):
         if tickMode == TickMode.DEFAULT:
             self._getBackend().setXAxisTimeSeries(False)
         elif tickMode == TickMode.TIME_SERIES:
@@ -451,7 +450,7 @@ class YAxis(Axis):
     def _internalSetLogarithmic(self, flag):
         self._getBackend().setYAxisLogarithmic(flag)
 
-    def setInverted(self, flag=True):
+    def setInverted(self, flag: bool = True):
         """Set the axis orientation.
 
         This is only available for the Y axis.
@@ -466,7 +465,7 @@ class YAxis(Axis):
         self._getPlot()._setDirtyPlot()
         self.sigInvertedChanged.emit(flag)
 
-    def isInverted(self):
+    def isInverted(self) -> bool:
         """Return True if the axis is inverted (top to bottom for the y-axis),
         False otherwise. It is always False for the X axis.
 
@@ -514,13 +513,13 @@ class YRightAxis(Axis):
     def _internalSetCurrentLabel(self, label):
         self._getBackend().setGraphYLabel(label, axis="right")
 
-    def _internalGetLimits(self):
+    def _internalGetLimits(self) -> tuple[float, float]:
         return self._getBackend().getGraphYLimits(axis="right")
 
     def _internalSetLimits(self, ymin, ymax):
         self._getBackend().setGraphYLimits(ymin, ymax, axis="right")
 
-    def setInverted(self, flag=True):
+    def setInverted(self, flag: bool = True):
         """Set the Y axis orientation.
 
         :param bool flag: True for Y axis going from top to bottom,
@@ -528,7 +527,7 @@ class YRightAxis(Axis):
         """
         return self.__mainAxis.setInverted(flag)
 
-    def isInverted(self):
+    def isInverted(self) -> bool:
         """Return True if Y axis goes from top to bottom, False otherwise."""
         return self.__mainAxis.isInverted()
 
@@ -536,36 +535,33 @@ class YRightAxis(Axis):
         """Returns whether the axis is displayed or not"""
         return self._getBackend().isYRightAxisVisible()
 
-    def getScale(self):
-        """Return the name of the scale used by this axis.
-
-        :rtype: str
-        """
+    def getScale(self) -> AxisScaleType:
+        """Return the name of the scale used by this axis."""
         return self.__mainAxis.getScale()
 
-    def setScale(self, scale):
+    def setScale(self, scale: AxisScaleType):
         """Set the scale to be used by this axis.
 
         :param str scale: Name of the scale ("log", or "linear")
         """
         self.__mainAxis.setScale(scale)
 
-    def _isLogarithmic(self):
+    def _isLogarithmic(self) -> bool:
         """Return True if Y axis scale is logarithmic, False if linear."""
         return self.__mainAxis._isLogarithmic()
 
-    def _setLogarithmic(self, flag):
+    def _setLogarithmic(self, flag: bool):
         """Set the Y axes scale (either linear or logarithmic).
 
         :param bool flag: True to use a logarithmic scale, False for linear.
         """
         return self.__mainAxis._setLogarithmic(flag)
 
-    def isAutoScale(self):
+    def isAutoScale(self) -> bool:
         """Return True if Y axes are automatically adjusting its limits."""
         return self.__mainAxis.isAutoScale()
 
-    def setAutoScale(self, flag=True):
+    def setAutoScale(self, flag: bool = True):
         """Set the Y axis limits adjusting behavior of :meth:`PlotWidget.resetZoom`.
 
         :param bool flag: True to resize limits automatically,

--- a/src/silx/gui/plot/items/curve.py
+++ b/src/silx/gui/plot/items/curve.py
@@ -152,8 +152,6 @@ class CurveStyle(_Style):
 
     def getSymbolSize(self) -> float | None:
         """Return the point marker size in points.
-
-        :rtype: Union[float,None]
         """
         return self._symbolsize
 

--- a/src/silx/gui/plot/items/curve.py
+++ b/src/silx/gui/plot/items/curve.py
@@ -102,24 +102,19 @@ class CurveStyle(_Style):
 
         self._gapcolor = None if gapcolor is None else colors.rgba(gapcolor)
 
-    def getColor(self, copy=True):
+    def getColor(self, copy: bool = True) -> colors.RGBAColorType | None:
         """Returns the color or None if not set.
 
-        :param bool copy: True to get a copy (default),
+        :param copy: True to get a copy (default),
             False to get internal representation (do not modify!)
-
-        :rtype: Union[List[float],None]
         """
         if isinstance(self._color, numpy.ndarray):
             return numpy.array(self._color, copy=copy or NP_OPTIONAL_COPY)
         else:
             return self._color
 
-    def getLineGapColor(self):
-        """Returns the color of dashed line gaps or None if not set.
-
-        :rtype: Union[List[float],None]
-        """
+    def getLineGapColor(self) -> colors.RGBAColorType | None:
+        """Returns the color of dashed line gaps or None if not set."""
         return self._gapcolor
 
     def getLineStyle(self) -> LineStyleType | None:
@@ -136,14 +131,11 @@ class CurveStyle(_Style):
         """
         return self._linestyle
 
-    def getLineWidth(self):
-        """Return the curve line width in pixels or None if not set.
-
-        :rtype: Union[float,None]
-        """
+    def getLineWidth(self) -> float | None:
+        """Return the curve line width in pixels or None if not set."""
         return self._linewidth
 
-    def getSymbol(self):
+    def getSymbol(self) -> str | None:
         """Return the point marker type.
 
         Marker type::
@@ -155,19 +147,17 @@ class CurveStyle(_Style):
             - 'x' x-cross
             - 'd' diamond
             - 's' square
-
-        :rtype: Union[str,None]
         """
         return self._symbol
 
-    def getSymbolSize(self):
+    def getSymbolSize(self) -> float | None:
         """Return the point marker size in points.
 
         :rtype: Union[float,None]
         """
         return self._symbolsize
 
-    def __eq__(self, other):
+    def __eq__(self, other) -> bool:
         if isinstance(other, CurveStyle):
             return (
                 numpy.array_equal(self.getColor(), other.getColor())
@@ -290,12 +280,10 @@ class Curve(
         else:
             raise IndexError("Index out of range: %s", str(item))
 
-    def getCurrentStyle(self):
+    def getCurrentStyle(self) -> CurveStyle:
         """Returns the current curve style.
 
         Curve style depends on curve highlighting
-
-        :rtype: CurveStyle
         """
         if self.isHighlighted():
             style = self.getHighlightedStyle()
@@ -325,23 +313,28 @@ class Curve(
                 gapcolor=self.getLineGapColor(),
             )
 
-    def setData(self, x, y, xerror=None, yerror=None, baseline=None, copy=True):
+    def setData(
+        self,
+        x: numpy.ndarray,
+        y: numpy.ndarray,
+        xerror: numpy.ndarray | None = None,
+        yerror: numpy.ndarray | None = None,
+        baseline: numpy.ndarray | float | None = None,
+        copy: bool = True,
+    ):
         """Set the data of the curve.
 
-        :param numpy.ndarray x: The data corresponding to the x coordinates.
-        :param numpy.ndarray y: The data corresponding to the y coordinates.
+        :param x: The data corresponding to the x coordinates.
+        :param y: The data corresponding to the y coordinates.
         :param xerror: Values with the uncertainties on the x values
-        :type xerror: A float, or a numpy.ndarray of float32.
-                      If it is an array, it can either be a 1D array of
-                      same length as the data or a 2D array with 2 rows
-                      of same length as the data: row 0 for positive errors,
-                      row 1 for negative errors.
+                       If it is an array, it can either be a 1D array of
+                       same length as the data or a 2D array with 2 rows
+                       of same length as the data: row 0 for positive errors,
+                       row 1 for negative errors.
         :param yerror: Values with the uncertainties on the y values.
-        :type yerror: A float, or a numpy.ndarray of float32. See xerror.
         :param baseline: curve baseline
-        :type baseline: Union[None,float,numpy.ndarray]
-        :param bool copy: True make a copy of the data (default),
-                          False to use provided arrays.
+        :param copy: True make a copy of the data (default),
+                     False to use provided arrays.
         """
         PointsBase.setData(self, x=x, y=y, xerror=xerror, yerror=yerror, copy=copy)
         self._setBaseline(baseline=baseline)

--- a/src/silx/gui/plot/items/curve.py
+++ b/src/silx/gui/plot/items/curve.py
@@ -151,8 +151,7 @@ class CurveStyle(_Style):
         return self._symbol
 
     def getSymbolSize(self) -> float | None:
-        """Return the point marker size in points.
-        """
+        """Return the point marker size in points."""
         return self._symbolsize
 
     def __eq__(self, other) -> bool:

--- a/src/silx/gui/plot/items/image.py
+++ b/src/silx/gui/plot/items/image.py
@@ -295,8 +295,6 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
 
     def getOrigin(self) -> tuple[float, float]:
         """Returns the offset from origin at which to display the image.
-
-        :rtype: 2-tuple of float
         """
         return self._origin
 
@@ -317,8 +315,6 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
 
     def getScale(self) -> tuple[float, float]:
         """Returns the scale of the image in data coordinates.
-
-        :rtype: 2-tuple of float
         """
         return self._scale
 
@@ -458,7 +454,7 @@ class ImageData(ImageDataBase):
     def getAlternativeImageData(self, copy: bool = True) -> numpy.ndarray | None:
         """Get the optional RGBA image that is displayed instead of the data
 
-        :param bool copy: True (Default) to get a copy,
+        :param copy: True (Default) to get a copy,
             False to use internal representation (do not modify!)
         """
         if self._alternativeImage is None:
@@ -613,7 +609,7 @@ class ImageStack(ImageDataAggregated):
         """Displayed position in the cube"""
 
     def setStackData(
-        self, stack: numpy.ndarray, position: int | None = None, copy=True
+        self, stack: numpy.ndarray, position: int | None = None, copy: bool = True
     ):
         """Set the stack data
 
@@ -661,8 +657,6 @@ class ImageStack(ImageDataAggregated):
 
     def getStackPosition(self) -> int:
         """Get the displayed position of the stack.
-
-        :rtype: int
         """
         return self.__stackPosition
 

--- a/src/silx/gui/plot/items/image.py
+++ b/src/silx/gui/plot/items/image.py
@@ -294,8 +294,7 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
         raise NotImplementedError("This MUST be implemented in sub-class")
 
     def getOrigin(self) -> tuple[float, float]:
-        """Returns the offset from origin at which to display the image.
-        """
+        """Returns the offset from origin at which to display the image."""
         return self._origin
 
     def setOrigin(self, origin: tuple[float, float]):
@@ -314,8 +313,7 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
             self._updated(ItemChangedType.POSITION)
 
     def getScale(self) -> tuple[float, float]:
-        """Returns the scale of the image in data coordinates.
-        """
+        """Returns the scale of the image in data coordinates."""
         return self._scale
 
     def setScale(self, scale: tuple[float, float]):
@@ -656,8 +654,7 @@ class ImageStack(ImageDataAggregated):
         self.__updateDisplayedData()
 
     def getStackPosition(self) -> int:
-        """Get the displayed position of the stack.
-        """
+        """Get the displayed position of the stack."""
         return self.__stackPosition
 
     def __updateDisplayedData(self):

--- a/src/silx/gui/plot/items/image.py
+++ b/src/silx/gui/plot/items/image.py
@@ -180,19 +180,18 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
         origin = self.getOrigin()
         self.setOrigin((origin[0] + to[0] - from_[0], origin[1] + to[1] - from_[1]))
 
-    def getData(self, copy=True):
+    def getData(self, copy: bool = True) -> numpy.ndarray:
         """Returns the image data
 
-        :param bool copy: True (Default) to get a copy,
-                          False to use internal representation (do not modify!)
-        :rtype: numpy.ndarray
+        :param copy: True (Default) to get a copy,
+                     False to use internal representation (do not modify!)
         """
         return numpy.array(self._data, copy=copy or NP_OPTIONAL_COPY)
 
-    def setData(self, data):
+    def setData(self, data: numpy.ndarray):
         """Set the image data
 
-        :param numpy.ndarray data:
+        :param data:
         """
         previousShape = self._data.shape
         self._data = data
@@ -208,12 +207,11 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
             # Send event, mask is lazily updated in getMaskData
             self._updated(ItemChangedType.MASK)
 
-    def getMaskData(self, copy=True):
+    def getMaskData(self, copy: bool = True) -> numpy.ndarray | None:
         """Returns the mask data
 
-        :param bool copy: True (Default) to get a copy,
-                          False to use internal representation (do not modify!)
-        :rtype: Union[None,numpy.ndarray]
+        :param copy: True (Default) to get a copy,
+                     False to use internal representation (do not modify!)
         """
         if self._mask is None:
             return None
@@ -230,12 +228,12 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
 
         return numpy.array(self._mask, copy=copy or NP_OPTIONAL_COPY)
 
-    def setMaskData(self, mask, copy=True):
+    def setMaskData(self, mask: numpy.ndarray | None, copy: bool = True):
         """Set the image data
 
-        :param numpy.ndarray data:
-        :param bool copy: True (Default) to make a copy,
-                          False to use as is (do not modify!)
+        :param mask: Mark for the data. It must have the same shape of the data.
+        :param copy: True (Default) to make a copy,
+                     False to use as is (do not modify!)
         """
         if mask is not None:
             mask = numpy.array(mask, copy=copy or NP_OPTIONAL_COPY)
@@ -265,14 +263,13 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
         """
         return self.getData(copy=copy)
 
-    def getValueData(self, copy=True):
+    def getValueData(self, copy: bool = True) -> numpy.ndarray:
         """Return data (converted to int or float) with mask applied.
 
         Masked values are set to Not-A-Number.
         It returns a 2D array of values (int or float).
 
-        :param bool copy:
-        :rtype: numpy.ndarray
+        :param copy:
         """
         if self.__valueDataCache is None:
             data = self._getValueData(copy=False)
@@ -287,23 +284,23 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
             self.__valueDataCache = data
         return numpy.array(self.__valueDataCache, copy=copy or NP_OPTIONAL_COPY)
 
-    def getRgbaImageData(self, copy=True):
+    def getRgbaImageData(self, copy: bool = True) -> numpy.ndarray:
         """Get the displayed RGB(A) image
 
-        :param bool copy: True (Default) to get a copy,
-                          False to use internal representation (do not modify!)
+        :param copy: True (Default) to get a copy,
+                     False to use internal representation (do not modify!)
         :returns: numpy.ndarray of uint8 of shape (height, width, 4)
         """
         raise NotImplementedError("This MUST be implemented in sub-class")
 
-    def getOrigin(self):
+    def getOrigin(self) -> tuple[float, float]:
         """Returns the offset from origin at which to display the image.
 
         :rtype: 2-tuple of float
         """
         return self._origin
 
-    def setOrigin(self, origin):
+    def setOrigin(self, origin: tuple[float, float]):
         """Set the offset from origin at which to display the image.
 
         :param origin: (ox, oy) Offset from origin
@@ -318,14 +315,14 @@ class ImageBase(DataItem, LabelsMixIn, DraggableMixIn, AlphaMixIn):
             self._boundsChanged()
             self._updated(ItemChangedType.POSITION)
 
-    def getScale(self):
+    def getScale(self) -> tuple[float, float]:
         """Returns the scale of the image in data coordinates.
 
         :rtype: 2-tuple of float
         """
         return self._scale
 
-    def setScale(self, scale):
+    def setScale(self, scale: tuple[float, float]):
         """Set the scale of the image
 
         :param scale: (sx, sy) Scale of the image
@@ -359,20 +356,19 @@ class ImageDataBase(ImageBase, ColormapMixIn):
             colormap.setVRange(*vrange)
         return colormap
 
-    def getRgbaImageData(self, copy=True):
+    def getRgbaImageData(self, copy=True) -> numpy.ndarray:
         """Get the displayed RGB(A) image
 
         :returns: Array of uint8 of shape (height, width, 4)
-        :rtype: numpy.ndarray
         """
         return self.getColormap().applyToData(self)
 
-    def setData(self, data, copy=True):
+    def setData(self, data: numpy.ndarray, copy: bool = True):
         """Set the image data
 
-        :param numpy.ndarray data: Data array with 2 dimensions (h, w)
-        :param bool copy: True (Default) to get a copy,
-                          False to use internal representation (do not modify!)
+        :param data: Data array with 2 dimensions (h, w)
+        :param copy: True (Default) to get a copy,
+                     False to use internal representation (do not modify!)
         """
         data = numpy.array(data, copy=copy or NP_OPTIONAL_COPY)
         assert data.ndim == 2
@@ -443,11 +439,10 @@ class ImageData(ImageDataBase):
 
         return params
 
-    def getRgbaImageData(self, copy=True):
+    def getRgbaImageData(self, copy: bool = True) -> numpy.ndarray:
         """Get the displayed RGB(A) image
 
         :returns: Array of uint8 of shape (height, width, 4)
-        :rtype: numpy.ndarray
         """
         alternative = self.getAlternativeImageData(copy=False)
         if alternative is not None:
@@ -460,19 +455,18 @@ class ImageData(ImageDataBase):
                 image[:, :, 3] = image[:, :, 3] * alphaImage
             return image
 
-    def getAlternativeImageData(self, copy=True):
+    def getAlternativeImageData(self, copy: bool = True) -> numpy.ndarray | None:
         """Get the optional RGBA image that is displayed instead of the data
 
         :param bool copy: True (Default) to get a copy,
             False to use internal representation (do not modify!)
-        :rtype: Union[None,numpy.ndarray]
         """
         if self._alternativeImage is None:
             return None
         else:
             return numpy.array(self._alternativeImage, copy=copy or NP_OPTIONAL_COPY)
 
-    def getAlphaData(self, copy=True):
+    def getAlphaData(self, copy: bool = True) -> numpy.ndarray | None:
         """Get the optional transparency image applied on the data
 
         :param bool copy: True (Default) to get a copy,
@@ -484,18 +478,22 @@ class ImageData(ImageDataBase):
         else:
             return numpy.array(self.__alpha, copy=copy or NP_OPTIONAL_COPY)
 
-    def setData(self, data, alternative=None, alpha=None, copy=True):
+    def setData(
+        self,
+        data: numpy.ndarray,
+        alternative: numpy.ndarray | None = None,
+        alpha: numpy.ndarray | None = None,
+        copy: bool = True,
+    ):
         """Set the image data and optionally an alternative RGB(A) representation
 
-        :param numpy.ndarray data: Data array with 2 dimensions (h, w)
+        :param data: Data array with 2 dimensions (h, w)
         :param alternative: RGB(A) image to display instead of data,
                             shape: (h, w, 3 or 4)
-        :type alternative: Union[None,numpy.ndarray]
         :param alpha: An array of transparency value in [0, 1] to use for
                       display with shape: (h, w)
-        :type alpha: Union[None,numpy.ndarray]
-        :param bool copy: True (Default) to get a copy,
-                          False to use internal representation (do not modify!)
+        :param copy: True (Default) to get a copy,
+                     False to use internal representation (do not modify!)
         """
         data = numpy.array(data, copy=copy or NP_OPTIONAL_COPY)
         assert data.ndim == 2
@@ -546,19 +544,19 @@ class ImageRgba(ImageBase):
             alpha=self.getAlpha(),
         )
 
-    def getRgbaImageData(self, copy=True):
+    def getRgbaImageData(self, copy: bool = True) -> numpy.ndarray:
         """Get the displayed RGB(A) image
 
         :returns: numpy.ndarray of uint8 of shape (height, width, 4)
         """
         return _convertImageToRgba32(self.getData(copy=False), copy=copy)
 
-    def setData(self, data, copy=True):
+    def setData(self, data: numpy.array, copy: bool = True):
         """Set the image data
 
         :param data: RGB(A) image data to set
-        :param bool copy: True (Default) to get a copy,
-                          False to use internal representation (do not modify!)
+        :param copy: True (Default) to get a copy,
+                     False to use internal representation (do not modify!)
         """
         data = numpy.array(data, copy=copy or NP_OPTIONAL_COPY)
         if data.ndim != 3:
@@ -614,7 +612,9 @@ class ImageStack(ImageDataAggregated):
         self.__stackPosition = None
         """Displayed position in the cube"""
 
-    def setStackData(self, stack, position=None, copy=True):
+    def setStackData(
+        self, stack: numpy.ndarray, position: int | None = None, copy=True
+    ):
         """Set the stack data
 
         :param stack: A 3D numpy array like
@@ -634,7 +634,7 @@ class ImageStack(ImageDataAggregated):
             self.__stackPosition = 0
         self.__updateDisplayedData()
 
-    def getStackData(self, copy=True):
+    def getStackData(self, copy: bool = True) -> numpy.ndarray:
         """Get the stored stack array.
 
         :param bool copy: True (Default) to get a copy,
@@ -646,7 +646,7 @@ class ImageStack(ImageDataAggregated):
         else:
             return self.__stack
 
-    def setStackPosition(self, pos):
+    def setStackPosition(self, pos: int):
         """Set the displayed position on the stack.
 
         This function will clamp the stack position according to
@@ -659,7 +659,7 @@ class ImageStack(ImageDataAggregated):
         self.__stackPosition = pos
         self.__updateDisplayedData()
 
-    def getStackPosition(self):
+    def getStackPosition(self) -> int:
         """Get the displayed position of the stack.
 
         :rtype: int

--- a/src/silx/gui/plot/items/roi.py
+++ b/src/silx/gui/plot/items/roi.py
@@ -286,8 +286,7 @@ class LineROI(HandleBasedROI, items.LineMixIn):
         self.sigRegionChanged.emit()
 
     def getEndPoints(self) -> tuple[numpy.ndarray, numpy.ndarray]:
-        """Returns bounding points of this ROI.
-        """
+        """Returns bounding points of this ROI."""
         startPoint = numpy.array(self._handleStart.getPosition())
         endPoint = numpy.array(self._handleEnd.getPosition())
         return (startPoint, endPoint)
@@ -1501,8 +1500,7 @@ class HorizontalRangeROI(RegionOfInterest, items.LineMixIn):
         self._updatePos(vmin + delta, vmax + delta)
 
     def getCenter(self) -> numpy.ndarray:
-        """Returns the center location of this ROI.
-        """
+        """Returns the center location of this ROI."""
         vmin, vmax = self.getRange()
         return (vmin + vmax) * 0.5
 

--- a/src/silx/gui/plot/items/roi.py
+++ b/src/silx/gui/plot/items/roi.py
@@ -84,6 +84,7 @@ class PointROI(RegionOfInterest, items.SymbolMixIn):
         self._marker.sigDragFinished.connect(self._editingFinished)
         self.addItem(self._marker)
 
+    @docstring(RegionOfInterest)
     def setFirstShapePoints(self, points):
         self.setPosition(points[0])
 
@@ -104,7 +105,7 @@ class PointROI(RegionOfInterest, items.SymbolMixIn):
         """Returns the position of this ROI"""
         return self._marker.getPosition()
 
-    def setPosition(self, pos):
+    def setPosition(self, pos: tuple[float, float]):
         """Set the position of this ROI
 
         :param pos: 2d-coordinate of this point
@@ -168,6 +169,7 @@ class CrossROI(HandleBasedROI, items.LineMixIn):
             marker.setLineStyle(style.getLineStyle())
             marker.setLineWidth(style.getLineWidth())
 
+    @docstring(RegionOfInterest)
     def setFirstShapePoints(self, points):
         pos = points[0]
         self.setPosition(pos)
@@ -243,6 +245,7 @@ class LineROI(HandleBasedROI, items.LineMixIn):
         self.__shape.setLineWidth(style.getLineWidth())
         self.__shape.setLineGapColor(style.getLineGapColor())
 
+    @docstring(RegionOfInterest)
     def setFirstShapePoints(self, points):
         assert len(points) == 2
         self.setEndPoints(points[0], points[1])
@@ -282,7 +285,7 @@ class LineROI(HandleBasedROI, items.LineMixIn):
         self.__shape.setPoints(line)
         self.sigRegionChanged.emit()
 
-    def getEndPoints(self):
+    def getEndPoints(self) -> tuple[numpy.ndarray, numpy.ndarray]:
         """Returns bounding points of this ROI.
 
         :rtype: Tuple(numpy.ndarray,numpy.ndarray)
@@ -347,7 +350,7 @@ class LineROI(HandleBasedROI, items.LineMixIn):
             )
         ) is not None
 
-    def __str__(self):
+    def __str__(self) -> str:
         start, end = self.getEndPoints()
         params = start[0], start[1], end[0], end[1]
         params = "start: %f %f; end: %f %f" % params
@@ -389,6 +392,7 @@ class HorizontalLineROI(RegionOfInterest, items.LineMixIn):
         self._marker.setLineStyle(style.getLineStyle())
         self._marker.setLineWidth(style.getLineWidth())
 
+    @docstring(RegionOfInterest)
     def setFirstShapePoints(self, points):
         pos = points[0, 1]
         if pos == self.getPosition():
@@ -456,6 +460,7 @@ class VerticalLineROI(RegionOfInterest, items.LineMixIn):
         self._marker.setLineStyle(style.getLineStyle())
         self._marker.setLineWidth(style.getLineWidth())
 
+    @docstring(RegionOfInterest)
     def setFirstShapePoints(self, points):
         pos = points[0, 0]
         self.setPosition(pos)
@@ -533,6 +538,7 @@ class RectangleROI(HandleBasedROI, items.LineMixIn):
         self.__shape.setLineWidth(style.getLineWidth())
         self.__shape.setLineGapColor(style.getLineGapColor())
 
+    @docstring(RegionOfInterest)
     def setFirstShapePoints(self, points):
         assert len(points) == 2
         self._setBound(points)
@@ -757,6 +763,7 @@ class CircleROI(HandleBasedROI, items.LineMixIn):
         self.__shape.setLineWidth(style.getLineWidth())
         self.__shape.setLineGapColor(style.getLineGapColor())
 
+    @docstring(RegionOfInterest)
     def setFirstShapePoints(self, points):
         assert len(points) == 2
         self._setRay(points)
@@ -902,6 +909,7 @@ class EllipseROI(HandleBasedROI, items.LineMixIn):
         self.__shape.setLineWidth(style.getLineWidth())
         self.__shape.setLineGapColor(style.getLineGapColor())
 
+    @docstring(RegionOfInterest)
     def setFirstShapePoints(self, points):
         assert len(points) == 2
         self._setRay(points)
@@ -1195,6 +1203,7 @@ class PolygonROI(HandleBasedROI, items.LineMixIn):
         shape.setColor(rgba(style.getColor()))
         return shape
 
+    @docstring(RegionOfInterest)
     def setFirstShapePoints(self, points):
         if self._handleClose is not None:
             self._handleClose.setPosition(*points[0])
@@ -1217,7 +1226,7 @@ class PolygonROI(HandleBasedROI, items.LineMixIn):
         self.__shape.setPoints(self._points)
         self.addItem(self.__shape)
 
-    def isBeingCreated(self):
+    def isBeingCreated(self) -> bool:
         """Returns true if the ROI is in creation step"""
         return self._handleClose is not None
 
@@ -1237,14 +1246,11 @@ class PolygonROI(HandleBasedROI, items.LineMixIn):
     def _updateText(self, text):
         self._handleLabel.setText(text)
 
-    def getPoints(self):
-        """Returns the list of the points of this polygon.
-
-        :rtype: numpy.ndarray
-        """
+    def getPoints(self) -> numpy.ndarray:
+        """Returns the list of the points of this polygon."""
         return self._points.copy()
 
-    def setPoints(self, points):
+    def setPoints(self, points: numpy.ndarray):
         """Set the position of this ROI
 
         :param numpy.ndarray pos: 2d-coordinate of this point
@@ -1291,7 +1297,7 @@ class PolygonROI(HandleBasedROI, items.LineMixIn):
         self.__shape.setPoints(self._points)
         self.sigRegionChanged.emit()
 
-    def translate(self, x, y):
+    def translate(self, x: float, y: float):
         points = self.getPoints()
         delta = numpy.array([x, y])
         self.setPoints(points)
@@ -1370,6 +1376,7 @@ class HorizontalRangeROI(RegionOfInterest, items.LineMixIn):
         self.addItem(self._markerMax)
         self.__filterReentrant = utils.LockReentrant()
 
+    @docstring(RegionOfInterest)
     def setFirstShapePoints(self, points):
         vmin = min(points[:, 0])
         vmax = max(points[:, 0])
@@ -1438,11 +1445,11 @@ class HorizontalRangeROI(RegionOfInterest, items.LineMixIn):
                 self._markerMax.setPosition(vmax, 0)
         self.sigRegionChanged.emit()
 
-    def setRange(self, vmin, vmax):
+    def setRange(self, vmin: float, vmax: float):
         """Set the range of this ROI.
 
-        :param float vmin: Staring location of the range
-        :param float vmax: Ending location of the range
+        :param vmin: Staring location of the range
+        :param vmax: Ending location of the range
         """
         if vmin is None or vmax is None:
             err = "Can't set vmin or vmax to None"
@@ -1455,46 +1462,37 @@ class HorizontalRangeROI(RegionOfInterest, items.LineMixIn):
             raise ValueError(err)
         self._updatePos(vmin, vmax)
 
-    def getRange(self):
-        """Returns the range of this ROI.
-
-        :rtype: Tuple[float,float]
-        """
+    def getRange(self) -> tuple[float, float]:
+        """Returns the range of this ROI."""
         vmin = self.getMin()
         vmax = self.getMax()
         return vmin, vmax
 
-    def setMin(self, vmin):
+    def setMin(self, vmin: float):
         """Set the min of this ROI.
 
-        :param float vmin: New min
+        :param vmin: New min
         """
         vmax = self.getMax()
         self._updatePos(vmin, vmax)
 
-    def getMin(self):
-        """Returns the min value of this ROI.
-
-        :rtype: float
-        """
+    def getMin(self) -> float:
+        """Returns the min value of this ROI."""
         return self._markerMin.getPosition()[0]
 
-    def setMax(self, vmax):
+    def setMax(self, vmax: float):
         """Set the max of this ROI.
 
-        :param float vmax: New max
+        :param vmax: New max
         """
         vmin = self.getMin()
         self._updatePos(vmin, vmax)
 
-    def getMax(self):
-        """Returns the max value of this ROI.
-
-        :rtype: float
-        """
+    def getMax(self) -> float:
+        """Returns the max value of this ROI."""
         return self._markerMax.getPosition()[0]
 
-    def setCenter(self, center):
+    def setCenter(self, center: numpy.ndarray):
         """Set the center of this ROI.
 
         :param float center: New center
@@ -1504,7 +1502,7 @@ class HorizontalRangeROI(RegionOfInterest, items.LineMixIn):
         delta = center - previousCenter
         self._updatePos(vmin + delta, vmax + delta)
 
-    def getCenter(self):
+    def getCenter(self) -> numpy.ndarray:
         """Returns the center location of this ROI.
 
         :rtype: float
@@ -1554,7 +1552,7 @@ class HorizontalRangeROI(RegionOfInterest, items.LineMixIn):
     def contains(self, position):
         return self.getMin() <= position[0] <= self.getMax()
 
-    def __str__(self):
+    def __str__(self) -> str:
         vrange = self.getRange()
         params = "min: %f; max: %f" % vrange
         return f"{self.__class__.__name__}({params})"

--- a/src/silx/gui/plot/items/roi.py
+++ b/src/silx/gui/plot/items/roi.py
@@ -287,8 +287,6 @@ class LineROI(HandleBasedROI, items.LineMixIn):
 
     def getEndPoints(self) -> tuple[numpy.ndarray, numpy.ndarray]:
         """Returns bounding points of this ROI.
-
-        :rtype: Tuple(numpy.ndarray,numpy.ndarray)
         """
         startPoint = numpy.array(self._handleStart.getPosition())
         endPoint = numpy.array(self._handleEnd.getPosition())
@@ -1504,8 +1502,6 @@ class HorizontalRangeROI(RegionOfInterest, items.LineMixIn):
 
     def getCenter(self) -> numpy.ndarray:
         """Returns the center location of this ROI.
-
-        :rtype: float
         """
         vmin, vmax = self.getRange()
         return (vmin + vmax) * 0.5

--- a/src/silx/gui/plot/items/scatter.py
+++ b/src/silx/gui/plot/items/scatter.py
@@ -955,7 +955,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
 
         return x, y, value, xerror, yerror
 
-    def getValueData(self, copy=True) -> numpy.ndarray:
+    def getValueData(self, copy: bool = True) -> numpy.ndarray:
         """Returns the value assigned to the scatter data points.
 
         :param copy: True (Default) to get a copy,
@@ -963,7 +963,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
         """
         return numpy.array(self._value, copy=copy or NP_OPTIONAL_COPY)
 
-    def getAlphaData(self, copy=True) -> numpy.ndarray:
+    def getAlphaData(self, copy: bool = True) -> numpy.ndarray:
         """Returns the alpha (transparency) assigned to the scatter data points.
 
         :param copy: True (Default) to get a copy,
@@ -972,7 +972,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
         return numpy.array(self.__alpha, copy=copy or NP_OPTIONAL_COPY)
 
     def getData(
-        self, copy=True, displayed=False
+        self, copy: bool = True, displayed: bool = False
     ) -> tuple[
         numpy.ndarray, numpy.ndarray, numpy.ndarray, numpy.ndarray, numpy.ndarray
     ]:
@@ -1009,7 +1009,7 @@ class Scatter(PointsBase, ColormapMixIn, ScatterVisualizationMixIn):
         xerror: float | numpy.ndarray | numpy.float32 | None = None,
         yerror: float | numpy.ndarray | numpy.float32 | None = None,
         alpha: float | numpy.ndarray | numpy.float32 | None = None,
-        copy=True,
+        copy: bool = True,
     ):
         """Set the data of the scatter.
 

--- a/src/silx/gui/plot/items/shape.py
+++ b/src/silx/gui/plot/items/shape.py
@@ -31,6 +31,7 @@ __date__ = "21/12/2018"
 import logging
 
 import numpy
+import typing
 
 from .core import (
     Item,
@@ -44,6 +45,7 @@ from .core import (
     YAxisMixIn,
 )
 from ....utils.deprecation import deprecated
+from ... import colors
 from silx._utils import NP_OPTIONAL_COPY
 
 
@@ -80,11 +82,11 @@ class _TwoColorsLineMixIn(LineMixIn, LineGapColorMixIn):
         LineGapColorMixIn.__init__(self)
 
     @deprecated(replacement="getLineGapColor", since_version="2.0.0")
-    def getLineBgColor(self):
+    def getLineBgColor(self) -> colors.RGBAColorType | None:
         return self.getLineGapColor()
 
     @deprecated(replacement="setLineGapColor", since_version="2.0.0")
-    def setLineBgColor(self, color, copy: bool = True):
+    def setLineBgColor(self, color: colors.ColorType, copy: bool = True):
         self.setLineGapColor(color)
         self._updated(ItemChangedType.LINE_BG_COLOR)
 
@@ -124,16 +126,14 @@ class Shape(_OverlayItem, ColorMixIn, FillMixIn, _TwoColorsLineMixIn):
             gapcolor=self.getLineGapColor(),
         )
 
-    def getType(self):
+    def getType(self) -> str:
         """Returns the type of shape to draw.
 
         One of: 'hline', 'polygon', 'rectangle', 'vline', 'polylines'
-
-        :rtype: str
         """
         return self._type
 
-    def getPoints(self, copy=True):
+    def getPoints(self, copy=True) -> numpy.ndarray:
         """Get the control points of the shape.
 
         :param bool copy: True (Default) to get a copy,
@@ -171,10 +171,10 @@ class BoundingRect(DataItem, YAxisMixIn):
         YAxisMixIn.__init__(self)
         self.__bounds = None
 
-    def setBounds(self, rect):
+    def setBounds(self, rect: typing.Annotated[list[float], 4] | None):
         """Set the bounding box of this item in data coordinates
 
-        :param Union[None,List[float]] rect: (xmin, xmax, ymin, ymax) or None
+        :param rect: (xmin, xmax, ymin, ymax) or None
         """
         if rect is not None:
             rect = float(rect[0]), float(rect[1]), float(rect[2]), float(rect[3])
@@ -220,11 +220,11 @@ class _BaseExtent(DataItem):
         self.__axis = axis
         self.__range = 1.0, 100.0
 
-    def setRange(self, min_, max_):
+    def setRange(self, min_: float, max_: float):
         """Set the range of the extent of this item in data coordinates.
 
-        :param float min_: Lower bound of the extent
-        :param float max_: Upper bound of the extent
+        :param min_: Lower bound of the extent
+        :param max_: Upper bound of the extent
         :raises ValueError: If min > max or not finite bounds
         """
         range_ = float(min_), float(max_)
@@ -238,10 +238,9 @@ class _BaseExtent(DataItem):
             self._boundsChanged()
             self._updated(ItemChangedType.DATA)
 
-    def getRange(self):
-        """Returns the range (min, max) of the extent in data coordinates.
-
-        :rtype: List[float]
+    def getRange(self) -> tuple[float, float]:
+        """
+        Returns the range (min, max) of the extent in data coordinates.
         """
         return self.__range
 
@@ -363,7 +362,9 @@ class Line(_OverlayItem, AlphaMixIn, ColorMixIn, _TwoColorsLineMixIn):
     def getIntercept(self) -> float:
         return self.__intercept
 
-    def setSlopeInterceptFromPoints(self, point0, point1):
+    def setSlopeInterceptFromPoints(
+        self, point0: tuple[float, float], point1: tuple[float, float]
+    ):
         """Set slope and intercept from 2 (x, y) points"""
         x0, y0 = point0
         x1, y1 = point1

--- a/src/silx/gui/plot/items/shape.py
+++ b/src/silx/gui/plot/items/shape.py
@@ -133,10 +133,10 @@ class Shape(_OverlayItem, ColorMixIn, FillMixIn, _TwoColorsLineMixIn):
         """
         return self._type
 
-    def getPoints(self, copy=True) -> numpy.ndarray:
+    def getPoints(self, copy: bool = True) -> numpy.ndarray:
         """Get the control points of the shape.
 
-        :param bool copy: True (Default) to get a copy,
+        :param copy: True (Default) to get a copy,
                          False to use internal representation (do not modify!)
         :return: Array of point coordinates
         :rtype: numpy.ndarray with 2 dimensions


### PR DESCRIPTION
Improve the typing around plot items.

The types are not extremely accurate, this can be improved later.

Nothing crazy <s>except a new `AxisScale` enum. As it's a `StrEnum` i expect it to stay compatible with the previous implementation</s> (`StrEnum` is python 3.11) so i fallback to a `AxisScaleType` with literal strings.

Checklist:

- [ ] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->
