### PR TITLE
silx.gui.utils.matplotlib: Fixed the used matplotlib backend with Qt6

### DIFF
--- a/src/silx/gui/utils/matplotlib.py
+++ b/src/silx/gui/utils/matplotlib.py
@@ -45,8 +45,8 @@ from .. import qt
 
 # This must be performed before any import from matplotlib
 if qt.BINDING in ("PySide6", "PyQt6", "PyQt5"):
-    matplotlib.use("Qt5Agg", force=False)
-    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg  # noqa
+    matplotlib.use("QtAgg", force=False)
+    from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg  # noqa
 
 else:
     raise ImportError("Unsupported Qt binding: %s" % qt.BINDING)


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

Fixed the used matplotlib backend with Qt6 bindings. 