### PR TITLE
silx view: Fixed ensure hdf5 file locking is disabled

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,22 @@
 Release Notes
 =============
 
-3.0.0: 2026/04/24
+This is a bug fix release fixing `silx view` v3.0.0 not disabling hdf5 file locking.
+
+3.0.1: 2026/05/07
 -----------------
+
+* `silx view`:
+
+  * Fixed to ensure hdf5 file locking is disabled (PR #4595)
+  * Fixed Ubuntu taskbar icon by setting deskop file name (PR #4475)
+
+* `silx.gui.hdf5.Hdf5Item`: Fixed performance issue by caching icons (PR #4592)
+* `silx.gui.plot3d.scene``: Added typing to `transform` and `utils` modules (PR #4560)
+* Tools: Updated tool to prepare release notes (PR #4578)
+
+3.0.0: 2026/04/24 [yanked]
+--------------------------
 
 This version of silx requires Python >=3.10 and uses PySide6 as its default Qt binding.
 

--- a/src/silx/_version.py
+++ b/src/silx/_version.py
@@ -71,7 +71,7 @@ PRERELEASE_NORMALIZED_NAME = {"dev": "a", "alpha": "a", "beta": "b", "candidate"
 
 MAJOR = 3
 MINOR = 0
-MICRO = 0
+MICRO = 1
 RELEV = "final"  # <16
 SERIAL = 0  # <16
 

--- a/src/silx/app/view/main.py
+++ b/src/silx/app/view/main.py
@@ -35,12 +35,6 @@ import traceback
 
 from silx.app.utils import parseutils
 
-try:
-    import hdf5plugin  # noqa
-except ImportError:
-    hdf5plugin = None
-
-
 _logger = logging.getLogger(__name__)
 """Module logger"""
 
@@ -128,12 +122,13 @@ def mainQt(options):
     _logger.info("Set HDF5_USE_FILE_LOCKING=%s", hdf5_file_locking)
     os.environ["HDF5_USE_FILE_LOCKING"] = hdf5_file_locking
 
-    if hdf5plugin is None:
-        message = (
+    try:
+        import hdf5plugin  # noqa
+    except ImportError:
+        _logger.debug(
             "Module 'hdf5plugin' is not installed. It supports additional hdf5"
             + ' compressions. You can install it using "pip install hdf5plugin".'
         )
-        _logger.debug(message)
 
     import silx
     from silx.gui import qt


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

Set `HDF5_USE_FILE_LOCKING` **before** importing `hdf5plugin`.

related to #4594
partly revert #4376

#### AI Disclosure
- [x] No AI used

