### PR TITLE
colormap: Improve percentile mode

### DIFF
--- a/examples/plotWidget.py
+++ b/examples/plotWidget.py
@@ -41,7 +41,7 @@ import numpy
 
 from silx.gui import qt
 
-from silx.gui.plot import PlotWidget
+from silx.gui.plot import Plot2D
 from silx.gui.plot import tools  # QToolbars to use with PlotWidget
 from silx.gui.plot import actions  # QAction to use with PlotWidget
 from silx.gui.plot import PlotToolButtons  # QToolButton to use with PlotWidget
@@ -57,7 +57,7 @@ class MyPlotWindow(qt.QMainWindow):
         super().__init__(parent)
 
         # Create a PlotWidget
-        self._plot = PlotWidget(parent=self)
+        self._plot = Plot2D(parent=self)
 
         # Create a colorbar linked with the PlotWidget
         colorBar = ColorBarWidget(parent=self, plot=self._plot)

--- a/examples/plotWidget.py
+++ b/examples/plotWidget.py
@@ -41,7 +41,7 @@ import numpy
 
 from silx.gui import qt
 
-from silx.gui.plot import PlotWindow
+from silx.gui.plot import PlotWidget
 from silx.gui.plot import tools  # QToolbars to use with PlotWidget
 from silx.gui.plot import actions  # QAction to use with PlotWidget
 from silx.gui.plot import PlotToolButtons  # QToolButton to use with PlotWidget
@@ -57,7 +57,7 @@ class MyPlotWindow(qt.QMainWindow):
         super().__init__(parent)
 
         # Create a PlotWidget
-        self._plot = PlotWindow(parent=self)
+        self._plot = PlotWidget(parent=self)
 
         # Create a colorbar linked with the PlotWidget
         colorBar = ColorBarWidget(parent=self, plot=self._plot)

--- a/examples/plotWidget.py
+++ b/examples/plotWidget.py
@@ -41,7 +41,7 @@ import numpy
 
 from silx.gui import qt
 
-from silx.gui.plot import Plot2D
+from silx.gui.plot import PlotWindow
 from silx.gui.plot import tools  # QToolbars to use with PlotWidget
 from silx.gui.plot import actions  # QAction to use with PlotWidget
 from silx.gui.plot import PlotToolButtons  # QToolButton to use with PlotWidget
@@ -57,7 +57,7 @@ class MyPlotWindow(qt.QMainWindow):
         super().__init__(parent)
 
         # Create a PlotWidget
-        self._plot = Plot2D(parent=self)
+        self._plot = PlotWindow(parent=self)
 
         # Create a colorbar linked with the PlotWidget
         colorBar = ColorBarWidget(parent=self, plot=self._plot)

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -333,10 +333,10 @@ class Colormap(qt.QObject):
     """constant for autoscale using mean +/- 3*std(data)
     with a clamp on min/max of the data"""
 
-    PERCENTILE_1_99 = "percentile_1_99"
-    """constant for autoscale using 1st and 99th percentile of data"""
+    PERCENTILE = "percentile"
+    """constant for autoscale using n'st and m'th percentile of data"""
 
-    AUTOSCALE_MODES = (MINMAX, STDDEV3, PERCENTILE_1_99)
+    AUTOSCALE_MODES = (MINMAX, STDDEV3, PERCENTILE)
     """Tuple of managed auto scale algorithms"""
 
     sigChanged = qt.Signal()
@@ -557,11 +557,11 @@ class Colormap(qt.QObject):
         return self.__gamma
 
     def getAutoscaleMode(self) -> str:
-        """Return the autoscale mode of the colormap ('minmax' or 'stddev3')"""
+        """Return the autoscale mode of the colormap. Possible values are ('minmax', 'stddev3', 'percentile')"""
         return self._autoscaleMode
 
     def setAutoscaleMode(self, mode: str):
-        """Set the autoscale mode: either 'minmax' or 'stddev3'
+        """Set the autoscale mode: either 'minmax', 'stddev3', 'percentile' or 'contrast_enhancer'
 
         :param mode: the mode to set
         """

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -344,6 +344,8 @@ class Colormap(qt.QObject):
 
     _DEFAULT_NAN_COLOR = 255, 255, 255, 0
 
+    DEFAULT_SATURATION: int = 2
+
     def __init__(
         self,
         name: str | None = None,
@@ -352,7 +354,6 @@ class Colormap(qt.QObject):
         vmin: float | None = None,
         vmax: float | None = None,
         autoscaleMode: str = MINMAX,
-        saturation: float = 0.0,
     ):
         qt.QObject.__init__(self)
         self._editable = True
@@ -392,11 +393,7 @@ class Colormap(qt.QObject):
         self._vmax = float(vmax) if vmax is not None else None
         self.__warnBadVmin = True
         self.__warnBadVmax = True
-        self._saturation: float = saturation
-
-    @property
-    def getSaturation(self) -> float:
-        return self._saturation
+        self._saturation: int = self._DEFAULT_NAN_COLOR
 
     def setFromColormap(self, other: Colormap):
         """Set this colormap using information from the `other` colormap.
@@ -546,14 +543,18 @@ class Colormap(qt.QObject):
             self.__warnBadVmax = True
             self.sigChanged.emit()
 
-    def getSaturation(self) -> float:
+    def getSaturation(self) -> int:
         """Colormap saturation in (0, 100)"""
         return self._saturation
 
-    def setSaturation(self, saturation: float):
-        if not (0.0 <= saturation <= 100.0):
+    def setSaturation(self, saturation: int):
+        if not isinstance(saturation, int):
+            raise TypeError(
+                f"saturation is expected to be an int. Got {type(saturation)}"
+            )
+        if not (0 <= saturation <= 100):
             raise ValueError(
-                f"saturation should be a float in [0.0, 100.0]. Got {saturation}"
+                f"saturation should be a float in [0, 100]. Got {saturation}"
             )
         if saturation != self._saturation:
             self._saturation = saturation

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -349,6 +349,9 @@ class Colormap(qt.QObject):
     _DEFAULT_NAN_COLOR = 255, 255, 255, 0
 
     _DEFAULT_SATURATION: int = 2
