### PR TITLE
silx.gui.plot.ImageStack: fix call to 'setNPrefetch'

### DIFF
--- a/src/silx/gui/plot/ImageStack.py
+++ b/src/silx/gui/plot/ImageStack.py
@@ -302,7 +302,10 @@ class ImageStack(qt.QMainWindow):
         """
         if n < 0:
             raise ValueError("'n' should be positive")
-        if self._urlData.maxsize < self.__n_prefetch:
+        if (
+            self._urlData.maxsize is not None
+            and self._urlData.maxsize < self.__n_prefetch
+        ):
             _logger.warning(
                 "Number of prefetchs lower that data cache size: This is not optimal"
             )

--- a/src/silx/gui/plot/test/test_imagestack.py
+++ b/src/silx/gui/plot/test/test_imagestack.py
@@ -63,6 +63,7 @@ class TestImageStack(TestCaseQt):
                     file_path=file_name, data_path=str(i), scheme="silx"
                 )
         self.widget = ImageStack()
+        self.widget.setNPrefetch(10)
 
         self.urlLoadedListener = SignalListener()
         self.widget.sigLoaded.connect(self.urlLoadedListener)


### PR DESCRIPTION
### PR summary

Fix condition when `setNPrefetch` is called. Now `_urlData.maxsize` can be None.

#### AI Disclosure
- [x] No AI used
- [ ] AI tool(s) ... used for ...
