### PR TITLE
silx.gui.plot.actions.histogram: Fixed `PixelIntensitiesHistoAction` to include max value in histogram

### DIFF
--- a/src/silx/gui/plot/actions/histogram.py
+++ b/src/silx/gui/plot/actions/histogram.py
@@ -406,6 +406,7 @@ class HistogramWidget(qt.QWidget):
             n_bins=max(2, self.__nbinsLineEdit.getValue()),
             histo_range=self.__rangeSlider.getValues(),
             weights=data,
+            last_bin_closed=True,
         )
         if len(histogram.edges) != 1:
             _logger.error("Error while computing the histogram")


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

The histogram was computed without including the last value in the counts.

closes #4464