### PR TITLE
Remove silx.gui.plot._utils.timestamp and future annotations

### DIFF
--- a/examples/compareBackends.py
+++ b/examples/compareBackends.py
@@ -26,8 +26,6 @@
 This script compares the rendering of PlotWidget's matplotlib and OpenGL backends.
 """
 
-from __future__ import annotations
-
 __license__ = "MIT"
 
 import numpy

--- a/src/silx/app/utils/parseutils.py
+++ b/src/silx/app/utils/parseutils.py
@@ -22,8 +22,6 @@
 # ############################################################################*/
 """Utils related to parsing"""
 
-from __future__ import annotations
-
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "28/05/2018"

--- a/src/silx/app/view/CustomPlotSelectionWindow.py
+++ b/src/silx/app/view/CustomPlotSelectionWindow.py
@@ -23,8 +23,6 @@
 
 """Custom plot selection window for selecting 1D datasets to plot."""
 
-from __future__ import annotations
-
 from silx.gui import qt, plot, icons
 import silx.gui
 import silx.gui.plot

--- a/src/silx/app/view/Viewer.py
+++ b/src/silx/app/view/Viewer.py
@@ -22,8 +22,6 @@
 # ############################################################################*/
 """Browse a data file with a GUI"""
 
-from __future__ import annotations
-
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "15/01/2019"

--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -23,8 +23,6 @@
 # ###########################################################################*/
 """This module provides API to manage colors."""
 
-from __future__ import annotations
-
 __authors__ = ["T. Vincent", "H.Payno"]
 __license__ = "MIT"
 __date__ = "29/01/2019"
@@ -255,7 +253,7 @@ class _Colormappable:
 
     def _getColormapAutoscaleRange(
         self,
-        colormap: Colormap | None,
+        colormap: "Colormap | None",
     ) -> tuple[float | None, float | None]:
         """Returns the autoscale range for given colormap.
 
@@ -396,7 +394,7 @@ class Colormap(qt.QObject):
         self.__warnBadVmin = True
         self.__warnBadVmax = True
 
-    def setFromColormap(self, other: Colormap):
+    def setFromColormap(self, other: "Colormap"):
         """Set this colormap using information from the `other` colormap.
 
         :param other: Colormap to use as reference.
@@ -894,7 +892,7 @@ class Colormap(qt.QObject):
         colormap._setFromDict(dic)
         return colormap
 
-    def copy(self) -> Colormap:
+    def copy(self) -> "Colormap":
         """Return a copy of the Colormap."""
         colormap = Colormap(
             name=self._name,

--- a/src/silx/gui/dialog/ColormapDialog.py
+++ b/src/silx/gui/dialog/ColormapDialog.py
@@ -58,8 +58,6 @@ The updates of the colormap description are also available through the signal:
 :attr:`ColormapDialog.sigColormapChanged`.
 """  # noqa
 
-from __future__ import annotations
-
 __authors__ = ["V.A. Sole", "T. Vincent", "H. Payno"]
 __license__ = "MIT"
 __date__ = "08/12/2020"

--- a/src/silx/gui/dialog/_ColormapPercentileWidget.py
+++ b/src/silx/gui/dialog/_ColormapPercentileWidget.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from silx.gui import qt
 from ..colors import Colormap
 

--- a/src/silx/gui/dialog/test/test_datafiledialog.py
+++ b/src/silx/gui/dialog/test/test_datafiledialog.py
@@ -23,8 +23,6 @@
 # ###########################################################################*/
 """Test for silx.gui.hdf5 module"""
 
-from __future__ import annotations
-
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "08/03/2019"

--- a/src/silx/gui/dialog/test/test_imagefiledialog.py
+++ b/src/silx/gui/dialog/test/test_imagefiledialog.py
@@ -23,8 +23,6 @@
 # ###########################################################################*/
 """Test for silx.gui.hdf5 module"""
 
-from __future__ import annotations
-
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "08/03/2019"

--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -23,8 +23,6 @@
 # ###########################################################################*/
 """Image stack view with data prefetch capabilty."""
 
-from __future__ import annotations
-
 __authors__ = ["H. Payno"]
 __license__ = "MIT"
 __date__ = "04/03/2019"

--- a/src/silx/gui/plot/PlotInteraction.py
+++ b/src/silx/gui/plot/PlotInteraction.py
@@ -23,8 +23,6 @@
 # ###########################################################################*/
 """Implementation of the interaction for the :class:`Plot`."""
 
-from __future__ import annotations
-
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "15/02/2019"

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -68,7 +68,6 @@ from .items.axis import TickMode  # noqa
 
 from .. import qt
 from ._utils.panzoom import ViewConstraints
