### PR TITLE
silx.utils.ExternalResources: remove clean_up method

### DIFF
--- a/src/silx/utils/ExternalResources.py
+++ b/src/silx/utils/ExternalResources.py
@@ -137,9 +137,6 @@ class ExternalResources:
                             self.save_json()
                     self._initialized = True
 
-    def clean_up(self):
-        pass
-
     def getfile(self, filename):
         """Downloads the requested file from web-server available
         at https://www.silx.org/pub/silx/


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

Fix #4360 