### PR TITLE
TestDictToNx: use 'pint.get_application_registry()' instead of 'pint.UnitRegistery

### DIFF
--- a/src/silx/io/test/test_dictdump.py
+++ b/src/silx/io/test/test_dictdump.py
@@ -827,7 +827,7 @@ class TestDictToNx(H5DictTestCase):
 
 @pytest.mark.skipif(pint is None, reason="Require pint")
 def test_dicttonx_pint(tmp_h5py_file):
-    ureg = pint.UnitRegistry()
+    ureg = pint.get_application_registry()
     treedict = {
         "array_mm": pint.Quantity([1, 2, 3], ureg.mm),
         "value_kg": 3 * ureg.kg,


### PR DESCRIPTION
close #4369 
- improve robustness of 'test_dicttonx_pint'

The issue looks to come from using `ureg = pint.UnitRegistry()` instead of `ureg = pint.get_application_registry()`.

Creation of registry seems kind of weak / fragile. See https://pint.readthedocs.io/en/stable/getting/pint-in-your-projects.html#having-a-shared-registry.