### PR TITLE
silx view: Added test of hdf5 file locking behavior

### DIFF
--- a/src/silx/app/view/main.py
+++ b/src/silx/app/view/main.py
@@ -136,7 +136,9 @@ def mainQt(options):
     # Make sure matplotlib is configured
     import silx.gui.utils.matplotlib  # noqa
 
-    app = qt.QApplication([])
+    app = qt.QApplication.instance()
+    if app is None:
+        app = qt.QApplication([])
     app.setDesktopFileName("org.silx.SilxView")
     if qt.BINDING != "PyQt5":
         app.styleHints().setColorScheme(qt.Qt.ColorScheme.Light)

--- a/src/silx/app/view/test/test_view.py
+++ b/src/silx/app/view/test/test_view.py
@@ -28,10 +28,15 @@ __license__ = "MIT"
 __date__ = "07/06/2018"
 
 
+import contextlib
+import pathlib
+import subprocess
+import sys
 import weakref
 import numpy
 import h5py
 import pytest
+from collections.abc import Callable
 
 from silx.gui import qt
 from silx.app.view.Viewer import Viewer
@@ -387,3 +392,70 @@ class TestCustomNxdataWidgetInteraction(TestCaseQt):
         axesIndex = self.model.index(1, 0, nxdataIndex)
         item = self.model.itemFromIndex(axesIndex)
         self.model.removeAxisItem(item)
+
+
+@pytest.fixture
+def silxViewSubprocess(tmp_path) -> Callable:
+    script = tmp_path / "script.py"
+    script.write_text("""
+import sys
+from silx.__main__ import main
+from silx.gui import qt
+
+
+app = qt.QApplication([])
+
+
+def isViewerReady():
+    for w in app.topLevelWidgets():
+        if isinstance(w, qt.QMainWindow) and w.isVisible():
+            print("ready", flush=True)
+            return
+
+
+timer = qt.QTimer()
+timer.timeout.connect(isViewerReady)
+timer.start(500)
+
+sys.argv = ["silx", "view"] + sys.argv[1:]
+main()
+""")
+
+    @contextlib.contextmanager
+    def runSilxViewInSubprocess(*options):
+        with subprocess.Popen(
+            [sys.executable, str(script.resolve())] + list(options),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        ) as process:
+            try:
+                for line in process.stdout:
+                    if line.strip() == "ready":
+                        break
+                else:
+                    raise RuntimeError("silx view subprocess never ready")
+
+                yield
+
+            finally:
+                process.terminate()
+                process.kill()
+
+    return runSilxViewInSubprocess
+
+
+def testSilxViewHdf5FileLockingDisabled(data_h5, silxViewSubprocess):
+    """Test that silx view does NOT locks hdf5 files when opening them"""
+    with silxViewSubprocess(str(pathlib.Path(data_h5).resolve())):
+        with h5py.File(str(data_h5), mode="a"):
+            pass
+
+
+def testSilxViewHdf5FileLockingEnabled(data_h5, silxViewSubprocess):
+    """Test that silx view --hdf5-file-locking locks hdf5 files when opening them"""
+    with silxViewSubprocess(
+        "--hdf5-file-locking", str(pathlib.Path(data_h5).resolve())
+    ):
+        with pytest.raises(IOError):
+            h5py.File(str(data_h5), mode="a")

--- a/src/silx/app/view/test/test_view.py
+++ b/src/silx/app/view/test/test_view.py
@@ -36,7 +36,6 @@ import weakref
 import numpy
 import h5py
 import pytest
-from collections.abc import Callable
 
 from silx.gui import qt
 from silx.app.view.Viewer import Viewer
@@ -394,11 +393,9 @@ class TestCustomNxdataWidgetInteraction(TestCaseQt):
         self.model.removeAxisItem(item)
 
 
-@pytest.fixture
-def silxViewSubprocess(tmp_path) -> Callable:
-    script = tmp_path / "script.py"
-    script.write_text("""
-import sys
+@contextlib.contextmanager
+def runSilxViewInSubprocess(*options):
+    cmd = f"""import sys
 from silx.__main__ import main
 from silx.gui import qt
 
@@ -406,55 +403,47 @@ from silx.gui import qt
 app = qt.QApplication([])
 
 
-def isViewerReady():
-    for w in app.topLevelWidgets():
-        if isinstance(w, qt.QMainWindow) and w.isVisible():
-            print("ready", flush=True)
-            return
+def isReady():
+    mainWindows = [w for w in app.topLevelWidgets() if isinstance(w, qt.QMainWindow)]
+    if any(w.isVisible() for w in mainWindows):
+        print("ready", flush=True)
 
 
 timer = qt.QTimer()
-timer.timeout.connect(isViewerReady)
+timer.timeout.connect(isReady)
 timer.start(500)
-
-sys.argv = ["silx", "view"] + sys.argv[1:]
+sys.argv = ["silx", "view"] + {list(options)}
 main()
-""")
+"""
+    with subprocess.Popen(
+        [sys.executable, "-c", cmd],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    ) as process:
+        try:
+            for line in process.stdout:
+                if line.strip() == "ready":
+                    break
+            else:
+                raise RuntimeError("silx view subprocess never ready")
 
-    @contextlib.contextmanager
-    def runSilxViewInSubprocess(*options):
-        with subprocess.Popen(
-            [sys.executable, str(script.resolve())] + list(options),
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            text=True,
-        ) as process:
-            try:
-                for line in process.stdout:
-                    if line.strip() == "ready":
-                        break
-                else:
-                    raise RuntimeError("silx view subprocess never ready")
+            yield
 
-                yield
-
-            finally:
-                process.terminate()
-                process.kill()
-
-    return runSilxViewInSubprocess
+        finally:
+            process.terminate()
 
 
-def testSilxViewHdf5FileLockingDisabled(data_h5, silxViewSubprocess):
+def testSilxViewHdf5FileLockingDisabled(data_h5):
     """Test that silx view does NOT locks hdf5 files when opening them"""
-    with silxViewSubprocess(str(pathlib.Path(data_h5).resolve())):
+    with runSilxViewInSubprocess(str(pathlib.Path(data_h5).resolve())):
         with h5py.File(str(data_h5), mode="a"):
             pass
 
 
-def testSilxViewHdf5FileLockingEnabled(data_h5, silxViewSubprocess):
+def testSilxViewHdf5FileLockingEnabled(data_h5):
     """Test that silx view --hdf5-file-locking locks hdf5 files when opening them"""
-    with silxViewSubprocess(
+    with runSilxViewInSubprocess(
         "--hdf5-file-locking", str(pathlib.Path(data_h5).resolve())
     ):
         with pytest.raises(IOError):


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

This PR adds a non-regression test of `silx view`'s hdf5 file locking behavior.

Follow-up of #4595
Closes #4594

#### AI Disclosure
- [x] No AI used
