### PR TITLE
Tests: replace `--low-mem` arg by `--no-high-mem` and skip high memory tests by default

### DIFF
--- a/package/debian12/rules
+++ b/package/debian12/rules
@@ -63,12 +63,12 @@ override_dh_python3:
 
 # WITH_QT_TEST=False to disable graphical tests
 # SILX_OPENCL=False to disable OpenCL tests
-# SILX_TEST_LOW_MEM=False to disable tests taking large amount of memory
+# WITH_HIGH_MEM_TEST=True to enable tests taking large amount of memory
 # GPU=False to disable the use of a GPU with OpenCL test
 # WITH_GL_TEST=False to disable tests using OpenGL
 override_dh_auto_test:
 	mkdir -p $(POCL_CACHE_DIR) # create POCL cachedir in order to avoid an FTBFS in sbuild
-	dh_auto_test -- -s custom --test-args="env PYTHONPATH={build_dir} GPU=False WITH_QT_TEST=False SILX_OPENCL=False SILX_TEST_LOW_MEM=False xvfb-run -a --server-args=\"-screen 0 1024x768x24\" {interpreter} run_tests.py -vv --installed"
+	dh_auto_test -- -s custom --test-args="env PYTHONPATH={build_dir} GPU=False WITH_QT_TEST=False SILX_OPENCL=False WITH_HIGH_MEM_TEST=False xvfb-run -a --server-args=\"-screen 0 1024x768x24\" {interpreter} run_tests.py -vv --installed"
 
 override_dh_installman:
 	dh_installman -p silx build/man/*.1

--- a/src/silx/conftest.py
+++ b/src/silx/conftest.py
@@ -55,11 +55,11 @@ def pytest_addoption(parser):
         help="Disable the test of the OpenCL part",
     )
     parser.addoption(
-        "--low-mem",
-        dest="low_mem",
-        default=False,
-        action="store_true",
-        help="Disable test with large memory consumption (>100Mbyte",
+        "--no-high-mem",
+        dest="high_mem",
+        default=True,
+        action="store_false",
+        help="Disable tests with large memory consumption (>100Mbytes)",
     )
 
 
@@ -112,10 +112,10 @@ def use_opencl(test_options):
 def use_large_memory(test_options):
     """Fixture to flag test using a large memory consumption.
 
-    This can be skipped with `--low-mem`.
+    This can be skipped with `--no-high-mem`.
     """
-    if test_options.TEST_LOW_MEM:
-        pytest.skip(test_options.TEST_LOW_MEM_REASON, allow_module_level=True)
+    if not test_options.WITH_HIGH_MEM_TEST:
+        pytest.skip(test_options.WITH_HIGH_MEM_TEST_REASON, allow_module_level=True)
 
 
 @pytest.fixture(scope="session")

--- a/src/silx/math/fft/test/test_fft.py
+++ b/src/silx/math/fft/test/test_fft.py
@@ -207,7 +207,7 @@ class TestFFT(ParametricTestCase):
             mode,
             str(size),
         )
-        if size == "3D" and self.test_options.TEST_LOW_MEM:
+        if size == "3D" and not self.test_options.WITH_HIGH_MEM_TEST:
             self.skipTest("low mem")
 
         ndim = len(size)

--- a/src/silx/test/utils.py
+++ b/src/silx/test/utils.py
@@ -70,11 +70,11 @@ class _TestOptions:
         self.WITH_GL_TEST_REASON = ""
         """Reason for OpenGL tests are disabled if any"""
 
-        self.TEST_LOW_MEM = False
+        self.WITH_HIGH_MEM_TEST = False
         """Skip tests using too much memory"""
 
-        self.TEST_LOW_MEM_REASON = ""
-        """Reason for low_memory tests are disabled if any"""
+        self.WITH_HIGH_MEM_TEST_REASON = "Skipped by default"
+        """Reason for high memory are disabled if any"""
 
     def configure(self, parsed_options=None):
         """Configure the TestOptions class from the command line arguments and the
@@ -118,12 +118,12 @@ class _TestOptions:
                 self.WITH_GL_TEST = False
                 self.WITH_GL_TEST_REASON = "OpenGL package not available"
 
-        if parsed_options is not None and parsed_options.low_mem:
-            self.TEST_LOW_MEM = True
-            self.TEST_LOW_MEM_REASON = "Skipped by command line"
-        elif os.environ.get("SILX_TEST_LOW_MEM", "True") == "False":
-            self.TEST_LOW_MEM = True
-            self.TEST_LOW_MEM_REASON = "Skipped by SILX_TEST_LOW_MEM env var"
+        if parsed_options is not None and not parsed_options.high_mem:
+            self.WITH_HIGH_MEM_TEST = False
+            self.WITH_HIGH_MEM_TEST_REASON = "Skipped by command line"
+        elif os.environ.get("WITH_HIGH_MEM_TEST") == "False":
+            self.WITH_HIGH_MEM_TEST = False
+            self.WITH_HIGH_MEM_TEST_REASON = "Skipped by WITH_HIGH_MEM_TEST env var"
 
         if self.WITH_QT_TEST:
             try:


### PR DESCRIPTION
Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

Fix #4285 

Argument name and associated env variables were changed:
- `--low-mem` becomes `--no-high-mem`
- `SILX_TEST_LOW_MEM` becomes `WITH_HIGH_MEM_TEST` 

I tried to be consistent with other options: `--no-opengl` /`WITH_GL_TEST`, `--no-gui/`WITH_QT_TEST` but there is also `--no-opencl`/`SILX_OPENCL`. 

Should I keep the `SILX` prefix for the env variable ?

The logic was also inverted so that high memory tests are skipped unless the env variable is set.
