### PR TITLE
[fix] Hdf5TreeModel 'destroyed' signal can segfault for python>=3.13

### DIFF
--- a/src/silx/_utils.py
+++ b/src/silx/_utils.py
@@ -39,12 +39,11 @@ def nfs_cache_refresh(dirname: str) -> None:
         pass
 
 
-class Partial:
+class IgnoreArgPartial:
     """
-    Alternative implementation of ``functools.partial``.
-
-    Stores a callable together with positional and keyword arguments and
-    invokes it later when called.
+    Alternative implementation of ``functools.partial`` but the partial
+    function ignores any arguments. This was done because the signature
+    is not correct which causes PyQt to pass arguments when it shouldn't.
 
     This class was introduced as a workaround for segfaults observed with
     ``functools.partial`` in Qt/Python object destruction and garbage
@@ -61,9 +60,8 @@ class Partial:
         self._args = args
         self._kwargs = kwargs
 
-    def __call__(self, *args, **kwargs):
-        kwargs = {**self._kwargs, **kwargs}
-        return self._func(*self._args, *args, **kwargs)
+    def __call__(self, *_, **__):
+        return self._func(*self._args, **self._kwargs)
 
     def __repr__(self):
         return (

--- a/src/silx/_utils.py
+++ b/src/silx/_utils.py
@@ -37,3 +37,38 @@ def nfs_cache_refresh(dirname: str) -> None:
                 _ = entry.stat()
     except Exception:
         pass
+
+
+class Partial:
+    """
+    Alternative implementation of ``functools.partial``.
+
+    Stores a callable together with positional and keyword arguments and
+    invokes it later when called.
+
+    This class was introduced as a workaround for segfaults observed with
+    ``functools.partial`` in Qt/Python object destruction and garbage
+    collection scenarios since Python 3.13.
+
+    This is possible caused by the partial keeping a reference to the
+    callstack in which the partial funcion was created.
+    """
+
+    __slots__ = ("_func", "_args", "_kwargs")
+
+    def __init__(self, func, *args, **kwargs):
+        self._func = func
+        self._args = args
+        self._kwargs = kwargs
+
+    def __call__(self, *args, **kwargs):
+        kwargs = {**self._kwargs, **kwargs}
+        return self._func(*self._args, *args, **kwargs)
+
+    def __repr__(self):
+        return (
+            f"{type(self).__name__}("
+            f"{self._func!r}, "
+            f"args={self._args!r}, "
+            f"kwargs={self._kwargs!r})"
+        )

--- a/src/silx/_utils.py
+++ b/src/silx/_utils.py
@@ -39,11 +39,12 @@ def nfs_cache_refresh(dirname: str) -> None:
         pass
 
 
-class IgnoreArgPartial:
+class NoArgPartial:
     """
     Alternative implementation of ``functools.partial`` but the partial
-    function ignores any arguments. This was done because the signature
-    is not correct which causes PyQt to pass arguments when it shouldn't.
+    function does not accept any arguments. This was done because otherwise
+    the function signature would not be correct which causes PyQt to pass
+    arguments when it shouldn't.
 
     This class was introduced as a workaround for segfaults observed with
     ``functools.partial`` in Qt/Python object destruction and garbage
@@ -60,7 +61,7 @@ class IgnoreArgPartial:
         self._args = args
         self._kwargs = kwargs
 
-    def __call__(self, *_, **__):
+    def __call__(self):
         return self._func(*self._args, **self._kwargs)
 
     def __repr__(self):

--- a/src/silx/gui/dialog/AbstractDataFileDialog.py
+++ b/src/silx/gui/dialog/AbstractDataFileDialog.py
@@ -41,7 +41,7 @@ from silx.gui import qt
 from silx.gui.hdf5.Hdf5TreeModel import Hdf5TreeModel
 from . import utils
 from .FileTypeComboBox import FileTypeComboBox
-from ..._utils import IgnoreArgPartial as _Partial
+from ..._utils import NoArgPartial as _Partial
 
 import fabio
 

--- a/src/silx/gui/dialog/AbstractDataFileDialog.py
+++ b/src/silx/gui/dialog/AbstractDataFileDialog.py
@@ -41,7 +41,7 @@ from silx.gui import qt
 from silx.gui.hdf5.Hdf5TreeModel import Hdf5TreeModel
 from . import utils
 from .FileTypeComboBox import FileTypeComboBox
-from ..._utils import Partial as _Partial
+from ..._utils import IgnoreArgPartial as _Partial
 
 import fabio
 

