### PR TITLE
silx.gui.data.DataViewer: split composite ImageView into Plot2dView and ComplexImageView

### DIFF
--- a/src/silx/gui/data/DataViewer.py
+++ b/src/silx/gui/data/DataViewer.py
@@ -32,6 +32,7 @@ from silx.gui import qt
 from silx.gui.data import DataViews
 from silx.gui.data.DataViews import (
     NXDATA_STACK_MODE,
+    PLOT2D_MODE,
     STACK_MODE,
     IMAGE_MODE,
     _normalizeData,
@@ -166,7 +167,8 @@ class DataViewer(qt.QFrame):
             DataViews._Hdf5View,
             DataViews._NXdataView,
             DataViews._Plot1dView,
-            DataViews._ImageView,
+            DataViews._Plot2dView,
+            DataViews._ComplexImageView,
             DataViews._Plot3dView,
             DataViews._RawView,
             DataViews._Plot2dRecordView,
@@ -358,7 +360,16 @@ class DataViewer(qt.QFrame):
             deprecated_warning(
                 "Argument",
                 "DataViews.STACK_MODE",
-                replacement="DataViews.IMAGE_MODE",
+                replacement="DataViews.PLOT2D_MODE for real images, DataViews.COMPLEX_PLOT2D_MODE for complex images",
+                since_version="3.0.0",
+            )
+            return None
+
+        if modeId == IMAGE_MODE:
+            deprecated_warning(
+                "Argument",
+                "DataViews.IMAGE_MODE",
+                replacement="DataViews.PLOT2D_MODE for real images, DataViews.COMPLEX_PLOT2D_MODE for complex images",
                 since_version="3.0.0",
             )
             return None
@@ -377,10 +388,11 @@ class DataViewer(qt.QFrame):
 
             - `DataViews.EMPTY_MODE`: display nothing
             - `DataViews.PLOT1D_MODE`: display the data as a curve
-            - `DataViews.IMAGE_MODE`: display the data as an image
+            - `DataViews.PLOT2D_MODE`: display real data as an image
+            - `DataViews.COMPLEX_PLOT2D_MODE`: display complex data as an image
             - `DataViews.PLOT3D_MODE`: display the data as an isosurface
             - `DataViews.RAW_MODE`: display the data as a table
-            - `DataViews.STACK_MODE`: deprecated. Use `DataViews.IMAGE_MODE` instead.
+            - `DataViews.STACK_MODE`: deprecated. Use `DataViews.PLOT2D_MODE` or `DataViews.COMPLEX_PLOT2D_MODE` instead.
             - `DataViews.HDF5_MODE`: display the data as a table of HDF5 info
             - `DataViews.NXDATA_MODE`: display the data as NXdata
         """
@@ -388,10 +400,19 @@ class DataViewer(qt.QFrame):
             deprecated_warning(
                 "Argument",
                 "DataViews.STACK_MODE",
-                replacement="DataViews.IMAGE_MODE",
+                replacement="DataViews.PLOT2D_MODE for real images, DataViews.COMPLEX_PLOT2D_MODE for complex images",
                 since_version="3.0.0",
             )
-            modeId = IMAGE_MODE
+            modeId = PLOT2D_MODE
+
+        if modeId == IMAGE_MODE:
+            deprecated_warning(
+                "Argument",
+                "DataViews.IMAGE_MODE",
+                replacement="DataViews.PLOT2D_MODE for real images, DataViews.COMPLEX_PLOT2D_MODE for complex images",
+                since_version="3.0.0",
+            )
+            modeId = PLOT2D_MODE
 
         try:
             view = self.getViewFromModeId(modeId)
@@ -612,9 +633,8 @@ class DataViewer(qt.QFrame):
 
             - `DataViews.EMPTY_MODE`
             - `DataViews.PLOT1D_MODE`
-            - `DataViews.IMAGE_MODE`
             - `DataViews.PLOT2D_MODE`
-            - `DataViews.COMPLEX_IMAGE_MODE`
+            - `DataViews.COMPLEX_PLOT2D_MODE`
             - `DataViews.PLOT3D_MODE`
             - `DataViews.RAW_MODE`
             - `DataViews.HDF5_MODE`
@@ -632,7 +652,16 @@ class DataViewer(qt.QFrame):
             deprecated_warning(
                 "Argument",
                 "DataViews.STACK_MODE",
-                replacement="DataViews.IMAGE_MODE",
+                replacement="DataViews.PLOT2D_MODE for real images, DataViews.COMPLEX_PLOT2D_MODE for complex images",
+                since_version="3.0.0",
+            )
+            return False
+
+        if modeId == IMAGE_MODE:
+            deprecated_warning(
+                "Argument",
+                "DataViews.IMAGE_MODE",
+                replacement="DataViews.PLOT2D_MODE for real images, DataViews.COMPLEX_PLOT2D_MODE for complex images",
                 since_version="3.0.0",
             )
             return False

--- a/src/silx/gui/data/DataViews.py
+++ b/src/silx/gui/data/DataViews.py
@@ -52,7 +52,7 @@ PLOT1D_MODE = 10
 RECORD_PLOT_MODE = 15
 IMAGE_MODE = 20
 PLOT2D_MODE = 21
-COMPLEX_IMAGE_MODE = 22
+COMPLEX_PLOT2D_MODE = 22
 PLOT3D_MODE = 30
 RAW_MODE = 40
 RAW_ARRAY_MODE = 41
@@ -1125,6 +1125,8 @@ class _Plot2dView(DataView):
             return DataView.UNSUPPORTED
         if data is None or not info.isArray or not (info.isNumeric or info.isBoolean):
             return DataView.UNSUPPORTED
+        if info.isComplex:
+            return DataView.UNSUPPORTED
         if info.dim < 2:
             return DataView.UNSUPPORTED
         if info.interpretation == "image":
@@ -1193,8 +1195,8 @@ class _ComplexImageView(DataView):
     def __init__(self, parent):
         super().__init__(
             parent=parent,
-            modeId=COMPLEX_IMAGE_MODE,
-            label="Complex Image",
+            modeId=COMPLEX_PLOT2D_MODE,
+            label="Image",
             icon=icons.getQIcon("view-2d"),
         )
 
@@ -1462,23 +1464,6 @@ class _RawView(CompositeDataView):
         self.addView(_ScalarView(parent))
         self.addView(_ArrayView(parent))
         self.addView(_RecordView(parent))
-
-
-class _ImageView(CompositeDataView):
-    """View displaying data as 2D image
-
-    It choose between Plot2D and ComplexImageView widgets
-    """
-
-    def __init__(self, parent):
-        super().__init__(
-            parent=parent,
-            modeId=IMAGE_MODE,
-            label="Image",
-            icon=icons.getQIcon("view-2d"),
-        )
-        self.addView(_ComplexImageView(parent))
-        self.addView(_Plot2dView(parent))
 
 
 class _InvalidNXdataView(DataView):

--- a/src/silx/gui/data/test/test_dataviewer.py
+++ b/src/silx/gui/data/test/test_dataviewer.py
@@ -105,7 +105,7 @@ class _TestAbstractDataViewer(TestCaseQt):
         widget.setData(data)
         availableModes = {v.modeId() for v in widget.currentAvailableViews()}
         self.assertEqual(DataViews.RAW_MODE, widget.displayMode())
-        self.assertIn(DataViews.IMAGE_MODE, availableModes)
+        self.assertIn(DataViews.PLOT2D_MODE, availableModes)
 
     def test_image_bool(self):
         data = numpy.zeros((10, 10), dtype=bool)
@@ -114,7 +114,7 @@ class _TestAbstractDataViewer(TestCaseQt):
         widget.setData(data)
         availableModes = {v.modeId() for v in widget.currentAvailableViews()}
         self.assertEqual(DataViews.RAW_MODE, widget.displayMode())
-        self.assertIn(DataViews.IMAGE_MODE, availableModes)
+        self.assertIn(DataViews.PLOT2D_MODE, availableModes)
 
     def test_image_complex_data(self):
         data = numpy.arange(3**2, dtype=numpy.complex64)
@@ -123,7 +123,7 @@ class _TestAbstractDataViewer(TestCaseQt):
         widget.setData(data)
         availableModes = {v.modeId() for v in widget.currentAvailableViews()}
         self.assertEqual(DataViews.RAW_MODE, widget.displayMode())
-        self.assertIn(DataViews.IMAGE_MODE, availableModes)
+        self.assertIn(DataViews.COMPLEX_PLOT2D_MODE, availableModes)
 
     def test_plot_3d_data(self):
         data = numpy.arange(3**3)
@@ -136,7 +136,7 @@ class _TestAbstractDataViewer(TestCaseQt):
 
             self.assertIn(DataViews.PLOT3D_MODE, availableModes)
         except ImportError:
-            self.assertIn(DataViews.IMAGE_MODE, availableModes)
+            self.assertIn(DataViews.PLOT2D_MODE, availableModes)
         self.assertEqual(DataViews.RAW_MODE, widget.displayMode())
 
     def test_array_1d_data(self):
@@ -205,8 +205,8 @@ class _TestAbstractDataViewer(TestCaseQt):
         assert listener.arguments() == [((0, 0, 0, slice(None)), None)]
         listener.clear()
 
-        widget.setDisplayMode(DataViews.IMAGE_MODE)
-        self.assertEqual(widget.displayedView().modeId(), DataViews.IMAGE_MODE)
+        widget.setDisplayMode(DataViews.PLOT2D_MODE)
+        self.assertEqual(widget.displayedView().modeId(), DataViews.PLOT2D_MODE)
         self.qWait(200)
         assert listener.arguments() == [((0, 0, slice(None), slice(None)), None)]
         listener.clear()


### PR DESCRIPTION

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

Fix #4423 

The root cause of #4423 is the fact that the two views (`Plot2dView` and `ComplexImageView`) of the composite `ImageView` are updating simultaneously the colorbar dialog (since it is shared for the whole `DataViewer`).

In specific circumstances, the limits can be set by the view that is **not** displayed on screen, mismatching the limits of the actual displayed image.

After a long ponder on how to proceed, we decided to split the composite `ImageView` into two simple views `Plot2dView` and `ComplexImageView` so that only one is instantiated at a time. This matches the previous behaviour where only one view over the two is visible at all time but required some minor changes:
- `_ImageView` is now deprecated
- `ComplexImageView` label was set to `Image` for consistency with the previous behaviour
- `Plot2dView` does not support complex anywore
- The mode (i.e. `id`) of the available visualization changes (from `20`, it becomes `21` for a regular image and `22` for a complex image)