### PR TITLE
silx.gui.data.DataViews.DataInfo: Make NXdata valid even if no widget can plot it

### DIFF
--- a/src/silx/gui/data/DataViews.py
+++ b/src/silx/gui/data/DataViews.py
@@ -129,20 +129,7 @@ class DataInfo:
             nx_class = get_attr_as_unicode(data, "NX_class")
             if nxd is not None:
                 self.hasNXdata = True
-                # can we plot it?
-                is_scalar = nxd.signal_is_0d or nxd.interpretation in [
-                    "scalar",
-                    "scaler",
-                ]
-                if not (
-                    is_scalar
-                    or nxd.is_curve
-                    or nxd.is_x_y_value_scatter
-                    or nxd.is_image
-                    or nxd.is_stack
-                ):
-                    # invalid: cannot be plotted by any widget
-                    self.isInvalidNXdata = True
+                self.isInvalidNXdata = False
             elif nx_class == "NXdata":
                 # group claiming to be NXdata could not be parsed
                 self.isInvalidNXdata = True


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

The fact that a NXdata cannot be plotted does not mean that it is invalid. Also, `DataInfo` should not worry about plotting: it is up to the views to declare if they can plot NXdata. 
