### PR TITLE
Doc: add link to installation on editable mode

### DIFF
--- a/doc/source/contribute/development.rst
+++ b/doc/source/contribute/development.rst
@@ -41,6 +41,8 @@ which is described in other projects like `scikit-image <https://scikit-image.or
 If you encounter any problems or have any questions you can always ask on the `Issues page <https://github.com/silx-kit/silx/issues>`_.
 
 
+.. _install-silx-editable:
+
 Install silx for development
 ----------------------------
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -101,6 +101,9 @@ To install silx from source, run:
        export LANG=en_US.UTF-9
 
 
+.. hint:: For editable installation see :ref:`install-silx-editable`.
+
+
 Build options
 +++++++++++++
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -101,7 +101,7 @@ To install silx from source, run:
        export LANG=en_US.UTF-9
 
 
-.. hint:: For editable installation see :ref:`install-silx-editable`.
+.. hint:: To install in `editable mode <https://setuptools.pypa.io/en/latest/userguide/development_mode.html>`_, see :ref:`install-silx-editable`.
 
 
 Build options


### PR DESCRIPTION
### PR summary

Doc: add link to how to install on `editable` mode on the installation section.


#### Screenshot

<img width="1161" height="657" alt="image" src="https://github.com/user-attachments/assets/84891f05-835a-49c4-970c-5817c0a0f925" />


#### AI Disclosure
- [x] No AI used
- [ ] AI tool(s) ... used for ...
