### PR TITLE
silx.gui.data.RgbaImagePlot: Added new widget to plot NXdata RGBA images

### DIFF
--- a/src/silx/gui/data/DataViews.py
+++ b/src/silx/gui/data/DataViews.py
@@ -40,6 +40,7 @@ from silx.gui.plot.items.image import ImageDataAggregated
 from silx.gui.plot.actions.image import AggregationModeAction
 from ._DataInfo import DataInfo
 from ._DataView import DataView
+from ._RgbaImagePlot import RgbaImagePlot
 
 # DataViewHooks is part of the public API of this module
 from ._DataView import DataViewHooks  # noqa: F401
@@ -1303,7 +1304,6 @@ class _NXdataImageView(_NXdataBaseDataView):
             axes_names=nxd.axes_names,
             axes_scales=nxd.plot_style.axes_scale_types,
             title=nxd.title,
-            isRgba=False,
         )
 
     def getDataPriority(self, data, info: DataInfo):
@@ -1327,10 +1327,7 @@ class _NXDataRgbaImageView(_NXdataBaseDataView):
         _NXdataBaseDataView.__init__(self, parent, modeId=NXDATA_RGBA_IMAGE_MODE)
 
     def createWidget(self, parent):
-        from silx.gui.data.NXdataWidgets import ArrayImagePlot
-
-        widget = ArrayImagePlot(parent)
-        return widget
+        return RgbaImagePlot(parent)
 
     def axesNames(self, data, info):
         # disabled (used by default axis selector widget in Hdf5Viewer)
@@ -1345,17 +1342,13 @@ class _NXDataRgbaImageView(_NXdataBaseDataView):
         if nxd is None:
             return
 
-        self._updateColormap(nxd)
-
-        widget: ArrayImagePlot = self.getWidget()
+        widget: RgbaImagePlot = self.getWidget()
         widget.setImageData(
             [nxd.signal] + nxd.auxiliary_signals,
             axes=nxd.axes,
-            signals_names=[nxd.signal_name] + nxd.auxiliary_signals_names,
-            axes_names=nxd.axes_names,
-            axes_scales=nxd.plot_style.axes_scale_types,
+            signalsNames=[nxd.signal_name] + nxd.auxiliary_signals_names,
+            axesNames=nxd.axes_names,
             title=nxd.title,
-            isRgba=True,
         )
 
     def getDataPriority(self, data, info: DataInfo):

--- a/src/silx/gui/data/NXdataWidgets.py
+++ b/src/silx/gui/data/NXdataWidgets.py
@@ -29,21 +29,24 @@ __date__ = "12/11/2018"
 
 import logging
 from typing import Literal
-import numpy
+
 import h5py
+import numpy
 
 from silx.gui import qt
+from silx.gui.colors import Colormap
+from silx.gui.data._RgbaImagePlot import BaseImagePlot
+from silx.gui.data._SignalSelector import SignalSelector
 from silx.gui.data.NumpyAxesSelector import NumpyAxesSelector
-from silx.gui.plot import Plot1D, Plot2D, StackView, ScatterView, items
+from silx.gui.plot import Plot1D, ScatterView, StackView, items
+from silx.gui.plot.actions.image import AggregationModeAction
 from silx.gui.plot.ComplexImageView import ComplexImageView
 from silx.gui.plot.items.image_aggregated import ImageDataAggregated
-from silx.gui.plot.actions.image import AggregationModeAction
-from silx.gui.colors import Colormap
-from silx.gui.data._SignalSelector import SignalSelector
-
 from silx.io.commonh5 import Dataset
-from silx.io.nxdata._utils import get_attr_as_unicode
-from silx.math.calibration import ArrayCalibration, NoCalibration, LinearCalibration
+from silx.math.calibration import ArrayCalibration, LinearCalibration, NoCalibration
+
+from ._utils import getAxesCalib, setImageCoords
+from ..utils import blockSignals
 
 _logger = logging.getLogger(__name__)
 
@@ -366,7 +369,7 @@ class XYVScatterPlot(qt.QWidget):
         self._plot.getPlotWidget().clear()
 
 
-class ArrayImagePlot(qt.QWidget):
+class ArrayImagePlot(BaseImagePlot):
     """
     Widget for plotting an image from a multi-dimensional signal array
     and two 1D axes array.
@@ -387,11 +390,8 @@ class ArrayImagePlot(qt.QWidget):
         :param parent: Parent QWidget
         """
         super().__init__(parent)
