### PR TITLE
silx.gui.plot, silx.gui.plot3d: Fixed colormap out-of-bound color with OpenGL backend

### DIFF
--- a/src/silx/gui/plot/backends/glutils/GLPlotImage.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotImage.py
@@ -342,7 +342,7 @@ class GLPlotColormap(_GLPlotData2D):
                 texUnit=self._CMAP_TEX_UNIT,
                 minFilter=gl.GL_NEAREST,
                 magFilter=gl.GL_NEAREST,
-                wrap=(gl.GL_CLAMP_TO_EDGE, gl.GL_CLAMP_TO_EDGE),
+                wrap=gl.GL_MIRRORED_REPEAT,
             )
             self._cmap_texture.prepare()
 

--- a/src/silx/gui/plot3d/scene/function.py
+++ b/src/silx/gui/plot3d/scene/function.py
@@ -526,7 +526,7 @@ class Colormap(event.Notifier, ProgramFunction):
             texUnit=self._COLORMAP_TEXTURE_UNIT,
             minFilter=gl.GL_NEAREST,
             magFilter=gl.GL_NEAREST,
-            wrap=gl.GL_CLAMP_TO_EDGE,
+            wrap=gl.GL_MIRRORED_REPEAT,
         )
 
         self.notify()


### PR DESCRIPTION
Fix #4356 

<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

This PR changes the texture wrap mode from clamp-to-edge to mirrored-repeat for the texture storing the colormap.
This fixes rendering issues on some computers (closes  #4356) and it should not impact rendering otherwise.