### PR TITLE
silx.gui.plot.PlotWidget: Allow to invert X axis

### DIFF
--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -590,6 +590,7 @@ class PlotWidget(qt.QMainWindow):
         xTimeZone = xaxis.getTimeZone()
         isXAxisTimeSeries = xaxis.getTickMode() == TickMode.TIME_SERIES
 
+        isXAxisInverted = self.getXAxis().isInverted()
         isYAxisInverted = self.getYAxis().isInverted()
 
         # Remove all items from previous backend
@@ -631,6 +632,7 @@ class PlotWidget(qt.QMainWindow):
         self._backend.setXAxisTimeZone(xTimeZone)
         self._backend.setXAxisTimeSeries(isXAxisTimeSeries)
         self._backend.setXAxisLogarithmic(xaxis.getScale() == items.Axis.LOGARITHMIC)
+        self._backend.setXAxisInverted(isXAxisInverted)
 
         for axis in ("left", "right"):
             self._backend.setGraphYLabel(self.getYAxis(axis).getLabel(), axis)
@@ -2863,6 +2865,18 @@ class PlotWidget(qt.QMainWindow):
         :return: (left, top, right, bottom)
         """
         return self.__axesMargins
+
+    def setXAxisInverted(self, flag: bool = True):
+        """Set the X axis orientation.
+
+        :param flag: True for X axis going from right to left,
+                     False for X axis going from left to right
+        """
+        self._xAxis.setInverted(flag)
+
+    def isXAxisInverted(self) -> bool:
+        """Return True if X axis goes from right to left, False otherwise."""
+        return self._xAxis.isInverted()
 
     def setYAxisInverted(self, flag: bool = True):
         """Set the Y axis orientation.

--- a/src/silx/gui/plot/backends/BackendBase.py
+++ b/src/silx/gui/plot/backends/BackendBase.py
@@ -61,6 +61,7 @@ class BackendBase:
         """
         self.__xLimits = 1.0, 100.0
         self.__yLimits = {"left": (1.0, 100.0), "right": (1.0, 100.0)}
+        self.__xAxisInverted = True
         self.__yAxisInverted = False
         self.__keepDataAspectRatio = False
         self.__xAxisTimeSeries = False
@@ -502,6 +503,17 @@ class BackendBase:
         :param bool flag: If True, the left axis will use a log scale
         """
         pass
+
+    def setXAxisInverted(self, flag):
+        """Invert the X axis.
+
+        :param bool flag: If True, put the horizontal axis origin on the right
+        """
+        self.__xAxisInverted = bool(flag)
+
+    def isXAxisInverted(self):
+        """Return True if X axis is inverted, False otherwise."""
+        return self.__xAxisInverted
 
     def setYAxisInverted(self, flag):
         """Invert the Y axis.

--- a/src/silx/gui/plot/backends/BackendBase.py
+++ b/src/silx/gui/plot/backends/BackendBase.py
@@ -504,14 +504,14 @@ class BackendBase:
         """
         pass
 
-    def setXAxisInverted(self, flag):
+    def setXAxisInverted(self, flag: bool):
         """Invert the X axis.
 
-        :param bool flag: If True, put the horizontal axis origin on the right
+        :param flag: If True, put the horizontal axis origin on the right
         """
         self.__xAxisInverted = bool(flag)
 
-    def isXAxisInverted(self):
+    def isXAxisInverted(self) -> bool:
         """Return True if X axis is inverted, False otherwise."""
         return self.__xAxisInverted
 

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1191,10 +1191,19 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
     # Graph limits
 
+    def _setXLimits(self, xmin: float, xmax: float):
+        xmin = min(xmin, xmax)
+        xmax = max(xmin, xmax)
+        if self.isXAxisInverted():
+            left, right = xmax, xmin
+        else:
+            left, right = xmin, xmax
+        self.ax.set_xlim(left, right)
+
     def setLimits(self, xmin, xmax, ymin, ymax, y2min=None, y2max=None):
         # Let matplotlib taking care of keep aspect ratio if any
         self._dirtyLimits = True
-        self.ax.set_xlim(min(xmin, xmax), max(xmin, xmax))
+        self._setXLimits(xmin, xmax)
 
         if y2min is not None and y2max is not None:
             self.ax2.set_ybound(min(y2min, y2max), max(y2min, y2max))
@@ -1212,7 +1221,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
     def setGraphXLimits(self, xmin, xmax):
         self._dirtyLimits = True
-        self.ax.set_xlim(min(xmin, xmax), max(xmin, xmax))
+        self._setXLimits(xmin, xmax)
         self._updateMarkers()
 
     def getGraphYLimits(self, axis):