+        self._axesScales = None
 
-        self.__signals = None
-        self.__signals_names = None
-
-        self._plot = Plot2D(self)
         self._plot.setDefaultColormap(
             Colormap(
                 name="viridis", vmin=None, vmax=None, normalization=Colormap.LINEAR
@@ -399,23 +399,6 @@ class ArrayImagePlot(qt.QWidget):
         )
         self._plot.getIntensityHistogramAction().setVisible(True)
         self._plot.setKeepDataAspectRatio(True)
-        maskToolWidget = self._plot.getMaskToolsDockWidget().widget()
-        maskToolWidget.setItemMaskUpdated(True)
-
-        self._axesSelector = NumpyAxesSelector(self)
-        self._axesSelector.selectionChanged.connect(self._updateImage)
-        self._axesSelector.selectedAxisChanged.connect(self._updateImageAxes)
-
-        self._signalSelector = SignalSelector(parent=self)
-        self._signalSelector.selectionChanged.connect(self._signalChanges)
-        self._signalSelector.setToolTip("Select signal")
-
-        layout = qt.QVBoxLayout()
-        layout.addWidget(self._plot)
-        layout.addWidget(self._axesSelector)
-        layout.addWidget(self._signalSelector)
-
-        self.setLayout(layout)
 
         self.__aggregationModeAction = AggregationModeAction(parent=self)
         self.getPlot().toolBar().addAction(self.__aggregationModeAction)
@@ -438,16 +421,6 @@ class ArrayImagePlot(qt.QWidget):
                 self.getAggregationModeAction().getAggregationMode()
             )
 
-    def _signalChanges(self, value):
-        self._updateImageAxes()
-
-    def getPlot(self):
-        """Returns the plot used for the display
-
-        :rtype: Plot2D
-        """
-        return self._plot
-
     def setImageData(
         self,
         signals: list[h5py.Dataset | Dataset],
@@ -456,7 +429,6 @@ class ArrayImagePlot(qt.QWidget):
         axes_names: list[str] | None = None,
         axes_scales: list[Literal["linear", "log"] | None] | None = None,
         title: str | None = None,
-        isRgba: bool = False,
     ):
         """
         Sets signals, axes and axes metadata that will be used to set the displayed image.
@@ -469,114 +441,41 @@ class ArrayImagePlot(qt.QWidget):
         :param title: Graph title
         :param isRgba: True if data is a 3D RGBA image
         """
-        self._axesSelector.selectionChanged.disconnect(self._updateImage)
-        self._axesSelector.selectedAxisChanged.disconnect(self._updateImageAxes)
-        self._signalSelector.selectionChanged.disconnect(self._signalChanges)
+        if len(signals) == 0:
+            raise ValueError("Cannot set image data from empty signals")
+        self._signals = signals
+        self._axes = axes
+        self._axesNames = axes_names
+        self._axesScales = axes_scales
+        self._title = title
 
-        self.__signals = signals
-        self.__signals_names = signals_names
-        self.__axes = axes
-        self.__axes_names = axes_names
-        self.__axes_scales = axes_scales
-        self.__title = title
-
-        self._axesSelector.clear()
-
-        if not isRgba:
+        with blockSignals(self._axesSelector, self._signalSelector):
+            self._axesSelector.clear()
             self._axesSelector.setAxisNames(["Y", "X"])
             self._axesSelector.setNamedAxesSelectorVisibility(True)
-            img_ndim = 2
-        else:
-            self._axesSelector.setAxisNames(["Y", "X", "RGB(A) channel"])
-            self._axesSelector.setNamedAxesSelectorVisibility(False)
-            img_ndim = 3
-        # Labels need to be set before the data
-        if self.__axes_names:
-            self._axesSelector.setLabels(self.__axes_names)
-        self._axesSelector.setData(signals[0])
 
-        if len(signals[0].shape) <= img_ndim:
-            self._axesSelector.hide()
-        else:
-            self._axesSelector.show()
+            # Labels need to be set before the data
+            if self._axesNames:
+                self._axesSelector.setLabels(self._axesNames)
+            self._axesSelector.setData(signals[0])
 
