### PR TITLE
silx.io.ndata.parse.NXdata: Deprecated attributes related to kind of plot and `signal_is_Nd`

### DIFF
--- a/src/silx/gui/data/_utils.py
+++ b/src/silx/gui/data/_utils.py
@@ -47,7 +47,7 @@ def normalizeComplex(data):
 def isRgba(nxd: NXdata) -> bool:
     return (
         nxd.interpretation in ("rgb-image", "rgba-image")
-        and nxd.signal_ndim >= 3
+        and nxd.signal.ndim >= 3
         and nxd.signal.shape[-1] in (3, 4)
     )
 

--- a/src/silx/io/nxdata/parse.py
+++ b/src/silx/io/nxdata/parse.py
@@ -47,6 +47,7 @@ import h5py
 import numpy
 
 from silx.io.utils import is_group, is_file, is_dataset, h5py_read_dataset
+from silx.utils.deprecation import deprecated
 
 from ._utils import (
     Interpretation,
@@ -192,11 +193,11 @@ class NXdata:
         """Signal long name, as specified in the @long_name attribute of the
         signal dataset. If not specified, the dataset name is used."""
 
-        self.signal_ndim = None
-        self.signal_is_0d = None
-        self.signal_is_1d = None
-        self.signal_is_2d = None
-        self.signal_is_3d = None
+        self._signal_ndim = None
+        self._signal_is_0d = None
+        self._signal_is_1d = None
+        self._signal_is_2d = None
+        self._signal_is_3d = None
 
         self.axes_names = None
         """List of axes names in a NXdata group.
@@ -212,13 +213,12 @@ class NXdata:
             self.signal = self.group[self.signal_dataset_name]
             self.signal_name = get_dataset_name(self.group, self.signal_dataset_name)
 
-            # ndim will be available in very recent h5py versions only
-            self.signal_ndim = getattr(self.signal, "ndim", len(self.signal.shape))
+            self._signal_ndim = self.signal.ndim
 
-            self.signal_is_0d = self.signal_ndim == 0
-            self.signal_is_1d = self.signal_ndim == 1
-            self.signal_is_2d = self.signal_ndim == 2
-            self.signal_is_3d = self.signal_ndim == 3
+            self._signal_is_0d = self._signal_ndim == 0
+            self._signal_is_1d = self._signal_ndim == 1
+            self._signal_is_2d = self._signal_ndim == 2
+            self._signal_is_3d = self._signal_ndim == 3
 
             self.axes_names = [
                 get_dataset_name(self.group, dsname)
@@ -226,11 +226,36 @@ class NXdata:
             ]
 
             # excludes scatters
-            self.signal_is_1d = (
-                self.signal_is_1d and len(self.axes) <= 1
+            self._signal_is_1d = (
+                self._signal_is_1d and len(self.axes) <= 1
             )  # excludes n-D scatters
 
             self._plot_style = _SilxStyle(self)
+
+    @property
+    @deprecated(since_version="3.0.0")
+    def signal_ndim(self) -> int:
+        return self._signal_ndim
+
+    @property
+    @deprecated(since_version="3.0.0")
+    def signal_is_0d(self) -> int:
+        return self._signal_is_0d
+
+    @property
+    @deprecated(since_version="3.0.0")
+    def signal_is_1d(self) -> int:
+        return self._signal_is_1d
+
+    @property
+    @deprecated(since_version="3.0.0")
+    def signal_is_2d(self) -> int:
+        return self._signal_is_2d
+
+    @property
+    @deprecated(since_version="3.0.0")
+    def signal_is_3d(self) -> int:
+        return self._signal_is_3d
 
     def _validate(self):
         """Fill :attr:`issues` with error messages for each error found."""
@@ -635,7 +660,7 @@ class NXdata:
                 axes_dataset_names[i] = None
 
         if len(axes_dataset_names) != ndims:
-            if self.is_scatter and ndims == 1:
+            if self.__is_scatter() and ndims == 1:
                 # case of a 1D signal with arbitrary number of axes
                 return list(axes_dataset_names)
             if self.interpretation not in ("rgb-image", "rgba-image"):
@@ -788,16 +813,13 @@ class NXdata:
 
         return self._plot_style
 
-    @property
-    def is_scatter(self) -> bool:
-        """True if the signal is 1D and all the axes have the
-        same size as the signal."""
+    def __is_scatter(self) -> bool:
         if not self.is_valid:
             raise InvalidNXdataError("Unable to parse invalid NXdata")
 
         if self._is_scatter is not None:
             return self._is_scatter
-        if not self.signal_is_1d:
+        if not self.signal.ndim == 1:
             self._is_scatter = False
         else:
             self._is_scatter = True
@@ -814,23 +836,33 @@ class NXdata:
         return self._is_scatter
 
     @property
+    @deprecated(since_version="3.0.0")
+    def is_scatter(self) -> bool:
+        """True if the signal is 1D and all the axes have the
+        same size as the signal."""
+        return self.__is_scatter()
+
+    @property
+    @deprecated(since_version="3.0.0")
     def is_x_y_value_scatter(self) -> bool:
         """True if this is a scatter with a signal and two axes."""
         if not self.is_valid:
             raise InvalidNXdataError("Unable to parse invalid NXdata")
 
-        return self.is_scatter and len(self.axes) == 2
+        return self.__is_scatter() and len(self.axes) == 2
 
     # we currently have no widget capable of plotting 4D data
     @property
+    @deprecated(since_version="3.0.0")
     def is_unsupported_scatter(self) -> bool:
         """True if this is a scatter with a signal and more than 2 axes."""
         if not self.is_valid:
             raise InvalidNXdataError("Unable to parse invalid NXdata")
 
-        return self.is_scatter and len(self.axes) > 2
+        return self.__is_scatter() and len(self.axes) > 2
 
     @property
+    @deprecated(since_version="3.0.0")
     def is_curve(self) -> bool:
         """This property is True if the signal is 1D or :attr:`interpretation` is
         *"spectrum"*, and there is at most one axis with a consistent length.
@@ -838,7 +870,11 @@ class NXdata:
         if not self.is_valid:
             raise InvalidNXdataError("Unable to parse invalid NXdata")
 
-        if self.signal_is_0d or self.interpretation not in [None, "scalar", "spectrum"]:
+        if self.signal.ndim == 0 or self.interpretation not in [
+            None,
+            "scalar",
+            "spectrum",
+        ]:
             return False
         # the axis, if any, must be of the same length as the last dimension
         # of the signal, or of length 2 (a + b *x scale)
@@ -850,11 +886,12 @@ class NXdata:
         if self.interpretation in (None, "scalar"):
             # We no longer test whether x values are monotonic
             # (in the past, in that case, we used to consider it a scatter)
-            return self.signal_is_1d
+            return self.signal.ndim == 1
         # everything looks good
         return True
 
     @property
+    @deprecated(since_version="3.0.0")
     def is_image(self) -> bool:
         """True if the signal is 2D, or 3D with last dimension of length 3 or 4
         and interpretation *[rgb|rgba]-image*, or >2D with interpretation *image*.
@@ -865,15 +902,15 @@ class NXdata:
 
         if self.interpretation == "spectrum":
             return False
-        if self.signal_is_0d or self.signal_is_1d:
+        if self.signal.ndim <= 1:
             return False
-        if not self.signal_is_2d and self.interpretation not in [
+        if not self.signal.ndim == 2 and self.interpretation not in [
             "image",
             "rgb-image",
             "rgba-image",
         ]:
             return False
-        if self.signal_is_3d and self.interpretation in ("rgb-image", "rgba-image"):
+        if self.signal.ndim == 3 and self.interpretation in ("rgb-image", "rgba-image"):
             if self.signal.shape[-1] not in [3, 4]:
                 return False
             img_axes = self.axes[0:2]
@@ -888,6 +925,7 @@ class NXdata:
         return True
 
     @property
+    @deprecated(since_version="3.0.0")
     def is_stack(self) -> bool:
         """True in the signal is at least 3D and interpretation is not
         "scalar", "spectrum", "image", "rgb-image" or "rgba-image".
@@ -897,7 +935,7 @@ class NXdata:
         if not self.is_valid:
             raise InvalidNXdataError("Unable to parse invalid NXdata")
 
-        if self.signal_ndim < 3 or self.interpretation in [
+        if self.signal.ndim < 3 or self.interpretation in [
             "spectrum",
             "image",
             "rgb-image",
@@ -911,6 +949,7 @@ class NXdata:
         return True
 
     @property
+    @deprecated(since_version="3.0.0")
     def is_volume(self) -> bool:
         """True in the signal is exactly 3D and interpretation
             "scalar", or nothing.
@@ -921,7 +960,7 @@ class NXdata:
         if not self.is_valid:
             raise InvalidNXdataError("Unable to parse invalid NXdata")
 
-        if self.signal_ndim != 3:
+        if self.signal.ndim != 3:
             return False
         if self.interpretation not in [None, "scalar"]:
             # 'scalar' for a three dimensional array indicate a scalar field in 3D


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

Following PR #4534, `NXdata.signal_is_Xd|signal_ndim` and `NXdata.is_[scatter|curve|...]` are no longer used in silx code base, so this PR proposes to deprecate them:
- `signal_is_Xd` can be replaced with `signal.ndim == X`
- `is_[scatter|curve|...]` are opinionated interpretation of NXdata information, the aim here would be to have the `NXdata` class more focus and handling: the axes to signal mapping, the axes/signal names and not the interpretation of the NXdata for plots.