### PR TITLE
silx.gui.plot.backends.BackendMatplotlib: move aspect ratio handling from matplotlib to the backend

### DIFF
--- a/src/silx/gui/plot/backends/BackendBase.py
+++ b/src/silx/gui/plot/backends/BackendBase.py
@@ -60,9 +60,9 @@ class BackendBase:
         """
         self.__xLimits = 1.0, 100.0
         self.__yLimits = {"left": (1.0, 100.0), "right": (1.0, 100.0)}
-        self.__xAxisInverted = True
+        self.__xAxisInverted = False
         self.__yAxisInverted = False
-        self.__keepDataAspectRatio = False
+        self._keepDataAspectRatio = False
         self.__xAxisTimeSeries = False
         self._xAxisTimeZone = None
         # Store a weakref to get access to the plot state.
@@ -523,7 +523,7 @@ class BackendBase:
 
     def isKeepDataAspectRatio(self):
         """Returns whether the plot is keeping data aspect ratio or not."""
-        return self.__keepDataAspectRatio
+        return self._keepDataAspectRatio
 
     def setKeepDataAspectRatio(self, flag):
         """Set whether to keep data aspect ratio or not.
@@ -531,7 +531,7 @@ class BackendBase:
         :param flag:  True to respect data aspect ratio
         :type flag: Boolean, default True
         """
-        self.__keepDataAspectRatio = bool(flag)
+        self._keepDataAspectRatio = bool(flag)
 
     def setGraphGrid(self, which):
         """Set grid.

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -564,9 +564,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
             axis.set_major_formatter(DefaultTickFormatter())
 
         # Autoscale is handled manually by the backend
-        self.ax.set_autoscalex_on(False)
-        self.ax.set_autoscaley_on(False)
-        self.ax2.set_autoscaley_on(False)
+        self.ax.autoscale(enable=False)
+        self.ax2.autoscale(enable=False)
 
         # this works but the figure color is left
         self.ax.set_facecolor("none")
@@ -1216,7 +1215,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
         return self.ax.get_xbound()
 
     def setGraphXLimits(self, xmin: float, xmax: float):
-        self._setPlotBounds(xRange=(xmin, xmax))
+        self._setPlotBounds(xRange=(xmin, xmax), keepDim="x")
 
     def getGraphYLimits(self, axis: Literal["left", "right"]) -> Range | None:
         assert axis in ("left", "right")
@@ -1229,15 +1228,16 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
     def setGraphYLimits(self, ymin: float, ymax: float, axis: Literal["left", "right"]):
         if axis == "right":
-            self._setPlotBounds(y2Range=(ymin, ymax))
+            self._setPlotBounds(y2Range=(ymin, ymax), keepDim="y")
         else:
-            self._setPlotBounds(yRange=(ymin, ymax))
+            self._setPlotBounds(yRange=(ymin, ymax), keepDim="y")
 
     def _setPlotBounds(
         self,
         xRange: Range | None = None,
         yRange: Range | None = None,
         y2Range: Range | None = None,
+        keepDim: Literal["x", "y"] | None = None,
     ):
         # Keep data aspect ratio
         if xRange is None:
@@ -1251,17 +1251,28 @@ class BackendMatplotlib(BackendBase.BackendBase):
             newXRange, newYRange, newY2Range = xRange, yRange, y2Range
         else:
             bbox = self.fig.get_window_extent()
+            if keepDim is None:
+                xDataRange, yDataRange, _ = self._plot.getDataRange()
+                keepDim = findDimToKeep(bbox.width, bbox.height, xDataRange, yDataRange)
             newXRange, newYRange, newY2Range = ensureAspectRatio(
                 bbox.width,
                 bbox.height,
                 xRange,
                 yRange,
                 y2Range,
-                keepDim=findDimToKeep(bbox.width, bbox.height, xRange, yRange),
+                keepDim=keepDim,
             )
         self.ax.set_xbound(*newXRange)
         self.ax.set_ybound(*newYRange)
         self.ax2.set_ybound(*newY2Range)
+        # If plot range has changed, then emit signal
+        if xRange != newXRange:
+            self._plot.getXAxis()._emitLimitsChanged()
+        if yRange != newYRange:
+            self._plot.getYAxis(axis="left")._emitLimitsChanged()
+        if y2Range != newY2Range:
+            self._plot.getYAxis(axis="right")._emitLimitsChanged()
+
         self._updateMarkers()
 
     # Graph axes
