### PR TITLE
silx.resources: Fixed not existing resource file access

### DIFF
--- a/src/silx/resources/__init__.py
+++ b/src/silx/resources/__init__.py
@@ -67,6 +67,7 @@ import os
 import sys
 from typing import NamedTuple
 
+import importlib
 import importlib.resources as importlib_resources
 
 
@@ -239,11 +240,8 @@ def _get_resource_filename(package: str, resource: str) -> str:
     # Caching prevents extracting the resource twice
     traversable = importlib_resources.files(package).joinpath(resource)
     if not traversable.is_file() and not traversable.is_dir():
-        package_dir_context = importlib_resources.as_file(
-            importlib_resources.files(package)
-        )
-        path = _file_manager.enter_context(package_dir_context)
-        return str(path.absolute() / resource)
+        module = importlib.import_module(package)
+        return os.path.join(os.path.dirname(module.__file__), resource)
 
     file_context = importlib_resources.as_file(traversable)
 

--- a/src/silx/resources/__init__.py
+++ b/src/silx/resources/__init__.py
@@ -1,6 +1,6 @@
 # /*##########################################################################
 #
-# Copyright (c) 2016-2023 European Synchrotron Radiation Facility
+# Copyright (c) 2016-2025 European Synchrotron Radiation Facility
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -65,7 +65,7 @@ import functools
 import logging
 import os
 import sys
-from typing import NamedTuple, Optional
+from typing import NamedTuple
 
 import importlib.resources as importlib_resources
 
@@ -237,9 +237,16 @@ def _get_resource_filename(package: str, resource: str) -> str:
     :return: Abolute resource path in the file system
     """
     # Caching prevents extracting the resource twice
-    file_context = importlib_resources.as_file(
-        importlib_resources.files(package) / resource
-    )
+    traversable = importlib_resources.files(package).joinpath(resource)
+    if not traversable.is_file() and not traversable.is_dir():
+        package_dir_context = importlib_resources.as_file(
+            importlib_resources.files(package)
+        )
+        path = _file_manager.enter_context(package_dir_context)
+        return str(path.absolute() / resource)
+
+    file_context = importlib_resources.as_file(traversable)
+
     path = _file_manager.enter_context(file_context)
     return str(path.absolute())
 


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This PR fixes an issue spotted with meson editable install (but actually not related to it): silx was calling `importlib.resources.as_file` on a non-existing resource file and this raises an exception in this case.
It works with the default resource management from Python, but we are miss-using the `as_file`.

For later, we should consider relying on `importlib.resources` directly now that it's standard rather than wrapping it in `silx.resources`.
