### PR TITLE
silx.tests: Fix warning related to missing pytest when generating docs

### DIFF
--- a/src/silx/test/__init__.py
+++ b/src/silx/test/__init__.py
@@ -25,21 +25,11 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
 import importlib
-import logging
 import os.path
 import subprocess
 import sys
-
-
-try:
-    import pytest  # noqa: F401
-except ImportError:
-    logging.getLogger(__name__).error(
-        "pytest is required to run the tests, please install it."
-    )
-    raise
+from collections.abc import Sequence
 
 
 def run_tests(


### PR DESCRIPTION
<!-- Thank you for your pull request! -->

Checklist:

- [X] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

<!-- provide a description of the changes below -->

Without the try/except, the message remains clear if the users want to run the test without having `pytest` installed (see https://github.com/silx-kit/silx/issues/4415)

```sh
Running pytest with this command:
silx-kit/silx/.venv/bin/python -m pytest --verbosity 0
silx-kit/silx/.venv/bin/python: No module named pytest
```
