### PR TITLE
silx.gui.data: Fixed RgbaImagePlot not removing previous images

### DIFF
--- a/src/silx/gui/data/_RgbaImagePlot.py
+++ b/src/silx/gui/data/_RgbaImagePlot.py
@@ -81,6 +81,8 @@ class RgbaImagePlot(BaseImagePlot):
         self._plot.resetZoom()
 
     def _addItemToPlot(self, xAxis: ImageAxis, yAxis: ImageAxis):
+        self._plot.remove(kind="image")
+
         image = self._getImageToDisplay()
 
         if image.ndim != 3:


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

This PR removes the previous RGB(A) image before displaying a new one.
Before, images where added but never removed.

#### AI Disclosure
- [x] No AI used
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