--- a/src/silx/gui/dialog/AbstractDataFileDialog.py
+++ b/src/silx/gui/dialog/AbstractDataFileDialog.py
@@ -33,7 +33,6 @@ __date__ = "05/03/2019"
 import sys
 import os
 import logging
-import functools
 
 import numpy
 
@@ -42,6 +41,7 @@ from silx.gui import qt
 from silx.gui.hdf5.Hdf5TreeModel import Hdf5TreeModel
 from . import utils
 from .FileTypeComboBox import FileTypeComboBox
+from ..._utils import Partial as _Partial
 
 import fabio
 
@@ -606,10 +606,15 @@ class AbstractDataFileDialog(qt.QDialog):
         # to access to the content of the Python object with the `destroyed`
         # signal cause the Python method was already removed with the QWidget,
         # while the QObject still exists.
+        #
         # We use a static method plus explicit references to objects to
         # release. The callback do not use any ref to self.
-        onDestroy = functools.partial(self._closeFileList, self.__openedFiles)
-        self.destroyed.connect(onDestroy)
+        #
+        # Since Python 3.13, `functools.partial` can cause the callback to
+        # still segfaults, possible because it keeps a reference to the
+        # current call stack and hence this Qt object.
+
+        self.destroyed.connect(_Partial(self._closeFileList, self.__openedFiles))
 
     @staticmethod
     def _closeFileList(fileList):

--- a/src/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/src/silx/gui/hdf5/Hdf5TreeModel.py
@@ -29,7 +29,6 @@ __date__ = "12/03/2019"
 
 import os
 import logging
-import functools
 from .. import qt
 from .. import icons
 from .Hdf5Node import Hdf5Node
@@ -40,6 +39,7 @@ from ... import io as silx_io
 from ...io._sliceh5 import DatasetSlice
 from ...io.url import DataUrl
 from ..._utils import nfs_cache_refresh as _nfs_cache_refresh
+from ..._utils import Partial as _Partial
 
 import h5py
 
@@ -241,10 +241,15 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         # to access to the content of the Python object with the `destroyed`
         # signal cause the Python method was already removed with the QWidget,
         # while the QObject still exists.
+        #
         # We use a static method plus explicit references to objects to
         # release. The callback do not use any ref to self.
-        onDestroy = functools.partial(self._closeFileList, self.__openedFiles)
-        self.destroyed.connect(onDestroy)
+        #
+        # Since Python 3.13, `functools.partial` can cause the callback to
+        # still segfaults, possible because it keeps a reference to the
+        # current call stack and hence this Qt object.
+
+        self.destroyed.connect(_Partial(self._closeFileList, self.__openedFiles))
 
     @staticmethod
     def _closeFileList(fileList):

--- a/src/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/src/silx/gui/hdf5/Hdf5TreeModel.py
@@ -39,7 +39,7 @@ from ... import io as silx_io
 from ...io._sliceh5 import DatasetSlice
 from ...io.url import DataUrl
 from ..._utils import nfs_cache_refresh as _nfs_cache_refresh
-from ..._utils import IgnoreArgPartial as _Partial
+from ..._utils import NoArgPartial as _Partial
 
 import h5py
 

--- a/src/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/src/silx/gui/hdf5/Hdf5TreeModel.py
@@ -39,7 +39,7 @@ from ... import io as silx_io
 from ...io._sliceh5 import DatasetSlice
 from ...io.url import DataUrl
 from ..._utils import nfs_cache_refresh as _nfs_cache_refresh
-from ..._utils import Partial as _Partial
+from ..._utils import IgnoreArgPartial as _Partial
 
 import h5py
 


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

Fix segfault on `gc.collect()` in the following situation, a Qt/Python object destruction and garbage collection scenario, on python 3.13 or 3.14

```bash
pip install --pre "ewoksfluo[test] @ git+https://gitlab.esrf.fr/workflow/ewoksapps/ewoksfluo.git@971b8c67a6447920ac9ce8be1d6aab17e24acd8a"
```

```bash
pytest -v -ra -W error -W ignore::DeprecationWarning:orangecanvas.utils.localization -W ignore::DeprecationWarning:orangecanvas.utils.localization.si -W ignore::DeprecationWarning:matplotlib._fontconfig_pattern -W ignore::DeprecationWarning:matplotlib._mathtext -W ignore::pydantic.warnings.PydanticDeprecatedSince20 -W "ignore:Field name \"pk\" in \"EmbeddedJsonModel\" shadows an attribute in parent \"JsonModel\":UserWarning" --pyargs ewoksfluo -k test_mesh_tasks_widget
```

#### AI Disclosure
- [x] No AI used
- [ ] AI tool(s) ... used for ...
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
