### PR TITLE
silx.gui.data.NXdataWidgets.ArrayImagePlot: fix error when an image has axis

### DIFF
--- a/src/silx/gui/data/NXdataWidgets.py
+++ b/src/silx/gui/data/NXdataWidgets.py
@@ -485,7 +485,7 @@ class ArrayImagePlot(BaseImagePlot):
             )
         )
         image = self._getImageToDisplay()
-        xCalib, yCalib = getAxesCalib(image, xAxis, yAxis)
+        xCalib, yCalib = getAxesCalib(image.shape[:2], xAxis, yAxis)
         if xCalib.is_affine() and yCalib.is_affine():
             if image.ndim != 2:
                 raise ValueError(f"image dims should be 2. Got {image.ndim}")

--- a/src/silx/gui/data/_utils.py
+++ b/src/silx/gui/data/_utils.py
@@ -62,17 +62,17 @@ def isScatter(nxd: NXdata, naxes: int) -> bool:
     return len(nxd.axes) == naxes
 
 
-def _getAxisCalib(x_axis: ImageAxis, axis_length: int) -> AbstractCalibration:
-    if x_axis is None:
-        # no calibration
+def _getAxisCalib(axis: ImageAxis, axis_length: int) -> AbstractCalibration:
+    if axis is None:
         return ArrayCalibration(numpy.arange(axis_length))
-    if numpy.isscalar(x_axis) or len(x_axis) == 1:
+    if numpy.isscalar(axis) or len(axis) == 1:
         # constant axis
-        return ArrayCalibration(x_axis * numpy.ones((axis_length,)))
-    if len(x_axis) == 2:
+        return ArrayCalibration(axis * numpy.ones((axis_length,)))
+    if len(axis) == 2:
         # linear calibration
-        return LinearCalibration(slope=x_axis[0], y_intercept=x_axis[1])
-    raise ValueError("Expected a scalar or two values. Got {x_axis}.")
+        return LinearCalibration(slope=axis[0], y_intercept=axis[1])
+    # array
+    return ArrayCalibration(axis)
 
 
 def getAxesCalib(

--- a/src/silx/gui/data/test/test_nexus_dataviewer.py
+++ b/src/silx/gui/data/test/test_nexus_dataviewer.py
@@ -3,18 +3,23 @@ import numpy
 
 from silx.gui.data import DataViews
 from silx.gui.data.DataViewer import DataViewer
+from silx.gui.plot import Plot2D
 from silx.gui.plot.items import ImageDataAggregated, ImageRgba
 from silx.gui.plot3d.items import Scatter3D
 
 
-def test_image_no_interpretation(qWidgetFactory, tmp_path):
+def test_image_no_interpretation(qapp, qWidgetFactory, tmp_path):
     widget: DataViewer = qWidgetFactory(DataViewer)
     with h5py.File(tmp_path / "test.h5", "w") as h5file:
         h5file.attrs["NX_class"] = "NXdata"
         h5file.attrs["signal"] = "signal"
-        h5file.create_dataset(name="signal", data=numpy.random.random((100, 100)))
+        h5file.create_dataset(name="signal", data=numpy.random.random((10, 100)))
+        h5file.create_dataset(name="y", data=numpy.arange(-5, 5))
+        h5file.attrs["axes"] = ["y", "."]
 
         widget.setData(h5file["/"])
+
+        qapp.processEvents()
 
         viewClasses = tuple(view.__class__ for view in widget.currentAvailableViews())
         assert viewClasses == (
@@ -23,8 +28,11 @@ def test_image_no_interpretation(qWidgetFactory, tmp_path):
             DataViews._Hdf5View,
         )
         imageView = widget.currentAvailableViews()[0]
-        plot = imageView.getWidget().getPlot()
-        isinstance(plot.getImage("signal"), ImageDataAggregated)
+        plot: Plot2D = imageView.getWidget().getPlot()
+        assert isinstance(plot.getImage("signal"), ImageDataAggregated)
+        # Disable keep aspect ratio so the limits of the axis match the limits of the image
+        plot.setKeepDataAspectRatio(False)
+        assert plot.getYAxis().getLimits() == (-5, 5)
 
 
 def test_rgb_image_with_interpretation(qapp, qWidgetFactory, tmp_path):


### PR DESCRIPTION
- [x] The use of generative AI is disclosed and described (see [AI policy](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst))
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

Henri and I pondered about the calibration to put if the axis was not a scalar or a 2-value array: https://github.com/silx-kit/silx/pull/4525#discussion_r2929586117

We decided to throw an error but in fact, we should return an `ArrayCalibration` since if it is not a scalar nor a 2-value array, it is a regular array :slightly_smiling_face: 

I also updated the test to add axes to prevent regression