@@ -1246,7 +1255,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
             newXRange = (xmax - xmin) * (ymax - ymin) / (curYMax - curYMin)
             xcenter = 0.5 * (xmin + xmax)
-            ax.set_xlim(xcenter - 0.5 * newXRange, xcenter + 0.5 * newXRange)
+            self._setXLimits(xcenter - 0.5 * newXRange, xcenter + 0.5 * newXRange)
 
         ax.set_ybound(ymin, ymax)
 
@@ -1289,9 +1298,9 @@ class BackendMatplotlib(BackendBase.BackendBase):
         # to log scale with both limits <= 0
         # In this case a draw with positive limits is needed first
         if flag and self._matplotlibVersion >= Version("2.1.0"):
-            xlim = self.ax.get_xlim()
+            xlim = self.ax.get_xbound()
             if xlim[0] <= 0 and xlim[1] <= 0:
-                self.ax.set_xlim(1, 10)
+                self._setXLimits(1, 10)
                 self.draw()
 
         xscale = "log" if flag else "linear"

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -379,7 +379,14 @@ class _MarkerContainer(_PickableContainer):
         if self.text is not None:
             self.text.draw(*args, **kwargs)
 
-    def updateMarkerText(self, xmin, xmax, ymin, ymax, yinverted):
+    def updateMarkerText(
+        self,
+        xmin: float,
+        xmax: float,
+        ymin: float,
+        ymax: float,
+        yinverted: bool,
+    ):
         """Update marker text position and visibility according to plot limits
 
         :param xmin: X axis lower limit
@@ -399,7 +406,7 @@ class _MarkerContainer(_PickableContainer):
                     valign = "baseline"
                 else:
                     if yinverted:
-                        valign = "bottom"
+                        valign = "bottom" if yinverted else "top"
                     else:
                         valign = "top"
                 self.text.set_verticalalignment(valign)
@@ -1321,13 +1328,21 @@ class BackendMatplotlib(BackendBase.BackendBase):
         self.ax.set_yscale("linear")
         self.ax.yaxis.set_major_formatter(DefaultTickFormatter())
 
-    def setYAxisInverted(self, flag):
+    def setYAxisInverted(self, flag: bool):
         if self.ax.yaxis_inverted() != bool(flag):
             self.ax.invert_yaxis()
             self._updateMarkers()
 
-    def isYAxisInverted(self):
+    def isYAxisInverted(self) -> bool:
         return self.ax.yaxis_inverted()
+
+    def setXAxisInverted(self, flag: bool):
+        if self.ax.xaxis_inverted() != bool(flag):
+            self.ax.invert_xaxis()
+            self._updateMarkers()
+
+    def isXAxisInverted(self) -> bool:
+        return self.ax.xaxis_inverted()
 
     def isYRightAxisVisible(self):
         return self.ax2.yaxis.get_visible()

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -405,10 +405,7 @@ class _MarkerContainer(_PickableContainer):
                 if self.symbol is None:
                     valign = "baseline"
                 else:
-                    if yinverted:
-                        valign = "bottom" if yinverted else "top"
-                    else:
-                        valign = "top"
+                    valign = "bottom" if yinverted else "top"
                 self.text.set_verticalalignment(valign)
 
             elif self.y is None:  # vertical line

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -1596,12 +1596,19 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             self._plotFrame.yAxis.isLog = flag
             self._plotFrame.y2Axis.isLog = flag
 
-    def setYAxisInverted(self, flag):
+    def setYAxisInverted(self, flag: bool):
         if flag != self._plotFrame.isYAxisInverted:
             self._plotFrame.isYAxisInverted = flag
 
-    def isYAxisInverted(self):
+    def isYAxisInverted(self) -> bool:
         return self._plotFrame.isYAxisInverted
+
+    def setXAxisInverted(self, flag: bool):
+        if flag != self._plotFrame.isXAxisInverted:
+            self._plotFrame.isXAxisInverted = flag
+
+    def isXAxisInverted(self) -> bool:
+        return self._plotFrame.isXAxisInverted
 
     def isYRightAxisVisible(self):
         return self._plotFrame.isY2Axis

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -1597,15 +1597,13 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             self._plotFrame.y2Axis.isLog = flag
 
     def setYAxisInverted(self, flag: bool):
-        if flag != self._plotFrame.isYAxisInverted:
-            self._plotFrame.isYAxisInverted = flag
+        self._plotFrame.isYAxisInverted = flag
 
     def isYAxisInverted(self) -> bool:
         return self._plotFrame.isYAxisInverted
 
     def setXAxisInverted(self, flag: bool):
-        if flag != self._plotFrame.isXAxisInverted:
-            self._plotFrame.isXAxisInverted = flag
+        self._plotFrame.isXAxisInverted = flag
 
     def isXAxisInverted(self) -> bool:
         return self._plotFrame.isXAxisInverted

--- a/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -1224,19 +1224,19 @@ class GLPlotFrame2D(GLPlotFrame):
         trBounds = self.transformedDataRanges
 
         if self.isXAxisInverted:
-            unscaled_xData = self.size[0] - self.margins.right - x - 0.5
+            unscaledXData = self.size[0] - self.margins.right - x - 0.5
         else:
-            unscaled_xData = x - self.margins.left + 0.5
-        xData = trBounds.x[0] + unscaled_xData / float(plotWidth) * (
+            unscaledXData = x - self.margins.left + 0.5
+        xData = trBounds.x[0] + unscaledXData / float(plotWidth) * (
             trBounds.x[1] - trBounds.x[0]
         )
 
         if self.isYAxisInverted:
-            unscaled_yData = y - self.margins.top + 0.5
+            unscaledYData = y - self.margins.top + 0.5
         else:
-            unscaled_yData = self.size[1] - self.margins.bottom - y - 0.5
+            unscaledYData = self.size[1] - self.margins.bottom - y - 0.5
         usedAxis = trBounds.y if axis == "left" else trBounds.y2
-        yData = usedAxis[0] + unscaled_yData / float(plotHeight) * (
+        yData = usedAxis[0] + unscaledYData / float(plotHeight) * (
             usedAxis[1] - usedAxis[0]
         )
 

--- a/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -879,6 +879,7 @@ class GLPlotFrame2D(GLPlotFrame):
             font=self._font,
         )
 
+        self._isXAxisInverted = False
         self._isYAxisInverted = False
 
         self._dataRanges = {"x": (1.0, 100.0), "y": (1.0, 100.0), "y2": (1.0, 100.0)}
@@ -933,15 +934,26 @@ class GLPlotFrame2D(GLPlotFrame):
             self._dirty()
 
     @property
-    def isYAxisInverted(self):
+    def isYAxisInverted(self) -> bool:
         """Whether Y axes are inverted or not as a bool."""
         return self._isYAxisInverted
 
     @isYAxisInverted.setter
-    def isYAxisInverted(self, value):
+    def isYAxisInverted(self, value: bool):
         value = bool(value)
         if value != self._isYAxisInverted:
             self._isYAxisInverted = value
+            self._dirty()
+
+    @property
+    def isXAxisInverted(self) -> bool:
+        return self._isXAxisInverted
+
+    @isXAxisInverted.setter
+    def isXAxisInverted(self, value: bool):
+        value = bool(value)
+        if value != self._isXAxisInverted:
+            self._isXAxisInverted = value
             self._dirty()
 
     DEFAULT_BASE_VECTORS = (1.0, 0.0), (0.0, 1.0)
@@ -1095,10 +1107,12 @@ class GLPlotFrame2D(GLPlotFrame):
             yMin, yMax = self.transformedDataRanges.y
 
             if self.isYAxisInverted:
-                mat = mat4Ortho(xMin, xMax, yMax, yMin, 1, -1)
-            else:
-                mat = mat4Ortho(xMin, xMax, yMin, yMax, 1, -1)
-            self._transformedDataProjMat = mat
+                yMax, yMin = yMin, yMax
+
+            if self.isXAxisInverted:
+                xMax, xMin = xMin, xMax
+
+            self._transformedDataProjMat = mat4Ortho(xMin, xMax, yMin, yMax, 1, -1)
 
         return self._transformedDataProjMat
 
@@ -1114,10 +1128,12 @@ class GLPlotFrame2D(GLPlotFrame):
             y2Min, y2Max = self.transformedDataRanges.y2
 
             if self.isYAxisInverted:
-                mat = mat4Ortho(xMin, xMax, y2Max, y2Min, 1, -1)
-            else:
-                mat = mat4Ortho(xMin, xMax, y2Min, y2Max, 1, -1)
-            self._transformedDataY2ProjMat = mat
+                y2Max, y2Min = y2Min, y2Max
+
+            if self.isXAxisInverted:
+                xMax, xMin = xMin, xMax
+
+            self._transformedDataY2ProjMat = mat4Ortho(xMin, xMax, y2Min, y2Max, 1, -1)
 
         return self._transformedDataY2ProjMat
 
@@ -1164,9 +1180,13 @@ class GLPlotFrame2D(GLPlotFrame):
 
         plotWidth, plotHeight = self.plotSize
 
-        xPixel = self.margins.left + plotWidth * (xDataTr - trBounds.x[0]) / (
-            trBounds.x[1] - trBounds.x[0]
+        xOffset = (
+            plotWidth * (xDataTr - trBounds.x[0]) / (trBounds.x[1] - trBounds.x[0])
         )
+        if self.isXAxisInverted:
+            xPixel = self.size[0] - self.margins.right - xOffset
+        else:
+            xPixel = self.margins.left + xOffset
 
         usedAxis = trBounds.y if axis == "left" else trBounds.y2
         yOffset = plotHeight * (yDataTr - usedAxis[0]) / (usedAxis[1] - usedAxis[0])
@@ -1203,17 +1223,22 @@ class GLPlotFrame2D(GLPlotFrame):
 
         trBounds = self.transformedDataRanges
 
-        xData = (x - self.margins.left + 0.5) / float(plotWidth)
-        xData = trBounds.x[0] + xData * (trBounds.x[1] - trBounds.x[0])
-
-        usedAxis = trBounds.y if axis == "left" else trBounds.y2
-        if self.isYAxisInverted:
-            yData = (y - self.margins.top + 0.5) / float(plotHeight)
-            yData = usedAxis[0] + yData * (usedAxis[1] - usedAxis[0])
+        if self.isXAxisInverted:
+            unscaled_xData = self.size[0] - self.margins.right - x - 0.5
         else:
-            yData = self.size[1] - self.margins.bottom - y - 0.5
-            yData /= float(plotHeight)
-            yData = usedAxis[0] + yData * (usedAxis[1] - usedAxis[0])
+            unscaled_xData = x - self.margins.left + 0.5
+        xData = trBounds.x[0] + unscaled_xData / float(plotWidth) * (
+            trBounds.x[1] - trBounds.x[0]
+        )
+
+        if self.isYAxisInverted:
+            unscaled_yData = y - self.margins.top + 0.5
+        else:
+            unscaled_yData = self.size[1] - self.margins.bottom - y - 0.5
+        usedAxis = trBounds.y if axis == "left" else trBounds.y2
+        yData = usedAxis[0] + unscaled_yData / float(plotHeight) * (
+            usedAxis[1] - usedAxis[0]
+        )
 
         # non-orthogonal axis
         if self.baseVectors != self.DEFAULT_BASE_VECTORS:
@@ -1327,46 +1352,56 @@ class GLPlotFrame2D(GLPlotFrame):
     def _buildVerticesAndLabels(self):
         width, height = self.size
 
-        xCoords = (self.margins.left - 0.5, width - self.margins.right + 0.5)
-        yCoords = (height - self.margins.bottom + 0.5, self.margins.top - 0.5)
+        xLeft = self.margins.left - 0.5
+        xRight = width - self.margins.right + 0.5
+        yBottom = height - self.margins.bottom + 0.5
+        yTop = self.margins.top - 0.5
 
-        self.axes[0].displayCoords = (
-            (xCoords[0], yCoords[0]),
-            (xCoords[1], yCoords[0]),
-        )
+        self._x2AxisCoords = ((xLeft, yTop), (xRight, yTop))
 
-        self._x2AxisCoords = ((xCoords[0], yCoords[1]), (xCoords[1], yCoords[1]))
-
-        # Set order&offset anchor **before** handling Y axis inversion
+        # Set order&offset anchor **before** handling axis inversion
         fontPixelSize = self._font.pixelSize()
         if fontPixelSize == -1:
             fontPixelSize = self._font.pointSizeF() / 72.0 * self.dotsPerInch
 
         self.axes[0].orderOffetAnchor = (
-            xCoords[1],
-            yCoords[0] + fontPixelSize * 1.2,
+            xRight,
+            yBottom + fontPixelSize * 1.2,
         )
         self.axes[1].orderOffetAnchor = (
-            xCoords[0],
-            yCoords[1] - 4 * self.devicePixelRatio,
+            xLeft,
+            yTop - 4 * self.devicePixelRatio,
         )
         self._y2Axis.orderOffetAnchor = (
-            xCoords[1],
-            yCoords[1] - 4 * self.devicePixelRatio,
+            xRight,
+            yTop - 4 * self.devicePixelRatio,
         )
 
         if self.isYAxisInverted:
-            # Y axes are inverted, axes coordinates are inverted
-            yCoords = yCoords[1], yCoords[0]
+            # Y axis is inverted: goes top to bottom
+            yCoords = yTop, yBottom
+        else:
+            yCoords = yBottom, yTop
+
+        if self.isXAxisInverted:
+            # X axis is inverted: goes right to left
+            xCoords = xRight, xLeft
+        else:
+            xCoords = xLeft, xRight
+
+        self.axes[0].displayCoords = (
+            (xCoords[0], yBottom),
+            (xCoords[1], yBottom),
+        )
 
         self.axes[1].displayCoords = (
-            (xCoords[0], yCoords[0]),
-            (xCoords[0], yCoords[1]),
+            (xLeft, yCoords[0]),
+            (xLeft, yCoords[1]),
         )
 
         self._y2Axis.displayCoords = (
-            (xCoords[1], yCoords[0]),
-            (xCoords[1], yCoords[1]),
+            (xRight, yCoords[0]),
+            (xRight, yCoords[1]),
         )
 
         super()._buildVerticesAndLabels()

--- a/src/silx/gui/plot/items/axis.py
+++ b/src/silx/gui/plot/items/axis.py
@@ -160,23 +160,24 @@ class Axis(qt.QObject):
         raise NotImplementedError()
 
     def isInverted(self) -> bool:
-        """Return True if the axis is inverted (top to bottom for the y-axis),
-        False otherwise. It is always False for the X axis.
-
-        :rtype: bool
+        """Return True if the axis is inverted, False otherwise.
+        An inverted x-axis goes right to left.
+        An inverted y-axis goes top to bottom.
         """
