### PR TITLE
silx.gui.data.NumpyAxesSelector: deprecate `customAxes`

### DIFF
--- a/src/silx/gui/data/DataViewer.py
+++ b/src/silx/gui/data/DataViewer.py
@@ -111,7 +111,6 @@ class DataViewer(qt.QFrame):
         self.__numpySelection = NumpyAxesSelector(self)
         self.__numpySelection.selectedAxisChanged.connect(self.__numpyAxisChanged)
         self.__numpySelection.selectionChanged.connect(self.__numpySelectionChanged)
-        self.__numpySelection.customAxisChanged.connect(self.__numpyCustomAxisChanged)
 
         self.setLayout(qt.QVBoxLayout(self))
         self.layout().addWidget(self.__stack, 1)
@@ -216,11 +215,6 @@ class DataViewer(qt.QFrame):
         if view is not None:
             view.clear()
 
-    def __numpyCustomAxisChanged(self, name, value):
-        view = self.__currentView
-        if view is not None:
-            view.setCustomAxisValue(name, value)
-
     def __updateNumpySelectionAxis(self):
         """
         Update the numpy-selector according to the needed axis names
@@ -241,9 +235,6 @@ class DataViewer(qt.QFrame):
             ):
                 self.__useAxisSelection = True
                 self.__numpySelection.setAxisNames(axisNames)
-                self.__numpySelection.setCustomAxis(
-                    self.__currentView.customAxisNames()
-                )
                 data = self.normalizeData(self.__data)
                 self.__numpySelection.setData(data)
 

--- a/src/silx/gui/data/DataViews.py
+++ b/src/silx/gui/data/DataViews.py
@@ -39,6 +39,7 @@ from silx.gui.colors import Colormap
 from silx.gui.dialog.ColormapDialog import ColormapDialog
 from silx.gui.plot.items.image import ImageDataAggregated
 from silx.gui.plot.actions.image import AggregationModeAction
+from silx.utils.deprecation import deprecated
 
 __authors__ = ["V. Valls", "P. Knobel"]
 __license__ = "MIT"
@@ -328,18 +329,12 @@ class DataView:
         Else returns the data."""
         return _normalizeData(data)
 
+    @deprecated(reason="Not used", since_version="3.0.0")
     def customAxisNames(self):
-        """Returns names of axes which can be custom by the user and provided
-        to the view."""
         return []
 
+    @deprecated(reason="Not used", since_version="3.0.0")
     def setCustomAxisValue(self, name, value):
-        """
-        Set the value of a custom axis
-
-        :param str name: Name of the custom axis
-        :param int value: Value of the custom axis
-        """
         pass
 
     def isWidgetInitialized(self):
@@ -631,16 +626,6 @@ class SelectOneDataView(_CompositeDataView):
         else:
             return views[0][1]
 
-    def customAxisNames(self):
-        if self.__currentView is None:
-            return
-        return self.__currentView.customAxisNames()
-
-    def setCustomAxisValue(self, name, value):
-        if self.__currentView is None:
-            return
-        self.__currentView.setCustomAxisValue(name, value)
-
     def __updateDisplayedView(self):
         widget = self.getWidget()
         if self.__currentView is None:
@@ -794,12 +779,6 @@ class SelectManyDataView(_CompositeDataView):
             if v.getCachedDataPriority(data, info) != DataView.UNSUPPORTED
         ]
         return views
-
-    def customAxisNames(self):
-        raise RuntimeError("Abstract view")
-
-    def setCustomAxisValue(self, name, value):
-        raise RuntimeError("Abstract view")
 
     def select(self):
         raise RuntimeError("Abstract view")

--- a/src/silx/gui/data/NumpyAxesSelector.py
+++ b/src/silx/gui/data/NumpyAxesSelector.py
@@ -36,6 +36,7 @@ import functools
 from silx.gui.widgets.FrameBrowser import HorizontalSliderWithBrowser
 from silx.gui import qt
 from silx.gui.utils import blockSignals
+from silx.utils.deprecation import deprecated
 import silx.utils.weakref
 
 
@@ -273,11 +274,8 @@ class NumpyAxesSelector(qt.QWidget):
                     axis.setAxisName("")
         self.__updateSelectedData()
 
+    @deprecated(reason="Not used", since_version="3.0.0")
     def setCustomAxis(self, axesNames: Sequence[str]):
-        """Set the available list of named axis which can be set to a value.
-
-        :param axesNames: List of customable axis names
-        """
         self.__customAxisNames = set(axesNames)
         for axis in self.__axis:
             axis.setCustomAxis(self.__customAxisNames)


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

For #4428 
