### PR TITLE
silx.gui.data: Fixed issue with NXdata 2D signal and "rgb-image" interpretation

### DIFF
--- a/src/silx/gui/data/DataViews.py
+++ b/src/silx/gui/data/DataViews.py
@@ -1292,7 +1292,11 @@ class _NXdataImageView(_NXdataBaseDataView):
         nxd = nxdata.get_default(data, validate=False)
         if nxd is None:
             return
-        isRgba = nxd.interpretation in ("rgb-image", "rgba-image")
+        isRgba = (
+            nxd.interpretation in ("rgb-image", "rgba-image")
+            and nxd.signal_ndim >= 3
+            and nxd.signal.shape[-1] in (3, 4)
+        )
 
         self._updateColormap(nxd)
 


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

This PR fixes an exception raised when opening a NXdata group with "rgba-image" interpretation and a 2D array signal dataset.
This PR proposes to ignore the RGBA interpretation in this case and display the 2D array as an image.

Exception raised without this PR:
```
ERROR:silx.app.view.main:<class 'KeyError'> 'Axes X and Y not found. Was an image loaded?'   File "silx/gui/data/DataViewer.py", line 298, in __setDataInView
    self.__currentView.setData(self.__displayedData)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "silx/gui/data/DataViews.py", line 647, in setData
    self.__currentView.setData(data)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "silx/gui/data/DataViews.py", line 1720, in setData
    widget.setImageData(
    ~~~~~~~~~~~~~~~~~~~^
        [nxd.signal] + nxd.auxiliary_signals,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
        isRgba=isRgba,
        ^^^^^^^^^^^^^^
    )
    ^
  File "silx/gui/data/NXdataWidgets.py", line 514, in setImageData
    self._updateImageAxes()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "silx/gui/data/NXdataWidgets.py", line 538, in _updateImageAxes
    raise KeyError("Axes X and Y not found. Was an image loaded?")
```