### PR TITLE
Doc: move existing links from 'silx.org' to 'readthedocs'

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1830,7 +1830,7 @@ Python 2.7 is no longer officially supported (even if tests pass and most of the
  * Adds specfile wrapper API compatible with legacy wrapper: silx.io.specfilewrapper
  * Transposes scan data in specfile module to have detector as first index
  * Set up nigthly build for sources package, debian packages (http://www.silx.org/pub/debian/)
-   and documentation (http://www.silx.org/doc/)
+   and documentation (https://silx.readthedocs.io/en/stable/)
 
 
 0.1.0: 2016/04/14

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,4 +1,4 @@
 CONTRIBUTING
 ============
 
-See https://silx.readthedocs.io/en/stable/contributing.html#how-to-contribute
+See https://silx.readthedocs.io/en/stable/contribute/#how-to-contribute

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,4 +1,4 @@
 CONTRIBUTING
 ============
 
-See https://www.silx.org/doc/silx/latest/contribute
+See https://silx.readthedocs.io/en/stable/contributing.html#how-to-contribute

--- a/README.rst
+++ b/README.rst
@@ -66,14 +66,14 @@ Unofficial packages for different distributions are available:
 - Fedora 23 rpm packages are provided by Max IV at http://pubrepo.maxiv.lu.se/rpm/fc23/x86_64/
 - Arch Linux (AUR) packages are also available: https://aur.archlinux.org/packages/python-silx
 
-`Detailed installation instructions <http://www.silx.org/doc/silx/latest/install.html>`_
+`Detailed installation instructions <https://silx.readthedocs.io/en/latest/install.html>`_
 are available in the documentation.
 
 Documentation
 -------------
 
-The documentation of `latest release <http://www.silx.org/doc/silx/latest/>`_ and
-the documentation of `the nightly build <http://www.silx.org/doc/silx/dev>`_ are
+The documentation of `latest release <https://silx.readthedocs.io/en/stable/>`_ and
+the documentation of `the nightly build <https://silx.readthedocs.io/en/latest>`_ are
 available at http://www.silx.org/doc/silx/
 
 Testing
@@ -84,14 +84,14 @@ all major operating systems:
 
 |Github Actions Status|
 
-Please refer to the `documentation on testing <http://www.silx.org/doc/silx/latest/install.html#testing>`_
+Please refer to the `documentation on testing <https://silx.readthedocs.io/en/latest/install.html#testing>`_
 for details.
 
 Examples
 --------
 
 Some examples of sample code using silx are provided with the
-`silx documentation <http://www.silx.org/doc/silx/latest/sample_code/index.html>`_.
+`silx documentation <https://silx.readthedocs.io/en/latest/sample_code/index.html>`_.
 
 
 License

--- a/doc/source/Tutorials/io.rst
+++ b/doc/source/Tutorials/io.rst
@@ -358,5 +358,5 @@ Additional resources
 
 - `h5py documentation <http://docs.h5py.org/en/latest/>`_
 - `Formats supported by FabIO <http://www.silx.org/doc/fabio/dev/getting_started.html#list-of-file-formats-that-fabio-can-read-and-write>`_
-- `Spec file with h5py-like structure <http://www.silx.org/doc/silx/dev/modules/io/spech5.html#api-description>`_
+- `Spec file with h5py-like structure <https://silx.readthedocs.io/en/latest/modules/io/spech5.html#api-description>`_
 - `HDF5 format documentation <https://support.hdfgroup.org/HDF5/>`_

--- a/doc/source/contribute/icons.rst
+++ b/doc/source/contribute/icons.rst
@@ -41,7 +41,7 @@ Add the files to silx
 
 Add both files to the `src/silx/resources/gui/icons <https://github.com/silx-kit/silx/tree/main/src/silx/resources/gui/icons>`_ folder. Both the SVG and PNG should be added to Git.
 
-Run the `tools/update_icons_rst.py <https://github.com/silx-kit/silx/blob/main/tools/update_icons_rst.py>`_ script to update the `documentation page <http://www.silx.org/doc/silx/latest/modules/gui/icons.html#available-icons>`_.
+Run the `tools/update_icons_rst.py <https://github.com/silx-kit/silx/blob/main/tools/update_icons_rst.py>`_ script to update the `documentation page <https://silx.readthedocs.io/en/latest/modules/gui/icons.html#available-icons>`_.
 
 
 .. _inkscape: https://inkscape.org/

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -10,7 +10,7 @@ ManyLinux, Debian/Ubuntu packages of released versions are made available in the
 - `Wheels and source code on PyPi <https://pypi.org/project/silx/>`_
 - `Conda package on conda-forge channel <https://anaconda.org/conda-forge/silx>`_
 - Windows application installer `on github release page <https://github.com/silx-kit/silx/releases/latest/>`_ (available in the `Assets` at the bottom).
-- `Documentation on silx.org <http://www.silx.org/doc/silx/latest/>`_
+- `Documentation on silx.org <https://silx.readthedocs.io/en/latest/>`_
 - `Unofficial Debian/Ubuntu packages <https://github.com/silx-kit/silx/releases/latest>`_
 - :doc:`changelog`
 
@@ -23,7 +23,7 @@ Linux packages and documentation are automatically generated from the tip of the
 
 - `Debian 10 and Ubuntu20.04 packages <http://www.silx.org/pub/linux-repo/>`_
 - `Wheels and Windows application <https://silx.gitlab-pages.esrf.fr/bob/silx/>`_
-- `Documentation <http://www.silx.org/doc/silx/dev/>`_
+- `Documentation <https://silx.readthedocs.io/en/latest/>`_
 
 Project
 -------

--- a/package/desktop/org.silx.SilxView.metainfo.xml
+++ b/package/desktop/org.silx.SilxView.metainfo.xml
@@ -17,13 +17,13 @@
   <screenshots>
     <screenshot type="default">
       <caption>silx view main window</caption>
-      <image>https://www.silx.org/doc/silx/latest/_images/silx-view-image.png</image>
+      <image>https://silx.readthedocs.io/en/latest/_images/silx-view-image.png</image>
     </screenshot>
   </screenshots>
 
   <url type="homepage">https://www.silx.org/</url>
   <url type="bugtracker">https://github.com/silx-kit/silx/issues</url>
-  <url type="help">http://www.silx.org/doc/silx/latest/</url>
+  <url type="help">https://silx.readthedocs.io/en/latest/</url>
 
   <update_contact>silx@esrf.fr</update_contact>
 </component>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ dev = [
 
 [project.urls]
 homepage = 'http://www.silx.org'
-documentation = 'http://www.silx.org/doc/silx/latest/'
+documentation = 'https://silx.readthedocs.io/en/latest/'
 source = 'https://github.com/silx-kit/silx'
 download = 'https://github.com/silx-kit/silx/releases'
 tracker = 'https://github.com/silx-kit/silx/issues'

--- a/src/silx/__init__.py
+++ b/src/silx/__init__.py
@@ -31,7 +31,7 @@
 - silx.sx: High-level silx functions suited for (I)Python console.
 - silx.utils: Miscellaneous convenient functions
 
-See silx documentation: http://www.silx.org/doc/silx/latest/
+See silx documentation: https://silx.readthedocs.io/en/latest/
 """
 
 __authors__ = ["Jérôme Kieffer"]

--- a/src/silx/gui/__init__.py
+++ b/src/silx/gui/__init__.py
@@ -40,7 +40,7 @@ It contains the following sub-packages and modules:
 - silx.gui.utils: Miscellaneous helpers for Qt
 - silx.gui.widgets: Miscellaneous standalone widgets
 
-See silx documentation: http://www.silx.org/doc/silx/latest/
+See silx documentation: https://silx.readthedocs.io/en/latest/
 """
 
 __authors__ = ["T. Vincent"]

--- a/src/silx/image/__init__.py
+++ b/src/silx/image/__init__.py
@@ -24,7 +24,7 @@
 
 For more processing functions, see the silx.math and silx.opencl packages.
 
-See silx documentation: http://www.silx.org/doc/silx/latest/
+See silx documentation: https://silx.readthedocs.io/en/latest/
 """
 
 __authors__ = ["H. Payno"]

--- a/src/silx/io/__init__.py
+++ b/src/silx/io/__init__.py
@@ -25,7 +25,7 @@
 
 It is geared towards support of and conversion to HDF5/NeXus.
 
-See silx documentation: http://www.silx.org/doc/silx/latest/
+See silx documentation: https://silx.readthedocs.io/en/latest/
 """
 
 __authors__ = ["P. Knobel"]

--- a/src/silx/math/__init__.py
+++ b/src/silx/math/__init__.py
@@ -26,7 +26,7 @@ For additional processing functions dedicated to 2D images,
 see the silx.image package.
 For OpenCL-based processing functions see the silx.opencl package.
 
-See silx documentation: http://www.silx.org/doc/silx/latest/
+See silx documentation: https://silx.readthedocs.io/en/latest/
 """
 
 __authors__ = ["D. Naudet", "V.A. Sole", "P. Knobel"]

--- a/src/silx/opencl/__init__.py
+++ b/src/silx/opencl/__init__.py
@@ -32,7 +32,7 @@
 
 For more processing functions, see the silx.math and silx.image packages.
 
-See silx documentation: http://www.silx.org/doc/silx/latest/
+See silx documentation: https://silx.readthedocs.io/en/latest/
 """
 
 __author__ = "Jerome Kieffer"

--- a/src/silx/utils/__init__.py
+++ b/src/silx/utils/__init__.py
@@ -23,5 +23,5 @@
 # ###########################################################################*/
 """This package contains a set of miscellaneous convenient features.
 
-See silx documentation: http://www.silx.org/doc/silx/latest/
+See silx documentation: https://silx.readthedocs.io/en/latest/
 """


### PR DESCRIPTION
Closes #4304 

### PR summary

This PR is linked to moving documentation officialy to readthedocs. It update a set of link from silx.org

#### AI Disclosure
- [x] No AI used
- [ ] AI tool(s) ... used for ...
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->

#### Operation done at edna-site (helped by AI :( ):

* added a .htaccess at ../doc/silx/latest to do the redirection
```bash
# Redirect silx.org/doc/silx/latest/ to silx.readthedocs.io/en/stable
RewriteEngine On

RewriteRule ^(.*)$ https://silx.readthedocs.io/en/stable/$1 [R=301,L]
```
* Added a specific configuration for silx to allow redirection for both `http` and `https`
```
<VirtualHost *:443>
    ...
    DocumentRoot /var/www/silx

    ...
    <Directory /var/www/silx/doc/silx/latest>
        Options Indexes FollowSymLinks
        AllowOverride FileInfo
        Require all granted
    </Directory>

    SSLEngine on

    ...
</VirtualHost>
```

And then we need to restart apache2 `sudo systemctl restart apache2`

:heavy_check_mark: Checked that other docs are not modified by this modification