### PR TITLE
silx.gui.plot.tools.PlotOptionButton: Updated to use setMenu

### DIFF
--- a/src/silx/gui/plot/tools/_PlotOptionButton.py
+++ b/src/silx/gui/plot/tools/_PlotOptionButton.py
@@ -18,9 +18,9 @@ class PlotOptionButton(PlotToolButton):
         self.setIcon(qtawesome.icon("fa6s.bars"))
 
         self._menu = qt.QMenu(self)
-
-        self.clicked.connect(self._showPlotActionMenu)
         self._menu.aboutToShow.connect(self._customControlButtonMenu)
+        self.setMenu(self._menu)
+        self.setPopupMode(qt.QToolButton.InstantPopup)
 
     def _customControlButtonMenu(self):
         plot = self.plot()
@@ -39,9 +39,6 @@ class PlotOptionButton(PlotToolButton):
         self._menu.addSeparator()
         self._menu.addAction(plot.getCrosshairAction())
         self._menu.addAction(plot.getPanWithArrowKeysAction())
-
-    def _showPlotActionMenu(self):
-        self._menu.exec(self.mapToGlobal(self.rect().bottomLeft()))
 
     def setPlot(self, plot: PlotWindow):
         from ..PlotWindow import PlotWindow  # noqa: F811 avoid cyclic import


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

Replace use of `clicked` signal with `QToolButton.setMenu`.
The down side is the extra array:
<img width="280" height="132" alt="image" src="https://github.com/user-attachments/assets/90a111bd-e26f-4d4b-aa71-18c859f86040" />

closes #4571

#### AI Disclosure
- [x] No AI used
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
