### PR TITLE
ProfileManager: remove workaround for Qt5 < 5.14

### DIFF
--- a/src/silx/gui/plot/tools/profile/manager.py
+++ b/src/silx/gui/plot/tools/profile/manager.py
@@ -1030,12 +1030,7 @@ class ProfileManager(qt.QObject):
 
         window = self.getPlotWidget().window()
         winGeom = window.frameGeometry()
-        if qt.BINDING == "PyQt5":
-            qapp = qt.QApplication.instance()
-            desktop = qapp.desktop()
-            screenGeom = desktop.availableGeometry(window)
-        else:  # Qt6 (and also Qt>=5.14)
-            screenGeom = window.screen().availableGeometry()
+        screenGeom = window.screen().availableGeometry()
         spaceOnLeftSide = winGeom.left()
         spaceOnRightSide = screenGeom.width() - winGeom.right()
 


### PR DESCRIPTION
I was not able to reproduce blinking with 'recent' PyQt5 version (5.15).

PyQt5 5.14 is form december 2019 and the most recent version of python it handle is 3.8... we are now supporting 3.10 or more recent. So let's go for the clean.

No issue met with PyQt6