-from ...gui.plot._utils.dtime_ticklayout import timestamp
 from ...utils.deprecation import deprecated_warning
 
 from .backends.BackendBase import BackendBase
@@ -1240,7 +1239,7 @@ class PlotWidget(qt.QMainWindow):
             # tickMode to TickMode.TIME_SERIES and, if necessary, set the axis
             # to the correct time zone.
             if len(x) > 0 and isinstance(x[0], dt.datetime):
-                x = [timestamp(d) for d in x]
+                x = [d.timestamp() for d in x]
 
             curve.setData(x, y, xerror, yerror, baseline=baseline, copy=copy)
 

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -25,8 +25,6 @@
 The :class:`PlotWidget` implements the plot API initially provided in PyMca.
 """
 
-from __future__ import annotations
-
 __authors__ = ["V.A. Sole", "T. Vincent"]
 __license__ = "MIT"
 __date__ = "21/12/2018"
@@ -100,7 +98,7 @@ class _PlotWidgetSelection(qt.QObject):
     sigSelectedItemsChanged = qt.Signal()
     """Signal emitted whenever the list of selected items changes."""
 
-    def __init__(self, parent: PlotWidget):
+    def __init__(self, parent: "PlotWidget"):
         assert isinstance(parent, PlotWidget)
         super().__init__(parent=parent)
 
@@ -379,7 +377,7 @@ class PlotWidget(qt.QMainWindow):
 
     def __init__(
         self,
-        parent: qt.Qt.Widget | None = None,
+        parent: qt.QWidget | None = None,
         backend: BackendType = None,
     ):
         self._autoreplot = False
@@ -665,7 +663,7 @@ class PlotWidget(qt.QMainWindow):
 
     # Default Qt context menu
 
-    def contextMenuEvent(self, event: qt.Qt.QContextEvent):
+    def contextMenuEvent(self, event: qt.QContextMenuEvent):
         """Override QWidget.contextMenuEvent to implement the context menu"""
         menu = qt.QMenu(self)
         from .actions.control import ZoomBackAction  # Avoid cyclic import

--- a/src/silx/gui/plot/_utils/dtime_ticklayout.py
+++ b/src/silx/gui/plot/_utils/dtime_ticklayout.py
@@ -35,9 +35,7 @@ import datetime as dt
 import enum
 import logging
 import math
-import time
 
-import dateutil.tz
 
 from dateutil.relativedelta import relativedelta
 
@@ -52,49 +50,6 @@ SECONDS_PER_HOUR = 60 * SECONDS_PER_MINUTE
 SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR
 SECONDS_PER_YEAR = 365.25 * SECONDS_PER_DAY
 SECONDS_PER_MONTH_AVERAGE = SECONDS_PER_YEAR / 12  # Seconds per average month
-
-
-# No dt.timezone in Python 2.7 so we use dateutil.tz.tzutc
-_EPOCH = dt.datetime(1970, 1, 1, tzinfo=dateutil.tz.tzutc())
-
-
-def timestamp(dtObj):
-    """Returns POSIX timestamp of a datetime objects.
-
-    If the dtObj object has a timestamp() method (python 3.3), this is
-    used. Otherwise (e.g. python 2.7) it is calculated here.
-
-    The POSIX timestamp is a floating point value of the number of seconds
-    since the start of an epoch (typically 1970-01-01). For details see:
-    https://docs.python.org/3/library/datetime.html#datetime.datetime.timestamp
-
-    :param datetime.datetime dtObj: date-time representation.
-    :return: POSIX timestamp
-    :rtype: float
-    """
-    if hasattr(dtObj, "timestamp"):
-        return dtObj.timestamp()
-    else:
-        # Back ported from Python 3.5
-        if dtObj.tzinfo is None:
-            return (
-                time.mktime(
-                    (
-                        dtObj.year,
-                        dtObj.month,
-                        dtObj.day,
-                        dtObj.hour,
-                        dtObj.minute,
-                        dtObj.second,
-                        -1,
-                        -1,
-                        -1,
-                    )
-                )
-                + dtObj.microsecond / 1e6
-            )
-        else:
-            return (dtObj - _EPOCH).total_seconds()
 
 
 @enum.unique

--- a/src/silx/gui/plot/_utils/dtime_ticklayout.py
+++ b/src/silx/gui/plot/_utils/dtime_ticklayout.py
@@ -21,7 +21,7 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-from __future__ import annotations
+
 
 """This module implements date-time labels layout on graph axes."""
 

--- a/src/silx/gui/plot/_utils/panzoom.py
+++ b/src/silx/gui/plot/_utils/panzoom.py
@@ -23,8 +23,6 @@
 # ###########################################################################*/
 """Functions to apply pan and zoom on a Plot"""
 
-from __future__ import annotations
-
 __authors__ = ["T. Vincent", "V. Valls"]
 __license__ = "MIT"
 __date__ = "08/08/2017"

--- a/src/silx/gui/plot/backends/BackendBase.py
+++ b/src/silx/gui/plot/backends/BackendBase.py
@@ -28,8 +28,6 @@ It documents the Plot backend API.
 This API is a simplified version of PyMca PlotBackend API.
 """
 
