### PR TITLE
silx.gui.plot.tools.profile: fix make profile take into account the mask properly

### DIFF
--- a/src/silx/gui/plot/tools/profile/core.py
+++ b/src/silx/gui/plot/tools/profile/core.py
@@ -219,6 +219,8 @@ def _alignedFullProfile(data, origin, scale, position, roiWidth, axis, method):
     assert axis in (0, 1)
     assert len(data.shape) == 3
     assert method in ("mean", "sum", "none")
+    # filter nan values
+    data = numpy.ma.masked_array(data=data, mask=numpy.isnan(data))
 
     # Convert from plot to image coords
     imgPos = int((position - origin[1 - axis]) / scale[1 - axis])

--- a/src/silx/gui/plot/tools/profile/core.py
+++ b/src/silx/gui/plot/tools/profile/core.py
@@ -219,8 +219,6 @@ def _alignedFullProfile(data, origin, scale, position, roiWidth, axis, method):
     assert axis in (0, 1)
     assert len(data.shape) == 3
     assert method in ("mean", "sum", "none")
-    # filter nan values
-    data = numpy.ma.masked_array(data=data, mask=numpy.isnan(data))
 
     # Convert from plot to image coords
     imgPos = int((position - origin[1 - axis]) / scale[1 - axis])
@@ -243,9 +241,9 @@ def _alignedFullProfile(data, origin, scale, position, roiWidth, axis, method):
     else:
         if start < height and end > 0:
             if method == "mean":
-                fct = numpy.mean
+                fct = numpy.nanmean
             elif method == "sum":
-                fct = numpy.sum
+                fct = numpy.nansum
             else:
                 raise ValueError("method not managed")
             profile = fct(data[:, max(0, start) : min(end, height), :], axis=1).astype(

--- a/src/silx/gui/plot/tools/test/test_profile.py
+++ b/src/silx/gui/plot/tools/test/test_profile.py
@@ -29,6 +29,7 @@ __date__ = "28/06/2018"
 import contextlib
 import numpy
 import logging
+import pytest
 
 from silx.gui import qt
 from silx.gui.utils.testutils import qWaitForWindowExposedAndActivate, QTest
@@ -528,7 +529,12 @@ class TestProfile3DToolBar(TestCaseQt):
         numpy.testing.assert_almost_equal(data, expected)
 
 
-def testProfile1D(qWidgetFactory):
+@pytest.mark.parametrize("with_mask", (True, False))
+def testProfile1D(qWidgetFactory, with_mask):
+    """Test that the profile plot associated to a Plot2D is a 1D plot and that mask is take into account.
+
+    Note: the mask; when applied; is at the center. As we have an od number of elements the expected result remains the same.
+    """
     plot = qWidgetFactory(Plot2D)
     plot.show()
     qWaitForWindowExposedAndActivate(plot)
@@ -563,9 +569,14 @@ def testProfile1D(qWidgetFactory):
     numpy.testing.assert_almost_equal(profile.getYData(), numpy.array([4.0, 5.0]))
 
 
-def testProfile2D(qWidgetFactory):
+@pytest.mark.parametrize("with_mask", (True, False))
+def testProfile2D(qWidgetFactory, with_mask):
     """Test that the profile plot associated to a stack view is either a
-    Plot1D or a plot 2D instance."""
+    Plot1D or a plot 2D instance.
+    Make sure also that the mask is take into account.
+
+    Note: the mask; when applied; is at the center. As we have an od number of elements the expected result remains the same.
+    """
     plot = qWidgetFactory(StackView)
     plot.show()
     qWaitForWindowExposedAndActivate(plot)
@@ -576,6 +587,10 @@ def testProfile2D(qWidgetFactory):
             numpy.arange(10, 20).reshape(5, 2),
         )
     )
+    if with_mask:
+        mask = numpy.zeros((5, 2))
+        mask[2, :] = 1
+        plot.getPlotWidget().setSelectionMask(mask)
 
     toolBar = plot.getProfileToolbar()
 

--- a/src/silx/gui/plot/tools/test/test_profile.py
+++ b/src/silx/gui/plot/tools/test/test_profile.py
@@ -540,6 +540,10 @@ def testProfile1D(qWidgetFactory, with_mask):
     qWaitForWindowExposedAndActivate(plot)
 
     plot.addImage([[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]])
+    if with_mask:
+        mask = numpy.zeros((5, 2))
+        mask[2, :] = 1
+        plot.setSelectionMask(mask)
 
     toolBar = plot.getProfileToolbar()
 


### PR DESCRIPTION
Closes #4493 
Closes https://github.com/silx-kit/silx/issues/3920
https://github.com/silx-kit/silx/pull/4624 to be merged first.

### PR summary

This PR improve handling of mask when computing profile. When a mask is applied values of the data will be `nan`.

### Demo

[Screencast from 2026-06-16 13-32-31.webm](https://github.com/user-attachments/assets/76218b10-db75-4937-949c-d44f4bb4ae1f)


#### AI Disclosure
- [x] No AI used
- [ ] AI tool(s) ... used for ...
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
