### PR TITLE
silx.gui.widgets.IntEdit: Add IntEdit widget (rather make it public)

### DIFF
--- a/doc/source/modules/gui/widgets/editwidgets.rst
+++ b/doc/source/modules/gui/widgets/editwidgets.rst
@@ -1,0 +1,24 @@
+
+.. currentmodule:: silx.gui.widgets
+
+Edition widgets
+===============
+
+:mod:`FloatEdit`
+--------------------
+
+.. automodule:: silx.gui.widgets.FloatEdit
+
+.. autoclass:: silx.gui.widgets.FloatEdit.FloatEdit
+   :members:
+   :show-inheritance:
+
+
+:mod:`IntEdit`
+--------------------
+
+.. automodule:: silx.gui.widgets.IntEdit
+
+.. autoclass:: silx.gui.widgets.IntEdit.IntEdit
+   :members:
+   :show-inheritance:

--- a/doc/source/modules/gui/widgets/index.rst
+++ b/doc/source/modules/gui/widgets/index.rst
@@ -13,6 +13,7 @@ Public modules:
     :maxdepth: 2
 
     collapsiblewidget.rst
+    editwidgets.rst
     flowlayout.rst
     framebrowser.rst
     periodictable.rst

--- a/src/silx/gui/plot/actions/histogram.py
+++ b/src/silx/gui/plot/actions/histogram.py
@@ -46,6 +46,7 @@ from silx.gui import qt
 from silx.gui.plot import items
 from silx.gui.widgets.ElidedLabel import ElidedLabel
 from silx.gui.widgets.RangeSlider import RangeSlider
+from silx.gui.widgets.IntEdit import IntEdit
 
 _logger = logging.getLogger(__name__)
 
@@ -94,137 +95,6 @@ class _StatWidget(qt.QWidget):
         self.__valueWidget.setText("-" if value is None else f"{value:.5g}")
 
 
-class _IntEdit(qt.QLineEdit):
-    """QLineEdit for integers with a default value and update on validation.
-
-    :param QWidget parent:
-    """
-
-    sigValueChanged = qt.Signal(int)
-    """Signal emitted when the value has changed (on editing finished)"""
-
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        self.__value = None
-        self.setAlignment(qt.Qt.AlignRight)
-        validator = qt.QIntValidator()
-        self.setValidator(validator)
-        validator.bottomChanged.connect(self.__updateSize)
-        validator.topChanged.connect(self.__updateSize)
-        self.__updateSize()
-
-        self.textEdited.connect(self.__textEdited)
-
-    def __updateSize(self, *args):
-        """Update widget's maximum size according to bounds"""
-        bottom, top = self.getRange()
-        nbchar = max(len(str(bottom)), len(str(top)))
-        font = self.font()
-        font.setStyle(qt.QFont.StyleItalic)
-        fontMetrics = qt.QFontMetrics(font)
-        self.setMaximumWidth(fontMetrics.boundingRect("0" * (nbchar + 1)).width())
-        self.setMaxLength(nbchar)
-
-    def __textEdited(self, _):
-        if self.font().style() != qt.QFont.StyleItalic:
-            font = self.font()
-            font.setStyle(qt.QFont.StyleItalic)
-            self.setFont(font)
-
-    # Use events rather than editingFinished to also trigger with empty text
-
-    def focusOutEvent(self, event):
-        self.__commitValue()
-        return super().focusOutEvent(event)
-
-    def keyPressEvent(self, event):
-        if event.key() in (qt.Qt.Key_Enter, qt.Qt.Key_Return):
-            self.__commitValue()
-        return super().keyPressEvent(event)
-
-    def __commitValue(self):
-        """Update the value returned by :meth:`getValue`"""
-        value = self.getCurrentValue()
-        if value is None:
-            value = self.getDefaultValue()
-            if value is None:
-                return  # No value, keep previous one
-
-        if self.font().style() != qt.QFont.StyleNormal:
-            font = self.font()
-            font.setStyle(qt.QFont.StyleNormal)
-            self.setFont(font)
-
-        if value != self.__value:
-            self.__value = value
-            self.sigValueChanged.emit(value)
-
-    def getValue(self) -> int | None:
-        """Return current value (None if never set)."""
-        return self.__value
-
-    def setRange(self, bottom: int, top: int):
-        """Set the range of valid values"""
-        self.validator().setRange(bottom, top)
-
-    def getRange(self) -> tuple[int, int]:
-        """Returns the current range of valid values
-
-        :returns: (bottom, top)
-        """
-        return self.validator().bottom(), self.validator().top()
-
-    def __validate(self, value: int, extend_range: bool):
-        """Ensure value is in range
-
-        :param int value:
-        :param bool extend_range:
-            True to extend range if needed.
-            False to clip value if needed.
-        """
-        if extend_range:
-            bottom, top = self.getRange()
-            self.setRange(min(value, bottom), max(value, top))
-        return numpy.clip(value, *self.getRange())
-
-    def setDefaultValue(self, value: int, extend_range: bool = False):
-        """Set default value when QLineEdit is empty
-
-        :param int value:
-        :param bool extend_range:
-            True to extend range if needed.
-            False to clip value if needed
-        """
-        self.setPlaceholderText(str(self.__validate(value, extend_range)))
-        if self.getCurrentValue() is None:
-            self.__commitValue()
-
-    def getDefaultValue(self) -> int | None:
-        """Return the default value or the bottom one if not set"""
-        try:
-            return int(self.placeholderText())
-        except ValueError:
-            return None
-
-    def setCurrentValue(self, value: int, extend_range: bool = False):
-        """Set the currently displayed value
-
-        :param int value:
-        :param bool extend_range:
-            True to extend range if needed.
-            False to clip value if needed
-        """
-        self.setText(str(self.__validate(value, extend_range)))
-        self.__commitValue()
-
-    def getCurrentValue(self) -> int | None:
-        """Returns the displayed value or None if not correct"""
-        try:
-            return int(self.text())
-        except ValueError:
-            return None
-
-
 class HistogramWidget(qt.QWidget):
     """Widget displaying a histogram and some statistic indicators"""
 