-from __future__ import annotations
-
 __authors__ = ["V.A. Sole", "T. Vincent"]
 __license__ = "MIT"
 __date__ = "21/12/2018"

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -64,7 +64,6 @@ from .._utils import FLOAT32_MINPOS
 from .._utils.dtime_ticklayout import (
     calcTicks,
     formatDatetimes,
-    timestamp,
 )
 from ...qt import inspect as qt_inspect
 from .... import config
@@ -205,7 +204,7 @@ class NiceDateLocator(Locator):
         dtTicks, self._spacing, self._unit = calcTicks(dtMin, dtMax, self.numTicks)
 
         # Convert datetime back to time stamps.
-        ticks = [timestamp(dtTick) for dtTick in dtTicks]
+        ticks = [dtTick.timestamp() for dtTick in dtTicks]
         return ticks
 
 

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -23,20 +23,17 @@
 # ###########################################################################*/
 """Matplotlib Plot backend."""
 
-from __future__ import annotations
-from typing import Literal
-
-from .utils import Range, ensureAspectRatio, findDimToKeep
-
 __authors__ = ["V.A. Sole", "T. Vincent, H. Payno"]
 __license__ = "MIT"
 __date__ = "21/12/2018"
 
 
+from typing import Literal
 import logging
 import datetime as dt
 import numpy
 
+from .utils import Range, ensureAspectRatio, findDimToKeep
 from ... import qt
 
 # First of all init matplotlib and set its backend

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -23,8 +23,6 @@
 # ############################################################################*/
 """OpenGL Plot backend."""
 
-from __future__ import annotations
-
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "21/12/2018"

--- a/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -58,7 +58,6 @@ from ..._utils.dtime_ticklayout import (
     calcTicksAdaptive,
     formatDatetimes,
 )
-from ..._utils.dtime_ticklayout import timestamp
 
 _logger = logging.getLogger(__name__)
 
@@ -466,7 +465,7 @@ class PlotAxis:
                     ticks = formatDatetimes(visibleDatetimes, spacing, unit)
 
                     for tickDateTime, text in ticks.items():
-                        dataPos = timestamp(tickDateTime)
+                        dataPos = tickDateTime.timestamp()
                         xPixel = x0 + (dataPos - dataMin) * xScale
                         yPixel = y0 + (dataPos - dataMin) * yScale
                         yield ((xPixel, yPixel), dataPos, text)

--- a/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -25,8 +25,6 @@
 This modules provides the rendering of plot titles, axes and grid.
 """
 
-from __future__ import annotations
-
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "03/04/2017"

--- a/src/silx/gui/plot/backends/glutils/GLText.py
+++ b/src/silx/gui/plot/backends/glutils/GLText.py
@@ -26,8 +26,6 @@ This module provides minimalistic text support for OpenGL.
 It provides Latin-1 (ISO8859-1) characters for one monospace font at one size.
 """
 
-from __future__ import annotations
-
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "03/04/2017"

--- a/src/silx/gui/plot/items/_cache.py
+++ b/src/silx/gui/plot/items/_cache.py
@@ -1,6 +1,3 @@
-from __future__ import annotations
-
-
 from collections import OrderedDict
 
 

--- a/src/silx/gui/plot/items/axis.py
+++ b/src/silx/gui/plot/items/axis.py
@@ -23,8 +23,6 @@
 # ###########################################################################*/
 """This module provides the class for axes of the :class:`PlotWidget`."""
 
-from __future__ import annotations
-
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "22/11/2018"

--- a/src/silx/gui/plot/items/core.py
+++ b/src/silx/gui/plot/items/core.py
@@ -23,8 +23,6 @@
 # ###########################################################################*/
 """This module provides the base class for items of the :class:`Plot`."""
 
-from __future__ import annotations
-
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "08/12/2020"

--- a/src/silx/gui/plot/items/curve.py
+++ b/src/silx/gui/plot/items/curve.py
@@ -23,8 +23,6 @@
 # ###########################################################################*/
 """This module provides the :class:`Curve` item of the :class:`Plot`."""
 
