### PR TITLE
silx.io.fabioh5.FabioReader: Convert to scalar strings to np.str_ rather than np.bytes_

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = ["Development Status :: 5 - Production/Stable",
 dependencies = [
    'numpy',
    'packaging',
-   'h5py',
+   'h5py >= 3',
    'fabio',
    'pydantic >= 2',
 ]

--- a/src/silx/io/commonh5.py
+++ b/src/silx/io/commonh5.py
@@ -168,36 +168,7 @@ class Dataset(Node):
 
     def __init__(self, name, data, parent=None, attrs=None):
         Node.__init__(self, name, parent, attrs=attrs)
-        if data is not None:
-            self._check_data(data)
         self.__data = data
-
-    def _check_data(self, data):
-        """Check that the data provided by the dataset is valid.
-
-        It is valid when it can be stored in a HDF5 using h5py.
-
-        :param numpy.ndarray data: Data associated to the dataset
-        :raises TypeError: In the case the data is not valid.
-        """
-        if isinstance(data, (str, bytes)):
-            return
-
-        chartype = data.dtype.char
-        if chartype == "U":
-            pass
-        elif chartype == "O":
-            d = h5py.special_dtype(vlen=data.dtype)
-            if d is not None:
-                return
-            d = h5py.special_dtype(ref=data.dtype)
-            if d is not None:
-                return
-        else:
-            return
-
-        msg = "Type of the dataset '%s' is not supported. Found '%s'."
-        raise TypeError(msg % (self.name, data.dtype))
 
     def _set_data(self, data):
         """Set the data exposed by the dataset.
@@ -207,7 +178,6 @@ class Dataset(Node):
 
         :param numpy.ndarray data: Data associated to the dataset
         """
-        self._check_data(data)
         self.__data = data
 
     def _get_data(self):

--- a/src/silx/io/fabioh5.py
+++ b/src/silx/io/fabioh5.py
@@ -630,13 +630,7 @@ class FabioReader:
     def _convert_value(
         self, value: list | dict | str | bytes | None
     ) -> (
-        numpy.ndarray
-        | numpy.void
-        | numpy.floating
-        | numpy.integer
-        | numpy.bytes_
-        | numpy.str_
-        | None
+        numpy.ndarray | numpy.void | numpy.floating | numpy.integer | numpy.str_ | None
     ):
         """Convert an object into a numpy object (scalar or array).
 
@@ -674,7 +668,7 @@ class FabioReader:
 
     def _convert_scalar_value(
         self, value: str
-    ) -> numpy.bytes_ | numpy.integer | numpy.floating:
+    ) -> numpy.str_ | numpy.integer | numpy.floating:
         """Convert a string into a numpy int or float.
 
         If it is not possible it returns a numpy string.
@@ -685,42 +679,30 @@ class FabioReader:
             try:
                 return numpy.float64(value)
             except ValueError:
-                pass
+                return numpy.str_(value)
         else:
             dtype = numpy.min_scalar_type(int_value)
             if dtype.kind in "iu":  # dtype is object for too big int
                 return dtype.type(int_value)
-        return numpy.bytes_(value)
+            return numpy.str_(value)
 
-    def _convert_list(self, value: str) -> numpy.ndarray | numpy.bytes_ | numpy.str_:
+    def _convert_list(self, value: str) -> numpy.ndarray | numpy.str_:
         """Convert a string into a typed numpy array.
 
         If it is not possible it returns a numpy string.
         """
         try:
-            numpy_values = []
-            values = value.split(" ")
-            types = set()
-            for string_value in values:
-                v = self._convert_scalar_value(string_value)
-                numpy_values.append(v)
-                types.add(v.dtype.type)
-
-            result_type = numpy.result_type(*types)
-
-            if issubclass(result_type.type, (numpy.bytes_, bytes)):
-                # use the raw data to create the result
-                return numpy.bytes_(value)
-            elif issubclass(result_type.type, (numpy.str_, str)):
-                # use the raw data to create the result
-                return numpy.str_(value)
-            else:
-                if len(types) == 1:
-                    return numpy.array(numpy_values, dtype=result_type)
-                else:
-                    return numpy.array(values, dtype=result_type)
+            raw_values = value.split(" ")
         except ValueError:
-            return numpy.bytes_(value)
+            return numpy.str_(value)
+
+        converted_values = [self._convert_scalar_value(v) for v in raw_values]
+        result_type = numpy.result_type(*converted_values)
+
+        if issubclass(result_type.type, (numpy.str_, str)):
+            return numpy.str_(value)
+
+        return numpy.array(converted_values, dtype=result_type)
 
     def has_sample_information(self):
         """Returns true if there is information about the sample in the

--- a/src/silx/io/test/test_commonh5.py
+++ b/src/silx/io/test/test_commonh5.py
@@ -26,7 +26,6 @@ __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "21/09/2017"
 
-import logging
 import numpy
 import unittest
 import tempfile
@@ -40,8 +39,6 @@ try:
     from .. import commonh5
 except ImportError:
     commonh5 = None
-
-_logger = logging.getLogger(__name__)
 
 
 class _TestCommonFeatures(unittest.TestCase):
@@ -268,11 +265,8 @@ class TestSpecificCommonH5(unittest.TestCase):
 
     def test_create_unicode_dataset(self):
         f = commonh5.File(name="Foo", mode="w")
-        try:
-            f.create_dataset("foo", data=numpy.array("aaaa"))
-            self.fail()
-        except TypeError:
-            pass
+        f.create_dataset("foo", data=numpy.array("aaaa"))
+        self.assertEqual(f["foo"][()], "aaaa")
 
     def test_setitem_dataset(self):
         self.h5 = commonh5.File(name="Foo", mode="w")

--- a/src/silx/io/test/test_fabioh5.py
+++ b/src/silx/io/test/test_fabioh5.py
@@ -170,8 +170,8 @@ class TestFabioH5(unittest.TestCase):
     def test_metadata_string(self):
         dataset = self.h5_image["/scan_0/instrument/detector_0/others/string"]
         self.assertEqual(dataset.h5py_class, h5py.Dataset)
-        self.assertEqual(dataset[()], numpy.bytes_("hi!"))
-        self.assertEqual(dataset.dtype.type, numpy.bytes_)
+        self.assertEqual(dataset[()], "hi!")
+        self.assertEqual(dataset.dtype.type, numpy.str_)
         self.assertEqual(dataset.shape, (1,))
 
     def test_metadata_list_integer(self):
@@ -195,8 +195,8 @@ class TestFabioH5(unittest.TestCase):
             "/scan_0/instrument/detector_0/others/string_looks_like_list"
         ]
         self.assertEqual(dataset.h5py_class, h5py.Dataset)
-        self.assertEqual(dataset[()], numpy.bytes_("2000 hi!"))
-        self.assertEqual(dataset.dtype.type, numpy.bytes_)
+        self.assertEqual(dataset[()], "2000 hi!")
+        self.assertEqual(dataset.dtype.type, numpy.str_)
         self.assertEqual(dataset.shape, (1,))
 
     def test_float_32(self):
@@ -624,4 +624,17 @@ def test_tiff_open_info(tmp_path):
     numpy.testing.assert_equal(image_data[()], data)
 
     info = h5_image["scan_0/measurement/image_0/info"]
-    assert info["others/software"][()] == "silx".encode()
+    assert info["others/software"][()] == "silx"
+
+
+def test_tiff_unicode_info(tmp_path):
+    data = numpy.array([[0, 0], [0, 0]], dtype=numpy.int8)
+    filename = str(tmp_path / "test.tiff")
+    tiff = TiffIO.TiffIO(filename, mode="w")
+    tiff.writeImage(data, info={"dimensions": "2 \xd7 2"})
+
+    h5_image = fabioh5.File(file_name=filename)
+    info = h5_image["scan_0/measurement/image_0/info/others/info"][0, 0]
+
+    assert info["key"] == "dimensions"
+    assert info["value"] == numpy.str_("2 \xd7 2")


### PR DESCRIPTION

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

Fix #4495

Since h5py v3, `np.str` is handled just fine so we don't have to manually convert to `np.bytes`. This simplifies the code and solves the bug reported in https://github.com/silx-kit/silx/issues/4495#issuecomment-4035846647.