-        self._signalSelector.setSignalNames(signals_names)
-        if len(signals) > 1:
-            self._signalSelector.show()
-        else:
-            self._signalSelector.hide()
-        self._signalSelector.setSignalIndex(0)
+            if len(signals[0].shape) <= 2:
+                self._axesSelector.hide()
+            else:
+                self._axesSelector.show()
 
-        self._axesSelector.selectionChanged.connect(self._updateImage)
-        self._axesSelector.selectedAxisChanged.connect(self._updateImageAxes)
-        self._signalSelector.selectionChanged.connect(self._signalChanges)
+            self._signalSelector.setSignalNames(signals_names)
+            if len(signals) > 1:
+                self._signalSelector.show()
+            else:
+                self._signalSelector.hide()
+            self._signalSelector.setSignalIndex(0)
 
         self._updateImageAxes()
         self._plot.resetZoom()
 
-    def __getImageToDisplay(self):
-        signal_index = self._signalSelector.getSignalIndex()
-        try:
-            signal = self.__signals[signal_index]
-        except KeyError:
-            raise KeyError("No image found. Was an image loaded?")
-        return signal[self._axesSelector.selection()]
-
-    def _updateImageAxes(self):
+    def _addItemToPlot(self, xAxis, yAxis):
         """Updates the image axes. Called when the user selects a different axis than the displayed one."""
-        signal_index = self._signalSelector.getSignalIndex()
-        legend = self.__signals_names[signal_index]
-
-        image = self.__getImageToDisplay()
-
-        axis_indices = self._axesSelector.getIndicesOfNamedAxes()
-        try:
-            x_axis_index = axis_indices["X"]
-            y_axis_index = axis_indices["Y"]
-        except KeyError:
-            raise KeyError("Axes X and Y not found. Was an image loaded?")
-
-        if self.__axes:
-            x_axis = self.__axes[x_axis_index]
-            y_axis = self.__axes[y_axis_index]
-            x_units = get_attr_as_unicode(x_axis, "units") if x_axis else None
-            y_units = get_attr_as_unicode(y_axis, "units") if y_axis else None
-        else:
-            x_axis = None
-            y_axis = None
-            x_units = None
-            y_units = None
-        self._plot.setKeepDataAspectRatio(x_units == y_units)
-
-        if x_axis is None and y_axis is None:
-            xcalib = NoCalibration()
-            ycalib = NoCalibration()
-        else:
-            if x_axis is None:
-                # no calibration
-                x_axis = numpy.arange(image.shape[1])
-            elif numpy.isscalar(x_axis) or len(x_axis) == 1:
-                # constant axis
-                x_axis = x_axis * numpy.ones((image.shape[1],))
-            elif len(x_axis) == 2:
-                # linear calibration
-                x_axis = x_axis[0] * numpy.arange(image.shape[1]) + x_axis[1]
-
-            if y_axis is None:
-                y_axis = numpy.arange(image.shape[0])
-            elif numpy.isscalar(y_axis) or len(y_axis) == 1:
-                y_axis = y_axis * numpy.ones((image.shape[0],))
-            elif len(y_axis) == 2:
-                y_axis = y_axis[0] * numpy.arange(image.shape[0]) + y_axis[1]
-
-            try:
-                xcalib = ArrayCalibration(x_axis)
-            except ValueError:
-                xcalib = NoCalibration()
-            try:
-                ycalib = ArrayCalibration(y_axis)
-            except ValueError:
-                ycalib = NoCalibration()
 
         self._plot.remove(
             kind=(
@@ -584,90 +483,43 @@ class ArrayImagePlot(qt.QWidget):
                 "image",
             )
         )
