### PR TITLE
`silx.gui.widgets`: Added `FilenameCompleter` that provides autocompletion for file paths

### DIFF
--- a/src/silx/gui/widgets/FilenameCompleter.py
+++ b/src/silx/gui/widgets/FilenameCompleter.py
@@ -1,0 +1,22 @@
+from .. import qt
+
+
+class FilenameCompleter(qt.QCompleter):
+    """
+    A QCompleter that provides autocompletion for file paths.
+    """
+
+    def __init__(
+        self, parent: qt.QWidget | None = None, root: str | None = None
+    ) -> None:
+        super().__init__(parent=parent)
+
+        completer = qt.QCompleter()
+        model = qt.QFileSystemModel(completer)
+        model.setOption(qt.QFileSystemModel.Option.DontWatchForChanges, True)
+        if root is None:
+            # Works on Windows and Linux
+            model.setRootPath("/")
+
+        completer.setModel(model)
+        completer.setCompletionRole(qt.QFileSystemModel.Roles.FileNameRole)


### PR DESCRIPTION
Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

Needs #4320 to integrate the new file in the meson build