### PR TITLE
silx.gui.plot.tools.toolbars: Fixed ImageToolBar

### DIFF
--- a/src/silx/gui/plot/tools/toolbars.py
+++ b/src/silx/gui/plot/tools/toolbars.py
@@ -139,6 +139,8 @@ class ImageToolBar(qt.QToolBar):
         self._xAxisInvertedButton = PlotToolButtons.XAxisOriginToolButton(
             parent=self, plot=plot
         )
+        self.addWidget(self._xAxisInvertedButton)
+
         self._yAxisInvertedButton = PlotToolButtons.YAxisOriginToolButton(
             parent=self, plot=plot
         )


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

The x axis orientation toolbutton was not added to the toolbar but it's parent was set to the toolbar.

closes #4442, related to #4425