-
-        if xcalib.is_affine() and ycalib.is_affine():
-            # regular image
-            xorigin, xscale = xcalib(0), xcalib.get_slope()
-            yorigin, yscale = ycalib(0), ycalib.get_slope()
-            origin = (xorigin, yorigin)
-            scale = (xscale, yscale)
-
-            self._plot.getXAxis().setScale("linear")
-            self._plot.getYAxis().setScale("linear")
-
-            if image.ndim == 2:
-                imageItem = ImageDataAggregated()
-                imageItem.setColormap(self._plot.getDefaultColormap())
-                imageItem.setAggregationMode(
-                    self.getAggregationModeAction().getAggregationMode()
-                )
-            elif image.ndim == 3:
-                imageItem = items.ImageRgba()
-            else:
-                raise ValueError(f"image dims should be 2 or 3. Got {image.ndim}")
-            imageItem.setName(legend)
+        image = self._getImageToDisplay()
+        xCalib, yCalib = getAxesCalib(image, xAxis, yAxis)
+        if xCalib.is_affine() and yCalib.is_affine():
+            if image.ndim != 2:
+                raise ValueError(f"image dims should be 2. Got {image.ndim}")
+            imageItem = ImageDataAggregated()
+            imageItem.setColormap(self._plot.getDefaultColormap())
+            imageItem.setAggregationMode(
+                self.getAggregationModeAction().getAggregationMode()
+            )
+            setImageCoords(imageItem, xCalib, yCalib)
+            imageItem.setName(self._signalSelector.getCurrentSignalName())
             imageItem.setData(image)
-            imageItem.setOrigin(origin)
-            imageItem.setScale(scale)
 
             self._plot.addItem(imageItem)
             self._plot.setActiveImage(imageItem)
+            self._plot.getXAxis().setScale("linear")
+            self._plot.getYAxis().setScale("linear")
         else:
-            if self.__axes_scales:
-                xaxisscale = self.__axes_scales[x_axis_index]
-                yaxisscale = self.__axes_scales[y_axis_index]
+            if self._axesScales:
+                xAxisIndex, yAxisIndex = self._getXYIndices()
+                xAxisScale = self._axesScales[xAxisIndex]
+                yAxisScale = self._axesScales[yAxisIndex]
             else:
-                xaxisscale = None
-                yaxisscale = None
+                xAxisScale = None
+                yAxisScale = None
 
-            if xaxisscale is not None:
-                self._plot.getXAxis().setScale(
-                    "log" if xaxisscale == "log" else "linear"
-                )
-            if yaxisscale is not None:
-                self._plot.getYAxis().setScale(
-                    "log" if yaxisscale == "log" else "linear"
-                )
+            self._plot.setXAxisLogarithmic(xAxisScale == "log")
+            self._plot.setYAxisLogarithmic(yAxisScale == "log")
 
-            scatterx, scattery = numpy.meshgrid(x_axis, y_axis)
-            # fixme: i don't think this can handle "irregular" RGBA images
+            xScatter, yScatter = numpy.meshgrid(xAxis, yAxis)
             self._plot.addScatter(
-                numpy.ravel(scatterx),
-                numpy.ravel(scattery),
+                numpy.ravel(xScatter),
+                numpy.ravel(yScatter),
                 numpy.ravel(image),
-                legend=legend,
+                legend=self._signalSelector.getCurrentSignalName(),
             )
-
-        self._plot.setGraphTitle(self._graphTitle())
-        self._plot.getXAxis().setLabel(self.__axes_names[x_axis_index])
-        self._plot.getYAxis().setLabel(self.__axes_names[y_axis_index])
-        self._plot.resetZoom()
-
-    def clear(self):
-        old = self._axesSelector.blockSignals(True)
-        self._axesSelector.clear()
-        self._axesSelector.blockSignals(old)
-        self._plot.clear()
-
-    def _updateImage(self):
-        """Updates the image itself. Called when the user slices through the image without changing the axes."""
-        image = self.__getImageToDisplay()
-        activeImageItem = self._plot.getActiveImage()
-        if activeImageItem:
-            activeImageItem.setData(image)
-
-    def _graphTitle(self) -> str:
-        signal_index = self._signalSelector.getSignalIndex()
-        title = self.__title
-        if not title:
-            if not self.__signals_names:
-                return ""
-            return self.__signals_names[signal_index]
-
-        if self.__signals_names and len(self.__signals_names) > 1:
-            # Append dataset name only when there are many datasets
-            title += "\n" + self.__signals_names[signal_index]
-        return title
 
 
 class ArrayComplexImagePlot(qt.QWidget):
@@ -813,36 +665,7 @@ class ArrayComplexImagePlot(qt.QWidget):
         x_axis = self.__x_axis
         y_axis = self.__y_axis
 