-from __future__ import annotations
-
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "24/04/2018"

--- a/src/silx/gui/plot/items/marker.py
+++ b/src/silx/gui/plot/items/marker.py
@@ -23,8 +23,6 @@
 # ###########################################################################*/
 """This module provides markers item of the :class:`Plot`."""
 
-from __future__ import annotations
-
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "06/03/2017"

--- a/src/silx/gui/plot/tools/PlotToolButton.py
+++ b/src/silx/gui/plot/tools/PlotToolButton.py
@@ -25,8 +25,6 @@
 plot tools for a toolbar.
 """
 
-from __future__ import annotations
-
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "20/12/2023"

--- a/src/silx/gui/plot/tools/_PlotOptionButton.py
+++ b/src/silx/gui/plot/tools/_PlotOptionButton.py
@@ -38,7 +38,7 @@ class PlotOptionButton(PlotToolButton):
         self._menu.addAction(plot.getCrosshairAction())
         self._menu.addAction(plot.getPanWithArrowKeysAction())
 
-    def setPlot(self, plot: PlotWindow):
+    def setPlot(self, plot: "PlotWindow"):
         from ..PlotWindow import PlotWindow  # noqa: F811 avoid cyclic import
 
         if not isinstance(plot, PlotWindow):

--- a/src/silx/gui/plot/tools/_PlotOptionButton.py
+++ b/src/silx/gui/plot/tools/_PlotOptionButton.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import TYPE_CHECKING
 from silx.gui import qt
 import qtawesome

--- a/src/silx/gui/plot/tools/profile/core.py
+++ b/src/silx/gui/plot/tools/profile/core.py
@@ -34,7 +34,7 @@ import weakref
 from silx.image.bilinear import BilinearImage
 from silx.gui import qt
 from silx.gui import colors
-import silx.gui.plot.items
+from ...items.core import Item
 
 
 class CurveProfileData(typing.NamedTuple):
@@ -186,7 +186,7 @@ class ProfileRoiMixIn:
             pass
 
     def computeProfile(
-        self, item: silx.gui.plot.items.Item
+        self, item: Item
     ) -> CurveProfileData | ImageProfileData | RgbaProfileData | CurvesProfileData:
         """
         Compute the profile which will be displayed.

--- a/src/silx/gui/plot/tools/profile/core.py
+++ b/src/silx/gui/plot/tools/profile/core.py
@@ -23,8 +23,6 @@
 # ###########################################################################*/
 """This module define core objects for profile tools."""
 
-from __future__ import annotations
-
 __authors__ = ["V.A. Sole", "T. Vincent", "P. Knobel", "H. Payno", "V. Valls"]
 __license__ = "MIT"
 __date__ = "17/04/2020"

--- a/src/silx/gui/plot3d/ParamTreeView.py
+++ b/src/silx/gui/plot3d/ParamTreeView.py
@@ -32,8 +32,6 @@ This module contains:
   :class:`Vector4DEditor`, :class:`IntSliderEditor`, :class:`BooleanEditor`
 """
 
-from __future__ import annotations
-
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "05/12/2017"

--- a/src/silx/gui/utils/glutils/__init__.py
+++ b/src/silx/gui/utils/glutils/__init__.py
@@ -23,9 +23,6 @@
 # ###########################################################################*/
 """This module provides the :func:`isOpenGLAvailable` utility function."""
 
-from __future__ import annotations
-
-
 import os
 import sys
 import subprocess

--- a/src/silx/gui/utils/matplotlib.py
+++ b/src/silx/gui/utils/matplotlib.py
@@ -30,8 +30,6 @@ It provides the matplotlib :class:`FigureCanvasQTAgg` class corresponding
 to the used backend.
 """
 
-from __future__ import annotations
-
 __authors__ = ["T. Vincent"]
 __license__ = "MIT"
 __date__ = "02/05/2018"

--- a/src/silx/gui/widgets/FloatEdit.py
+++ b/src/silx/gui/widgets/FloatEdit.py
@@ -23,8 +23,6 @@
 # ###########################################################################*/
 """Module contains a float editor"""
 
-from __future__ import annotations
-
 __authors__ = ["V.A. Sole", "T. Vincent"]
 __license__ = "MIT"
 __date__ = "02/10/2017"

--- a/src/silx/gui/widgets/FrameBrowser.py
+++ b/src/silx/gui/widgets/FrameBrowser.py
@@ -21,17 +21,18 @@
 # THE SOFTWARE.
 #
 # ###########################################################################*/
