### PR TITLE
silx.gui.data.NumpyAxesSelector: Fix label alignment by normalizing widths

### DIFF
--- a/src/silx/gui/data/NumpyAxesSelector.py
+++ b/src/silx/gui/data/NumpyAxesSelector.py
@@ -352,7 +352,7 @@ class NumpyAxesSelector(qt.QWidget):
             a.slider().lineEdit().setFixedWidth(lineEditWidth)
             a.slider().limitWidget().setFixedWidth(limitWidth)
 
-        labelWidth = max([a.label().width() for a in self.__axis])
+        labelWidth = max([a.label().minimumSizeHint().width() for a in self.__axis])
         for a in self.__axis:
             a.label().setFixedWidth(labelWidth)
 


### PR DESCRIPTION
For https://github.com/silx-kit/silx/issues/4428

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

While reworking https://github.com/silx-kit/silx/pull/4459, I noticed the presence of a hook `__normalizeAxisGeometry` to have consistent slider widths.

In this PR, I extend this hook to also have consistent label widths, making it an alternative of #4459. Even though we are sort of wrestling against Qt layouts, the amount of changes is way less important.

What do you think @t20100 ?