-        return False
+        raise NotImplementedError()
 
-    def setInverted(self, isInverted: bool):
+    def setInverted(self, flag: bool):
         """Set the axis orientation.
 
-        This is only available for the Y axis.
+        If True, x-axis will go right to left
+        and y-axis will go top to bottom.
+
+        If False, x-axis will go left to right
+        and y-axis will go bottom to top.
 
         :param flag: True for Y axis going from top to bottom,
                      False for Y axis going from bottom to top
         """
-        if isInverted == self.isInverted():
-            return
         raise NotImplementedError()
 
     def isVisible(self) -> bool:
@@ -428,6 +429,25 @@ class XAxis(Axis):
         ranges = self._getPlot().getDataRange()
         return ranges.x
 
+    def setInverted(self, flag: bool = True):
+        """Set the axis orientation.
+
+        :param flag: True for X axis going from left to right,
+                     False for X axis going from right to left
+        """
+        flag = bool(flag)
+        if self.isInverted() == flag:
+            return
+        self._getBackend().setXAxisInverted(flag)
+        self._getPlot()._setDirtyPlot()
+        self.sigInvertedChanged.emit(flag)
+
+    def isInverted(self) -> bool:
+        """Return True if the axis is inverted (right to left),
+        False otherwise.
+        """
+        return self._getBackend().isXAxisInverted()
+
 
 class YAxis(Axis):
     """Axis class defining primitives for the Y axis"""
