### PR TITLE
silx.gui.colors.Colormap: Fixed support of deprecated argument "percentile_1_99"

### DIFF
--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -365,6 +365,15 @@ class Colormap(qt.QObject):
         self.__nanColor = numpy.array(self._DEFAULT_NAN_COLOR, dtype=numpy.uint8)
 
         assert normalization in Colormap.NORMALIZATIONS
+
+        if autoscaleMode == self.PERCENTILE_1_99:
+            deprecated_warning(
+                type_="Argument",
+                name="autoscaleMode='percentile_1_99'",
+                replacement="autoscaleMode='percentile'",
+                since_version="3.0",
+            )
+            autoscaleMode = self.PERCENTILE
         assert autoscaleMode in Colormap.AUTOSCALE_MODES
 
         if normalization is Colormap.LOGARITHM:
@@ -575,9 +584,9 @@ class Colormap(qt.QObject):
             raise NotEditableError("Colormap is not editable")
         if mode == self.PERCENTILE_1_99:
             deprecated_warning(
-                type_="Mode",
-                name="mode",
-                replacement="percentile",
+                type_="Argument",
+                name="mode='percentile_1_99'",
+                replacement="mode='percentile'",
                 since_version="3.0",
             )
             mode = self.PERCENTILE


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

follow-up of #4379