-        if x_axis is None and y_axis is None:
-            xcalib = NoCalibration()
-            ycalib = NoCalibration()
-        else:
-            if x_axis is None:
-                # no calibration
-                x_axis = numpy.arange(image.shape[1])
-            elif numpy.isscalar(x_axis) or len(x_axis) == 1:
-                # constant axis
-                x_axis = x_axis * numpy.ones((image.shape[1],))
-            elif len(x_axis) == 2:
-                # linear calibration
-                x_axis = x_axis[0] * numpy.arange(image.shape[1]) + x_axis[1]
-
-            if y_axis is None:
-                y_axis = numpy.arange(image.shape[0])
-            elif numpy.isscalar(y_axis) or len(y_axis) == 1:
-                y_axis = y_axis * numpy.ones((image.shape[0],))
-            elif len(y_axis) == 2:
-                y_axis = y_axis[0] * numpy.arange(image.shape[0]) + y_axis[1]
-
-            try:
-                xcalib = ArrayCalibration(x_axis)
-            except ValueError:
-                xcalib = NoCalibration()
-            try:
-                ycalib = ArrayCalibration(y_axis)
-            except ValueError:
-                ycalib = NoCalibration()
-
+        xcalib, ycalib = getAxesCalib(image.shape[0:2], x_axis, y_axis)
         self._plot.setData(image)
         if xcalib.is_affine():
             xorigin, xscale = xcalib(0), xcalib.get_slope()

--- a/src/silx/gui/data/_BaseImagePlot.py
+++ b/src/silx/gui/data/_BaseImagePlot.py
@@ -1,0 +1,119 @@
+import h5py
+
+from ...io.commonh5 import Dataset
+from ...io.nxdata import get_attr_as_unicode
+from .. import qt
+from ..plot import Plot2D
+from ..plot.items import ImageBase
+from ..plot.MaskToolsWidget import MaskToolsWidget
+from ..utils import blockSignals
+from ._SignalSelector import SignalSelector
+from ._utils import ImageAxis
+from .NumpyAxesSelector import NumpyAxesSelector
+
+
+class BaseImagePlot(qt.QWidget):
+    """
+    Widget for plotting images with a multi-dimensional signal array
+    and two 1D axes array.
+    """
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self._signals: list[h5py.Dataset | Dataset] = []
+        self._axes: list[h5py.Dataset | Dataset] = []
+        self._axesNames: list[str] = []
+        self._title = ""
+
+        self._plot = Plot2D(self)
+        self._plot.setKeepDataAspectRatio(True)
+        maskToolWidget = self._plot.getMaskToolsDockWidget().widget()
+        if isinstance(maskToolWidget, MaskToolsWidget):
+            maskToolWidget.setItemMaskUpdated(True)
+
+        self._axesSelector = NumpyAxesSelector(self)
+        self._axesSelector.selectionChanged.connect(self._updateImage)
+        self._axesSelector.selectedAxisChanged.connect(self._updateImageAxes)
+
+        self._signalSelector = SignalSelector(parent=self)
+        self._signalSelector.selectionChanged.connect(self._updateImageAxes)
+        self._signalSelector.setToolTip("Select signal")
+
+        layout = qt.QVBoxLayout()
+        layout.addWidget(self._plot)
+        layout.addWidget(self._axesSelector)
+        layout.addWidget(self._signalSelector)
+
+        self.setLayout(layout)
+
+    def getPlot(self) -> Plot2D:
+        return self._plot
+
+    def _getImageToDisplay(self):
+        signalIndex = self._signalSelector.getSignalIndex()
+        try:
+            signal = self._signals[signalIndex]
+        except KeyError:
+            raise KeyError("No image found. Was an image loaded?")
+        return signal[self._axesSelector.selection()]
+
+    def _getImageName(self):
+        if len(self._signalSelector.getSignalNames()) > 0:
+            return self._signalSelector.getCurrentSignalName()
+        return ""
+
+    def _updateImageAxes(self):
+        """Updates the image axes. Called when the user selects a different axis than the displayed one."""
+
+        xAxisIndex, yAxisIndex = self._getXYIndices()
+        if self._axes:
+            xAxis = self._axes[xAxisIndex]
+            yAxis = self._axes[yAxisIndex]
+            xUnits = get_attr_as_unicode(xAxis, "units") if xAxis else None
+            yUnits = get_attr_as_unicode(yAxis, "units") if yAxis else None
+        else:
+            xAxis = None
+            yAxis = None
+            xUnits = None
+            yUnits = None
+        self._plot.setKeepDataAspectRatio(xUnits == yUnits)
+
+        self._addItemToPlot(xAxis, yAxis)
+
+        self._plot.setGraphTitle(self._graphTitle())
+        self._plot.setGraphXLabel(self._axesNames[xAxisIndex])
+        self._plot.setGraphYLabel(self._axesNames[yAxisIndex])
+        self._plot.resetZoom()
+
+    def _addItemToPlot(self, xAxis: ImageAxis, yAxis: ImageAxis):
+        raise NotImplementedError()
+
+    def clear(self):
+        with blockSignals(self._axesSelector):
+            self._axesSelector.clear()
+        self._plot.clear()
+
+    def _updateImage(self):
+        """Updates the image itself. Called when the user slices through the image without changing the axes."""
+        image = self._getImageToDisplay()
+        activeImageItem = self._plot.getActiveImage()
+        if isinstance(activeImageItem, ImageBase):
+            activeImageItem.setData(image)
+
+    def _graphTitle(self) -> str:
+        title = self._title
+        if not title:
+            return self._getImageName()
+
+        if len(self._signals) > 1:
+            # Append dataset name only when there are many datasets
+            return f"{title}\n{self._getImageName()}"
+        return title
+
+    def _getXYIndices(self) -> tuple[int, int]:
+        axisIndices = self._axesSelector.getIndicesOfNamedAxes()
+        try:
+            return axisIndices["X"], axisIndices["Y"]
+        except KeyError:
+            raise KeyError("Axes X and Y not found. Was an image loaded?")

