### PR TITLE
silx.gui.data.DataViews: give the possibility to change the X axis when viewing NXdata as curves and add support for aux signal errors

### DIFF
--- a/src/silx/gui/data/DataViews.py
+++ b/src/silx/gui/data/DataViews.py
@@ -1196,10 +1196,14 @@ class _NXdataCurveView(_NXdataBaseDataView):
             else:
                 axes_errors.append(nxd.get_axis_errors(axis))
 
+        signal_errors = [
+            nxd.get_axis_errors(signal) for signal in nxd.auxiliary_signals_names
+        ]
+
         self.getWidget().setCurvesData(
             signals=[nxd.signal] + nxd.auxiliary_signals,
             signal_names=[nxd.signal_name] + nxd.auxiliary_signals_names,
-            signal_errors=nxd.errors,
+            signal_errors=[nxd.errors] + signal_errors,
             signal_scale=nxd.plot_style.signal_scale_type,
             axes=nxd.axes,
             axes_scales=nxd.plot_style.axes_scale_types,

--- a/src/silx/gui/data/DataViews.py
+++ b/src/silx/gui/data/DataViews.py
@@ -42,6 +42,7 @@ from silx.math.combo import min_max
 from ._DataInfo import DataInfo
 from ._DataView import DataView
 from ._RgbaImagePlot import RgbaImagePlot
+from ._NxCurvePlot import NxCurvePlot
 
 # DataViewHooks is part of the public API of this module
 from ._DataView import DataViewHooks  # noqa: F401
@@ -1170,10 +1171,8 @@ class _NXdataCurveView(_NXdataBaseDataView):
             icon=icons.getQIcon("view-1d"),
         )
 
-    def createWidget(self, parent):
-        from silx.gui.data.ArrayCurvePlot import ArrayCurvePlot
-
-        widget = ArrayCurvePlot(parent)
+    def createWidget(self, parent) -> NxCurvePlot:
+        widget = NxCurvePlot(parent)
         return widget
 
     def axesNames(self, data, info):
@@ -1186,22 +1185,27 @@ class _NXdataCurveView(_NXdataBaseDataView):
     def setData(self, data):
         data = self.normalizeData(data)
         nxd = nxdata.get_default(data, validate=False)
-        signals_names = [nxd.signal_name] + nxd.auxiliary_signals_names
-        if nxd.axes_dataset_names[-1] is not None:
-            x_errors = nxd.get_axis_errors(nxd.axes_dataset_names[-1])
-        else:
-            x_errors = None
+
+        if nxd is None:
+            return
+
+        axes_errors = []
+        for axis in nxd.axes_dataset_names:
+            if axis is None:
+                axes_errors.append(None)
+            else:
+                axes_errors.append(nxd.get_axis_errors(axis))
 
         self.getWidget().setCurvesData(
-            [nxd.signal] + nxd.auxiliary_signals,
-            nxd.axes[-1],
-            yerror=nxd.errors,
-            xerror=x_errors,
-            ylabels=signals_names,
-            xlabel=nxd.axes_names[-1],
-            title=nxd.title or signals_names[0],
-            xscale=nxd.plot_style.axes_scale_types[-1],
-            yscale=nxd.plot_style.signal_scale_type,
+            signals=[nxd.signal] + nxd.auxiliary_signals,
+            signal_names=[nxd.signal_name] + nxd.auxiliary_signals_names,
+            signal_errors=nxd.errors,
+            signal_scale=nxd.plot_style.signal_scale_type,
+            axes=nxd.axes,
+            axes_scales=nxd.plot_style.axes_scale_types,
+            axes_names=nxd.axes_names,
+            axes_errors=axes_errors,
+            title=nxd.title or nxd.signal_name,
         )
 
     def _getNXDataPriority(self, nxd: NXdata) -> int:

--- a/src/silx/gui/data/_NxCurvePlot.py
+++ b/src/silx/gui/data/_NxCurvePlot.py
@@ -58,15 +58,35 @@ class NxCurvePlot(qt.QWidget):
         title: str | None = None,
     ):
         self.__signals = list(signals)
+        if len(signal_names) != len(signals):
+            raise ValueError("Signal names must match the length of signals")
         self.__signals_names = list(signal_names)
-        self.__signal_errors = list(signal_errors) if signal_errors else None
+        if signal_errors:
+            if len(signal_errors) != len(signals):
+                raise ValueError("Signal errors must match the length of signals")
+            self.__signal_errors = list(signal_errors)
+        else:
+            self.__signal_errors = None
         self.__signal_scale = signal_scale or "linear"
         self.__axes = list(axes) if axes else None
