### PR TITLE
Project: Fixed flake8 warnings outside of `src/`

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -26,14 +26,6 @@ logging.basicConfig()
 logger = logging.getLogger("bootstrap")
 
 
-def is_debug_python():
-    """Returns true if the Python interpreter is in debug mode."""
-    if sysconfig.get_config_var("Py_DEBUG"):
-        return True
-
-    return hasattr(sys, "gettotalrefcount")
-
-
 def get_project_name(root_dir):
     """Retrieve project name by running python setup.py --name in root_dir.
 
@@ -244,9 +236,9 @@ def main(argv):
         res = find_executable(script)
         kind = res[0]
         if kind == "path":
-            run_file(target, argv)
+            run_file(res[1], argv)
         elif kind == "entry_point":
-            run_entry_point(target, argv)
+            run_entry_point(res[1], res[2], argv)
         else:
             logger.error("Script %s not found", options.script)
 

--- a/ci/info_platform.py
+++ b/ci/info_platform.py
@@ -8,7 +8,7 @@ __license__ = "MIT"
 import sys
 import platform
 import subprocess
-
+from sysconfig import get_config_vars
 
 print("Python %s bits" % (tuple.__itemsize__ * 8))
 print(f"       maxsize: {sys.maxsize}\t maxunicode: {sys.maxunicode}")
@@ -19,7 +19,6 @@ print("Platform: " + platform.platform())
 print("- Machine: " + platform.machine())
 print(" ")
 
-from sysconfig import get_config_vars
 
 print("Config: " + str(get_config_vars("CONFIG_ARGS")))
 print("")

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -35,12 +35,7 @@ import importlib
 import os
 import sys
 
-# If extensions (or modules to document with autodoc) are in another directory,
-# add these directories to sys.path here. If the directory is relative to the
-# documentation root, use os.path.abspath to make it absolute, like shown here.
-# sys.path.insert(0, os.path.abspath('.'))
-project = "silx"
-import silx
+from silx._version import strictversion, __date__ as _date
 
 # Disable deprecation warnings:
 # It avoid to spam documentation logs with deprecation warnings.
@@ -49,6 +44,13 @@ import silx
 from silx.utils.deprecation import depreclog
 
 depreclog.disabled = 1
+
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+# sys.path.insert(0, os.path.abspath('.'))
+project = "silx"
 
 # Add local sphinx extension directory
 sys.path.append(os.path.join(os.path.dirname(os.path.abspath(__file__)), "ext"))
@@ -94,8 +96,6 @@ source_suffix = {".rst": "restructuredtext"}
 master_doc = "index"
 
 # General information about the project.
-from silx._version import strictversion, version, __date__ as _date
-
 year = _date.split("/")[-1]
 copyright = (
     "2015-%s, Data analysis unit, European Synchrotron Radiation Facility, Grenoble"

--- a/package/pyinstaller/bootstrap-silx-view.py
+++ b/package/pyinstaller/bootstrap-silx-view.py
@@ -1,9 +1,9 @@
 import logging
+import sys
 
 logging.basicConfig()
 
-import sys
-from silx.app.view.main import main
+from silx.app.view.main import main  # noqa: E402
 
 if __name__ == "__main__":
     main(sys.argv)

--- a/package/pyinstaller/bootstrap.py
+++ b/package/pyinstaller/bootstrap.py
@@ -3,11 +3,11 @@ import logging
 logging.basicConfig()
 
 # Import here for static analysis to work
-import silx.app.view.main
-import silx.app.convert
-import silx.app.test_
+import silx.app.view.main  # noqa: E402, F401
+import silx.app.convert  # noqa: E402, F401
+import silx.app.test_  # noqa: E402, F401
 
-from silx.__main__ import main
+from silx.__main__ import main  # noqa: E402
 
 if __name__ == "__main__":
     main()

--- a/run_tests.py
+++ b/run_tests.py
@@ -37,15 +37,13 @@ __license__ = "MIT"
 import sys
 import logging
 import os
-import sys
 import sysconfig
 from argparse import ArgumentParser
 from pathlib import Path
-
+import warnings
 
 # Capture all default warnings
 logging.captureWarnings(True)
-import warnings
 
 warnings.simplefilter("default")
 
@@ -94,7 +92,7 @@ else:
 
 
 PROJECT_DIR = os.path.dirname(os.path.abspath(__file__))
-from bootstrap import get_project_name, build_project
+from bootstrap import get_project_name, build_project  # noqa: E402
 
 PROJECT_NAME = get_project_name(PROJECT_DIR)
 logger.info("Project name: %s", PROJECT_NAME)

--- a/tools/build_man_page.py
+++ b/tools/build_man_page.py
@@ -29,7 +29,6 @@ The project's package MUST be installed in the current Python environment.
 
 import logging
 from pathlib import Path
-import re
 import subprocess
 import sys
 from collections.abc import Iterator
@@ -59,7 +58,7 @@ def entry_points(project_path: Path) -> Iterator[tuple[str, str, str]]:
         for entry, value in entry_points_config.get(group, {}).items():
             try:
                 module, fnt = value.split(":", 1)
-            except:
+            except ValueError:
                 logger.error(f"Unable to parse entry {value}!")
             else:
                 yield entry, module, fnt

--- a/tools/create_h5_sample.py
+++ b/tools/create_h5_sample.py
@@ -34,17 +34,17 @@ import json
 import logging
 import sys
 
+import h5py
+import numpy
+
 logging.basicConfig()
 logger = logging.getLogger("create_h5file")
 
 
 try:
-    import hdf5plugin
+    import hdf5plugin  # noqa: F401
 except ImportError:
     logger.error("Backtrace", exc_info=True)
-
-import h5py
-import numpy
 
 
 if sys.version_info.major < 3:

--- a/tools/mesonify.py
+++ b/tools/mesonify.py
@@ -6,11 +6,11 @@ Does NOT update missing files. Manual edition is needed.
 """
 
 
-import os, sys
+import os
 
 
 def mesonify(where, top=None):
-    if top == None:
+    if top is None:
         top = os.path.join(where, "src")
     # print(where, "top: ", top)
     txt = []


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

There was a `target` undeclared variable in `bootstrap.py` which makes the "scripts" option not working. I updated the code to what seems reasonable however it still does not work... Anyway IMO `bootstrap.py` is no longer needed since we can now pip install with `-e` thanks to meson, so I leave it as it is.