@@ -261,7 +131,7 @@ class HistogramWidget(qt.QWidget):
 
         controlsLayout.addWidget(qt.QLabel("<b>Histogram:<b>"))
         controlsLayout.addWidget(qt.QLabel("N. bins:"))
-        self.__nbinsLineEdit = _IntEdit(self)
+        self.__nbinsLineEdit = IntEdit(self)
         self.__nbinsLineEdit.setRange(2, 9999)
         self.__nbinsLineEdit.sigValueChanged.connect(self.__updateHistogramFromControls)
         controlsLayout.addWidget(self.__nbinsLineEdit)

--- a/src/silx/gui/widgets/IntEdit.py
+++ b/src/silx/gui/widgets/IntEdit.py
@@ -1,0 +1,134 @@
+import numpy
+
+from silx.gui import qt
+
+
+class IntEdit(qt.QLineEdit):
+    """QLineEdit for integers with a default value and update on validation.
+
+    :param QWidget parent:
+    """
+
+    sigValueChanged = qt.Signal(int)
+    """Signal emitted when the value has changed (on editing finished)"""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.__value = None
+        self.setAlignment(qt.Qt.AlignRight)
+        validator = qt.QIntValidator()
+        self.setValidator(validator)
+        validator.bottomChanged.connect(self.__updateSize)
+        validator.topChanged.connect(self.__updateSize)
+        self.__updateSize()
+
+        self.textEdited.connect(self.__textEdited)
+
+    def __updateSize(self, *args):
+        """Update widget's maximum size according to bounds"""
+        bottom, top = self.getRange()
+        nbchar = max(len(str(bottom)), len(str(top)))
+        font = self.font()
+        font.setStyle(qt.QFont.StyleItalic)
+        fontMetrics = qt.QFontMetrics(font)
+        self.setMaximumWidth(fontMetrics.boundingRect("0" * (nbchar + 1)).width())
+        self.setMaxLength(nbchar)
+
+    def __textEdited(self, _):
+        if self.font().style() != qt.QFont.StyleItalic:
+            font = self.font()
+            font.setStyle(qt.QFont.StyleItalic)
+            self.setFont(font)
+
+    # Use events rather than editingFinished to also trigger with empty text
+
+    def focusOutEvent(self, event):
+        self.__commitValue()
+        return super().focusOutEvent(event)
+
+    def keyPressEvent(self, event):
+        if event.key() in (qt.Qt.Key_Enter, qt.Qt.Key_Return):
+            self.__commitValue()
+        return super().keyPressEvent(event)
+
+    def __commitValue(self):
+        """Update the value returned by :meth:`getValue`"""
+        value = self.getCurrentValue()
+        if value is None:
+            value = self.getDefaultValue()
+            if value is None:
+                return  # No value, keep previous one
+
+        if self.font().style() != qt.QFont.StyleNormal:
+            font = self.font()
+            font.setStyle(qt.QFont.StyleNormal)
+            self.setFont(font)
+
+        if value != self.__value:
+            self.__value = value
+            self.sigValueChanged.emit(value)
+
+    def getValue(self) -> int | None:
+        """Return current value (None if never set)."""
+        return self.__value
+
+    def setRange(self, bottom: int, top: int):
+        """Set the range of valid values"""
+        self.validator().setRange(bottom, top)
+
+    def getRange(self) -> tuple[int, int]:
+        """Returns the current range of valid values
+
+        :returns: (bottom, top)
+        """
+        return self.validator().bottom(), self.validator().top()
+
+    def __validate(self, value: int, extend_range: bool):
+        """Ensure value is in range
+
+        :param int value:
+        :param bool extend_range:
+            True to extend range if needed.
+            False to clip value if needed.
+        """
+        if extend_range:
+            bottom, top = self.getRange()
+            self.setRange(min(value, bottom), max(value, top))
+        return numpy.clip(value, *self.getRange())
+
+    def setDefaultValue(self, value: int, extend_range: bool = False):
+        """Set default value when QLineEdit is empty
+
+        :param int value:
+        :param bool extend_range:
+            True to extend range if needed.
+            False to clip value if needed
+        """
+        self.setPlaceholderText(str(self.__validate(value, extend_range)))
+        if self.getCurrentValue() is None:
+            self.__commitValue()
+
+    def getDefaultValue(self) -> int | None:
+        """Return the default value or the bottom one if not set"""
+        try:
+            return int(self.placeholderText())
+        except ValueError:
+            return None
+
+    def setCurrentValue(self, value: int, extend_range: bool = False):
+        """Set the currently displayed value
+
+        :param int value:
+        :param bool extend_range:
+            True to extend range if needed.
+            False to clip value if needed
+        """
+        self.setText(str(self.__validate(value, extend_range)))
+        self.__commitValue()
+
+    def getCurrentValue(self) -> int | None:
+        """Returns the displayed value or None if not correct"""
+        try:
+            return int(self.text())
+        except ValueError:
+            return None