-        self.__axes_names = list(axes_names) if axes_names else None
-        self.__axes_errors = list(axes_errors) if axes_errors else None
-        self.__axes_scales = (
-            [scale or "linear" for scale in axes_scales] if axes_scales else None
-        )
+        if axes_names:
+            if axes and len(axes) != len(axes_names):
+                raise ValueError("Axis names must match the length of axes")
+            self.__axes_names = list(axes_names)
+        else:
+            self.__axes_names = None
+        if axes_errors:
+            if axes and len(axes) != len(axes_errors):
+                raise ValueError("Axis errors must match the length of axes")
+            self.__axes_errors = list(axes_errors)
+        else:
+            self.__axes_errors = None
+        if axes_scales:
+            if axes and len(axes) != len(axes_scales):
+                raise ValueError("Axis scales must match the length of axes")
+            self.__axes_scales = list(scale or "linear" for scale in axes_scales)
+        else:
+            self.__axes_scales = None
 
         with blockSignals(self._axesSelector):
             self._axesSelector.clear()

--- a/src/silx/gui/data/_NxCurvePlot.py
+++ b/src/silx/gui/data/_NxCurvePlot.py
@@ -1,3 +1,5 @@
+from typing import Sequence
+
 import numpy
 
 from silx.gui import qt
@@ -22,7 +24,7 @@ class NxCurvePlot(qt.QWidget):
 
         self.__signals: list[numpy.ndarray] | None = None
         self.__signals_names: list[str] | None = None
-        self.__signal_errors: numpy.ndarray | None = None
+        self.__signal_errors: list[numpy.ndarray] | None = None
         self.__signal_scale: AxisScaleType = "linear"
         self.__axes: list[numpy.ndarray] | None = None
         self.__axes_names: list[str] | None = None
@@ -45,23 +47,23 @@ class NxCurvePlot(qt.QWidget):
 
     def setCurvesData(
         self,
-        signals: list[numpy.ndarray],
-        signal_names: list[str] | None = None,
-        signal_errors: numpy.ndarray | None = None,
+        signals: Sequence[numpy.ndarray],
+        signal_names: Sequence[str],
+        signal_errors: Sequence[numpy.ndarray] | None = None,
         signal_scale: AxisScaleType | None = None,
-        axes: list[numpy.ndarray] | None = None,
-        axes_names: list[str] | None = None,
-        axes_errors: list[numpy.ndarray | None] | None = None,
-        axes_scales: list[AxisScaleType | None] | None = None,
+        axes: Sequence[numpy.ndarray] | None = None,
+        axes_names: Sequence[str] | None = None,
+        axes_errors: Sequence[numpy.ndarray | None] | None = None,
+        axes_scales: Sequence[AxisScaleType | None] | None = None,
         title: str | None = None,
     ):
-        self.__signals = signals
-        self.__signals_names = signal_names
-        self.__signal_errors = signal_errors
+        self.__signals = list(signals)
+        self.__signals_names = list(signal_names)
+        self.__signal_errors = list(signal_errors) if signal_errors else None
         self.__signal_scale = signal_scale or "linear"
-        self.__axes = axes
-        self.__axes_names = axes_names
-        self.__axes_errors = axes_errors
+        self.__axes = list(axes) if axes else None
+        self.__axes_names = list(axes_names) if axes_names else None
+        self.__axes_errors = list(axes_errors) if axes_errors else None
         self.__axes_scales = (
             [scale or "linear" for scale in axes_scales] if axes_scales else None
         )
@@ -84,10 +86,9 @@ class NxCurvePlot(qt.QWidget):
         self._updateCurve()
 
     def _updateCurve(self):
-        if self.__signals is None:
+        if self.__signals is None or self.__signals_names is None:
             return
 
-        legends = self.__signals_names or [None] * len(self.__signals)
         self._plot.clear()
 
         axes_selection = self._axesSelector.selection()
@@ -104,28 +105,22 @@ class NxCurvePlot(qt.QWidget):
 
         # Main signal
         if self.__signal_errors is not None:
-            y_errors = self.__signal_errors[axes_selection]
+            y_errors = [errors[axes_selection] for errors in self.__signal_errors]
         else:
-            y_errors = None
+            y_errors = [None] * len(self.__signals)
 