+    """Saturation value to be used with percentile mode.
+    We convert saturation to percentile by taking the percentile [saturation / 2, 100 - saturation / 2]
+    For example if saturation is 2 then we will take 1st and 99th percentiles."""
 
     def __init__(
         self,

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -421,7 +421,9 @@ class Colormap(qt.QObject):
                 assert colors is not None
                 self.setColormapLUT(colors)
             self.setNaNColor(other.getNaNColor())
-            self.setSaturationAutoscaleParameter(other.getSaturationAutoscaleParameter())
+            self.setSaturationAutoscaleParameter(
+                other.getSaturationAutoscaleParameter()
+            )
             self.setNormalization(other.getNormalization())
             self.setGammaNormalizationParameter(other.getGammaNormalizationParameter())
             self.setAutoscaleMode(other.getAutoscaleMode())
@@ -708,7 +710,9 @@ class Colormap(qt.QObject):
         :return: (vmin, vmax) range
         """
         return self._getNormalizer().autoscale(
-            data, mode=self.getAutoscaleMode(), saturation=self.getSaturationAutoscaleParameter()
+            data,
+            mode=self.getAutoscaleMode(),
+            saturation=self.getSaturationAutoscaleParameter(),
         )
 
     def getColormapRange(
@@ -751,7 +755,9 @@ class Colormap(qt.QObject):
                 max_ = normalizer.DEFAULT_RANGE[1] if max_ is None else max_
             else:
                 min_, max_ = normalizer.autoscale(
-                    data, mode=self.getAutoscaleMode(), saturation=self.getSaturationAutoscaleParameter()
+                    data,
+                    mode=self.getAutoscaleMode(),
+                    saturation=self.getSaturationAutoscaleParameter(),
                 )
 
         # Handle autoscale

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -400,7 +400,7 @@ class Colormap(qt.QObject):
         self._vmax = float(vmax) if vmax is not None else None
         self.__warnBadVmin = True
         self.__warnBadVmax = True
-        self._saturation: int = self.DEFAULT_SATURATION
+        self._saturation: int = self._DEFAULT_SATURATION
 
     def setFromColormap(self, other: Colormap):
         """Set this colormap using information from the `other` colormap.

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -421,7 +421,7 @@ class Colormap(qt.QObject):
                 assert colors is not None
                 self.setColormapLUT(colors)
             self.setNaNColor(other.getNaNColor())
-            self.setSaturation(other.getSaturation())
+            self.setSaturationAutoscaleParameter(other.getSaturationAutoscaleParameter())
             self.setNormalization(other.getNormalization())
             self.setGammaNormalizationParameter(other.getGammaNormalizationParameter())
             self.setAutoscaleMode(other.getAutoscaleMode())
@@ -550,11 +550,18 @@ class Colormap(qt.QObject):
             self.__warnBadVmax = True
             self.sigChanged.emit()
 
-    def getSaturation(self) -> int:
+    def getSaturationAutoscaleParameter(self) -> int:
         """Colormap saturation in (0, 100)"""
         return self._saturation
 
-    def setSaturation(self, saturation: int):
+    def setSaturationAutoscaleParameter(self, saturation: int):
+        """Set the 'saturation' parameter.
+
+        Only used for autoscale 'percentile' mode
+
+        :raise ValueError: If saturation is not valid
+        :raise TypeError: If saturation is not an integer
+        """
         if not isinstance(saturation, int):
             raise TypeError(
                 f"saturation is expected to be an int. Got {type(saturation)}"
@@ -701,7 +708,7 @@ class Colormap(qt.QObject):
         :return: (vmin, vmax) range
         """
         return self._getNormalizer().autoscale(
-            data, mode=self.getAutoscaleMode(), saturation=self.getSaturation()
+            data, mode=self.getAutoscaleMode(), saturation=self.getSaturationAutoscaleParameter()
         )
 
     def getColormapRange(
@@ -744,7 +751,7 @@ class Colormap(qt.QObject):
                 max_ = normalizer.DEFAULT_RANGE[1] if max_ is None else max_
             else:
                 min_, max_ = normalizer.autoscale(
-                    data, mode=self.getAutoscaleMode(), saturation=self.getSaturation()
+                    data, mode=self.getAutoscaleMode(), saturation=self.getSaturationAutoscaleParameter()
                 )
 
         # Handle autoscale

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -417,6 +417,7 @@ class Colormap(qt.QObject):
                 assert colors is not None
                 self.setColormapLUT(colors)
             self.setNaNColor(other.getNaNColor())
+            self.setSaturation(other.getSaturation())
             self.setNormalization(other.getNormalization())
             self.setGammaNormalizationParameter(other.getGammaNormalizationParameter())
             self.setAutoscaleMode(other.getAutoscaleMode())

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -395,7 +395,7 @@ class Colormap(qt.QObject):
         self._saturation: float = saturation
 
     @property
-    def getSaturation(self):
+    def getSaturation(self) -> float:
         return self._saturation
 
     def setFromColormap(self, other: Colormap):

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -44,6 +44,7 @@ from silx.gui import qt
 from silx.gui.utils import blockSignals
 from silx.math import colormap as _colormap
 from silx.utils.exceptions import NotEditableError
+from silx.utils.deprecation import deprecated_warning
 
 
 _logger = logging.getLogger(__name__)
@@ -333,6 +334,9 @@ class Colormap(qt.QObject):
     """constant for autoscale using mean +/- 3*std(data)
     with a clamp on min/max of the data"""
 
+    PERCENTILE_1_99 = "percentile_1_99"
+    """constant for autoscale using 1st and 99th percentile of data. Deprecated to the benefit of 'percentile'"""
+
     PERCENTILE = "percentile"
     """constant for autoscale using n'st and m'th percentile of data"""
 
@@ -582,12 +586,23 @@ class Colormap(qt.QObject):
         return self._autoscaleMode
 
     def setAutoscaleMode(self, mode: str):
-        """Set the autoscale mode: either 'minmax', 'stddev3' or 'percentile'
+        """Set the autoscale mode: either 'minmax', 'stddev3' or 'percentile'.
 
         :param mode: the mode to set
+
+        .. warning:: 'percentile_1_99' is deprecated
         """
         if self.isEditable() is False:
             raise NotEditableError("Colormap is not editable")
+        if mode == self.PERCENTILE_1_99:
+            deprecated_warning(
+                type_="Mode",
+                name="mode",
+                replacement="percentile",
+                since_version="3.0",
+            )
+            mode = self.PERCENTILE
+
         assert mode in self.AUTOSCALE_MODES
         if mode != self._autoscaleMode:
             self._autoscaleMode = mode

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -393,7 +393,7 @@ class Colormap(qt.QObject):
         self._vmax = float(vmax) if vmax is not None else None
         self.__warnBadVmin = True
         self.__warnBadVmax = True
-        self._saturation: int = self._DEFAULT_NAN_COLOR
+        self._saturation: int = self.DEFAULT_SATURATION
 
     def setFromColormap(self, other: Colormap):
         """Set this colormap using information from the `other` colormap.

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -584,11 +584,11 @@ class Colormap(qt.QObject):
         """Returns the gamma correction parameter value."""
         return self.__gamma
 
-    def getAutoscaleMode(self) -> AutoScaleModeType:
+    def getAutoscaleMode(self) -> str:
         """Return the autoscale mode of the colormap. Possible values are ('minmax', 'stddev3', 'percentile')"""
         return self._autoscaleMode
 
-    def setAutoscaleMode(self, mode: AutoScaleModeType):
+    def setAutoscaleMode(self, mode: str):
         """Set the autoscale mode: either 'minmax', 'stddev3' or 'percentile'.
 
         :param mode: the mode to set

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -394,6 +394,10 @@ class Colormap(qt.QObject):
         self.__warnBadVmax = True
         self._saturation: float = saturation
 
+    @property
+    def getSaturation(self):
+        return self._saturation
+
     def setFromColormap(self, other: Colormap):
         """Set this colormap using information from the `other` colormap.
 
@@ -546,7 +550,13 @@ class Colormap(qt.QObject):
         return self._saturation
 
     def setSaturation(self, saturation: float):
-        self._saturation = saturation
+        if not (0.0 <= saturation <= 100.0):
+            raise ValueError(
+                f"saturation should be a float in [0.0, 100.0]. Got {saturation}"
+            )
+        if saturation != self._saturation:
+            self._saturation = saturation
+            self.sigChanged.emit()
 
     def setGammaNormalizationParameter(self, gamma: float):
         """Set the gamma correction parameter.
@@ -574,10 +584,6 @@ class Colormap(qt.QObject):
 
         :param mode: the mode to set
         """
-        print("==============")
-        import traceback
-        traceback.print_stack(limit=5)
-        print("==============")
         if self.isEditable() is False:
             raise NotEditableError("Colormap is not editable")
         assert mode in self.AUTOSCALE_MODES
@@ -717,7 +723,6 @@ class Colormap(qt.QObject):
                 min_ = normalizer.DEFAULT_RANGE[0] if min_ is None else min_
                 max_ = normalizer.DEFAULT_RANGE[1] if max_ is None else max_
             else:
-                print("self.getSaturation()", self.getSaturation())
                 min_, max_ = normalizer.autoscale(
                     data, mode=self.getAutoscaleMode(), saturation=self.getSaturation()
                 )

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -580,7 +580,7 @@ class Colormap(qt.QObject):
         return self._autoscaleMode
 
     def setAutoscaleMode(self, mode: str):
-        """Set the autoscale mode: either 'minmax', 'stddev3', 'percentile' or 'contrast_enhancer'
+        """Set the autoscale mode: either 'minmax', 'stddev3' or 'percentile'
 
         :param mode: the mode to set
         """

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -348,7 +348,7 @@ class Colormap(qt.QObject):
 
     _DEFAULT_NAN_COLOR = 255, 255, 255, 0
 
-    DEFAULT_SATURATION: int = 2
+    _DEFAULT_SATURATION: int = 2
 
     def __init__(
         self,

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -584,11 +584,11 @@ class Colormap(qt.QObject):
         """Returns the gamma correction parameter value."""
         return self.__gamma
 
-    def getAutoscaleMode(self) -> str:
+    def getAutoscaleMode(self) -> AutoScaleModeType:
         """Return the autoscale mode of the colormap. Possible values are ('minmax', 'stddev3', 'percentile')"""
         return self._autoscaleMode
 
-    def setAutoscaleMode(self, mode: str):
+    def setAutoscaleMode(self, mode: AutoScaleModeType):
         """Set the autoscale mode: either 'minmax', 'stddev3' or 'percentile'.
 
         :param mode: the mode to set

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -1741,7 +1741,7 @@ class ColormapDialog(qt.QDialog):
                 if activate_saturation:
                     colormap.setSaturation(self._saturation.value())
                 else:
-                    colormap.setSaturation(0.0)
+                    colormap.setSaturation(Colormap.DEFAULT_SATURATION)
                 colormap.setAutoscaleMode(mode)
 
         self._updateSaturationVisibility()

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -1654,6 +1654,8 @@ class ColormapDialog(qt.QDialog):
             with utils.blockSignals(self._autoButtons):
                 self._autoButtons.setEnabled(colormap.isEditable())
                 self._autoButtons.setAutoRangeFromColormap(colormap)
+            with utils.blockSignals(self._saturationSlider):
+                self._saturationSlider.setValue(colormap.getSaturation())
 
             vmin, vmax = colormap.getVRange()
             if vmin is None or vmax is None:

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -976,7 +976,7 @@ class ColormapDialog(qt.QDialog):
 
         self._saturation = qt.QSlider(qt.Qt.Horizontal, self)
         self._saturation.setRange(0, 100)
-        self._saturation.setValue(2) # 2 <=> 1-99 percentile mode
+        self._saturation.setValue(2)  # 2 <=> 1-99 percentile mode
         self._saturation.valueChanged.connect(self._saturationChanged)
         self._saturation.setVisible(False)
 
@@ -1536,9 +1536,7 @@ class ColormapDialog(qt.QDialog):
 
     def _updateWidgetRange(self):
         """Update the colormap range displayed into the widget."""
-        print("update _updateWidgetRange")
         xmin, xmax = self._getFiniteColormapRange()
-        print("xmin", xmin, "xmax", xmax)
         colormap = self.getColormap()
         if colormap is not None:
             vRange = colormap.getVRange()
@@ -1738,11 +1736,11 @@ class ColormapDialog(qt.QDialog):
         activate_saturation = self._autoScaleCombo.currentText() == "Percentile"
         if colormap is not None:
             with self._colormapChange:
-                colormap.setAutoscaleMode(mode)
                 if activate_saturation:
-                    colormap.setSaturation(self._saturation.value)
+                    colormap.setSaturation(self._saturation.value())
                 else:
                     colormap.setSaturation(0.0)
+                colormap.setAutoscaleMode(mode)
 
         self._saturation.setVisible(activate_saturation)
         self._saturationLabel.setVisible(activate_saturation)
@@ -1754,7 +1752,6 @@ class ColormapDialog(qt.QDialog):
         if colormap is not None:
             with self._colormapChange:
                 colormap.setSaturation(value)
-        print("saturation  value is", value)
         self._updateWidgetRange()
 
     def _minAutoscaleUpdated(self, autoEnabled):

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -978,6 +978,7 @@ class ColormapDialog(qt.QDialog):
         self._saturationSlider.setTickPosition(qt.QSlider.TicksBelow)
         self._saturationSlider.setRange(0, 100)
         self._saturationSlider.setValue(2)  # 2 <=> 1-99 percentile mode
+        self._saturationSlider.setTracking(False)
         self._saturationSlider.valueChanged.connect(self._saturationChanged)
 
         rangeLayout = qt.QGridLayout()

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -1658,7 +1658,9 @@ class ColormapDialog(qt.QDialog):
                 self._autoButtons.setEnabled(colormap.isEditable())
                 self._autoButtons.setAutoRangeFromColormap(colormap)
             with utils.blockSignals(self._saturationSlider):
-                self._saturationSlider.setValue(colormap.getSaturationAutoscaleParameter())
+                self._saturationSlider.setValue(
+                    colormap.getSaturationAutoscaleParameter()
+                )
 
             vmin, vmax = colormap.getVRange()
             if vmin is None or vmax is None:
@@ -1746,9 +1748,13 @@ class ColormapDialog(qt.QDialog):
             enable_saturation = self._autoScaleCombo.currentText() == "Percentile"
             with self._colormapChange:
                 if enable_saturation:
-                    colormap.setSaturationAutoscaleParameter(self._saturationSlider.value())
+                    colormap.setSaturationAutoscaleParameter(
+                        self._saturationSlider.value()
+                    )
                 else:
-                    colormap.setSaturationAutoscaleParameter(Colormap._DEFAULT_SATURATION)
+                    colormap.setSaturationAutoscaleParameter(
+                        Colormap._DEFAULT_SATURATION
+                    )
                 colormap.setAutoscaleMode(mode)
 
         self._updateWidgetRange()

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -958,7 +958,9 @@ class ColormapDialog(qt.QDialog):
         autoScaleCombo = _AutoscaleModeComboBox(self)
         autoScaleCombo.currentIndexChanged.connect(self._autoscaleModeUpdated)
         self._autoScaleCombo = autoScaleCombo
-        self._autoScaleCombo.currentTextChanged.connect(self._updateSaturationVisibility)
+        self._autoScaleCombo.currentTextChanged.connect(
+            self._updateSaturationVisibility
+        )
 
         # Min row
         self._minValue = _BoundaryWidget(parent=self, value=1.0)
@@ -975,6 +977,8 @@ class ColormapDialog(qt.QDialog):
         self._autoButtons = _AutoScaleButton(self)
         self._autoButtons.autoRangeChanged.connect(self._autoRangeButtonsUpdated)
 
+        # saturation
+        self._saturationLabel = qt.QLabel("saturation")
         self._saturationSlider = qt.QSlider(qt.Qt.Horizontal, self)
         self._saturationSlider.setTickPosition(qt.QSlider.TicksBelow)
         self._saturationSlider.setRange(0, 100)
@@ -1066,16 +1070,16 @@ class ColormapDialog(qt.QDialog):
         self._scaleToAreaGroup.setLayout(layout)
         self._scaleToAreaGroup.setVisible(False)
 
-        layoutScale = qt.QHBoxLayout()
+        layoutScale = qt.QGridLayout()
         layoutScale.setContentsMargins(0, 0, 0, 0)
-        layoutScale.addWidget(self._autoButtons)
-        layoutScale.addWidget(self._autoScaleCombo)
-        layoutScale.addStretch()
+        layoutScale.addWidget(self._autoButtons, 0, 0, 1, 1)
+        layoutScale.addWidget(self._autoScaleCombo, 0, 1, 1, 1)
+        layoutScale.addItem(
+            qt.QSpacerItem(0, 0, qt.QSizePolicy.Fixed, qt.QSizePolicy.Fixed), 0, 2, 1, 1
+        )
 
-        layoutSaturation = qt.QFormLayout()
-        self._saturationLabel = qt.QLabel("saturation")
-        self._saturationLabel.setVisible(False)
-        layoutSaturation.addRow(self._saturationLabel, self._saturationSlider)
+        layoutScale.addWidget(self._saturationLabel, 1, 0, 1, 1)
+        layoutScale.addWidget(self._saturationSlider, 1, 1, 1, 2)
 
         formLayout = FormGridLayout(self)
         formLayout.setContentsMargins(10, 10, 10, 10)
@@ -1094,7 +1098,6 @@ class ColormapDialog(qt.QDialog):
             qt.QSpacerItem(1, 1, qt.QSizePolicy.Fixed, qt.QSizePolicy.Fixed)
         )
         formLayout.addRow("Scale:", layoutScale)
-        formLayout.addRow("", layoutSaturation)
         formLayout.addRow("Fixed scale on:", self._scaleToAreaGroup)
         formLayout.addRow(self._buttonsModal)
         formLayout.addRow(self._buttonsNonModal)

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -975,6 +975,7 @@ class ColormapDialog(qt.QDialog):
         self._autoButtons.autoRangeChanged.connect(self._autoRangeButtonsUpdated)
 
         self._saturation = qt.QSlider(qt.Qt.Horizontal, self)
+        self._saturation.setTickPosition(qt.QSlider.TicksBelow)
         self._saturation.setRange(0, 100)
         self._saturation.setValue(2)  # 2 <=> 1-99 percentile mode
         self._saturation.valueChanged.connect(self._saturationChanged)

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -1736,9 +1736,9 @@ class ColormapDialog(qt.QDialog):
 
         colormap = self.getColormap()
         if colormap is not None:
-            activate_saturation = self._autoScaleCombo.currentText() == "Percentile"
+            enable_saturation = self._autoScaleCombo.currentText() == "Percentile"
             with self._colormapChange:
-                if activate_saturation:
+                if enable_saturation:
                     colormap.setSaturation(self._saturationSlider.value())
                 else:
                     colormap.setSaturation(Colormap._DEFAULT_SATURATION)
@@ -1748,9 +1748,9 @@ class ColormapDialog(qt.QDialog):
         self._updateWidgetRange()
 
     def _updateSaturationVisibility(self):
-        activate_saturation = self._autoScaleCombo.currentText() == "Percentile"
-        self._saturationSlider.setVisible(activate_saturation)
-        self._saturationLabel.setVisible(activate_saturation)
+        enable_saturation = self._autoScaleCombo.currentText() == "Percentile"
+        self._saturationSlider.setEnabled(enable_saturation)
+        self._saturationLabel.setEnabled(enable_saturation)
 
     def _saturationChanged(self, value):
         """Callback executed when the saturation level has been changed (will impact the 'PERCENTILE' mode)"""

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -974,11 +974,11 @@ class ColormapDialog(qt.QDialog):
         self._autoButtons = _AutoScaleButton(self)
         self._autoButtons.autoRangeChanged.connect(self._autoRangeButtonsUpdated)
 
-        self._saturation = qt.QSlider(qt.Qt.Horizontal, self)
-        self._saturation.setTickPosition(qt.QSlider.TicksBelow)
-        self._saturation.setRange(0, 100)
-        self._saturation.setValue(2)  # 2 <=> 1-99 percentile mode
-        self._saturation.valueChanged.connect(self._saturationChanged)
+        self._saturationSlider = qt.QSlider(qt.Qt.Horizontal, self)
+        self._saturationSlider.setTickPosition(qt.QSlider.TicksBelow)
+        self._saturationSlider.setRange(0, 100)
+        self._saturationSlider.setValue(2)  # 2 <=> 1-99 percentile mode
+        self._saturationSlider.valueChanged.connect(self._saturationChanged)
 
         rangeLayout = qt.QGridLayout()
         miniFont = qt.QFont(self.font())
@@ -1073,7 +1073,7 @@ class ColormapDialog(qt.QDialog):
         layoutSaturation = qt.QFormLayout()
         self._saturationLabel = qt.QLabel("saturation")
         self._saturationLabel.setVisible(False)
-        layoutSaturation.addRow(self._saturationLabel, self._saturation)
+        layoutSaturation.addRow(self._saturationLabel, self._saturationSlider)
 
         formLayout = FormGridLayout(self)
         formLayout.setContentsMargins(10, 10, 10, 10)
@@ -1739,7 +1739,7 @@ class ColormapDialog(qt.QDialog):
             activate_saturation = self._autoScaleCombo.currentText() == "Percentile"
             with self._colormapChange:
                 if activate_saturation:
-                    colormap.setSaturation(self._saturation.value())
+                    colormap.setSaturation(self._saturationSlider.value())
                 else:
                     colormap.setSaturation(Colormap._DEFAULT_SATURATION)
                 colormap.setAutoscaleMode(mode)
@@ -1749,7 +1749,7 @@ class ColormapDialog(qt.QDialog):
 
     def _updateSaturationVisibility(self):
         activate_saturation = self._autoScaleCombo.currentText() == "Percentile"
-        self._saturation.setVisible(activate_saturation)
+        self._saturationSlider.setVisible(activate_saturation)
         self._saturationLabel.setVisible(activate_saturation)
 
     def _saturationChanged(self, value):

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -1655,7 +1655,7 @@ class ColormapDialog(qt.QDialog):
                 self._autoButtons.setEnabled(colormap.isEditable())
                 self._autoButtons.setAutoRangeFromColormap(colormap)
             with utils.blockSignals(self._saturationSlider):
-                self._saturationSlider.setValue(colormap.getSaturation())
+                self._saturationSlider.setValue(colormap.getSaturationAutoscaleParameter())
 
             vmin, vmax = colormap.getVRange()
             if vmin is None or vmax is None:
@@ -1743,9 +1743,9 @@ class ColormapDialog(qt.QDialog):
             enable_saturation = self._autoScaleCombo.currentText() == "Percentile"
             with self._colormapChange:
                 if enable_saturation:
-                    colormap.setSaturation(self._saturationSlider.value())
+                    colormap.setSaturationAutoscaleParameter(self._saturationSlider.value())
                 else:
-                    colormap.setSaturation(Colormap._DEFAULT_SATURATION)
+                    colormap.setSaturationAutoscaleParameter(Colormap._DEFAULT_SATURATION)
                 colormap.setAutoscaleMode(mode)
 
         self._updateWidgetRange()
@@ -1760,7 +1760,7 @@ class ColormapDialog(qt.QDialog):
         colormap = self.getColormap()
         if colormap is not None:
             with self._colormapChange:
-                colormap.setSaturation(value)
+                colormap.setSaturationAutoscaleParameter(value)
         self._updateWidgetRange()
 
     def _minAutoscaleUpdated(self, autoEnabled):

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -978,7 +978,6 @@ class ColormapDialog(qt.QDialog):
         self._saturation.setRange(0, 100)
         self._saturation.setValue(2)  # 2 <=> 1-99 percentile mode
         self._saturation.valueChanged.connect(self._saturationChanged)
-        self._saturation.setVisible(False)
 
         rangeLayout = qt.QGridLayout()
         miniFont = qt.QFont(self.font())
@@ -1043,6 +1042,7 @@ class ColormapDialog(qt.QDialog):
         button.setDefault(True)
         button = self._buttonsNonModal.button(qt.QDialogButtonBox.Reset)
         button.clicked.connect(self.resetColormap)
+        button.clicked.connect(self._updateSaturationVisibility)
 
         self._buttonsModal.setFocus(qt.Qt.OtherFocusReason)
         self._buttonsNonModal.setFocus(qt.Qt.OtherFocusReason)
@@ -1610,6 +1610,7 @@ class ColormapDialog(qt.QDialog):
             return
 
         self._syncScaleToButtonsEnabled()
+        self._updateSaturationVisibility()
 
         colormap = self.getColormap()
         if colormap is None:
@@ -1733,8 +1734,8 @@ class ColormapDialog(qt.QDialog):
         mode = self._autoScaleCombo.currentMode()
 
         colormap = self.getColormap()
-        activate_saturation = self._autoScaleCombo.currentText() == "Percentile"
         if colormap is not None:
+            activate_saturation = self._autoScaleCombo.currentText() == "Percentile"
             with self._colormapChange:
                 if activate_saturation:
                     colormap.setSaturation(self._saturation.value())
@@ -1742,9 +1743,13 @@ class ColormapDialog(qt.QDialog):
                     colormap.setSaturation(0.0)
                 colormap.setAutoscaleMode(mode)
 
+        self._updateSaturationVisibility()
+        self._updateWidgetRange()
+
+    def _updateSaturationVisibility(self):
+        activate_saturation = self._autoScaleCombo.currentText() == "Percentile"
         self._saturation.setVisible(activate_saturation)
         self._saturationLabel.setVisible(activate_saturation)
-        self._updateWidgetRange()
 
     def _saturationChanged(self, value):
         """Callback executed when the saturation level has been changed (will impact the 'PERCENTILE' mode)"""

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -233,9 +233,9 @@ class _AutoscaleModeComboBox(qt.QComboBox):
     DATA = {
         Colormap.MINMAX: ("Min/max", "Use the data min/max"),
         Colormap.STDDEV3: ("Mean±3std", "Use the data mean ± 3 × standard deviation"),
-        Colormap.PERCENTILE_1_99: (
-            "Percentile 1-99",
-            "Use 1st to 99th percentile of data",
+        Colormap.PERCENTILE: (
+            "Percentile",
+            "Use n'st to m'th percentile of data",
         ),
     }
 

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -1741,7 +1741,7 @@ class ColormapDialog(qt.QDialog):
                 if activate_saturation:
                     colormap.setSaturation(self._saturation.value())
                 else:
-                    colormap.setSaturation(Colormap.DEFAULT_SATURATION)
+                    colormap.setSaturation(Colormap._DEFAULT_SATURATION)
                 colormap.setAutoscaleMode(mode)
 
         self._updateSaturationVisibility()

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -958,6 +958,7 @@ class ColormapDialog(qt.QDialog):
         autoScaleCombo = _AutoscaleModeComboBox(self)
         autoScaleCombo.currentIndexChanged.connect(self._autoscaleModeUpdated)
         self._autoScaleCombo = autoScaleCombo
+        self._autoScaleCombo.currentTextChanged.connect(self._updateSaturationVisibility)
 
         # Min row
         self._minValue = _BoundaryWidget(parent=self, value=1.0)
@@ -1110,6 +1111,7 @@ class ColormapDialog(qt.QDialog):
         self.setTabOrder(self._selectedAreaButton, self._buttonsModal)
         self.setTabOrder(self._buttonsModal, self._buttonsNonModal)
 
+        self._updateSaturationVisibility()
         self._applyColormap()
 
     def getHistogramWidget(self):
@@ -1612,7 +1614,6 @@ class ColormapDialog(qt.QDialog):
             return
 
         self._syncScaleToButtonsEnabled()
-        self._updateSaturationVisibility()
 
         colormap = self.getColormap()
         if colormap is None:
@@ -1745,7 +1746,6 @@ class ColormapDialog(qt.QDialog):
                     colormap.setSaturation(Colormap._DEFAULT_SATURATION)
                 colormap.setAutoscaleMode(mode)
 
-        self._updateSaturationVisibility()
         self._updateWidgetRange()
 
     def _updateSaturationVisibility(self):

--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -655,17 +655,17 @@ class ColormapMixIn(_Colormappable, ItemMixInBase):
         )
         self.__cacheColormapRange = {}  # Reset cache
 
+        colormap = self.getColormap()
         # Fill-up colormap range cache if values are provided
         if max_ is not None and numpy.isfinite(max_):
             if min_ is not None and numpy.isfinite(min_):
-                self.__cacheColormapRange[Colormap.LINEAR, Colormap.MINMAX, colormap.saturation] = (min_, max_)
+                self.__cacheColormapRange[Colormap.LINEAR, Colormap.MINMAX, colormap.getSaturation()] = (min_, max_)
             if minPositive is not None and numpy.isfinite(minPositive):
-                self.__cacheColormapRange[Colormap.LOGARITHM, Colormap.MINMAX, colormap.saturation] = (
+                self.__cacheColormapRange[Colormap.LOGARITHM, Colormap.MINMAX, colormap.getSaturation()] = (
                     minPositive,
                     max_,
                 )
 
-        colormap = self.getColormap()
         if None in (colormap.getVMin(), colormap.getVMax()):
             self._colormapChanged()
 

--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -704,7 +704,7 @@ class ColormapMixIn(_Colormappable, ItemMixInBase):
         normalization = colormap.getNormalization()
         autoscaleMode = colormap.getAutoscaleMode()
         if autoscaleMode == Colormap.PERCENTILE:
-            saturation = colormap.getSaturation()
+            saturation = colormap.getSaturationAutoscaleParameter()
         else:
             saturation = None
         key = normalization, autoscaleMode, saturation

--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -608,7 +608,9 @@ class ColormapMixIn(_Colormappable, ItemMixInBase):
         self._colormap = Colormap()
         self._colormap.sigChanged.connect(self._colormapChanged)
         self.__data = None
-        self.__cacheColormapRange: dict[tuple[str, str, int|None], tuple[float]] = {}  # Store {normalization, mode, saturation: range}
+        self.__cacheColormapRange: dict[tuple[str, str, int | None], tuple[float]] = (
+            {}
+        )  # Store {normalization, mode, saturation: range}
 
     def getColormap(self):
         """Return the used colormap"""
@@ -659,7 +661,10 @@ class ColormapMixIn(_Colormappable, ItemMixInBase):
         # Fill-up colormap range cache if values are provided
         if max_ is not None and numpy.isfinite(max_):
             if min_ is not None and numpy.isfinite(min_):
-                self.__cacheColormapRange[Colormap.LINEAR, Colormap.MINMAX, None] = (min_, max_)
+                self.__cacheColormapRange[Colormap.LINEAR, Colormap.MINMAX, None] = (
+                    min_,
+                    max_,
+                )
             if minPositive is not None and numpy.isfinite(minPositive):
                 self.__cacheColormapRange[Colormap.LOGARITHM, Colormap.MINMAX, None] = (
                     minPositive,

--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -608,7 +608,7 @@ class ColormapMixIn(_Colormappable, ItemMixInBase):
         self._colormap = Colormap()
         self._colormap.sigChanged.connect(self._colormapChanged)
         self.__data = None
-        self.__cacheColormapRange: dict[tuple[str, str, int], tuple[float]] = {}  # Store {normalization, mode, saturation: range}
+        self.__cacheColormapRange: dict[tuple[str, str, int|None], tuple[float]] = {}  # Store {normalization, mode, saturation: range}
 
     def getColormap(self):
         """Return the used colormap"""
@@ -659,9 +659,9 @@ class ColormapMixIn(_Colormappable, ItemMixInBase):
         # Fill-up colormap range cache if values are provided
         if max_ is not None and numpy.isfinite(max_):
             if min_ is not None and numpy.isfinite(min_):
-                self.__cacheColormapRange[Colormap.LINEAR, Colormap.MINMAX, colormap.getSaturation()] = (min_, max_)
+                self.__cacheColormapRange[Colormap.LINEAR, Colormap.MINMAX, None] = (min_, max_)
             if minPositive is not None and numpy.isfinite(minPositive):
-                self.__cacheColormapRange[Colormap.LOGARITHM, Colormap.MINMAX, colormap.getSaturation()] = (
+                self.__cacheColormapRange[Colormap.LOGARITHM, Colormap.MINMAX, None] = (
                     minPositive,
                     max_,
                 )
@@ -698,7 +698,11 @@ class ColormapMixIn(_Colormappable, ItemMixInBase):
 
         normalization = colormap.getNormalization()
         autoscaleMode = colormap.getAutoscaleMode()
-        key = normalization, autoscaleMode, colormap.getSaturation()
+        if autoscaleMode == Colormap.PERCENTILE:
+            saturation = colormap.getSaturation()
+        else:
+            saturation = None
+        key = normalization, autoscaleMode, saturation
         vRange = self.__cacheColormapRange.get(key, None)
         if vRange is None:
             vRange = colormap._computeAutoscaleRange(data)

--- a/src/silx/gui/plot3d/_model/items.py
+++ b/src/silx/gui/plot3d/_model/items.py
@@ -965,6 +965,8 @@ class ColormapRow(_ColormapBaseProxyRow):
         self.addRow(_ColormapBoundRow(item, name="Min.", index=0))
         self.addRow(_ColormapBoundRow(item, name="Max.", index=1))
 
+        # TODO: add option of the saturation for 3D
+
         self._sigColormapChanged.connect(self._updateColormapImage)
 
     def getColormapImage(self):

--- a/src/silx/gui/test/test_colors.py
+++ b/src/silx/gui/test/test_colors.py
@@ -671,7 +671,7 @@ class TestAutoscaleRange(ParametricTestCase):
         ]
         for norm, mode, array, expectedRange in data:
             with self.subTest(norm=norm, mode=mode, array=array):
-                colormap = Colormap()
+                colormap = Colormap(saturation=2.0)
                 colormap.setNormalization(norm)
                 colormap.setAutoscaleMode(mode)
                 vRange = colormap._computeAutoscaleRange(array)

--- a/src/silx/gui/test/test_colors.py
+++ b/src/silx/gui/test/test_colors.py
@@ -678,7 +678,7 @@ class TestAutoscaleRange(ParametricTestCase):
         for norm, mode, array, expectedRange in data:
             with self.subTest(norm=norm, mode=mode, array=array):
                 colormap = Colormap()
-                colormap.setSaturation(2)
+                colormap.setSaturationAutoscaleParameter(2)
                 colormap.setNormalization(norm)
                 colormap.setAutoscaleMode(mode)
                 vRange = colormap._computeAutoscaleRange(array)

--- a/src/silx/gui/test/test_colors.py
+++ b/src/silx/gui/test/test_colors.py
@@ -671,7 +671,8 @@ class TestAutoscaleRange(ParametricTestCase):
         ]
         for norm, mode, array, expectedRange in data:
             with self.subTest(norm=norm, mode=mode, array=array):
-                colormap = Colormap(saturation=2.0)
+                colormap = Colormap()
+                colormap.setSaturation(2)
                 colormap.setNormalization(norm)
                 colormap.setAutoscaleMode(mode)
                 vRange = colormap._computeAutoscaleRange(array)

--- a/src/silx/gui/test/test_colors.py
+++ b/src/silx/gui/test/test_colors.py
@@ -429,8 +429,8 @@ class TestObjectAPI(ParametricTestCase):
         self.assertEqual(colormap.getAutoscaleMode(), Colormap.STDDEV3)
         colormap.setAutoscaleMode(Colormap.MINMAX)
         self.assertEqual(colormap.getAutoscaleMode(), Colormap.MINMAX)
-        colormap.setAutoscaleMode(Colormap.PERCENTILE_1_99)
-        self.assertEqual(colormap.getAutoscaleMode(), Colormap.PERCENTILE_1_99)
+        colormap.setAutoscaleMode(Colormap.PERCENTILE)
+        self.assertEqual(colormap.getAutoscaleMode(), Colormap.PERCENTILE)
 
     def testStoreRestore(self):
         colormaps = [Colormap(name="viridis"), Colormap(normalization=Colormap.SQRT)]
@@ -595,13 +595,13 @@ class TestAutoscaleRange(ParametricTestCase):
             (Colormap.LOGARITHM, Colormap.STDDEV3, numpy.array([10, 100]), (10, 100)),
             (
                 Colormap.LINEAR,
-                Colormap.PERCENTILE_1_99,
+                Colormap.PERCENTILE,
                 numpy.array([10, 100]),
                 (10.9, 99.1),
             ),
             (
                 Colormap.LOGARITHM,
-                Colormap.PERCENTILE_1_99,
+                Colormap.PERCENTILE,
                 numpy.array([10, 100]),
                 (10.9, 99.1),
             ),
@@ -632,13 +632,13 @@ class TestAutoscaleRange(ParametricTestCase):
             ),
             (
                 Colormap.LINEAR,
-                Colormap.PERCENTILE_1_99,
+                Colormap.PERCENTILE,
                 numpy.array([10, 20, 50, nan]),
                 (10.2, 49.4),
             ),
             (
                 Colormap.LOGARITHM,
-                Colormap.PERCENTILE_1_99,
+                Colormap.PERCENTILE,
                 numpy.array([10, 50, 100, nan]),
                 (10.8, 99.0),
             ),
@@ -657,14 +657,14 @@ class TestAutoscaleRange(ParametricTestCase):
             ),
             (
                 Colormap.LOGARITHM,
-                Colormap.PERCENTILE_1_99,
+                Colormap.PERCENTILE,
                 numpy.array([10, 50, 100, -50]),
                 (10.8, 99.0),
             ),
             # With inf
             (
                 Colormap.LOGARITHM,
-                Colormap.PERCENTILE_1_99,
+                Colormap.PERCENTILE,
                 numpy.array([10, 50, 100, float("inf")]),
                 (10.8, 99.0),
             ),

--- a/src/silx/gui/test/test_colors.py
+++ b/src/silx/gui/test/test_colors.py
@@ -661,6 +661,12 @@ class TestAutoscaleRange(ParametricTestCase):
                 numpy.array([10, 50, 100, -50]),
                 (10.8, 99.0),
             ),
+            (
+                Colormap.LOGARITHM,
+                Colormap.PERCENTILE_1_99,
+                numpy.array([10, 50, 100, -50]),
+                (10.8, 99.0),
+            ),
             # With inf
             (
                 Colormap.LOGARITHM,

--- a/src/silx/math/colormap.py
+++ b/src/silx/math/colormap.py
@@ -237,7 +237,7 @@ class _NormalizationMixIn:
         else:
             return True
 
-    def autoscale(self, data: numpy.ndarray | None, mode: str, saturation: int = 0):
+    def autoscale(self, data: numpy.ndarray | None, mode: AutoScaleModeType, saturation: int = 0) -> tuple[float, float]:
         """Returns range for given data and autoscale mode.
 
         :param Union[None,numpy.ndarray] data:
@@ -474,7 +474,7 @@ def _get_range(
     vmin: float | None,
     vmax: float | None,
     saturation: int = 0,
-):
+) -> tuple[float, float]:
     """Returns effective range"""
     if vmin is None or vmax is None:
         auto_vmin, auto_vmax = normalizer.autoscale(

--- a/src/silx/math/colormap.py
+++ b/src/silx/math/colormap.py
@@ -34,10 +34,12 @@ from typing import NamedTuple, Literal
 import warnings
 import numpy
 
+
 from ..resources import resource_filename as _resource_filename
 from .combo import min_max as _min_max
 from . import _colormap
 from ._colormap import cmap  # noqa
+from ..utils.deprecation import deprecated_warning
 from ..utils.proxy import docstring
 
 
@@ -246,6 +248,15 @@ class _NormalizationMixIn:
         data = None if data is None else numpy.asarray(data)
         if data is None or data.size == 0:
             return self.DEFAULT_RANGE
+
+        if mode == "percentile_1_99":
+            deprecated_warning(
+                type_="Mode",
+                name="mode",
+                replacement="percentile",
+                since_version="3.0",
+            )
+            mode = "percentile"
 
         if mode == "minmax":
             vmin, vmax = self.autoscale_minmax(data)

--- a/src/silx/math/colormap.py
+++ b/src/silx/math/colormap.py
@@ -266,9 +266,8 @@ class _NormalizationMixIn:
                 vmax = dmax
             else:
                 vmax = min(dmax, stdmax)
-        elif mode == "percentile_1_99":
-            vmin, vmax = self.autoscale_percentile_1_99(data)
-
+        elif mode == "percentile":
+            vmin, vmax = self.autoscale_percentile(data)
         else:
             raise ValueError("Unsupported mode: %s" % mode)
 
@@ -324,12 +323,13 @@ class _NormalizationMixIn:
             mean + 3 * std, 0.0, 1.0
         )
 
-    def autoscale_percentile_1_99(
-        self, data: numpy.ndarray
+    def autoscale_percentile(
+        self, data: numpy.ndarray, percentile=(1, 99)
     ) -> tuple[float, float] | tuple[None, None]:
         """Autoscale using [1st, 99th] percentiles
 
         :param data: The data to process
+        :param percentile: percentile to be used for autoscale calculation
         :returns: (vmin, vmax)
         """
         data = data[self.is_valid(data)]
@@ -337,7 +337,8 @@ class _NormalizationMixIn:
             data = data[numpy.isfinite(data)]
         if data.size == 0:
             return None, None
-        return numpy.nanpercentile(data, (1, 99))
+
+        return numpy.nanpercentile(data, percentile)
 
 
 class _LinearNormalizationMixIn(_NormalizationMixIn):

--- a/src/silx/math/colormap.py
+++ b/src/silx/math/colormap.py
@@ -269,9 +269,6 @@ class _NormalizationMixIn:
             vmin, vmax = self.autoscale_percentile(
                 data, percentile=(saturation / 2.0, 100 - saturation / 2.0)
             )
-        elif mode == "contrast_enhancer":
-            vmin, vmax = self.autoscale_contrast_enhancer(data)
-
         else:
             raise ValueError("Unsupported mode: %s" % mode)
 

--- a/src/silx/math/colormap.py
+++ b/src/silx/math/colormap.py
@@ -237,7 +237,9 @@ class _NormalizationMixIn:
         else:
             return True
 
-    def autoscale(self, data: numpy.ndarray | None, mode: AutoScaleModeType, saturation: int = 0) -> tuple[float, float]:
+    def autoscale(
+        self, data: numpy.ndarray | None, mode: AutoScaleModeType, saturation: int = 0
+    ) -> tuple[float, float]:
         """Returns range for given data and autoscale mode.
 
         :param Union[None,numpy.ndarray] data:

--- a/src/silx/math/colormap.py
+++ b/src/silx/math/colormap.py
@@ -237,7 +237,7 @@ class _NormalizationMixIn:
         else:
             return True
 
-    def autoscale(self, data, mode, saturation: float = 0.0):
+    def autoscale(self, data: numpy.ndarray | None, mode: str, saturation: int = 0):
         """Returns range for given data and autoscale mode.
 
         :param Union[None,numpy.ndarray] data:
@@ -467,7 +467,14 @@ def _get_normalizer(norm: str, gamma: float) -> _NormalizationMixIn:
     return _BASIC_NORMALIZATIONS[norm]
 
 
-def _get_range(normalizer, data, autoscale, vmin, vmax, saturation: float = 0.0):
+def _get_range(
+    normalizer: _NormalizationMixIn,
+    data: numpy.ndarray | None,
+    autoscale: str,
+    vmin: float | None,
+    vmax: float | None,
+    saturation: int = 0,
+):
     """Returns effective range"""
     if vmin is None or vmax is None:
         auto_vmin, auto_vmax = normalizer.autoscale(

--- a/src/silx/math/colormap.py
+++ b/src/silx/math/colormap.py
@@ -488,9 +488,9 @@ def apply_colormap(
     colormap: str,
     norm: str = "linear",
     autoscale: str = "minmax",
-    vmin=None,
-    vmax=None,
-    gamma=1.0,
+    vmin: float | None = None,
+    vmax: float | None = None,
+    gamma: float = 1.0,
     saturation: int = 0,
 ):
     """Apply colormap to data with given normalization and autoscale.

--- a/src/silx/math/colormap.py
+++ b/src/silx/math/colormap.py
@@ -534,9 +534,9 @@ def normalize(
     data: numpy.ndarray,
     norm: str = "linear",
     autoscale: str = "minmax",
-    vmin=None,
-    vmax=None,
-    gamma=1.0,
+    vmin: float | None = None,
+    vmax: float | None = None,
+    gamma: float = 1.0,
     saturation: int = 0,
 ):
     """Normalize data to an array of uint8.

--- a/src/silx/math/colormap.py
+++ b/src/silx/math/colormap.py
@@ -475,7 +475,7 @@ def apply_colormap(
     vmin=None,
     vmax=None,
     gamma=1.0,
-    saturation: float = 0.0,
+    saturation: int = 0,
 ):
     """Apply colormap to data with given normalization and autoscale.
 
@@ -521,7 +521,7 @@ def normalize(
     vmin=None,
     vmax=None,
     gamma=1.0,
-    saturation=0.0,
+    saturation: int = 0,
 ):
     """Normalize data to an array of uint8.
 


### PR DESCRIPTION
# Question

1. usage of '__cacheColormapRange' might be reconsidered. This was targetting another usage but might add complexity. If we keep it this was we must at least have a limited cache (10 elements ? 100 ?)
2. naming: I think @t20100 was not much in favor of using 'saturation'. Maybe percentile can be considered - more generic - or something else. Ideas welcome
3. The GUI side can be improved. But I don't have strong opinion on it. Should we allow a QLineEdit / QSpinBox to let the user see and define manually the saturation value ?

# video

[simple video demo](https://github.com/user-attachments/assets/4a935964-c76a-46af-981e-6e7df5665951)