--- a/src/silx/gui/widgets/test/test_intedit.py
+++ b/src/silx/gui/widgets/test/test_intedit.py
@@ -1,0 +1,60 @@
+import pytest
+
+from silx.gui.widgets.IntEdit import IntEdit
+
+
+@pytest.fixture
+def intEdit(qWidgetFactory):
+    widget = qWidgetFactory(IntEdit)
+    yield widget
+
+
+def test_value(intEdit: IntEdit):
+    intEdit.setCurrentValue(150)
+    assert intEdit.getCurrentValue() == 150
+    assert intEdit.getValue() == 150
+
+    intEdit.setCurrentValue(-50)
+    assert intEdit.getCurrentValue() == -50
+    assert intEdit.getValue() == -50
+
+    intEdit.setCurrentValue(5.5)
+    assert intEdit.getCurrentValue() is None
+    assert intEdit.getValue() == -50
+
+
+def test_default_value(intEdit: IntEdit):
+    intEdit.setDefaultValue(145)
+    assert intEdit.getCurrentValue() is None
+    assert intEdit.getValue() == 145
+
+    intEdit.setCurrentValue(50)
+    assert intEdit.getCurrentValue() == 50
+    assert intEdit.getValue() == 50
+
+    intEdit.setCurrentValue(9.1)
+    assert intEdit.getCurrentValue() is None
+    assert intEdit.getValue() == 145
+
+
+def test_range(intEdit: IntEdit):
+    intEdit.setRange(-10, 20)
+    assert intEdit.getRange() == (-10, 20)
+
+    intEdit.setCurrentValue(25)
+    assert intEdit.getCurrentValue() == 20
+    assert intEdit.getValue() == 20
+
+    intEdit.setCurrentValue(-50)
+    assert intEdit.getCurrentValue() == -10
+    assert intEdit.getValue() == -10
+
+    intEdit.setCurrentValue(25, extend_range=True)
+    assert intEdit.getCurrentValue() == 25
+    assert intEdit.getValue() == 25
+    assert intEdit.getRange() == (-10, 25)
+
+    intEdit.setCurrentValue(-20, extend_range=True)
+    assert intEdit.getCurrentValue() == -20
+    assert intEdit.getValue() == -20
+    assert intEdit.getRange() == (-20, 25)


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

As discussed previsouly @t20100 , `IntEdit` could be useful in other projects as `FloatEdit`. 

This PR makes it public and adds tests and references to it in the doc.