### PR TITLE
silx.io.nxdata: Added support for "rgb-image" NeXus interpretation

### DIFF
--- a/src/silx/gui/data/DataViews.py
+++ b/src/silx/gui/data/DataViews.py
@@ -1711,7 +1711,7 @@ class _NXdataImageView(_NXdataBaseDataView):
         nxd = nxdata.get_default(data, validate=False)
         if nxd is None:
             return
-        isRgba = nxd.interpretation == "rgba-image"
+        isRgba = nxd.interpretation in ("rgb-image", "rgba-image")
 
         self._updateColormap(nxd)
 

--- a/src/silx/io/nxdata/_utils.py
+++ b/src/silx/io/nxdata/_utils.py
@@ -39,14 +39,17 @@ __date__ = "17/04/2018"
 
 nxdata_logger = logging.getLogger("silx.io.nxdata")
 
-Interpretation = Literal["scalar", "spectrum", "image", "rgba-image", "vertex"]
+Interpretation = Literal[
+    "scalar", "spectrum", "image", "rgb-image", "rgba-image", "vertex"
+]
 
 
 INTERPDIM: dict[Interpretation, int] = {
     "scalar": 0,
     "spectrum": 1,
     "image": 2,
-    "rgba-image": 3,  # "hsla-image": 3, "cmyk-image": 3, # TODO
+    "rgb-image": 3,
+    "rgba-image": 3,
     "vertex": 1,
 }  # 3D scatter: 1D signal + 3 axes (x, y, z) of same legth
 """Number of signal dimensions associated to each possible @interpretation
@@ -180,7 +183,7 @@ def validate_number_of_axes(
             issues.append(
                 f"Unrecognized @interpretation={interpretation} for data with wrong number of defined @axes"
             )
-        elif interpretation == "rgba-image":
+        elif interpretation in ("rgb-image", "rgba-image"):
             if ndims != 3 or group[signal_name].shape[-1] not in [3, 4]:
                 issues.append(
                     "Inconsistent RGBA Image. Expected 3 dimensions with "

--- a/src/silx/io/nxdata/parse.py
+++ b/src/silx/io/nxdata/parse.py
@@ -496,7 +496,8 @@ class NXdata:
             "scalar",
             "spectrum",
             "image",
-            "rgba-image",  # "hsla-image", "cmyk-image"
+            "rgb-image",
+            "rgba-image",
             "vertex",
         ]
 
@@ -636,7 +637,7 @@ class NXdata:
             if self.is_scatter and ndims == 1:
                 # case of a 1D signal with arbitrary number of axes
                 return list(axes_dataset_names)
-            if self.interpretation != "rgba-image":
+            if self.interpretation not in ("rgb-image", "rgba-image"):
                 # @axes may only define 1 or 2 axes if @interpretation=spectrum/image.
                 # Use the existing names for the last few dims, and prepend with Nones.
                 assert len(axes_dataset_names) == INTERPDIM[self.interpretation]
@@ -855,7 +856,7 @@ class NXdata:
     @property
     def is_image(self) -> bool:
         """True if the signal is 2D, or 3D with last dimension of length 3 or 4
-        and interpretation *rgba-image*, or >2D with interpretation *image*.
+        and interpretation *[rgb|rgba]-image*, or >2D with interpretation *image*.
         The axes (if any) length must also be consistent with the signal shape.
         """
         if not self.is_valid:
@@ -865,9 +866,13 @@ class NXdata:
             return False
         if self.signal_is_0d or self.signal_is_1d:
             return False
-        if not self.signal_is_2d and self.interpretation not in ["image", "rgba-image"]:
+        if not self.signal_is_2d and self.interpretation not in [
+            "image",
+            "rgb-image",
+            "rgba-image",
+        ]:
             return False
-        if self.signal_is_3d and self.interpretation == "rgba-image":
+        if self.signal_is_3d and self.interpretation in ("rgb-image", "rgba-image"):
             if self.signal.shape[-1] not in [3, 4]:
                 return False
             img_axes = self.axes[0:2]
@@ -884,7 +889,7 @@ class NXdata:
     @property
     def is_stack(self) -> bool:
         """True in the signal is at least 3D and interpretation is not
-        "scalar", "spectrum", "image" or "rgba-image".
+        "scalar", "spectrum", "image", "rgb-image" or "rgba-image".
         The axes length must also be consistent with the last 3 dimensions
         of the signal.
         """
@@ -896,6 +901,7 @@ class NXdata:
             "scaler",
             "spectrum",
             "image",
+            "rgb-image",
             "rgba-image",
         ]:
             return False

--- a/src/silx/io/test/test_nxdata.py
+++ b/src/silx/io/test/test_nxdata.py
@@ -361,7 +361,9 @@ class TestNXdata:
             assert not nxd.is_x_y_value_scatter
             assert nxd.interpretation == "image"
 
-    def testRGBAImage(self, tmp_path):
+    @pytest.mark.parametrize("interpretation", ("rgb-image", "rgba-image"))
+    @pytest.mark.parametrize("nchannels", (3, 4))
+    def testRGBAImage(self, tmp_path, interpretation, nchannels):
         with h5py.File(tmp_path / "nxdata_rgba_image.h5", "w") as h5f:
             group = h5f.create_group("rgba_image")
             group.attrs["NX_class"] = "NXdata"
@@ -369,12 +371,14 @@ class TestNXdata:
             group.attrs["axes"] = numpy.array(
                 ["rows_calib", "columns_coordinates"], dtype=text_dtype
             )
-            rgba_image = numpy.linspace(0, 1, num=7 * 8 * 3).reshape((7, 8, 3))
+            rgba_image = numpy.linspace(0, 1, num=7 * 8 * nchannels).reshape(
+                (7, 8, nchannels)
+            )
             rgba_image[:, :, 1] = (
                 1 - rgba_image[:, :, 1]
             )  # invert G channel to add some color
             ds = group.create_dataset("image", data=rgba_image)
-            ds.attrs["interpretation"] = "rgba-image"
+            ds.attrs["interpretation"] = interpretation
             ds = group.create_dataset("rows_calib", data=(10, 5))
             ds.attrs["long_name"] = "Calibrated Y"
             group.create_dataset(
@@ -386,7 +390,7 @@ class TestNXdata:
             nxd = nxdata.NXdata(group)
 
             assert nxd.is_image
-            assert nxd.interpretation == "rgba-image"
+            assert nxd.interpretation == interpretation
             assert nxd.signal_is_3d
             assert nxd.axes_names == ["Calibrated Y", "columns_coordinates", None]
             assert list(nxd.axes_dataset_names) == [


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

This PR adds support for for "@interpretation=rgb-image" to nxdata parsing, to DataViewer and so to silx view.