### PR TITLE
silx.gui.data.Hdf5TableView: display check icon when the copy of field was done

### DIFF
--- a/src/silx/gui/data/Hdf5TableView.py
+++ b/src/silx/gui/data/Hdf5TableView.py
@@ -600,7 +600,9 @@ class _CopyableQLineEdit(qt.QWidget):
 
         self.setLayout(qt.QHBoxLayout())
         self.layout().addWidget(self._qLineEdit)
-        self._button = qt.QPushButton(icon=qtawesome.icon("mdi6.content-copy"))
+        self._button = qt.QPushButton(
+            icon=qtawesome.icon("mdi6.content-copy", active="mdi6.check")
+        )
         self._button.setFlat(True)
         self.layout().addWidget(self._button)
 


### PR DESCRIPTION


- [x] The use of generative AI is disclosed and described (see [AI policy](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst))
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

Follow-up of https://github.com/silx-kit/silx/pull/4518

[Screencast from 2026-03-16 17-09-34.webm](https://github.com/user-attachments/assets/ff24416e-4c3e-4105-a645-639541d87bf1)



