### PR TITLE
silx.gui.plot: Change tooltips for X and Y orientation actions

### DIFF
--- a/src/silx/gui/plot/PlotToolButtons.py
+++ b/src/silx/gui/plot/PlotToolButtons.py
@@ -41,17 +41,15 @@ __date__ = "27/06/2017"
 
 import functools
 import logging
-from typing import TypedDict
 
-from .. import icons
-from .. import qt
 from ... import config
 from ...utils.deprecation import deprecated_warning
-from .tools.PlotToolButton import PlotToolButton
-
-from .items import SymbolMixIn, Scatter
+from .. import icons, qt
+from ._utils.axis_orientation_states import X_AXIS_STATE, Y_AXIS_STATE, AxisState
+from .items import Scatter, SymbolMixIn
 from .items.axis import XAxis, YAxis, YRightAxis
 from .PlotWidget import PlotWidget
+from .tools.PlotToolButton import PlotToolButton
 
 _logger = logging.getLogger(__name__)
 
@@ -126,12 +124,6 @@ class AspectToolButton(PlotToolButton):
         self.setToolTip(toolTip)
 
 
-class _AxisState(TypedDict):
-    icon: qt.QIcon
-    state: str
-    action: str
-
-
 class _AxisOriginToolButton(PlotToolButton):
     """Tool button to switch the axis orientation of a plot."""
 
@@ -157,12 +149,12 @@ class _AxisOriginToolButton(PlotToolButton):
     def _getAxis(self, plot: PlotWidget):
         raise NotImplementedError()
 
-    def _getState(self, inverted: bool) -> _AxisState:
+    def _getState(self, inverted: bool) -> AxisState:
         raise NotImplementedError()
 
     def _createAction(self, inverted: bool) -> qt.QAction:
         state = self._getState(inverted)
-        return qt.QAction(state["icon"], state["action"], self)
+        return qt.QAction(icons.getQIcon(state["icon"]), state["action"], self)
 
     def _connectPlot(self, plot: PlotWidget):
         axis = self._getAxis(plot)
@@ -194,7 +186,7 @@ class _AxisOriginToolButton(PlotToolButton):
 
     def _axisInvertedChanged(self, inverted: bool):
         state = self._getState(inverted)
-        self.setIcon(state["icon"])
+        self.setIcon(icons.getQIcon(state["icon"]))
         self.setToolTip(state["state"])
 
 
@@ -202,38 +194,16 @@ class XAxisOriginToolButton(_AxisOriginToolButton):
     def _getAxis(self, plot: PlotWidget) -> XAxis:
         return plot.getXAxis()
 
-    def _getState(self, inverted: bool) -> _AxisState:
-        if inverted:
-            return {
-                "icon": icons.getQIcon("plot-xleft"),
-                "state": "X-axis goes from right to left",
-                "action": "Orient X-axis from right to left",
-            }
-        else:
-            return {
-                "icon": icons.getQIcon("plot-xright"),
-                "state": "X-axis goes from left to right",
-                "action": "Orient X-axis from left to right",
-            }
+    def _getState(self, inverted: bool) -> AxisState:
+        return X_AXIS_STATE[inverted]
 
 
 class YAxisOriginToolButton(_AxisOriginToolButton):
     def _getAxis(self, plot: PlotWidget) -> YAxis | YRightAxis:
         return plot.getYAxis()
 
-    def _getState(self, inverted: bool) -> _AxisState:
-        if inverted:
-            return {
-                "icon": icons.getQIcon("plot-ydown"),
-                "state": "Y-axis is oriented downward",
-                "action": "Orient Y-axis downward",
-            }
-        else:
-            return {
-                "icon": icons.getQIcon("plot-yup"),
-                "state": "Y-axis is oriented upward",
-                "action": "Orient Y-axis upward",
-            }
+    def _getState(self, inverted: bool) -> AxisState:
+        return Y_AXIS_STATE[inverted]
 
     def setYAxisUpward(self):
         deprecated_warning(

--- a/src/silx/gui/plot/_utils/axis_orientation_states.py
+++ b/src/silx/gui/plot/_utils/axis_orientation_states.py
@@ -1,0 +1,36 @@
+from typing import TypedDict
+
+InversionState = bool
+
+
+class AxisState(TypedDict):
+    icon: str
+    state: str
+    action: str
+
+
+Y_AXIS_STATE: dict[InversionState, AxisState] = {
+    True: {
+        "icon": "plot-ydown",
+        "state": "Y-axis origin is at the top",
+        "action": "Set Y-axis origin at the top",
+    },
+    False: {
+        "icon": "plot-yup",
+        "state": "Y-axis origin is at the bottom",
+        "action": "Set Y-axis origin at the bottom",
+    },
+}
+
+X_AXIS_STATE: dict[InversionState, AxisState] = {
+    True: {
+        "icon": "plot-xleft",
+        "state": "X-axis origin is on the right",
+        "action": "Set X-axis origin on the right",
+    },
+    False: {
+        "icon": "plot-xright",
+        "state": "X-axis origin is on the left",
+        "action": "Set X-axis origin on the left",
+    },
+}

--- a/src/silx/gui/plot/actions/control.py
+++ b/src/silx/gui/plot/actions/control.py
@@ -49,15 +49,13 @@ __authors__ = ["V.A. Sole", "T. Vincent", "P. Knobel"]
 __license__ = "MIT"
 __date__ = "27/11/2020"
 
-from . import PlotAction
-import logging
+from silx.gui import icons, qt
 from silx.gui.plot import items
 from silx.gui.plot._utils import applyZoomToPlot as _applyZoomToPlot
-from silx.gui import qt
-from silx.gui import icons
 from silx.utils.deprecation import deprecated
 
-_logger = logging.getLogger(__name__)
+from .._utils.axis_orientation_states import Y_AXIS_STATE
+from . import PlotAction
 
 
 class ResetZoomAction(PlotAction):
@@ -537,18 +535,12 @@ class YAxisInvertedAction(PlotAction):
     """
 
     def __init__(self, plot, parent=None):
-        # Uses two images for checked/unchecked states
-        self._states = {
-            False: (icons.getQIcon("plot-ydown"), "Orient Y axis downward"),
-            True: (icons.getQIcon("plot-yup"), "Orient Y axis upward"),
-        }
-
-        icon, tooltip = self._states[plot.getYAxis().isInverted()]
+        state = Y_AXIS_STATE[plot.getYAxis().isInverted()]
         super().__init__(
             plot,
-            icon=icon,
+            icon=icons.getQIcon(state["icon"]),
             text="Invert Y Axis",
-            tooltip=tooltip,
+            tooltip=state["action"],
             triggered=self._actionTriggered,
             checkable=False,
             parent=parent,
@@ -557,9 +549,9 @@ class YAxisInvertedAction(PlotAction):
 
     def _yAxisInvertedChanged(self, inverted):
         """Handle Plot set y axis inverted signal"""
-        icon, tooltip = self._states[inverted]
-        self.setIcon(icon)
-        self.setToolTip(tooltip)
+        new_state = Y_AXIS_STATE[inverted]
+        self.setIcon(icons.getQIcon(new_state["icon"]))
+        self.setToolTip(new_state["action"])
 
     def _actionTriggered(self, checked=False):
         # This will trigger _yAxisInvertedChanged


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

Fix #4452 

I introduced a new module to hold the tooltips since it was used at two places.