### PR TITLE
silx.gui: Fixed use of `destroyed` signal

### DIFF
--- a/src/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/src/silx/gui/hdf5/Hdf5TreeModel.py
@@ -29,7 +29,6 @@ __date__ = "12/03/2019"
 
 import os
 import logging
-import functools
 from .. import qt
 from .. import icons
 from .Hdf5Node import Hdf5Node
@@ -243,7 +242,13 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         # while the QObject still exists.
         # We use a static method plus explicit references to objects to
         # release. The callback do not use any ref to self.
-        onDestroy = functools.partial(self._closeFileList, self.__openedFiles)
+        # onDestroy = functools.partial(self._closeFileList, self.__openedFiles)
+        def onDestroy():
+            try:
+                self._closeFileList(self.__openedFiles)
+            except Exception:
+                pass
+
         self.destroyed.connect(onDestroy)
 
     @staticmethod


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

This PR aims at fixing an issue occurring at application closure (see #4605).
Since it modifies a workaround added 8 years ago (PR #1649), it needs through testing with currently supported pyqt/pyside versions


#### AI Disclosure
- [x] No AI used
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
