### PR TITLE
silx.gui.plot.MaskToolsWidget: improve docstring. 

### DIFF
--- a/src/silx/gui/plot/MaskToolsWidget.py
+++ b/src/silx/gui/plot/MaskToolsWidget.py
@@ -329,6 +329,9 @@ class MaskToolsWidget(BaseMaskToolsWidget):
         :return: None if failed, shape of mask as 2-tuple if successful.
                  The mask can be cropped or padded to fit active image,
                  the returned shape is that of the active image.
+
+        .. warning:: The selection mask is a dedicated item. Its is independent from the `item.item.setMaskData` / `item.item.getMaskData` mechanism.
+
         """
         if mask is None:
             self.resetSelectionMask()


### PR DESCRIPTION
add warning about the difference between the selection mask and the 'item.setMaskData'

- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

<!-- Thank you for your pull request! Please, provide a description of the changes below -->


#### AI Disclosure
- [x] No AI used
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
