### PR TITLE
Draft: Colormap: add 'CONTRAST_ENHANCER' mode

### DIFF
--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -334,7 +334,9 @@ class Colormap(qt.QObject):
     PERCENTILE_1_99 = "percentile_1_99"
     """constant for autoscale using 1st and 99th percentile of data"""
 
-    AUTOSCALE_MODES = (MINMAX, STDDEV3, PERCENTILE_1_99)
+    CONTRAST_ENHANCER = "contrast_enhancer"
+
+    AUTOSCALE_MODES = (MINMAX, STDDEV3, PERCENTILE_1_99, CONTRAST_ENHANCER)
     """Tuple of managed auto scale algorithms"""
 
     sigChanged = qt.Signal()
@@ -552,11 +554,11 @@ class Colormap(qt.QObject):
         return self.__gamma
 
     def getAutoscaleMode(self) -> str:
-        """Return the autoscale mode of the colormap ('minmax' or 'stddev3')"""
+        """Return the autoscale mode of the colormap. Possible values are ('minmax', 'stddev3', 'percentile_1_99', 'contrast_enhancer')"""
         return self._autoscaleMode
 
     def setAutoscaleMode(self, mode: str):
-        """Set the autoscale mode: either 'minmax' or 'stddev3'
+        """Set the autoscale mode: either 'minmax', 'stddev3', 'percentile_1_99' or 'contrast_enhancer'
 
         :param mode: the mode to set
         """

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -237,6 +237,10 @@ class _AutoscaleModeComboBox(qt.QComboBox):
             "Percentile 1-99",
             "Use 1st to 99th percentile of data",
         ),
+        Colormap.CONTRAST_ENHANCER: (
+            "Contrast enhancer",
+            "Contrast enhancer by minimal saturation",
+        ),
     }
 
     def __init__(self, parent: qt.QWidget):

--- a/src/silx/gui/test/test_colors.py
+++ b/src/silx/gui/test/test_colors.py
@@ -431,6 +431,8 @@ class TestObjectAPI(ParametricTestCase):
         self.assertEqual(colormap.getAutoscaleMode(), Colormap.MINMAX)
         colormap.setAutoscaleMode(Colormap.PERCENTILE_1_99)
         self.assertEqual(colormap.getAutoscaleMode(), Colormap.PERCENTILE_1_99)
+        colormap.setAutoscaleMode(Colormap.CONTRAST_ENHANCER)
+        self.assertEqual(colormap.getAutoscaleMode(), Colormap.CONTRAST_ENHANCER)
 
     def testStoreRestore(self):
         colormaps = [Colormap(name="viridis"), Colormap(normalization=Colormap.SQRT)]

--- a/src/silx/image/ContrastEnhancer.py
+++ b/src/silx/image/ContrastEnhancer.py
@@ -1,0 +1,72 @@
+import numpy
+from silx.math.histogram import Histogramnd
+from silx.math.combo import min_max
+
+
+class _ContrastEnhancer:
+    """ """
+
+    DEFAULT_SATURATION = 0.35
+
+    def __init__(self):
+        self.saturation: float = _ContrastEnhancer.DEFAULT_SATURATION
+        self.equalize: bool = True
+        self.normalize: bool = True
+
+    def get_min_max(
+        self, image: numpy.ndarray, histogram_stats: dict | None = None
+    ) -> tuple[float]:
+        """
+        Return min max value to be set to the colormap in order to enhance the contrast
+        by saturating self.saturation ratio of pixels
+        """
+
+        if not isinstance(image, numpy.ndarray) and not image.ndim == 2:
+            raise TypeError("image is expected to be a 2D array.")
+
+        if histogram_stats is None:
+            histogram_stats: dict = self.get_histogram(image=image)
+
+        h_min = histogram_stats["hist_min"]
+        h_max = histogram_stats["hist_max"]
+        bin_size = histogram_stats["bin_size"]
+        histogram = histogram_stats["histogram"]
+
+        # compute histogram cumulative sum to determine new min / max location in the histogram
+        # we know that we want to saturate 'nb_points_to_skip' on each side of the histogram
+        hist_cum_sum = numpy.cumsum(histogram)
+        hist_cum_sum_inv = numpy.cumsum(histogram[::-1])
+
+        nb_points_to_skip = numpy.prod(image.shape) * self.DEFAULT_SATURATION / 2.0
+
+        min_index_bin = numpy.where(hist_cum_sum > nb_points_to_skip)[0][0]
+        max_index_bin = numpy.where(hist_cum_sum_inv > nb_points_to_skip)[0][0]
+
+        min_val = h_min + bin_size * min_index_bin
+        max_val = h_max - bin_size * max_index_bin
+
+        return min_val, max_val
+
+    @staticmethod
+    def get_histogram(image: numpy.ndarray) -> dict:
+        """
+        Compute histogram image and metadata for downstream calculation.
+        :return: dict with the following keys:
+
+            - **histogram**: nupy.ndarray
+            - **hist_min**: histogram range lower value
+            - **hist_max**: histogram range higher value
+            - **bin_size**: numpy.float
+        """
+        min, max = min_max(image)
+        n_bins = 256
+        # cast image to float32 to make it compatible with 'Histogramnd'
+        image = image.ravel().astype(numpy.float32)
+        histogram, _, _ = Histogramnd(image, histo_range=(min, max), n_bins=n_bins)
+        # hist_min, hist_max = bin_edges
+        return {
+            "histogram": histogram,
+            "hist_min": min,
+            "hist_max": max,
+            "bin_size": (max - min) / n_bins,
+        }

--- a/src/silx/math/colormap.py
+++ b/src/silx/math/colormap.py
@@ -267,6 +267,8 @@ class _NormalizationMixIn:
                 vmax = min(dmax, stdmax)
         elif mode == "percentile_1_99":
             vmin, vmax = self.autoscale_percentile_1_99(data)
+        elif mode == "contrast_enhancer":
+            vmin, vmax = self.autoscale_contrast_enhancer(data)
 
         else:
             raise ValueError("Unsupported mode: %s" % mode)
@@ -329,6 +331,17 @@ class _NormalizationMixIn:
         if data.size == 0:
             return None, None
         return numpy.nanpercentile(data, (1, 99))
+
+    def autoscale_contrast_enhancer(self, data: numpy.ndarray):
+        """Autoscale using pixel saturation"""
+        from silx.image.ContrastEnhancer import _ContrastEnhancer
+
+        data = data[self.is_valid(data)]
+        if data.dtype.kind == "f":  # Strip +/-inf
+            data = data[numpy.isfinite(data)]
+        if data.size == 0:
+            return None, None
+        return _ContrastEnhancer().get_min_max(image=data)
 
 
 class _LinearNormalizationMixIn(_NormalizationMixIn):


### PR DESCRIPTION
The PR add a new 'autoscale' mode named 'contrast enhancer'.

This is highly inspired by the imagej 'auto' mode.
It defines the new min / max values based on the histogram and take deliberately the policy to saturate N percent of the pixels (DEFAULT_SATURATION). Half on each side of the histogram.

# screenshots

![image](https://github.com/user-attachments/assets/2c7bc967-3ac0-4587-9b0a-83233cb89ee3)

# details

close #4123 

# TODO

- [x]  first version of the algorithm
- [ ] add test
- [ ] add doc
- [ ] Allow to define the 'saturation' percentage from a `QSlider` from the `ColormapDialog`.