### PR TITLE
647 threadpoolpushbutton exception while closing the application

### DIFF
--- a/src/silx/gui/widgets/ThreadPoolPushButton.py
+++ b/src/silx/gui/widgets/ThreadPoolPushButton.py
@@ -48,7 +48,7 @@ class _Wrapper(qt.QRunnable):
         self.__kwargs = kwargs
 
         # connect signal / slots
-        signalHolder.destroyed.connect(self.clear_signal_holder)
+        signalHolder.destroyed.connect(self._clearSignalHolder)
 
     def _getSignalHolder(self):
         if self.__signalHolder is None:

--- a/src/silx/gui/widgets/ThreadPoolPushButton.py
+++ b/src/silx/gui/widgets/ThreadPoolPushButton.py
@@ -63,33 +63,34 @@ class _Wrapper(qt.QRunnable):
         if not holder:
             return
 
-        holder.started.emit()
+        self._emitIfHolder("started")
         try:
             result = self.__callable(*self.__args, **self.__kwargs)
-            holder = self._getSignalHolder()
-            if holder:
-                holder.succeeded.emit(result)
+            self._emitIfHolder("succeeded", result)
         except Exception as e:
             module = self.__callable.__module__
             name = self.__callable.__name__
             _logger.error(
                 "Error while executing callable %s.%s.", module, name, exc_info=True
             )
-            holder = self._getSignalHolder()
-            if holder:
-                holder.failed.emit(e)
+            self._emitIfHolder("failed", e)
         finally:
             holder = self._getSignalHolder()
-            if holder:
-                holder.finished.emit()
-        holder = self._getSignalHolder()
-        if holder:
-            holder._sigReleaseRunner.emit(self)
+            self._emitIfHolder("finished")
+
+        self._emitIfHolder("_sigReleaseRunner", self)
 
     def autoDelete(self):
         """Returns true to ask the QThreadPool to manage the life cycle of
         this QRunner."""
         return True
+
+    def _emitIfHolder(self, emit_func, *args, **kwargs):
+        """Emit signal only if holder still exists."""
+        holder = self._getSignalHolder()
+        if not holder:
+            return
+        getattr(holder, emit_func).emit(*args, **kwargs)
 
 
 class ThreadPoolPushButton(WaitingPushButton):

--- a/src/silx/gui/widgets/ThreadPoolPushButton.py
+++ b/src/silx/gui/widgets/ThreadPoolPushButton.py
@@ -75,7 +75,6 @@ class _Wrapper(qt.QRunnable):
             )
             self._emitIfHolder("failed", e)
         finally:
-            holder = self._getSignalHolder()
             self._emitIfHolder("finished")
 
         self._emitIfHolder("_sigReleaseRunner", self)

--- a/src/silx/gui/widgets/ThreadPoolPushButton.py
+++ b/src/silx/gui/widgets/ThreadPoolPushButton.py
@@ -29,6 +29,7 @@ __date__ = "13/10/2016"
 
 import weakref
 import logging
+from typing import Any
 from .. import qt
 from .WaitingPushButton import WaitingPushButton
 

--- a/src/silx/gui/widgets/ThreadPoolPushButton.py
+++ b/src/silx/gui/widgets/ThreadPoolPushButton.py
@@ -47,10 +47,16 @@ class _Wrapper(qt.QRunnable):
         self.__args = args
         self.__kwargs = kwargs
 
+        # connect signal / slots
+        signalHolder.destroyed.connect(self.clear_signal_holder)
+
     def _getSignalHolder(self):
         if self.__signalHolder is None:
             return None
         return self.__signalHolder()
+
+    def clear_signal_holder(self):
+        self.__signalHolder = None
 
     def run(self):
         holder = self._getSignalHolder()

--- a/src/silx/gui/widgets/ThreadPoolPushButton.py
+++ b/src/silx/gui/widgets/ThreadPoolPushButton.py
@@ -55,7 +55,7 @@ class _Wrapper(qt.QRunnable):
             return None
         return self.__signalHolder()
 
-    def clear_signal_holder(self):
+    def _clearSignalHolder(self):
         self.__signalHolder = None
 
     def run(self):

--- a/src/silx/gui/widgets/ThreadPoolPushButton.py
+++ b/src/silx/gui/widgets/ThreadPoolPushButton.py
@@ -63,33 +63,63 @@ class _Wrapper(qt.QRunnable):
         if not holder:
             return
 
-        self._emitIfHolder("started")
+        self._emitStarted()
         try:
             result = self.__callable(*self.__args, **self.__kwargs)
-            self._emitIfHolder("succeeded", result)
+            self._emitSucceeded(result)
         except Exception as e:
             module = self.__callable.__module__
             name = self.__callable.__name__
             _logger.error(
                 "Error while executing callable %s.%s.", module, name, exc_info=True
             )
-            self._emitIfHolder("failed", e)
+            self._emitFailed(e)
         finally:
-            self._emitIfHolder("finished")
+            self._emitFinished()
 
-        self._emitIfHolder("_sigReleaseRunner", self)
+        self._emitSigReleaseRunner(self)
 
     def autoDelete(self):
         """Returns true to ask the QThreadPool to manage the life cycle of
         this QRunner."""
         return True
 
-    def _emitIfHolder(self, emit_func, *args, **kwargs):
-        """Emit signal only if holder still exists."""
+    # Signal emission under condition of holder existing
+
+    def _emitSucceeded(self, result):
+        """Emit 'succeeded' signal only if holder still exists."""
         holder = self._getSignalHolder()
         if not holder:
             return
