### PR TITLE
Build: Fix compilation warning about unsafe cast under windows

### DIFF
--- a/src/silx/math/histogramnd/src/histogramnd_template.c
+++ b/src/silx/math/histogramnd/src/histogramnd_template.c
@@ -51,7 +51,7 @@ int TEMPLATE(histogramnd, HISTO_SAMPLE_T, HISTO_WEIGHT_T, HISTO_CUMUL_T)
     size_t elem_idx = 0;
 
     HISTO_WEIGHT_T * weight_ptr = 0;
-    HISTO_SAMPLE_T elem_coord = 0.;
+    HISTO_SAMPLE_T elem_coord = (HISTO_SAMPLE_T)0;
 
     /* computed bin index (i_sample -> grid) */
     long bin_idx = 0;


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [X] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->
Ensure the variable is initialized with a zero of the proper type.

Close #4307 