### PR TITLE
silx.gui.plot3d: Global size parameters now scales symbols with array sizes

### DIFF
--- a/src/silx/gui/plot3d/items/mixins.py
+++ b/src/silx/gui/plot3d/items/mixins.py
@@ -171,6 +171,7 @@ class SymbolMixIn(_SymbolMixIn):
     def __init__(self):
         super().__init__()
         self.__primitive = None
+        self.__sizeScaleFactor = 1.0
 
     def _setPrimitive(self, primitive: primitives.Points):
         """Set the scene primitive on which to set the symbol and size"""
@@ -193,12 +194,21 @@ class SymbolMixIn(_SymbolMixIn):
         super().setSymbolSize(size, copy)
         self._syncPointsPrimitive()
 
+    def getSymbolSizeScaleFactor(self) -> float:
+        return self.__sizeScaleFactor
+
+    def setSymbolSizeScaleFactor(self, sizeScaleFactor: float):
+        self.__sizeScaleFactor = sizeScaleFactor
+        self._syncPointsPrimitive()
+
     def _syncPointsPrimitive(self):
         """Synchronize scene object's symbol and size"""
         if self.__primitive is not None:
             symbol, size = self._getSceneSymbol()
             self.__primitive.marker = symbol
-            self.__primitive.setAttribute("size", size, copy=False)
+            self.__primitive.setAttribute(
+                "size", self.__sizeScaleFactor * size, copy=False
+            )
 
     def _getPickingDistances(self) -> float | numpy.ndarray:
         """Returns distances below which to consider a point as picked
@@ -208,7 +218,7 @@ class SymbolMixIn(_SymbolMixIn):
         _, size = self._getSceneSymbol()
         return numpy.maximum(size / 2, 3.0)
 
-    def _getSceneSymbol(self) -> tuple[str, float | ArrayLike]:
+    def _getSceneSymbol(self) -> tuple[str, float | numpy.ndarray]:
         """Returns a symbol name and size suitable for scene primitives.
 
         :return: (symbol, size)

--- a/src/silx/gui/plot3d/tools/GroupPropertiesWidget.py
+++ b/src/silx/gui/plot3d/tools/GroupPropertiesWidget.py
@@ -185,8 +185,12 @@ class GroupPropertiesWidget(qt.QWidget):
 
         markerSize = self._markerSizeSlider.value()
         for item in group.visit():
-            if isinstance(item, SymbolMixIn) and item.isSingleSymbolSize():
+            if not isinstance(item, SymbolMixIn):
+                continue
+            if item.isSingleSymbolSize():
                 item.setSymbolSize(markerSize)
+            else:
+                item.setSymbolSizeScaleFactor(markerSize)
 
     def _lineWidthButtonClicked(self, checked=False):
         """Handle line width set button clicked"""


### PR DESCRIPTION
- [x] The use of generative AI is disclosed and described (see [AI policy](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst))
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

https://github.com/silx-kit/silx/pull/4538#discussion_r2941041391