### PR TITLE
silx.gui.plot.stats: Fixed support of PlotWidget items containing no data

### DIFF
--- a/src/silx/gui/plot/items/histogram.py
+++ b/src/silx/gui/plot/items/histogram.py
@@ -142,6 +142,7 @@ class Histogram(
         LineGapColorMixIn.__init__(self)
         YAxisMixIn.__init__(self)
 
+        self._alignement = "center"
         self._histogram = ()
         self._edges = ()
         self._setBaseline(Histogram._DEFAULT_BASELINE)

--- a/src/silx/gui/plot/stats/stats.py
+++ b/src/silx/gui/plot/stats/stats.py
@@ -313,6 +313,12 @@ class _CurveContext(_ScatterCurveHistoMixInContext):
         self.onlimits = onlimits
         xData, yData = item.getData(copy=True)[0:2]
 
+        if xData.size == 0 or yData.size == 0:
+            self.values = None
+            self.min, self.max = None, None
+            self.axes = None
+            return
+
         # Determine mask
         if onlimits:
             # Mask defined by viewport
@@ -373,6 +379,12 @@ class _HistogramContext(_ScatterCurveHistoMixInContext):
 
         yData, edges = item.getData(copy=True)[0:2]
         xData = item._revertComputeEdges(x=edges, histogramType=item.getAlignment())
+
+        if xData.size == 0 or yData.size == 0:
+            self.values = None
+            self.min, self.max = None, None
+            self.axes = None
+            return
 
         # Determine mask
         if onlimits:
@@ -437,6 +449,12 @@ class _ScatterContext(_ScatterCurveHistoMixInContext):
         valueData = item.getValueData(copy=True)
         xData = item.getXData(copy=True)
         yData = item.getYData(copy=True)
+
+        if valueData.size == 0:
+            self.values = None
+            self.min, self.max = None, None
+            self.axes = None
+            return
 
         # Determine mask
         if onlimits:
@@ -536,6 +554,12 @@ class _ImageContext(_StatsContext):
         self.origin = item.getOrigin()
         self.scale = item.getScale()
         self.data = item.getData(copy=True)
+
+        if self.data.size == 0:
+            self.values = None
+            self.min, self.max = None, None
+            self.axes = None
+            return
 
         xsize = self.data.shape[1]
         ysize = self.data.shape[0]

--- a/src/silx/gui/plot/test/test_stats.py
+++ b/src/silx/gui/plot/test/test_stats.py
@@ -33,7 +33,8 @@ from silx.gui.plot.stats import stats
 from silx.gui.plot import StatsWidget
 from silx.gui.plot.stats import statshandler
 from silx.gui.utils.testutils import TestCaseQt, SignalListener
-from silx.gui.plot import Plot1D, Plot2D
+from silx.gui.plot import Plot1D, Plot2D, PlotWidget
+from silx.gui.plot import items
 from silx.gui.plot.items.roi import (
     RectangleROI,
     PolygonROI,
@@ -51,10 +52,33 @@ from silx.gui.plot.tools.roi import RegionOfInterestManager
 from silx.gui.plot.stats.stats import Stats
 from silx.gui.plot.CurvesROIWidget import ROI
 from silx.utils.testutils import ParametricTestCase
-import logging
 import numpy
+import pytest
 
-_logger = logging.getLogger(__name__)
+
+@pytest.mark.parametrize(
+    "itemclass", [items.Curve, items.Histogram, items.ImageData, items.Scatter]
+)
+def testStatsOfEmptyPlotItems(itemclass):
+    plot = PlotWidget(backend="none")
+    item = itemclass()
+    plot.addItem(item)
+
+    stats_ = stats.Stats()
+    for stat in [
+        stats.StatMin(),
+        stats.StatCoordMin(),
+        stats.StatMax(),
+        stats.StatCoordMax(),
+        stats.Stat(name="std", fct=numpy.std),
+        stats.Stat(name="mean", fct=numpy.mean),
+        stats.StatCOM(),
+    ]:
+        stats_.add(stat)
+
+    results = stats_.calculate(item, plot, onlimits=False, roi=None)
+    assert stats_.keys() == results.keys()
+    assert all(map(lambda v: v is None, results.values()))
 
 
 class TestStatsBase:


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

This PR adds support of empty plot items are they are when instanciated.
It also fixes a small bug in the `Histogram` item.

closes #4580

#### AI Disclosure
- [x] No AI used
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