--- a/src/silx/gui/data/_RgbaImagePlot.py
+++ b/src/silx/gui/data/_RgbaImagePlot.py
@@ -1,0 +1,83 @@
+import h5py
+
+from ...io.commonh5 import Dataset
+from ..plot import items
+from ..utils import blockSignals
+from ._BaseImagePlot import BaseImagePlot
+from ._utils import ImageAxis, getAxesCalib, setImageCoords
+
+
+class RgbaImagePlot(BaseImagePlot):
+    """
+    Widget for plotting a RGB(A) image with a multi-dimensional signal array
+    and two 1D axes array.
+    """
+
+    def setImageData(
+        self,
+        signals: list[h5py.Dataset | Dataset],
+        axes: list[h5py.Dataset | Dataset] | None = None,
+        signalsNames: list[str] | None = None,
+        axesNames: list[str] | None = None,
+        title: str | None = None,
+    ):
+        """
+        Sets signals, axes and axes metadata that will be used to set the displayed image.
+
+        :param signals: list of n-D datasets or list of 3D datasets interpreted as RGBA image.
+        :param axes: list of 1D datasets to be used as axes
+        :param signals_names: Names for each image, used as subtitle and legend.
+        :param axes_names: Names for each axis, used as graph label.
+        :param axes_scales: Scale of axes in (None, 'linear', 'log')
+        :param title: Graph title
+        """
+        if len(signals) == 0:
+            raise ValueError("Cannot set image data from empty signals")
+        if axes is None:
+            axes = []
+        if signalsNames is None:
+            signalsNames = []
+
+        self._signals = signals
+        self._axes = axes
+        self._title = title
+
+        with blockSignals(self._axesSelector, self._signalSelector):
+            self._axesSelector.clear()
+            self._axesSelector.setAxisNames(["Y", "X", "RGB(A) channel"])
+            self._axesSelector.setNamedAxesSelectorVisibility(False)
+
+            # Labels need to be set before the data
+            if axesNames:
+                self._axesNames = axesNames
+                self._axesSelector.setLabels(axesNames)
+            self._axesSelector.setData(signals[0])
+
+            if len(signals[0].shape) <= 3:
+                self._axesSelector.hide()
+            else:
+                self._axesSelector.show()
+            if signalsNames:
+                self._signalSelector.setSignalNames(signalsNames)
+            if len(signals) > 1:
+                self._signalSelector.show()
+            else:
+                self._signalSelector.hide()
+            self._signalSelector.setSignalIndex(0)
+
+        self._updateImageAxes()
+        self._plot.resetZoom()
+
+    def _addItemToPlot(self, xAxis: ImageAxis, yAxis: ImageAxis):
+        image = self._getImageToDisplay()
+
+        if image.ndim != 3:
+            raise ValueError(f"image dims should be 3. Got {image.ndim}")
+        imageItem = items.ImageRgba()
+        imageItem.setName(self._getImageName())
+        imageItem.setData(image)
+        xCalib, yCalib = getAxesCalib(image.shape[0:2], xAxis, yAxis)
+        setImageCoords(imageItem, xCalib, yCalib)
+
+        self._plot.addItem(imageItem)
+        self._plot.setActiveImage(imageItem)

