### PR TITLE
Win11 Hdf5TreeView: gui.hdf5.Hdf5Item: cache expensive qt.QApplication.style().standardIcon() lookups

### DIFF
--- a/src/silx/gui/hdf5/Hdf5Item.py
+++ b/src/silx/gui/hdf5/Hdf5Item.py
@@ -45,19 +45,12 @@ _hdf5Formatter = Hdf5Formatter(textFormatter=_formatter)
 _standardIconCache = {}
 
 
-def _getStandardIcon(icon):
-    style = qt.QApplication.style()
-    devicePixelRatio = None
-    app = qt.QApplication.instance()
-    if app is not None:
-        screen = app.primaryScreen()
-        if screen is not None:
-            devicePixelRatio = screen.devicePixelRatio()
-    key = style.objectName(), devicePixelRatio, icon
-    qicon = _standardIconCache.get(key)
+def _getStandardIcon(icon_type):
+    qicon = _standardIconCache.get(icon_type)
     if qicon is None:
-        qicon = style.standardIcon(icon)
-        _standardIconCache[key] = qicon
+        style = qt.QApplication.style()
+        qicon = style.standardIcon(icon_type)
+        _standardIconCache[icon_type] = qicon
     return qicon
 
 

--- a/src/silx/gui/hdf5/Hdf5Item.py
+++ b/src/silx/gui/hdf5/Hdf5Item.py
@@ -42,6 +42,17 @@ _logger = logging.getLogger(__name__)
 _formatter = TextFormatter()
 _hdf5Formatter = Hdf5Formatter(textFormatter=_formatter)
 # FIXME: The formatter should be an attribute of the Hdf5Model
+_standardIconCache = {}
+
+
+def _getStandardIcon(icon):
+    style = qt.QApplication.style()
+    key = style.objectName(), icon
+    qicon = _standardIconCache.get(key)
+    if qicon is None:
+        qicon = style.standardIcon(icon)
+        _standardIconCache[key] = qicon
+    return qicon
 
 
 class DescriptionType(enum.Enum):
@@ -312,19 +323,18 @@ class Hdf5Item(Hdf5Node):
         """
         # Pre-fetch the object, in case it is broken
         obj = self.obj
-        style = qt.QApplication.style()
         if self.__isBroken:
-            icon = style.standardIcon(qt.QStyle.SP_MessageBoxCritical)
+            icon = _getStandardIcon(qt.QStyle.SP_MessageBoxCritical)
             return icon
         class_ = self.h5Class
         if class_ == silx.io.utils.H5Type.FILE:
-            return style.standardIcon(qt.QStyle.SP_FileIcon)
+            return _getStandardIcon(qt.QStyle.SP_FileIcon)
         elif class_ == silx.io.utils.H5Type.GROUP:
-            return style.standardIcon(qt.QStyle.SP_DirIcon)
+            return _getStandardIcon(qt.QStyle.SP_DirIcon)
         elif class_ == silx.io.utils.H5Type.SOFT_LINK:
-            return style.standardIcon(qt.QStyle.SP_DirLinkIcon)
+            return _getStandardIcon(qt.QStyle.SP_DirLinkIcon)
         elif class_ == silx.io.utils.H5Type.EXTERNAL_LINK:
-            return style.standardIcon(qt.QStyle.SP_FileLinkIcon)
+            return _getStandardIcon(qt.QStyle.SP_FileLinkIcon)
         elif class_ == silx.io.utils.H5Type.DATASET:
             if obj.shape is None:
                 name = "item-none"

--- a/src/silx/gui/hdf5/Hdf5Item.py
+++ b/src/silx/gui/hdf5/Hdf5Item.py
@@ -47,7 +47,13 @@ _standardIconCache = {}
 
 def _getStandardIcon(icon):
     style = qt.QApplication.style()
-    key = style.objectName(), icon
+    devicePixelRatio = None
+    app = qt.QApplication.instance()
+    if app is not None:
+        screen = app.primaryScreen()
+        if screen is not None:
+            devicePixelRatio = screen.devicePixelRatio()
+    key = style.objectName(), devicePixelRatio, icon
     qicon = _standardIconCache.get(key)
     if qicon is None:
         qicon = style.standardIcon(icon)


### PR DESCRIPTION
Addresses #4485

### PR summary

Fixes Hdf5TreeView slowness on Win 11 caused by slow `qt.QApplication.style().standardIcon(icon)` calls in `gui.hdf5.Hdf5Item`.

This PR just adds simple caching of the icons in a `dict`. 

The scaling factor of the primary screen is added as key to the icon cache. This should account for multi-monitor setups with different DPI scaling. - Works on my two screens.

There is a related issue addressing silx icon caching, which causes Exceptions when leaving silx
https://github.com/silx-kit/silx/issues/1771

But I haven't encountered this issue with the simple dict solution.

pytests fail on my machine with a probably unrelated issue:

```python

tmp_path = WindowsPath('C:/Users/timof/AppData/Local/Temp/pytest-of-timof/pytest-0/testErrorInInsertFilenameAsync0')
caplog = <_pytest.logging.LogCaptureFixture object at 0x00000246CAEE6900>
qapp_utils = <silx.gui.utils.testutils.TestCaseQt testMethod=runTest>

    def testErrorInInsertFilenameAsync(tmp_path, caplog, qapp_utils):
        filename = str(tmp_path / "corrupt.h5")
        with open(filename, "wb") as h5file:
            h5file.write("8736553".encode())

        model = hdf5.Hdf5TreeModel()
        assert model.rowCount(qt.QModelIndex()) == 0
        model.insertFileAsync(filename)

        assert qt.silxGlobalThreadPool().waitForDone(2000)  # Needed for PySide6
>       waitForPendingOperations(qapp_utils, model)

test\test_hdf5.py:85:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

qapp_utils = <silx.gui.utils.testutils.TestCaseQt testMethod=runTest>
model = <silx.gui.hdf5.Hdf5TreeModel.Hdf5TreeModel(0x246c59908c0) at 0x00000246CB5F9E00>

    def waitForPendingOperations(qapp_utils: TestCaseQt, model):
        for _ in range(20):
            if not model.hasPendingOperations():
                break
            qapp_utils.qWait(200)
        else:
>           raise RuntimeError("Still waiting for a pending operation")
E           RuntimeError: Still waiting for a pending operation
```

#### AI Disclosure
AI tool Codex used for automated bug finding, benchmarks and code generation.


