### PR TITLE
Fix Test: with h5py 3.16 the earliest libver is lower than v110 which does not support SWMR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = ["Development Status :: 5 - Production/Stable",
 dependencies = [
    'numpy',
    'packaging',
-   'h5py < 3.16',
+   'h5py',
    'fabio',
    'pydantic >= 2',
 ]

--- a/src/silx/io/test/test_h5py_utils.py
+++ b/src/silx/io/test/test_h5py_utils.py
@@ -153,9 +153,14 @@ class TestH5pyUtils(unittest.TestCase):
         self._subtest_options = {"mode": "w"}
         self.filename_generator = self._filenames()
         yield self._subtest_options
+
+        self._subtest_options = {"mode": "w", "libver": "v110"}
+        self.filename_generator = self._filenames()
+        yield self._subtest_options
+
         self._subtest_options = {"mode": "w", "libver": "latest"}
         self.filename_generator = self._filenames()
-        yield
+        yield self._subtest_options
 
     def _filenames(self):
         i = 1
@@ -332,6 +337,12 @@ class TestH5pyUtils(unittest.TestCase):
     @subtests
     @unittest.skipIf(not h5py_utils.HAS_SWMR, "SWMR not supported")
     def test_modes_multi_process_swmr(self):
+        libver = self._subtest_options.get("libver", "earliest")
+        if libver == "earliest":
+            self.skipTest(
+                "HDF5 file version is 'earliest': SWMR is not always supported since it needs v110"
+            )
+
         filename = self._new_filename()
 
         with self._open_context(filename, mode="w", libver="latest") as f:


### PR DESCRIPTION
For #4499

Subtests: no libver, libver=v110, libver=latest

The test that was failing is now skipped when no libver. Seems like h5py 3.16 saves files by default with an older libver than older h5py versions.