### PR TITLE
silx.gui.data.DataViews._NxDataScatter3D: Use first auxiliary signal as scatter sizes

### DIFF
--- a/src/silx/gui/data/DataViews.py
+++ b/src/silx/gui/data/DataViews.py
@@ -38,6 +38,7 @@ from silx.io.nxdata import get_attr_as_unicode
 from silx.io.nxdata.parse import NXdata
 from silx.gui.plot.items.image import ImageDataAggregated
 from silx.gui.plot.actions.image import AggregationModeAction
+from silx.math.combo import min_max
 from ._DataInfo import DataInfo
 from ._DataView import DataView
 from ._RgbaImagePlot import RgbaImagePlot
@@ -1630,6 +1631,15 @@ class _NxDataScatter3D(_NXdataBaseDataView):
         self._scatterItem.setData(
             nxd.axes[0], nxd.axes[1], nxd.axes[2], nxd.signal, copy=False
         )
+
+        if len(nxd.auxiliary_signals) >= 1:
+            sig_min, sig_max = min_max(nxd.auxiliary_signals[0])
+
+            # Scale between 1 and 5
+            sizes = 1 + 4 * (nxd.auxiliary_signals[0][()] - sig_min) / (
+                sig_max - sig_min
+            )
+            self._scatterItem.setSymbolSize(sizes)
 
     def getDataPriority(self, data: Any, info: DataInfo) -> int:
         data = self.normalizeData(data)

--- a/src/silx/gui/data/test/test_nexus_dataviewer.py
+++ b/src/silx/gui/data/test/test_nexus_dataviewer.py
@@ -53,9 +53,11 @@ def test_3d_scatter(qapp, qWidgetFactory, tmp_path):
 
     with h5py.File(tmp_path / "scatter.h5", "w") as h5file:
         h5file.attrs["signal"] = "intensity"
+        h5file.attrs["auxiliary_signals"] = ["sizes"]
         h5file.attrs["axes"] = ("x", "y", "z")
         h5file.attrs["NX_class"] = "NXdata"
         h5file.create_dataset("intensity", data=numpy.random.random((len(x))))
+        h5file.create_dataset("sizes", data=numpy.arange(len(x)))
         h5file.create_dataset("x", data=x)
         h5file.create_dataset("y", data=x)
         h5file.create_dataset("z", data=x)
@@ -76,3 +78,4 @@ def test_3d_scatter(qapp, qWidgetFactory, tmp_path):
         plotItem = plotItems[0]
         assert isinstance(plotItem, Scatter3D)
         numpy.testing.assert_equal(plotItem.getXData(), x)
+        assert len(plotItem.getSymbolSize()) == len(x)


### PR DESCRIPTION
- [x] The use of generative AI is disclosed and described (see [AI policy](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst))
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

Follow-up of  https://github.com/silx-kit/silx/pull/4507
