### PR TITLE
silx.gui.plot.PlotWidget: Allow directive zoom with shortcut ALT and SHIFT like h5web

### DIFF
--- a/src/silx/gui/plot/PlotInteraction.py
+++ b/src/silx/gui/plot/PlotInteraction.py
@@ -1896,18 +1896,28 @@ class PlotInteraction(qt.QObject):
         if not self.isZoomOnWheelEnabled():
             return
 
+        if angle == 0:
+            return
         plotWidget = self.parent()
         if plotWidget is None:
             return
 
         # All axes are enabled if keep aspect ratio is on
-        enabledAxes = (
-            EnabledAxes()
-            if plotWidget.isKeepDataAspectRatio()
-            else self.getZoomEnabledAxes()
-        )
+        if plotWidget.isKeepDataAspectRatio():
+            enabledAxes = EnabledAxes()
+        else:
+            modifiers = qt.QApplication.keyboardModifiers()
+            shiftPressed = modifiers & qt.Qt.ShiftModifier
+            altPressed = modifiers & qt.Qt.AltModifier
+            if shiftPressed or altPressed:
+                enabledAxes = EnabledAxes(
+                    xaxis=altPressed, yaxis=shiftPressed, y2axis=shiftPressed
+                )
+            else:
+                enabledAxes = self.getZoomEnabledAxes()
         if enabledAxes.isDisabled():
             return
 
         scale = 1.1 if angle > 0 else 1.0 / 1.1
+
         applyZoomToPlot(plotWidget, scale, (x, y), enabledAxes)

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1695,3 +1695,27 @@ class BackendMatplotlibQt(BackendMatplotlib, FigureCanvasQTAgg):
         else:
             cursor = self._QT_CURSORS[cursor]
             FigureCanvasQTAgg.setCursor(self, qt.QCursor(cursor))
+
+    def wheelEvent(self, event):
+        #  https://github.com/qt/qtbase/blob/120883a028a59864dc7691dd1efa318bd602755d/src/plugins/platforms/xcb/qxcbwindow.cpp#L1955-L1956
+        # qt xcb plugin put angleDelta in x rather than in y when alt modifier is pressed.
+        # matplotlib/matplotlib#25671 marked as 'won't fix'
+        # Fix here as we want to be able to use alt modifier in silx plot.
+        # https://github.com/silx-kit/silx/pull/4631
+        if event.angleDelta().y() == 0:
+            event = qt.QWheelEvent(
+                event.position(),
+                event.globalPosition(),
+                event.pixelDelta(),
+                qt.QPoint(0, event.angleDelta().x()),
+                event.buttons(),
+                event.modifiers(),
+                event.phase(),
+                event.isInverted(),
+                event.source(),
+                event.pointingDevice(),
+            )
+            super().wheelEvent(event)
+            return
+
+        super().wheelEvent(event)

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -321,7 +321,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         event.accept()
 
     def wheelEvent(self, event):
-        delta = event.angleDelta().y()
+        delta = event.angleDelta().x() + event.angleDelta().y()
         angleInDegrees = delta / 8.0
         x, y = qt.getMouseEventPosition(event)
         self._plot.onMouseWheel(x, y, angleInDegrees)

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -321,7 +321,14 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
         event.accept()
 
     def wheelEvent(self, event):
-        delta = event.angleDelta().x() + event.angleDelta().y()
+        delta = event.angleDelta().y()
+        #  https://github.com/qt/qtbase/blob/120883a028a59864dc7691dd1efa318bd602755d/src/plugins/platforms/xcb/qxcbwindow.cpp#L1955-L1956
+        # qt xcb plugin put angleDelta in x rather than in y when alt modifier is pressed.
+        # matplotlib/matplotlib#25671 marked as 'won't fix'
+        # Fix here as we want to be able to use alt modifier in silx plot.
+        # https://github.com/silx-kit/silx/pull/4631
+        if event.angleDelta().y() == 0:
+            delta = event.angleDelta().x()
         angleInDegrees = delta / 8.0
         x, y = qt.getMouseEventPosition(event)
         self._plot.onMouseWheel(x, y, angleInDegrees)

--- a/src/silx/gui/plot/tools/menus.py
+++ b/src/silx/gui/plot/tools/menus.py
@@ -52,9 +52,9 @@ class ZoomEnabledAxesMenu(qt.QMenu):
         self.__plotRef = weakref.ref(plot)
 
         self.addSection("Enabled axes")
-        self.__xAxisAction = qt.QAction("X axis", parent=self)
-        self.__yAxisAction = qt.QAction("Y left axis", parent=self)
-        self.__y2AxisAction = qt.QAction("Y right axis", parent=self)
+        self.__xAxisAction = qt.QAction("X axis (alt)", parent=self)
+        self.__yAxisAction = qt.QAction("Y left axis (shift)", parent=self)
+        self.__y2AxisAction = qt.QAction("Y right axis (shift)", parent=self)
 
         for action in (self.__xAxisAction, self.__yAxisAction, self.__y2AxisAction):
             action.setCheckable(True)

--- a/src/silx/gui/plot/tools/menus.py
+++ b/src/silx/gui/plot/tools/menus.py
@@ -52,9 +52,9 @@ class ZoomEnabledAxesMenu(qt.QMenu):
         self.__plotRef = weakref.ref(plot)
 
         self.addSection("Enabled axes")
-        self.__xAxisAction = qt.QAction("X axis (alt)", parent=self)
-        self.__yAxisAction = qt.QAction("Y left axis (shift)", parent=self)
-        self.__y2AxisAction = qt.QAction("Y right axis (shift)", parent=self)
+        self.__xAxisAction = qt.QAction("X axis (Alt+Wheel)", parent=self)
+        self.__yAxisAction = qt.QAction("Y left axis (Shift+Wheel)", parent=self)
+        self.__y2AxisAction = qt.QAction("Y right axis (Shift+Wheel)", parent=self)
 
         for action in (self.__xAxisAction, self.__yAxisAction, self.__y2AxisAction):
             action.setCheckable(True)


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

Add 2 short cut for directive zoom.

Alt for X and Shift for Y (like h5web)

<!-- Thank you for your pull request! Please, provide a description of the changes below -->


#### AI Disclosure
- [x] No AI used
- [ ] AI tool(s) ... used for ...
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
