### PR TITLE
silx.utils.ExternalResources: Replace all occurrences of "image" with "file"

### DIFF
--- a/src/silx/utils/ExternalResources.py
+++ b/src/silx/utils/ExternalResources.py
@@ -145,7 +145,7 @@ class ExternalResources:
         """Downloads the requested file from web-server available
         at https://www.silx.org/pub/silx/
 
-        :param: relative name of the image.
+        :param: relative name of the file.
         :return: full path of the locally saved file.
         """
         logger.debug("ExternalResources.getfile('%s')", filename)
@@ -157,7 +157,7 @@ class ExternalResources:
 
         if not os.path.isfile(fullfilename):
             logger.debug(
-                "Trying to download image %s, timeout set to %ss",
+                "Trying to download file %s, timeout set to %ss",
                 filename,
                 self.timeout,
             )
@@ -178,7 +178,7 @@ class ExternalResources:
                 data = opener(
                     f"{self.url_base}/{filename}", data=None, timeout=self.timeout
                 ).read()
-                logger.info("Image %s successfully downloaded.", filename)
+                logger.info("File %s successfully downloaded.", filename)
             except urllib.error.URLError:
                 raise unittest.SkipTest("network unreachable.")
 
@@ -198,11 +198,11 @@ class ExternalResources:
 
             if not os.path.isfile(fullfilename):
                 raise RuntimeError(
-                    """Could not automatically download test images %s!
+                    """Could not automatically download test files %s!
                     If you are behind a firewall, please set both environment variable
                      http_proxy and https_proxy.
                     This even works under windows !
-                    Otherwise please try to download the images manually from
+                    Otherwise please try to download the files manually from
                     %s/%s"""
                     % (filename, self.url_base, filename)
                 )
@@ -223,9 +223,9 @@ class ExternalResources:
         return fullfilename
 
     def save_json(self):
-        image_list = list(self.all_data.keys())
-        image_list.sort()
-        dico = {i: self.all_data[i] for i in image_list}
+        file_list = list(self.all_data.keys())
+        file_list.sort()
+        dico = {i: self.all_data[i] for i in file_list}
         try:
             with open(self.testdata, "w") as fp:
                 json.dump(dico, fp, indent=4)
@@ -237,7 +237,7 @@ class ExternalResources:
         https://www.silx.org/pub/silx/
         and unzips it into the data directory
 
-        :param: relative name of the image.
+        :param: relative name of the file.
         :return: list of files with their full path.
         """
         lodn = dirname.lower()
@@ -265,7 +265,7 @@ class ExternalResources:
         """
         Download the requested file, decompress and repack it to bz2 and gz.
 
-        :param str filename: name of the image.
+        :param str filename: name of the file.
         :rtype: str
         :return: full path of the locally saved file
         """
@@ -274,39 +274,38 @@ class ExternalResources:
         if filename not in self.all_data:
             self.all_data[filename] = self.get_hash(filename)
             self.save_json()
-        baseimage = os.path.basename(filename)
-        logger.info("UtilsTest.getimage('%s')" % baseimage)
+        basefilename = os.path.basename(filename)
 
         if not os.path.exists(self.data_home):
             os.makedirs(self.data_home)
-        fullimagename = os.path.abspath(os.path.join(self.data_home, baseimage))
+        fullfilename = os.path.abspath(os.path.join(self.data_home, basefilename))
 
-        if baseimage.endswith(".bz2"):
-            bzip2name = baseimage
-            basename = baseimage[:-4]
+        if basefilename.endswith(".bz2"):
+            bzip2name = basefilename
+            basename = basefilename[:-4]
             gzipname = basename + ".gz"
-        elif baseimage.endswith(".gz"):
-            gzipname = baseimage
-            basename = baseimage[:-3]
+        elif basefilename.endswith(".gz"):
+            gzipname = basefilename
+            basename = basefilename[:-3]
             bzip2name = basename + ".bz2"
         else:
-            basename = baseimage
-            gzipname = baseimage + "gz2"
+            basename = basefilename
+            gzipname = basefilename + "gz2"
             bzip2name = basename + ".bz2"
 
-        fullimagename_gz = os.path.abspath(os.path.join(self.data_home, gzipname))
-        fullimagename_raw = os.path.abspath(os.path.join(self.data_home, basename))
-        fullimagename_bz2 = os.path.abspath(os.path.join(self.data_home, bzip2name))
+        fullfilename_gz = os.path.abspath(os.path.join(self.data_home, gzipname))
+        fullfilename_raw = os.path.abspath(os.path.join(self.data_home, basename))
+        fullfilename_bz2 = os.path.abspath(os.path.join(self.data_home, bzip2name))
 
         # The files are recreated from the bz2 file
-        if not os.path.isfile(fullimagename_bz2):
+        if not os.path.isfile(fullfilename_bz2):
             self.getfile(bzip2name)
-            if not os.path.isfile(fullimagename_bz2):
+            if not os.path.isfile(fullfilename_bz2):
                 raise RuntimeError(
-                    """Could not automatically download test images %s!
+                    """Could not automatically download test files %s!
                     If you are behind a firewall, please set the environment variable
                      http_proxy.
-                    Otherwise please try to download the images manually from
+                    Otherwise please try to download the files manually from
                     %s"""
                     % (self.url_base, filename)
                 )
@@ -320,17 +319,17 @@ class ExternalResources:
         except ImportError:
             gzip = None
 
-        raw_file_exists = os.path.isfile(fullimagename_raw)
-        gz_file_exists = os.path.isfile(fullimagename_gz)
+        raw_file_exists = os.path.isfile(fullfilename_raw)
+        gz_file_exists = os.path.isfile(fullfilename_gz)
         if not raw_file_exists or not gz_file_exists:
-            with open(fullimagename_bz2, "rb") as f:
+            with open(fullfilename_bz2, "rb") as f:
                 data = f.read()
             decompressed = bz2.decompress(data)
 
             if not raw_file_exists:
                 try:
-                    with open(fullimagename_raw, "wb") as fullimage:
-                        fullimage.write(decompressed)
+                    with open(fullfilename_raw, "wb") as fullfile:
+                        fullfile.write(decompressed)
                 except OSError:
                     raise OSError(
                         "unable to write decompressed \
@@ -342,7 +341,7 @@ class ExternalResources:
                 if gzip is None:
                     raise RuntimeError("gzip library is expected to recompress data")
                 try:
-                    gzip.open(fullimagename_gz, "wb").write(decompressed)
+                    gzip.open(fullfilename_gz, "wb").write(decompressed)
                 except OSError:
                     raise OSError(
                         "unable to write gzipped \
@@ -350,7 +349,7 @@ class ExternalResources:
                         % self.data_home
                     )
 
-        return fullimagename
+        return fullfilename
 
     def download_all(self, imgs=None):
         """Download all data needed for the test/benchmarks


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

I use the `ExternalResources` class in another project to download test data. In my case, these are HDF5 files, so the logging message that mentions that images are being downloaded was inconsistent. It is likely also inconsistent in the case of `silx`. The replacement of references to  "image" with "file" should provide better generalization.