### PR TITLE
Build: Changed way to pass build options

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -100,12 +100,6 @@ To install silx from source, run:
        export LC_ALL=en_US.UTF-9
        export LANG=en_US.UTF-9
 
-Build options can be set through environment variables, for example:
-
-.. code-block::
-
-   SILX_WITH_OPENMP=False pip install silx --no-binary silx
-
 
 Build options
 +++++++++++++
@@ -114,20 +108,25 @@ Build options
    :widths: 1 4
    :header-rows: 1
 
-   * - Environment variable
+   * - Build option
      - Description
-   * - ``SILX_WITH_OPENMP``
-     - Whether or not to compile Cython code with OpenMP support (default: ``True`` except on macOS where it is ``False``)
-   * - ``SILX_FORCE_CYTHON``
-     - Whether or not to force re-generating the C/C++ source code from Cython files (default: ``False``).
-   * - ``SPECFILE_USE_GNU_SOURCE``
-     - Whether or not to use a cleaner locale independent implementation of :mod:`silx.io.specfile` by using `_GNU_SOURCE=1`
-       (default: ``False``; POSIX operating system only).
-   * - ``SILX_FULL_INSTALL_REQUIRES``
-     - Set it to put all dependencies as ``install_requires`` (For packaging purpose).
-   * - ``SILX_INSTALL_REQUIRES_STRIP``
-     - Comma-separated list of package names to remove from ``install_requires`` (For packaging purpose).
-.. note:: Boolean options are passed as ``True`` or ``False``.
+   * - ``use_openmp``
+     - Whether or not to compile Cython code with OpenMP support.
+       Accepted values: ``auto`` (default), ``enabled``, ``disabled``.
+   * - ``specfile_use_gnu_source``
+     - Whether or not to use a cleaner locale independent implementation of :mod:`silx.io.specfile` by using `_GNU_SOURCE=1`.
+       Only used on POSIX operating systems.
+       Accepted values: ``false`` (default), ``true``.
+
+
+Build options can be passed to
+`meson's setup-args <https://mesonbuild.com/meson-python/reference/config-settings.html#cmdoption-arg-setup-args>`_
+through `pip install -C <https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-C>`_,
+for example:
+
+.. code-block:: bash
+
+   pip install silx --no-binary silx -Csetup-args="-Duse-openmp=disabled"
 
 
 .. _dependencies:

--- a/meson.build
+++ b/meson.build
@@ -16,22 +16,8 @@ if meson.backend() != 'ninja'
   error('Ninja backend required')
 endif
 
-# OpenMP can be used? several ways to disable it:
-#  -> use -Duse_openmp=disabled
-#  -> or the file SILX_WITH_OPENMP should contain False
-#  -> or OpenMP can be unsuported on your achitecture/compiler
 
-
-# How to disable OpenMP:
-# The 'SILX_WITH_OPENMP' file should contain 'False'
-res = run_command(py, '-c', 'import os; print(os.environ["SILX_WITH_OPENMP"])',
-                  check:false)
-if res.returncode() == 0
-  openmp_var = res.stdout().strip()
-else
-  openmp_var = ''
-endif
-omp = dependency('openmp', required: get_option('use_openmp').disable_auto_if(openmp_var=='False'))
+omp = dependency('openmp', required: get_option('use_openmp'))
 
 
 cc = meson.get_compiler('c')

--- a/meson.options
+++ b/meson.options
@@ -1,8 +1,8 @@
-option('use_openmp', 
-       type : 'feature', 
+option('use_openmp',
+       type : 'feature',
        value : 'auto',
        description : 'force enable/disable the usage of OpenMP')
-#option('SPECFILE_use_GNU_source', 
-#       type : 'feature', 
-#       value : 'disabled',
-#       description : 'force specfile to use the `strtod_l` from gcc')
+option('specfile_use_gnu_source',
+       type : 'boolean',
+       value : false,
+       description : 'force specfile to use the `strtod_l` from gcc')

--- a/src/silx/io/specfile/meson.build
+++ b/src/silx/io/specfile/meson.build
@@ -1,22 +1,16 @@
 # Definitions of macros specific to specfile
-macros = []
 if target_machine.system() == 'windows'
     macros = [ '-DSPECFILE_POSIX', '-DWIN32']
 elif target_machine.system() in ['linux', 'darwin', 'dragonfly', 'freebsd', 'gnu']
-    res = run_command(py, '-c', 'import os; print(os.environ["SPECFILE_USE_GNU_SOURCE"])',
-                      check:false)
-    if res.returncode() == 0
-        specfile_use_gnu = res.stdout().strip()
+    use_gnu_source = get_option('specfile_use_gnu_source')
+    if use_gnu_source
+        macros = ['-D_GNU_SOURCE=1']
     else
-        specfile_use_gnu = ''
+        macros = ['-DSPECFILE_POSIX']
     endif
-    if specfile_use_gnu in ['1', 'true', 'True', 'TRUE']
-        macros += ['-D_GNU_SOURCE=1']
-    else
-        macros += ['-DSPECFILE_POSIX']
-    endif
+else
+    macros = []
 endif
-
 
 
 py.extension_module('specfile', 


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This PR removes the use of env. var. to configure the build and replaces them with standard meson setup-args options.
It also updates the documentation accordingly.