-        mainCurve = self._plot.addCurve(
-            x,
-            self.__signals[0][axes_selection],
-            legend=legends[0],
-            xerror=x_errors,
-            yerror=y_errors,
-        )
-        self._plot.getYAxis().setScale(self.__signal_scale)
-        self._plot.setActiveCurve(mainCurve.getLegend())
-
-        # Aux signals
-        for i, signal in enumerate(self.__signals[1:]):
+        for signal, legend, y_error in zip(
+            self.__signals, self.__signals_names, y_errors
+        ):
             self._plot.addCurve(
                 x,
                 signal[axes_selection],
-                legend=legends[i],
+                legend=legend,
                 xerror=x_errors,
+                yerror=y_error,
             )
+        self._plot.getYAxis().setScale(self.__signal_scale)
+        self._plot.setActiveCurve(self.__signals_names[0])
 
         if self.__axes_names:
             self._plot.setGraphXLabel(self.__axes_names[xIndex])

--- a/src/silx/gui/data/_NxCurvePlot.py
+++ b/src/silx/gui/data/_NxCurvePlot.py
@@ -24,7 +24,7 @@ class NxCurvePlot(qt.QWidget):
 
         self.__signals: list[numpy.ndarray] | None = None
         self.__signals_names: list[str] | None = None
-        self.__signal_errors: list[numpy.ndarray] | None = None
+        self.__signal_errors: list[numpy.ndarray | None] | None = None
         self.__signal_scale: AxisScaleType = "linear"
         self.__axes: list[numpy.ndarray] | None = None
         self.__axes_names: list[str] | None = None
@@ -49,7 +49,7 @@ class NxCurvePlot(qt.QWidget):
         self,
         signals: Sequence[numpy.ndarray],
         signal_names: Sequence[str],
-        signal_errors: Sequence[numpy.ndarray] | None = None,
+        signal_errors: Sequence[numpy.ndarray | None] | None = None,
         signal_scale: AxisScaleType | None = None,
         axes: Sequence[numpy.ndarray] | None = None,
         axes_names: Sequence[str] | None = None,
@@ -123,11 +123,10 @@ class NxCurvePlot(qt.QWidget):
         else:
             x_errors = None
 
-        # Main signal
-        if self.__signal_errors is not None:
-            y_errors = [errors[axes_selection] for errors in self.__signal_errors]
-        else:
+        if self.__signal_errors is None:
             y_errors = [None] * len(self.__signals)
+        else:
+            y_errors = self.__signal_errors
 
         for signal, legend, y_error in zip(
             self.__signals, self.__signals_names, y_errors
@@ -137,7 +136,7 @@ class NxCurvePlot(qt.QWidget):
                 signal[axes_selection],
                 legend=legend,
                 xerror=x_errors,
-                yerror=y_error,
+                yerror=y_error[axes_selection] if y_error else None,
             )
         self._plot.getYAxis().setScale(self.__signal_scale)
         self._plot.setActiveCurve(self.__signals_names[0])

