### PR TITLE
src.silx.io.url.DataUrl: Fix typing of file_path method

### DIFF
--- a/src/silx/io/url.py
+++ b/src/silx/io/url.py
@@ -409,7 +409,7 @@ class DataUrl:
                 return True
         return False
 
-    def file_path(self) -> str:
+    def file_path(self) -> str | None:
         """Returns the path to the file containing the data."""
         return self.__file_path
 


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

`file_path` can be `None` since https://github.com/silx-kit/silx/pull/4051