--- a/src/silx/gui/data/_SignalSelector.py
+++ b/src/silx/gui/data/_SignalSelector.py
@@ -43,3 +43,6 @@ class SignalSelector(qt.QWidget):
 
     def getSignalIndex(self) -> int:
         return self._combobox.currentIndex()
+
+    def getCurrentSignalName(self) -> str:
+        return self._combobox.currentText()

--- a/src/silx/gui/data/_utils.py
+++ b/src/silx/gui/data/_utils.py
@@ -1,9 +1,20 @@
 import numbers
 
+import h5py
 import numpy
 
+from ...io.commonh5 import Dataset
 from ...io.nxdata.parse import NXdata
+from ...math.calibration import (
+    AbstractCalibration,
+    ArrayCalibration,
+    LinearCalibration,
+    NoCalibration,
+)
 from ..hdf5 import H5Node
+from ..plot.items import ImageBase
+
+ImageAxis = h5py.Dataset | Dataset | None
 
 
 def normalizeData(data):
@@ -39,3 +50,32 @@ def isRgba(nxd: NXdata) -> bool:
         and nxd.signal_ndim >= 3
         and nxd.signal.shape[-1] in (3, 4)
     )
+
+
+def _getAxisCalib(x_axis: ImageAxis, axis_length: int) -> AbstractCalibration:
+    if x_axis is None:
+        # no calibration
+        return ArrayCalibration(numpy.arange(axis_length))
+    if numpy.isscalar(x_axis) or len(x_axis) == 1:
+        # constant axis
+        return ArrayCalibration(x_axis * numpy.ones((axis_length,)))
+    if len(x_axis) == 2:
+        # linear calibration
+        return LinearCalibration(slope=x_axis[0], y_intercept=x_axis[1])
+    raise ValueError("Expected a scalar or two values. Got {x_axis}.")
+
+
+def getAxesCalib(
+    image_shape: tuple[int, int], x_axis: ImageAxis, y_axis: ImageAxis
+) -> tuple[AbstractCalibration, AbstractCalibration]:
+    if x_axis is None and y_axis is None:
+        return NoCalibration(), NoCalibration()
+
+    return _getAxisCalib(x_axis, image_shape[1]), _getAxisCalib(y_axis, image_shape[0])
+
+
+def setImageCoords(
+    item: ImageBase, xcalib: AbstractCalibration, ycalib: AbstractCalibration
+):
+    item.setOrigin((xcalib(0), ycalib(0)))
+    item.setScale((xcalib.get_slope(), ycalib.get_slope()))

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -2317,10 +2317,10 @@ class PlotWidget(qt.QMainWindow):
         """
         return self._getActiveItem(kind="image", just_legend=just_legend)
 
-    def setActiveImage(self, legend: str) -> str | None:
+    def setActiveImage(self, legend: str | items.ImageBase) -> str | None:
         """Make the image associated to legend the active image.
 
-        :param str legend: The legend associated to the image
+        :param legend: The legend associated to the image
                            or None to have no active image.
         """
         return self._setActiveItem(kind="image", item=legend)


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

For #4434 

Last refactoring step before moving to the actual bug fix.

In this PR, I breakdown the `ArrayImagePlot` widget that handles RGBA images in two widgets: 
- `ArrayImagePlot` that only handle images (regular or irregular, but no RGBA)
- `RgbaImagePlot` that only handle regular RGBA images

To avoid copy-pasting too much code, I created a new base widget `BaseImagePlot` that abstract a lot of common behaviour of the two aforementionned widgets.

I also introduced some utility functions that can be used elsewhere (e.g. `ArrayComplexImagePlot`). There is still some duplication but I think it was reduced and I had to stop refactoring at some point :clown_face: 

The changelist may be a bit too big but I'll try to underline the changes in comments. If needed, I can break down in several commits.