-        getattr(holder, emit_func).emit(*args, **kwargs)
+        holder.succeeded.emit(result)
+
+    def _emitStarted(self):
+        """Emit 'started' signal only if holder still exists."""
+        holder = self._getSignalHolder()
+        if not holder:
+            return
+        holder.started.emit()
+
+    def _emitFinished(self):
+        """Emit 'finished' signal only if holder still exists."""
+        holder = self._getSignalHolder()
+        if not holder:
+            return
+        holder.finished.emit()
+
+    def _emitFailed(self, error):
+        """Emit 'failed' signal only if holder still exists."""
+        holder = self._getSignalHolder()
+        if not holder:
+            return
+        holder.failed.emit(error)
+
+    def _emitSigReleaseRunner(self, runner):
+        """Emit '_sigReleaseRunner' signal only if holder still exists."""
+        holder = self._getSignalHolder()
+        if not holder:
+            return
+        self._sigReleaseRunner.emit(runner)
 
 
 class ThreadPoolPushButton(WaitingPushButton):

--- a/src/silx/gui/widgets/ThreadPoolPushButton.py
+++ b/src/silx/gui/widgets/ThreadPoolPushButton.py
@@ -120,7 +120,7 @@ class _Wrapper(qt.QRunnable):
         holder = self._getSignalHolder()
         if not holder:
             return
-        self._sigReleaseRunner.emit(self)
+        holder._sigReleaseRunner.emit(self)
 
 
 class ThreadPoolPushButton(WaitingPushButton):

--- a/src/silx/gui/widgets/ThreadPoolPushButton.py
+++ b/src/silx/gui/widgets/ThreadPoolPushButton.py
@@ -27,6 +27,7 @@ __authors__ = ["V. Valls"]
 __license__ = "MIT"
 __date__ = "13/10/2016"
 
+import weakref
 import logging
 from .. import qt
 from .WaitingPushButton import WaitingPushButton
@@ -41,27 +42,43 @@ class _Wrapper(qt.QRunnable):
     def __init__(self, signalHolder, function, args, kwargs):
         """Constructor"""
         super().__init__()
-        self.__signalHolder = signalHolder
+        self.__signalHolder = weakref.ref(signalHolder)
         self.__callable = function
         self.__args = args
         self.__kwargs = kwargs
 
+    def _getSignalHolder(self):
+        if self.__signalHolder is None:
+            return None
+        return self.__signalHolder()
+
     def run(self):
-        holder = self.__signalHolder
+        holder = self._getSignalHolder()
+        if not holder:
+            return
+
         holder.started.emit()
         try:
             result = self.__callable(*self.__args, **self.__kwargs)
-            holder.succeeded.emit(result)
+            holder = self._getSignalHolder()
+            if holder:
+                holder.succeeded.emit(result)
         except Exception as e:
             module = self.__callable.__module__
             name = self.__callable.__name__
             _logger.error(
                 "Error while executing callable %s.%s.", module, name, exc_info=True
             )
-            holder.failed.emit(e)
+            holder = self._getSignalHolder()
+            if holder:
+                holder.failed.emit(e)
         finally:
-            holder.finished.emit()
-        holder._sigReleaseRunner.emit(self)
+            holder = self._getSignalHolder()
+            if holder:
+                holder.finished.emit()
+        holder = self._getSignalHolder()
+        if holder:
+            holder._sigReleaseRunner.emit(self)
 
     def autoDelete(self):
         """Returns true to ask the QThreadPool to manage the life cycle of

--- a/src/silx/gui/widgets/ThreadPoolPushButton.py
+++ b/src/silx/gui/widgets/ThreadPoolPushButton.py
@@ -107,7 +107,7 @@ class _Wrapper(qt.QRunnable):
             return
         holder.finished.emit()
 
-    def _emitFailed(self, error):
+    def _emitFailed(self, error: Exception):
         """Emit 'failed' signal only if holder still exists."""
         holder = self._getSignalHolder()
         if not holder:

--- a/src/silx/gui/widgets/ThreadPoolPushButton.py
+++ b/src/silx/gui/widgets/ThreadPoolPushButton.py
@@ -77,7 +77,7 @@ class _Wrapper(qt.QRunnable):
         finally:
             self._emitFinished()
 
-        self._emitSigReleaseRunner(self)
+        self._emitSigReleaseRunner()
 
     def autoDelete(self):
         """Returns true to ask the QThreadPool to manage the life cycle of
@@ -114,12 +114,12 @@ class _Wrapper(qt.QRunnable):
             return
         holder.failed.emit(error)
 
-    def _emitSigReleaseRunner(self, runner):
+    def _emitSigReleaseRunner(self):
         """Emit '_sigReleaseRunner' signal only if holder still exists."""
         holder = self._getSignalHolder()
         if not holder:
             return
-        self._sigReleaseRunner.emit(runner)
+        self._sigReleaseRunner.emit(self)
 
 
 class ThreadPoolPushButton(WaitingPushButton):

--- a/src/silx/gui/widgets/ThreadPoolPushButton.py
+++ b/src/silx/gui/widgets/ThreadPoolPushButton.py
@@ -86,7 +86,7 @@ class _Wrapper(qt.QRunnable):
 
     # Signal emission under condition of holder existing
 
-    def _emitSucceeded(self, result):
+    def _emitSucceeded(self, result: Any):
         """Emit 'succeeded' signal only if holder still exists."""
         holder = self._getSignalHolder()
         if not holder:


### PR DESCRIPTION
Closes #647 

### PR summary

Fix exception if the `ThreadPoolPushButton` executable still alive after `ThreadPoolPushButton` destruction.

#### AI Disclosure
- [ ] No AI used
- [x] AI tool(s) used to check for alternatives.