@@ -1303,7 +1314,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
             # In this case a draw with positive limits is needed first
             xlim = self.ax.get_xbound()
             if xlim[0] <= 0 and xlim[1] <= 0:
-                self._setXLimits(1, 10)
+                self._setPlotBounds(xRange=(1, 10))
                 self.draw()
         self.ax2.set_xscale(scale)
         self.ax.set_xscale(scale)

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -24,6 +24,9 @@
 """Matplotlib Plot backend."""
 
 from __future__ import annotations
+from typing import Literal
+
+from .utils import Range, ensureAspectRatio, findDimToKeep
 
 __authors__ = ["V.A. Sole", "T. Vincent, H. Payno"]
 __license__ = "MIT"
@@ -519,13 +522,6 @@ class BackendMatplotlib(BackendBase.BackendBase):
     def __init__(self, plot, parent=None):
         super().__init__(plot, parent)
 
-        # matplotlib is handling keep aspect ratio at draw time
-        # When keep aspect ratio is on, and one changes the limits and
-        # ask them *before* next draw has been performed he will get the
-        # limits without applying keep aspect ratio.
-        # This attribute is used to ensure consistent values returned
-        # when getting the limits at the expense of a replot
-        self._dirtyLimits = True
         self._axesDisplayed = True
 
         self.fig = Figure(
@@ -567,6 +563,8 @@ class BackendMatplotlib(BackendBase.BackendBase):
         for axis in (self.ax.yaxis, self.ax.xaxis, self.ax2.yaxis, self.ax2.xaxis):
             axis.set_major_formatter(DefaultTickFormatter())
 
+        # Autoscale is handled manually by the backend
+        self.ax.set_autoscalex_on(False)
         self.ax.set_autoscaley_on(False)
         self.ax2.set_autoscaley_on(False)
 
@@ -1137,7 +1135,6 @@ class BackendMatplotlib(BackendBase.BackendBase):
         # TODO images, markers? scatter plot? move in remove?
         # Right Y axis only support curve for now
         # Hide right Y axis if no line is present
-        self._dirtyLimits = False
         if not self.ax2.lines:
             self._enableAxis("right", False)
 
@@ -1200,74 +1197,71 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
     # Graph limits
 
-    def _setXLimits(self, xmin: float, xmax: float):
-        xmin = min(xmin, xmax)
-        xmax = max(xmin, xmax)
-        if self.isXAxisInverted():
-            left, right = xmax, xmin
+    def setLimits(
+        self,
+        xmin: float,
+        xmax: float,
+        ymin: float,
+        ymax: float,
+        y2min: float | None = None,
+        y2max: float | None = None,
+    ):
+        if y2min is None or y2max is None:
+            y2Range = None
         else:
-            left, right = xmin, xmax
-        self.ax.set_xlim(left, right)
+            y2Range = (y2min, y2max)
+        self._setPlotBounds(xRange=(xmin, xmax), yRange=(ymin, ymax), y2Range=y2Range)
 
-    def setLimits(self, xmin, xmax, ymin, ymax, y2min=None, y2max=None):
-        # Let matplotlib taking care of keep aspect ratio if any
-        self._dirtyLimits = True
-        self._setXLimits(xmin, xmax)
-
-        if y2min is not None and y2max is not None:
-            self.ax2.set_ybound(min(y2min, y2max), max(y2min, y2max))
-
-        self.ax.set_ybound(min(ymin, ymax), max(ymin, ymax))
-
-        self._updateMarkers()
-
-    def getGraphXLimits(self):
-        if self._dirtyLimits and self.isKeepDataAspectRatio():
-            self.ax.apply_aspect()
-            self.ax2.apply_aspect()
-            self._dirtyLimits = False
+    def getGraphXLimits(self) -> Range:
         return self.ax.get_xbound()
 
-    def setGraphXLimits(self, xmin, xmax):
-        self._dirtyLimits = True
-        self._setXLimits(xmin, xmax)
-        self._updateMarkers()
+    def setGraphXLimits(self, xmin: float, xmax: float):
+        self._setPlotBounds(xRange=(xmin, xmax))
 
-    def getGraphYLimits(self, axis):
+    def getGraphYLimits(self, axis: Literal["left", "right"]) -> Range | None:
         assert axis in ("left", "right")
         ax = self.ax2 if axis == "right" else self.ax
 
         if not ax.get_visible():
             return None
 
-        if self._dirtyLimits and self.isKeepDataAspectRatio():
-            self.ax.apply_aspect()
-            self.ax2.apply_aspect()
-            self._dirtyLimits = False
-
         return ax.get_ybound()
 
-    def setGraphYLimits(self, ymin, ymax, axis):
-        ax = self.ax2 if axis == "right" else self.ax
-        if ymax < ymin:
-            ymin, ymax = ymax, ymin
-        self._dirtyLimits = True
+    def setGraphYLimits(self, ymin: float, ymax: float, axis: Literal["left", "right"]):
+        if axis == "right":
+            self._setPlotBounds(y2Range=(ymin, ymax))
+        else:
+            self._setPlotBounds(yRange=(ymin, ymax))
 
-        if self.isKeepDataAspectRatio():
-            # matplotlib keeps limits of shared axis when keeping aspect ratio
-            # So x limits are kept when changing y limits....
-            # Change x limits first by taking into account aspect ratio
-            # and then change y limits.. so matplotlib does not need
-            # to make change (to y) to keep aspect ratio
-            xmin, xmax = ax.get_xbound()
-            curYMin, curYMax = ax.get_ybound()
+    def _setPlotBounds(
+        self,
+        xRange: Range | None = None,
+        yRange: Range | None = None,
+        y2Range: Range | None = None,
+    ):
+        # Keep data aspect ratio
+        if xRange is None:
+            xRange = self.ax.get_xbound()
+        if yRange is None:
+            yRange = self.ax.get_ybound()
+        if y2Range is None:
+            y2Range = self.ax2.get_ybound()
 
-            newXRange = (xmax - xmin) * (ymax - ymin) / (curYMax - curYMin)
-            xcenter = 0.5 * (xmin + xmax)
-            self._setXLimits(xcenter - 0.5 * newXRange, xcenter + 0.5 * newXRange)
-
-        ax.set_ybound(ymin, ymax)
-
+        if not self.isKeepDataAspectRatio():
+            newXRange, newYRange, newY2Range = xRange, yRange, y2Range
+        else:
+            bbox = self.fig.get_window_extent()
+            newXRange, newYRange, newY2Range = ensureAspectRatio(
+                bbox.width,
+                bbox.height,
+                xRange,
+                yRange,
+                y2Range,
+                keepDim=findDimToKeep(bbox.width, bbox.height, xRange, yRange),
+            )
+        self.ax.set_xbound(*newXRange)
+        self.ax.set_ybound(*newYRange)
+        self.ax2.set_ybound(*newY2Range)
         self._updateMarkers()
 
     # Graph axes
@@ -1357,13 +1351,6 @@ class BackendMatplotlib(BackendBase.BackendBase):
 
     def isYRightAxisVisible(self):
         return self.ax2.yaxis.get_visible()
-
-    def isKeepDataAspectRatio(self):
-        return self.ax.get_aspect() in (1.0, "equal")
-
-    def setKeepDataAspectRatio(self, flag):
-        self.ax.set_aspect(1.0 if flag else "auto")
-        self.ax2.set_aspect(1.0 if flag else "auto")
 
     def setGraphGrid(self, which):
         self.ax.grid(False, which="both")  # Disable all grid first
@@ -1505,8 +1492,6 @@ class BackendMatplotlibQt(BackendMatplotlib, FigureCanvasQTAgg):
         FigureCanvasQTAgg.__init__(self, self.fig)
         self.setParent(parent)
 
-        self._limitsBeforeResize = None
-
         FigureCanvasQTAgg.setSizePolicy(
             self, qt.QSizePolicy.Expanding, qt.QSizePolicy.Expanding
         )
@@ -1626,17 +1611,10 @@ class BackendMatplotlibQt(BackendMatplotlib, FigureCanvasQTAgg):
     # replot control
 
     def resizeEvent(self, event):
-        # Store current limits
-        self._limitsBeforeResize = (
-            self.ax.get_xbound(),
-            self.ax.get_ybound(),
-            self.ax2.get_ybound(),
-        )
-
         FigureCanvasQTAgg.resizeEvent(self, event)
-        if self.isKeepDataAspectRatio() or self._hasOverlays():
-            # This is needed with matplotlib 1.5.x and 2.0.x
-            self._plot._setDirtyPlot()
+        self._setPlotBounds(
+            self.ax.get_xbound(), self.ax.get_ybound(), self.ax2.get_ybound()
+        )
 
     def draw(self):
         """Overload draw
@@ -1670,21 +1648,6 @@ class BackendMatplotlibQt(BackendMatplotlib, FigureCanvasQTAgg):
             self._background = self.copy_from_bbox(self.fig.bbox)
         else:
             self._background = None  # Reset background
-
-        # Check if limits changed due to a resize of the widget
-        if self._limitsBeforeResize is not None:
-            xLimits, yLimits, yRightLimits = self._limitsBeforeResize
-            self._limitsBeforeResize = None
-
-            if xLimits != self.ax.get_xbound() or yLimits != self.ax.get_ybound():
-                self._updateMarkers()
-
-            if xLimits != self.ax.get_xbound():
-                self._plot.getXAxis()._emitLimitsChanged()
-            if yLimits != self.ax.get_ybound():
-                self._plot.getYAxis(axis="left")._emitLimitsChanged()
-            if yRightLimits != self.ax2.get_ybound():
-                self._plot.getYAxis(axis="right")._emitLimitsChanged()
 
         self._drawOverlays()
 

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1632,8 +1632,6 @@ class BackendMatplotlibQt(BackendMatplotlib, FigureCanvasQTAgg):
             self.ax.get_ybound(),
             self.ax2.get_ybound(),
         )
-        self.ax.set_autoscaley_on(True)
-        self.ax2.set_autoscaley_on(True)
 
         FigureCanvasQTAgg.resizeEvent(self, event)
         if self.isKeepDataAspectRatio() or self._hasOverlays():
@@ -1680,9 +1678,6 @@ class BackendMatplotlibQt(BackendMatplotlib, FigureCanvasQTAgg):
 
             if xLimits != self.ax.get_xbound() or yLimits != self.ax.get_ybound():
                 self._updateMarkers()
-
-            self.ax.set_autoscaley_on(False)
-            self.ax2.set_autoscaley_on(False)
 
             if xLimits != self.ax.get_xbound():
                 self._plot.getXAxis()._emitLimitsChanged()

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -31,6 +31,7 @@ __date__ = "21/12/2018"
 
 import logging
 import weakref
+from typing import Literal
 
 import numpy
 
@@ -45,6 +46,7 @@ from ... import _glutils as glu
 from . import glutils
 from .glutils.PlotImageFile import saveImageToFile
 from silx.gui.colors import RGBAColorType
+from .utils import findDimToKeep, ensureAspectRatio
 
 _logger = logging.getLogger(__name__)
 
@@ -254,8 +256,6 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         self._progBase = glu.Program(_baseVertShd, _baseFragShd, attrib0="position")
         self._progTex = glu.Program(_texVertShd, _texFragShd, attrib0="position")
         self._plotFBOs = weakref.WeakKeyDictionary()
-
-        self._keepDataAspectRatio = False
 
         self._crosshairCursor = None
         self._mousePosInPixels = None
@@ -1483,7 +1483,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         # Update axes range with a clipped range if too wide
         self._plotFrame.setDataRanges(xlim, ylim, y2lim)
 
-    def _ensureAspectRatio(self, keepDim=None):
+    def _ensureAspectRatio(self, keepDim: Literal["x", "y"] | None = None):
         """Update plot bounds in order to keep aspect ratio.
 
         Warning: keepDim on right Y axis is not implemented !
@@ -1492,44 +1492,16 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
             If None (the default), the dimension with the largest range.
         """
         plotWidth, plotHeight = self._plotFrame.plotSize
-        if plotWidth <= 2 or plotHeight <= 2:
-            return
-
+        xRange, yRange, y2Range = self._plotFrame.dataRanges
         if keepDim is None:
             ranges = self._plot.getDataRange()
-            if (
-                ranges.y is not None
-                and ranges.x is not None
-                and (ranges.y[1] - ranges.y[0]) != 0.0
-            ):
-                dataRatio = (ranges.x[1] - ranges.x[0]) / float(
-                    ranges.y[1] - ranges.y[0]
-                )
-                plotRatio = plotWidth / float(plotHeight)  # Test != 0 before
-
-                keepDim = "x" if dataRatio > plotRatio else "y"
-            else:  # Limit case
-                keepDim = "x"
-
-        (xMin, xMax), (yMin, yMax), (y2Min, y2Max) = self._plotFrame.dataRanges
-        if keepDim == "y":
-            dataW = (yMax - yMin) * plotWidth / float(plotHeight)
-            xCenter = 0.5 * (xMin + xMax)
-            xMin = xCenter - 0.5 * dataW
-            xMax = xCenter + 0.5 * dataW
-        elif keepDim == "x":
-            dataH = (xMax - xMin) * plotHeight / float(plotWidth)
-            yCenter = 0.5 * (yMin + yMax)
-            yMin = yCenter - 0.5 * dataH
-            yMax = yCenter + 0.5 * dataH
-            y2Center = 0.5 * (y2Min + y2Max)
-            y2Min = y2Center - 0.5 * dataH
-            y2Max = y2Center + 0.5 * dataH
-        else:
-            raise RuntimeError("Unsupported dimension to keep: %s" % keepDim)
+            keepDim = findDimToKeep(plotWidth, plotHeight, ranges.x, ranges.y)
+        newXRange, newYRange, newY2Range = ensureAspectRatio(
+            plotWidth, plotHeight, xRange, yRange, y2Range, keepDim
+        )
 
         # Update plot frame bounds
-        self._setDataRanges(xlim=(xMin, xMax), ylim=(yMin, yMax), y2lim=(y2Min, y2Max))
+        self._setDataRanges(xlim=newXRange, ylim=newYRange, y2lim=newY2Range)
 
     def _setPlotBounds(self, xRange=None, yRange=None, y2Range=None, keepDim=None):
         # Update axes range with a clipped range if too wide
@@ -1632,7 +1604,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         else:
             return self._keepDataAspectRatio
 
-    def setKeepDataAspectRatio(self, flag):
+    def setKeepDataAspectRatio(self, flag: bool):
         if flag and (self._plotFrame.xAxis.isLog or self._plotFrame.yAxis.isLog):
             _logger.warning("KeepDataAspectRatio is ignored with log axes")
 

--- a/src/silx/gui/plot/backends/utils.py
+++ b/src/silx/gui/plot/backends/utils.py
@@ -27,8 +27,7 @@ def ensureAspectRatio(
 
     Warning: keepDim on right Y axis is not implemented !
 
-    :param str keepDim: The dimension to maintain: 'x', 'y' or None.
-        If None (the default), the dimension with the largest range.
+    :param keepDim: The dimension to maintain: 'x' or 'y'
     """
     if plotWidth <= 2 or plotHeight <= 2:
         return xRange, yRange, y2Range

--- a/src/silx/gui/plot/backends/utils.py
+++ b/src/silx/gui/plot/backends/utils.py
@@ -1,0 +1,53 @@
+from typing import Literal
+
+
+Range = tuple[float, float]
+
+
+def findDimToKeep(
+    width: float, height: float, xRange: Range | None, yRange: Range | None
+) -> Literal["x"] | Literal["y"]:
+    if xRange is None or yRange is None or (yRange[1] - yRange[0]) == 0 or height == 0:
+        return "x"
+    dataRatio = (xRange[1] - xRange[0]) / float(yRange[1] - yRange[0])
+    plotRatio = width / float(height)
+
+    return "x" if dataRatio > plotRatio else "y"
+
+
+def ensureAspectRatio(
+    plotWidth: float,
+    plotHeight: float,
+    xRange: Range,
+    yRange: Range,
+    y2Range: Range,
+    keepDim: Literal["x", "y"],
+) -> tuple[Range, Range, Range]:
+    """Update plot bounds in order to keep aspect ratio.
+
+    Warning: keepDim on right Y axis is not implemented !
+
+    :param str keepDim: The dimension to maintain: 'x', 'y' or None.
+        If None (the default), the dimension with the largest range.
+    """
+    if plotWidth <= 2 or plotHeight <= 2:
+        return xRange, yRange, y2Range
+
+    (xMin, xMax), (yMin, yMax), (y2Min, y2Max) = xRange, yRange, y2Range
+    if keepDim == "y":
+        dataW = (yMax - yMin) * plotWidth / float(plotHeight)
+        xCenter = 0.5 * (xMin + xMax)
+        xMin = xCenter - 0.5 * dataW
+        xMax = xCenter + 0.5 * dataW
+        return (xMin, xMax), yRange, y2Range
+
+    if keepDim == "x":
+        dataH = (xMax - xMin) * plotHeight / float(plotWidth)
+        yCenter = 0.5 * (yMin + yMax)
+        yMin = yCenter - 0.5 * dataH
+        yMax = yCenter + 0.5 * dataH
+        y2Center = 0.5 * (y2Min + y2Max)
+        y2Min = y2Center - 0.5 * dataH
+        y2Max = y2Center + 0.5 * dataH
+        return xRange, (yMin, yMax), (y2Min, y2Max)
+    raise RuntimeError("Unsupported dimension to keep: %s" % keepDim)

--- a/src/silx/gui/plot/test/test_plotwidget.py
+++ b/src/silx/gui/plot/test/test_plotwidget.py
@@ -100,7 +100,7 @@ class TestPlotWidget(PlotWidgetTestCase, ParametricTestCase):
             self.assertTrue(numpy.allclose(expectedRatio, ratio, atol=0.01))
 
     def testChangeLimitsWithAspectRatio(self):
-        self.plot.setKeepDataAspectRatio()
+        self.plot.setKeepDataAspectRatio(True)
         self.qapp.processEvents()
         xlim = self.plot.getXAxis().getLimits()
         ylim = self.plot.getYAxis().getLimits()
@@ -1744,7 +1744,7 @@ class TestPlotCurveLog(PlotWidgetTestCase, ParametricTestCase):
                 self.assertEqual(yLim, (min(yData), max(yData)))
 
                 # x axis log
-                self.plot.getXAxis()._setLogarithmic(True)
+                self.plot.setXAxisLogarithmic(True)
                 self.qapp.processEvents()
 
                 xLim = self.plot.getXAxis().getLimits()

--- a/src/silx/gui/plot/test/test_utilsaxis.py
+++ b/src/silx/gui/plot/test/test_utilsaxis.py
@@ -21,12 +21,12 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-"""Basic tests for PlotWidget"""
 
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "20/11/2018"
 
+import numpy
 
 from silx.gui.plot import PlotWidget
 from silx.gui.utils.testutils import TestCaseQt
@@ -237,3 +237,16 @@ class TestAxisSync(TestCaseQt):
         self.assertEqual(self.plot1.getXAxis().getLimits(), (10, 500))
         self.assertEqual(self.plot2.getXAxis().getLimits(), (10, 500))
         self.assertNotEqual(self.plot3.getXAxis().getLimits(), (10, 500))
+
+    def testAddImage(self):
+        x_sync = SyncAxes([self.plot1.getXAxis()])
+        x_sync.addAxis(self.plot2.getXAxis())
+        y_sync = SyncAxes([self.plot1.getYAxis()])
+        y_sync.addAxis(self.plot2.getYAxis())
+
+        self.plot1.addImage(numpy.arange(100).reshape(5, 20))
+        assert self.plot1.getGraphXLimits() == (0, 20)
+        assert self.plot2.getGraphXLimits() == (0, 20)
+
+        assert self.plot1.getGraphYLimits() == (0, 5)
+        assert self.plot2.getGraphYLimits() == (0, 5)


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

Fix #4588 

Linked to https://github.com/silx-kit/silx/pull/4256 and https://github.com/silx-kit/silx/pull/4204 among others

I tracked down the origin of #4588 to https://github.com/silx-kit/silx/pull/4204. While seemingly unrelated, setting the label width programatically triggers a resize of the plot window with a wrong value of `YAxisInverted`.

@t20100 suspected something fishy with the treatement of the aspect ratio in the matplotlib backend that tries to delegate a bit the aspect ratio but not totally.

In this PR, I move the handling of the aspect ratio **completely** in the backend to not rely at all on matplotlib. For this, I reused the handling of the aspect ratio used in OpenGL by putting it in helper functions.

This seems to have fixed the issue.

<s>Unfortunately, a little problem remains: the first render of the matplotlib figure does not respect the fixed aspect ratio. </s>

**Now fixed:** I forgot to disable autoscaling for X in the last commit

<!-- Thank you for your pull request! Please, provide a description of the changes below -->


#### AI Disclosure
- [x] No AI used
- [ ] AI tool(s) ... used for ...
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