-from __future__ import annotations
+
 
 """This module defines two main classes:
 
-    - :class:`FrameBrowser`: a widget with 4 buttons (first, previous, next,
-      last) to browse between frames and a text entry to access a specific frame
-      by typing it's number)
-    - :class:`HorizontalSliderWithBrowser`: a FrameBrowser with an additional
-      slider. This class inherits :class:`qt.QAbstractSlider`.
+- :class:`FrameBrowser`: a widget with 4 buttons (first, previous, next,
+  last) to browse between frames and a text entry to access a specific frame
+  by typing it's number)
+- :class:`HorizontalSliderWithBrowser`: a FrameBrowser with an additional
+  slider. This class inherits :class:`qt.QAbstractSlider`.
 
 """
+
 from silx.gui import qt
 from silx.gui import icons
 

--- a/src/silx/gui/widgets/StackedProgressBar.py
+++ b/src/silx/gui/widgets/StackedProgressBar.py
@@ -22,7 +22,6 @@
 #
 # ###########################################################################*/
 
-from __future__ import annotations
 
 from typing import NamedTuple, Any
 
@@ -67,7 +66,7 @@ class StackedProgressBar(qt.QProgressBar):
     Multiple stacked progress bar in single component
     """
 
-    def __init__(self, parent: qt.Qwidget | None = None):
+    def __init__(self, parent: qt.QWidget | None = None):
         super().__init__(parent=parent)
         self.__stacks: dict[str, ProgressItem] = {}
         self._animated: int = 0

--- a/src/silx/gui/widgets/UrlList.py
+++ b/src/silx/gui/widgets/UrlList.py
@@ -22,7 +22,6 @@
 #
 # ###########################################################################*/
 
-from __future__ import annotations
 
 import logging
 from collections.abc import Iterable

--- a/src/silx/io/_sliceh5.py
+++ b/src/silx/io/_sliceh5.py
@@ -22,8 +22,6 @@
 # ############################################################################*/
 """Provides a wrapper to expose a dataset slice as a `commonh5.Dataset`."""
 
-from __future__ import annotations
-
 from typing import Union
 
 import h5py

--- a/src/silx/io/h5py_utils.py
+++ b/src/silx/io/h5py_utils.py
@@ -20,7 +20,7 @@
 # THE SOFTWARE.
 #
 # ############################################################################*/
-from __future__ import annotations
+
 
 """
 This module provides utility methods on top of h5py, mainly to handle

--- a/src/silx/io/test/test_url.py
+++ b/src/silx/io/test/test_url.py
@@ -22,8 +22,6 @@
 # ############################################################################*/
 """Tests for url module"""
 
-from __future__ import annotations
-
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "29/01/2018"

--- a/src/silx/io/url.py
+++ b/src/silx/io/url.py
@@ -23,8 +23,6 @@
 # ###########################################################################*/
 """URL module"""
 
-from __future__ import annotations
-
 __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "29/01/2018"

--- a/src/silx/resources/__init__.py
+++ b/src/silx/resources/__init__.py
@@ -53,8 +53,6 @@ of this modules to ensure access across different distribution schemes:
              )
 """
 
-from __future__ import annotations
-
 __authors__ = ["V.A. Sole", "Thomas Vincent", "J. Kieffer"]
 __license__ = "MIT"
 __date__ = "08/03/2019"

--- a/src/silx/test/__init__.py
+++ b/src/silx/test/__init__.py
@@ -23,8 +23,6 @@
 # ###########################################################################*/
 """This package provides test of the root modules"""
 
-from __future__ import annotations
-
 import importlib
 import os.path
 import subprocess


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

Fix #4235 

- [silx.gui.plot._utils: Remove timestamp function](https://github.com/silx-kit/silx/commit/be6eb315e10db12c80b93ca436390a2aa0ea7910) Could have been removed earlier
- [Remove from __future__ import annotations](https://github.com/silx-kit/silx/commit/2471a2f15c4573e3de38420dc7ec71541617ca04)

There is still some mention to Python 2.7 in very specific code (e.g. `EdfFile`). To be discussed if we want to remove it.

`from __future__ import annotations` is actually still needed if the class name is used as a type hint before the class is defined (forward references, present in e.g. `colors`, `PlotWidget`). This is because the lazy evaluation of annotations is only implemented in Python 3.14 (https://peps.python.org/pep-0749/), even though the `from __future__ import annotations` behaviour dates as far as Python 3.7 (https://peps.python.org/pep-0563/).

Instead of keeping `from __future__ import annotations`  in only a few files, I converted the forward references to string annotations (doing explicitely what `from __future__` is doing) where needed.

#### AI Disclosure
- [x] I chatted with Claude to build an understanding of the need of the  `from __future__ import annotations` 
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