--- a/src/silx/gui/data/_NxCurvePlot.py
+++ b/src/silx/gui/data/_NxCurvePlot.py
@@ -1,0 +1,139 @@
+import numpy
+
+from silx.gui import qt
+from silx.gui.plot.items.axis import AxisScaleType
+
+from ..plot import Plot1D
+from ..utils import blockSignals
+from .NumpyAxesSelector import NumpyAxesSelector
+
+
+class NxCurvePlot(qt.QWidget):
+    """
+    Widget for plotting NXdata signals as curves, with support of auxiliary signals errors and axes.
+
+    The signal array can have an arbitrary number of dimensions.
+
+    Only one will be plotted the user can change the indices of the other dimensions or the plotted dimension itself.
+    """
+
+    def __init__(self, parent: qt.QWidget | None = None):
+        super().__init__(parent)
+
+        self.__signals: list[numpy.ndarray] | None = None
+        self.__signals_names: list[str] | None = None
+        self.__signal_errors: numpy.ndarray | None = None
+        self.__signal_scale: AxisScaleType = "linear"
+        self.__axes: list[numpy.ndarray] | None = None
+        self.__axes_names: list[str] | None = None
+        self.__axes_errors: list[numpy.ndarray | None] | None = None
+        self.__axes_scales: list[AxisScaleType] | None = None
+
+        self._plot = Plot1D(self)
+        self._plot.setGraphGrid(True)
+
+        self._axesSelector = NumpyAxesSelector(self)
+        self._axesSelector.selectionChanged.connect(self._updateCurve)
+        self._axesSelector.selectedAxisChanged.connect(self._updateCurve)
+
+        layout = qt.QVBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self._plot)
+        layout.addWidget(self._axesSelector)
+
+        self.setLayout(layout)
+
+    def setCurvesData(
+        self,
+        signals: list[numpy.ndarray],
+        signal_names: list[str] | None = None,
+        signal_errors: numpy.ndarray | None = None,
+        signal_scale: AxisScaleType | None = None,
+        axes: list[numpy.ndarray] | None = None,
+        axes_names: list[str] | None = None,
+        axes_errors: list[numpy.ndarray | None] | None = None,
+        axes_scales: list[AxisScaleType | None] | None = None,
+        title: str | None = None,
+    ):
+        self.__signals = signals
+        self.__signals_names = signal_names
+        self.__signal_errors = signal_errors
+        self.__signal_scale = signal_scale or "linear"
+        self.__axes = axes
+        self.__axes_names = axes_names
+        self.__axes_errors = axes_errors
+        self.__axes_scales = (
+            [scale or "linear" for scale in axes_scales] if axes_scales else None
+        )
+
+        with blockSignals(self._axesSelector):
+            self._axesSelector.clear()
+            self._axesSelector.setAxisNames(["X"])
+
+            # Labels need to be set before the data
+            if self.__axes_names:
+                self._axesSelector.setLabels(self.__axes_names)
+            self._axesSelector.setData(signals[0])
+
+            if len(signals[0].shape) < 2:
+                self._axesSelector.hide()
+            else:
+                self._axesSelector.show()
+
+        self._plot.setGraphTitle(title or "")
+        self._updateCurve()
+
+    def _updateCurve(self):
+        if self.__signals is None:
+            return
+
+        legends = self.__signals_names or [None] * len(self.__signals)
+        self._plot.clear()
+
+        axes_selection = self._axesSelector.selection()
+        xIndex = self._axesSelector.getIndicesOfNamedAxes()["X"]
+        if self.__axes:
+            x = self.__axes[xIndex]
+        else:
+            signalLength = len(self.__signals[0][axes_selection])
+            x = numpy.arange(signalLength)
+        if self.__axes_errors is not None:
+            x_errors = self.__axes_errors[xIndex]
+        else:
+            x_errors = None
+
+        # Main signal
+        if self.__signal_errors is not None:
+            y_errors = self.__signal_errors[axes_selection]
+        else:
+            y_errors = None
+
+        mainCurve = self._plot.addCurve(
+            x,
+            self.__signals[0][axes_selection],
+            legend=legends[0],
+            xerror=x_errors,
+            yerror=y_errors,
+        )
+        self._plot.getYAxis().setScale(self.__signal_scale)
+        self._plot.setActiveCurve(mainCurve.getLegend())
+
+        # Aux signals
+        for i, signal in enumerate(self.__signals[1:]):
+            self._plot.addCurve(
+                x,
+                signal[axes_selection],
+                legend=legends[i],
+                xerror=x_errors,
+            )
+
+        if self.__axes_names:
+            self._plot.setGraphXLabel(self.__axes_names[xIndex])
+        if self.__axes_scales:
+            self._plot.getXAxis().setScale(self.__axes_scales[xIndex])
+        self._plot.resetZoom()
+
+    def clear(self):
+        with blockSignals(self._axesSelector):
+            self._axesSelector.clear()
+        self._plot.clear()


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

For #4428 

<img width="1117" height="908" alt="image" src="https://github.com/user-attachments/assets/cc4fec0f-a4e6-447a-a19b-7a5ae775d302" />
My first idea for this was to refactor `ArrayCurvePlot` which is why I prepared the way in #4641. However, I realized that I had to change the behaviour of the widget quite extensively so it was difficult to go through a deprecation cycle. 

After discussion with @t20100 , we chose to create a completely new widget (`NxCurvePlot`) to leave `ArrayCurvePlot` untouched. **I therefore suggest for the review to look at a meld of `ArrayCurvePlot.py` and `NxCurvePlot.py` to see the changes**. 

In essence
`setCurvesData` was changed to refer to `signals` and `axes` rather than `x` and `y`. The internal behaviour can now handle X axis changes, changing the value, the error and the scale dynamically.

Some parts were removed: 
- `getPlot` was unused
- special treatment of 1 or 2-value array for X was removed
- the handling of the active curve via `_setYLabelFromActiveLegend` will be refactored in a future PR
- the dynamic connection of  `_axesSelector` via `__axes_selector_is_connected` was removed as well

#### AI Disclosure
- [x] No AI used
- [ ] AI tool(s) ... used for ...
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
