### PR TITLE
Build: Added `--vsenv` meson build option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,10 +70,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4        
-      - name: Set up MSVC environment if applicable
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -83,14 +79,7 @@ jobs:
         run: |
           pip install --upgrade --pre build wheel 
 
-      - name: Build Wheel (Windows)
-        if: runner.os == 'Windows'
-        shell: cmd
-        run: |
-          python -m build
-
-      - name: Build Wheel (Unix)
-        if: runner.os != 'Windows'
+      - name: Build Wheel
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.9"
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,10 @@ tracker = 'https://github.com/silx-kit/silx/issues'
 silx = 'silx.__main__:main'
 
 
+[tool.meson-python.args]
+setup = ['--vsenv']
+
+
 [tool.cibuildwheel]
 # Skip 32-bit builds and PyPy
 skip = ["*-win32", "*-manylinux_i686", "pp*", "*musllinux*"]


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This PR makes use of meson `--vsenv` to force using MSVC on Windows.
This simplifies the CI config a bit.
See:
- https://mesonbuild.com/meson-python/how-to-guides/meson-args.html#force-the-use-of-the-msvc-compilers-on-windows
- https://mesonbuild.com/Builtin-options.html#details-for-vsenv