@@ -450,10 +470,8 @@ class YAxis(Axis):
     def setInverted(self, flag: bool = True):
         """Set the axis orientation.
 
-        This is only available for the Y axis.
-
-        :param bool flag: True for Y axis going from top to bottom,
-                          False for Y axis going from bottom to top
+        :param flag: True for Y axis going from top to bottom,
+                     False for Y axis going from bottom to top
         """
         flag = bool(flag)
         if self.isInverted() == flag:
@@ -463,10 +481,8 @@ class YAxis(Axis):
         self.sigInvertedChanged.emit(flag)
 
     def isInverted(self) -> bool:
-        """Return True if the axis is inverted (top to bottom for the y-axis),
-        False otherwise. It is always False for the X axis.
-
-        :rtype: bool
+        """Return True if the axis is inverted (top to bottom),
+        False otherwise.
         """
         return self._getBackend().isYAxisInverted()
 


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

For #4253

This PR adds the internal machinery to allow to invert X axis programatically in `PlotWidget` for both backends (see example code below).

GUI control implementation is left to completely handle #4253


## Example code
```python
from silx.gui import qt
from silx.gui.plot.PlotWidget import PlotWidget

app = qt.QApplication()

X = [-4, -3, -2, -1, 0, 1, 2, 3, 4]
Y = [x**3 for x in X]

w = qt.QWidget()
layout = qt.QHBoxLayout(w)


w1 = PlotWidget(backend="mpl")
w1.addCurve(X, Y)
w1.setXAxisInverted(True)
w1.setYAxisInverted(True)

w2 = PlotWidget(backend="gl")
w2.addCurve(X, Y)
w2.setXAxisInverted(True)
w2.setYAxisInverted(True)

layout.addWidget(w1)
layout.addWidget(w2)

w.show()
app.exec()
```

<img width="480" height="200" alt="image" src="https://github.com/user-attachments/assets/52a0e7cb-3a4c-4281-9720-4c48c5739c06" />

 
