### PR TITLE
silx.math.calibration: Updated `ArrayCalibration.is_affine` test to be less strict

### DIFF
--- a/src/silx/math/calibration.py
+++ b/src/silx/math/calibration.py
@@ -147,8 +147,8 @@ class ArrayCalibration(AbstractCalibration):
             return False
         delta = numpy.diff(self.calibration_array)
         # use a less strict relative tolerance to account for rounding errors
-        # e.g. when using float64 into float32 (see #1823)
-        return numpy.allclose(delta, delta[0], rtol=1e-4)
+        # e.g. when using float64 into float32 (see #1823, #4465)
+        return numpy.allclose(delta, delta[0], rtol=1e-3)
 
     def get_slope(self):
         """If the calibration array is regularly spaced, return the spacing."""


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

Not really nice, but working... a relative tolerance of 1e-3 still sounds good to me.

closes #4465
related to #1828