### PR TITLE
silx.sx/silx.test/silx.utils: Improved code to pass flake8, black, ruff tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,8 +60,3 @@ silx.resources =
     opencl/codec/*.cl
     gui/colormaps/*.npy
 silx.examples = *.png
-
-[flake8]
-max-line-length = 88
-extend-ignore = E203, W503
-exclude = .venv,build,dist

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,4 +63,5 @@ silx.examples = *.png
 
 [flake8]
 max-line-length = 88
+extend-ignore = E203, W503
 exclude = .venv,build,dist

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,3 +63,4 @@ silx.examples = *.png
 
 [flake8]
 max-line-length = 88
+exclude = .venv,build,dist

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,3 +60,6 @@ silx.resources =
     opencl/codec/*.cl
     gui/colormaps/*.npy
 silx.examples = *.png
+
+[flake8]
+max-line-length = 88

--- a/src/silx/sx/__init__.py
+++ b/src/silx/sx/__init__.py
@@ -119,7 +119,7 @@ def enable_gui():
     from ._plot import plot, imshow, scatter, ginput  # noqa
 
     try:
-        import OpenGL
+        import OpenGL  # noqa: F401
     except ImportError:
         _logger.warning(
             "Not loading silx.gui.plot3d features: PyOpenGL is not installed"

--- a/src/silx/sx/_plot3d.py
+++ b/src/silx/sx/_plot3d.py
@@ -54,7 +54,8 @@ def contour3d(
     opacity=1.0,
 ):
     """
-    Plot isosurfaces of a 3D scalar field in a :class:`~silx.gui.plot3d.ScalarFieldView.ScalarFieldView` widget.
+    Plot isosurfaces of a 3D scalar field in a
+    :class:`~silx.gui.plot3d.ScalarFieldView.ScalarFieldView` widget.
 
     How to use:
 
@@ -183,7 +184,8 @@ def points3d(
     mode=None,
 ):
     """
-    Plot a 3D scatter plot in a :class:`~silx.gui.plot3d.SceneWindow.SceneWindow` widget.
+    Plot a 3D scatter plot in a :class:`~silx.gui.plot3d.SceneWindow.SceneWindow`
+    widget.
 
     How to use:
 

--- a/src/silx/test/__init__.py
+++ b/src/silx/test/__init__.py
@@ -33,7 +33,7 @@ import sys
 
 
 try:
-    import pytest
+    import pytest  # noqa: F401
 except ImportError:
     logging.getLogger(__name__).error(
         "pytest is required to run the tests, please install it."

--- a/src/silx/test/utils.py
+++ b/src/silx/test/utils.py
@@ -113,7 +113,7 @@ class _TestOptions:
             self.WITH_GL_TEST_REASON = "DISPLAY env variable not set"
         else:
             try:
-                import OpenGL
+                import OpenGL  # noqa: F401
             except ImportError:
                 self.WITH_GL_TEST = False
                 self.WITH_GL_TEST_REASON = "OpenGL package not available"
@@ -127,7 +127,7 @@ class _TestOptions:
 
         if self.WITH_QT_TEST:
             try:
-                from silx.gui import qt
+                from silx.gui import qt  # noqa: F401
             except ImportError:
                 self.WITH_QT_TEST = False
                 self.WITH_QT_TEST_REASON = "Qt is not installed"

--- a/src/silx/utils/ExternalResources.py
+++ b/src/silx/utils/ExternalResources.py
@@ -199,7 +199,8 @@ class ExternalResources:
             if not os.path.isfile(fullfilename):
                 raise RuntimeError(
                     """Could not automatically download test images %s!
-                    If you are behind a firewall, please set both environment variable http_proxy and https_proxy.
+                    If you are behind a firewall, please set both environment variable
+                     http_proxy and https_proxy.
                     This even works under windows !
                     Otherwise please try to download the images manually from
                     %s/%s"""
@@ -245,7 +246,7 @@ class ExternalResources:
 
         if lodn.endswith(("tar", "tgz", "tbz2", "tar.gz", "tar.bz2")):
             with tarfile.TarFile.open(full_path, mode="r") as fd:
-                # Avoid unsafe filter deprecation warning during transistion of mode change
+                # Avoid unsafe filter deprecation warning during mode change
                 if (3, 12) <= sys.version_info < (3, 14):
                     fd.extraction_filter = tarfile.data_filter
                 fd.extractall(output)
@@ -272,7 +273,7 @@ class ExternalResources:
             self._initialize_data()
         if filename not in self.all_data:
             self.all_data[filename] = self.get_hash(filename)
-            seld.save_json()
+            self.save_json()
         baseimage = os.path.basename(filename)
         logger.info("UtilsTest.getimage('%s')" % baseimage)
 
@@ -303,7 +304,8 @@ class ExternalResources:
             if not os.path.isfile(fullimagename_bz2):
                 raise RuntimeError(
                     """Could not automatically download test images %s!
-                    If you are behind a firewall, please set the environment variable http_proxy.
+                    If you are behind a firewall, please set the environment variable
+                     http_proxy.
                     Otherwise please try to download the images manually from
                     %s"""
                     % (self.url_base, filename)

--- a/src/silx/utils/retry.py
+++ b/src/silx/utils/retry.py
@@ -118,7 +118,8 @@ def retry(
         if inspect.isgeneratorfunction(method):
             if "start_index" not in inspect.signature(method).parameters:
                 raise TypeError(
-                    "The generator function '%s' needs a `start_index` named argument because it is wrapped with the `retry` decorator."
+                    "The generator function '%s' needs a `start_index` named argument"
+                    " because it is wrapped with the `retry` decorator."
                     % method.__name__
                 )
 

--- a/src/silx/utils/test/test_array_like.py
+++ b/src/silx/utils/test/test_array_like.py
@@ -373,31 +373,33 @@ class TestFunctions(unittest.TestCase):
     object"""
 
     def testListOfLists(self):
-        l = [[0, 1, 2], [2, 3, 4]]
-        self.assertEqual(get_dtype(l), numpy.dtype(int))
-        self.assertEqual(get_shape(l), (2, 3))
-        self.assertTrue(is_nested_sequence(l))
-        self.assertFalse(is_array(l))
-        self.assertFalse(is_list_of_arrays(l))
+        test_list = [[0, 1, 2], [2, 3, 4]]
+        self.assertEqual(get_dtype(test_list), numpy.dtype(int))
+        self.assertEqual(get_shape(test_list), (2, 3))
+        self.assertTrue(is_nested_sequence(test_list))
+        self.assertFalse(is_array(test_list))
+        self.assertFalse(is_list_of_arrays(test_list))
 
-        l = [[0.0, 1.0], [2.0, 3.0]]
-        self.assertEqual(get_dtype(l), numpy.dtype(float))
-        self.assertEqual(get_shape(l), (2, 2))
-        self.assertTrue(is_nested_sequence(l))
-        self.assertFalse(is_array(l))
-        self.assertFalse(is_list_of_arrays(l))
+        test_list = [[0.0, 1.0], [2.0, 3.0]]
+        self.assertEqual(get_dtype(test_list), numpy.dtype(float))
+        self.assertEqual(get_shape(test_list), (2, 2))
+        self.assertTrue(is_nested_sequence(test_list))
+        self.assertFalse(is_array(test_list))
+        self.assertFalse(is_list_of_arrays(test_list))
 
         # concatenated dtype of int and float
-        l = [
+        test_list = [
             numpy.array([[0, 1, 2], [2, 3, 4]]),
             numpy.array([[0.0, 1.0, 2.0], [2.0, 3.0, 4.0]]),
         ]
 
-        self.assertEqual(get_concatenated_dtype(l), numpy.array(l).dtype)
-        self.assertEqual(get_shape(l), (2, 2, 3))
-        self.assertFalse(is_nested_sequence(l))
-        self.assertFalse(is_array(l))
-        self.assertTrue(is_list_of_arrays(l))
+        self.assertEqual(
+            get_concatenated_dtype(test_list), numpy.array(test_list).dtype
+        )
+        self.assertEqual(get_shape(test_list), (2, 2, 3))
+        self.assertFalse(is_nested_sequence(test_list))
+        self.assertFalse(is_array(test_list))
+        self.assertTrue(is_list_of_arrays(test_list))
 
     def testNumpyArray(self):
         a = numpy.array([[0, 1], [2, 3]])

--- a/src/silx/utils/test/test_number.py
+++ b/src/silx/utils/test/test_number.py
@@ -116,7 +116,8 @@ class TestConversionTypes(testutils.ParametricTestCase):
 
         if Version(numpy.version.version) <= Version("1.10.4"):
             # numpy 1.8.2 -> Debian 8
-            # Checking a float128 precision with numpy 1.8.2 using abs(diff) is not working.
+            # Checking a float128 precision with numpy 1.8.2 using abs(diff) is not
+            # working.
             # It looks like the difference is done using float64 (diff == 0.0)
             expected = (numpy.longdouble, numpy.float64)
         else:

--- a/src/silx/utils/test/test_weakref.py
+++ b/src/silx/utils/test/test_weakref.py
@@ -233,11 +233,11 @@ class TestWeakList(unittest.TestCase):
 
     def testAdd(self):
         others = [Dummy()]
-        l = self.list + others
-        self.assertIs(l[0], self.object1)
-        self.assertEqual(len(l), 3)
+        test_list = self.list + others
+        self.assertIs(test_list[0], self.object1)
+        self.assertEqual(len(test_list), 3)
         others = None
-        self.assertEqual(len(l), 2)
+        self.assertEqual(len(test_list), 2)
 
     def testExtend(self):
         others = [Dummy()]
@@ -256,13 +256,13 @@ class TestWeakList(unittest.TestCase):
         self.assertEqual(len(self.list), 2)
 
     def testMul(self):
-        l = self.list * 2
-        self.assertIs(l[0], self.object1)
-        self.assertEqual(len(l), 4)
+        test_list = self.list * 2
+        self.assertIs(test_list[0], self.object1)
+        self.assertEqual(len(test_list), 4)
         self.object1 = None
-        self.assertEqual(len(l), 2)
-        self.assertIs(l[0], self.object2)
-        self.assertIs(l[1], self.object2)
+        self.assertEqual(len(test_list), 2)
+        self.assertIs(test_list[0], self.object2)
+        self.assertIs(test_list[1], self.object2)
 
     def testImul(self):
         self.list *= 2

--- a/src/silx/utils/weakref.py
+++ b/src/silx/utils/weakref.py
@@ -283,9 +283,9 @@ class WeakList(list):
 
     def __add__(self, other):
         """Returns a WeakList containing this list an the other"""
-        l = WeakList(self)
-        l.extend(other)
-        return l
+        weak_list = WeakList(self)
+        weak_list.extend(other)
+        return weak_list
 
     def __iadd__(self, other):
         """Add objects to this list inplace"""


### PR DESCRIPTION
Added # noqa: F401 to ignore valid imported modules which aren't used
Changed lines with length longer than 88 characters (according to black) to properly wrap
Fixed a typo in silx.utils.ExternalResources which may have caused bugs elsewhere
Refactored ambiguous variable "l" within silx.utils with a more descriptive name
