### PR TITLE
silx.gui.hdf5.Hdf5TreeView: Allow to set Hdf5TreeView's model in __init__

### DIFF
--- a/src/silx/app/view/Viewer.py
+++ b/src/silx/app/view/Viewer.py
@@ -75,7 +75,20 @@ class Viewer(qt.QMainWindow):
 
         self.__dialogState = None
         self.__customNxDataItem = None
-        self.__treeview = silx.gui.hdf5.Hdf5TreeView(self)
+
+        # Custom the model to be able to manage the life cycle of the files
+        self.__treeModelSorted = silx.gui.hdf5.NexusSortFilterProxyModel(self)
+        self.__treeModelSorted.sort(0, qt.Qt.AscendingOrder)
+        self.__treeModelSorted.setSortCaseSensitivity(qt.Qt.CaseInsensitive)
+
+        treeModel = silx.gui.hdf5.Hdf5TreeModel(self.__treeModelSorted, ownFiles=False)
+        treeModel.sigH5pyObjectLoaded.connect(self.__h5FileLoaded)
+        treeModel.sigH5pyObjectRemoved.connect(self.__h5FileRemoved)
+        treeModel.sigH5pyObjectSynchronized.connect(self.__h5FileSynchonized)
+        treeModel.setDatasetDragEnabled(True)
+        self.__treeModelSorted.setSourceModel(treeModel)
+
+        self.__treeview = silx.gui.hdf5.Hdf5TreeView(self, model=self.__treeModelSorted)
         self.__treeview.setExpandsOnDoubleClick(False)
         """Silx HDF5 TreeView"""
 
@@ -85,21 +98,6 @@ class Viewer(qt.QMainWindow):
 
         self.__displayIt = None
         self.__treeWindow = self.__createTreeWindow(self.__treeview)
-
-        # Custom the model to be able to manage the life cycle of the files
-        treeModel = silx.gui.hdf5.Hdf5TreeModel(self.__treeview, ownFiles=False)
-        treeModel.sigH5pyObjectLoaded.connect(self.__h5FileLoaded)
-        treeModel.sigH5pyObjectRemoved.connect(self.__h5FileRemoved)
-        treeModel.sigH5pyObjectSynchronized.connect(self.__h5FileSynchonized)
-        treeModel.setDatasetDragEnabled(True)
-        self.__treeModelSorted = silx.gui.hdf5.NexusSortFilterProxyModel(
-            self.__treeview
-        )
-        self.__treeModelSorted.setSourceModel(treeModel)
-        self.__treeModelSorted.sort(0, qt.Qt.AscendingOrder)
-        self.__treeModelSorted.setSortCaseSensitivity(qt.Qt.CaseInsensitive)
-
-        self.__treeview.setModel(self.__treeModelSorted)
         rightPanel.addWidget(self.__treeWindow)
 
         self.__customNxdata = CustomNxdataWidget(self)

--- a/src/silx/gui/dialog/AbstractDataFileDialog.py
+++ b/src/silx/gui/dialog/AbstractDataFileDialog.py
@@ -586,7 +586,7 @@ class AbstractDataFileDialog(qt.QDialog):
         self.__fileModel.setReadOnly(True)
         self.__fileModel.directoryLoaded.connect(self.__directoryLoaded)
 
-        self.__dataModel = Hdf5TreeModel(self)
+        self.__dataModel = Hdf5TreeModel(self, ownFiles=False)
 
         self.__createWidgets()
         self.__initLayout()

--- a/src/silx/gui/hdf5/Hdf5TreeModel.py
+++ b/src/silx/gui/hdf5/Hdf5TreeModel.py
@@ -237,14 +237,15 @@ class Hdf5TreeModel(qt.QAbstractItemModel):
         """Store the list of files opened by the model itself."""
         # FIXME: It should be managed one by one by Hdf5Item itself
 
-        # It is not possible to override the QObject destructor nor
-        # to access to the content of the Python object with the `destroyed`
-        # signal cause the Python method was already removed with the QWidget,
-        # while the QObject still exists.
-        # We use a static method plus explicit references to objects to
-        # release. The callback do not use any ref to self.
-        onDestroy = functools.partial(self._closeFileList, self.__openedFiles)
-        self.destroyed.connect(onDestroy)
+        if self.__ownFiles:
+            # It is not possible to override the QObject destructor nor
+            # to access to the content of the Python object with the `destroyed`
+            # signal cause the Python method was already removed with the QWidget,
+            # while the QObject still exists.
+            # We use a static method plus explicit references to objects to
+            # release. The callback do not use any ref to self.
+            onDestroy = functools.partial(self._closeFileList, self.__openedFiles)
+            self.destroyed.connect(onDestroy)
 
     @staticmethod
     def _closeFileList(fileList):

--- a/src/silx/gui/hdf5/Hdf5TreeView.py
+++ b/src/silx/gui/hdf5/Hdf5TreeView.py
@@ -58,7 +58,11 @@ class Hdf5TreeView(qt.QTreeView):
     to the selected objects.
     """
 
-    def __init__(self, parent=None):
+    def __init__(
+        self,
+        parent: qt.QWidget | None = None,
+        model: Hdf5TreeModel | qt.QAbstractProxyModel | None = None,
+    ):
         """
         Constructor
 
@@ -66,7 +70,8 @@ class Hdf5TreeView(qt.QTreeView):
         """
         qt.QTreeView.__init__(self, parent)
 
-        model = self.createDefaultModel()
+        if model is None:
+            model = self.createDefaultModel()
         self.setModel(model)
 
         self.setHeader(Hdf5HeaderView(qt.Qt.Horizontal, self))


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

<!-- Thank you for your pull request! Please, provide a description of the changes below -->
Merge PR #4616  first!

This PR:
- only connects to `Hdf5TreeModel`'s `destroyed` signal if `ownFiles=True` = when it is needed.
- in silx view `Viewer`, avoids the creation of a first default model in `Hdf5TreeView` with `ownFiles=True` that is immediately replaced by a model with `ownFiles=False`.

This is achieved by adding an optional `model` argument to `Hdf5TreeView` to pass a custom model.
The alternative would be through inheritance and overriding `Hdf5TreeView.createDefaultModel`.

This PR mitigates issue #4605 by avoiding using the `destroyed` signal when it is not needed, but it does not fix `functools.partial` issue. PR #4616 fixes it.

With this PR, ewoksfluo segfault #4605 no longer occurs.

#### AI Disclosure
- [x] No AI used
- [ ] AI tool(s) ... used for ...
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
