### PR TITLE
pyproject.toml: Add uv tool field to tell that the project is not managed by uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,9 +114,12 @@ skip = ["*-win32", "*-manylinux_i686", "pp*", "*musllinux*"]
 
 
 [tool.black]
-required-version = 25
+required-version = "25"
 target-version = ["py310", "py311", "py312", "py313"]
 
 [tool.pytest.ini_options]
 minversion = "6.0"
 testpaths = [ "src/silx" ]
+
+[tool.uv]
+managed = false


### PR DESCRIPTION
Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

This is to be able to use `uv` seamlessly (i.e. so thatr `uv` does not try to do too much by thinking that it needs to handle the project its way) 