### PR TITLE
silx.gui.data.NXdataWidget: Use axis names as slider labels (when present)

### DIFF
--- a/src/silx/gui/data/DataViews.py
+++ b/src/silx/gui/data/DataViews.py
@@ -1754,6 +1754,8 @@ class _NXdataImageView(_NXdataBaseDataView):
     def setData(self, data):
         data = self.normalizeData(data)
         nxd = nxdata.get_default(data, validate=False)
+        if nxd is None:
+            return
         isRgba = nxd.interpretation == "rgba-image"
 
         self._updateColormap(nxd)
@@ -1771,6 +1773,7 @@ class _NXdataImageView(_NXdataBaseDataView):
             x_axis=x_axis,
             y_axis=y_axis,
             signals_names=[nxd.signal_name] + nxd.auxiliary_signals_names,
+            axes_names=nxd.axes_names,
             xlabel=x_label,
             ylabel=y_label,
             title=nxd.title,

--- a/src/silx/gui/data/NXdataWidgets.py
+++ b/src/silx/gui/data/NXdataWidgets.py
@@ -457,6 +457,7 @@ class ArrayImagePlot(qt.QWidget):
         x_axis=None,
         y_axis=None,
         signals_names=None,
+        axes_names=None,
         xlabel=None,
         ylabel=None,
         title=None,
@@ -489,6 +490,7 @@ class ArrayImagePlot(qt.QWidget):
 
         self.__signals = signals
         self.__signals_names = signals_names
+        self.__axis_names = axes_names
         self.__x_axis = x_axis
         self.__x_axis_name = xlabel
         self.__y_axis = y_axis
@@ -508,6 +510,9 @@ class ArrayImagePlot(qt.QWidget):
             self._axesSelector.hide()
         else:
             self._axesSelector.show()
+
+        if self.__axis_names:
+            self._axesSelector.setLabels(self.__axis_names)
 
         self._signalSelector.setSignalNames(signals_names)
         if len(signals) > 1:


### PR DESCRIPTION


<!-- Thank you for your pull request! -->

Checklist:

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/CONTRIBUTING.rst#pull-request-title-format))

<hr>

Fix #4213

When the NXdata has named axes, `silx view` will now use these as labels for the slicing sliders.

<img width="890" height="676" alt="image" src="https://github.com/user-attachments/assets/852c6c6c-1bac-4a46-ad52-55a810903415" />

I only added it for images for now. If we agree that the implementation is sensible, I could add it to other visualizations as well. 

