### PR TITLE
silx.io.nxdata.parse.NXdata: add `auxiliary_signal_errors` property

### DIFF
--- a/src/silx/gui/data/DataViews.py
+++ b/src/silx/gui/data/DataViews.py
@@ -1176,7 +1176,8 @@ class _NXdataCurveView(_NXdataBaseDataView):
         return widget
 
     def axesNames(self, data, info):
-        # disabled (used by default axis selector widget in Hdf5Viewer)
+        # Disabled the default axis selector widget
+        # NxCurvePlot implements its own
         return None
 
     def clear(self):
@@ -1196,14 +1197,10 @@ class _NXdataCurveView(_NXdataBaseDataView):
             else:
                 axes_errors.append(nxd.get_axis_errors(axis))
 
-        signal_errors = [
-            nxd.get_axis_errors(signal) for signal in nxd.auxiliary_signals_names
-        ]
-
         self.getWidget().setCurvesData(
             signals=[nxd.signal] + nxd.auxiliary_signals,
             signal_names=[nxd.signal_name] + nxd.auxiliary_signals_names,
-            signal_errors=[nxd.errors] + signal_errors,
+            signal_errors=[nxd.errors] + nxd.auxiliary_signal_errors,
             signal_scale=nxd.plot_style.signal_scale_type,
             axes=nxd.axes,
             axes_scales=nxd.plot_style.axes_scale_types,

--- a/src/silx/io/nxdata/parse.py
+++ b/src/silx/io/nxdata/parse.py
@@ -490,6 +490,16 @@ class NXdata:
         return [self.group[dsname] for dsname in self.auxiliary_signals_dataset_names]
 
     @property
+    def auxiliary_signal_errors(self) -> list[h5py.Dataset | None]:
+        if not self.is_valid:
+            raise InvalidNXdataError("Unable to parse invalid NXdata")
+
+        return [
+            _get_errors(self.group, signal)
+            for signal in self.auxiliary_signals_dataset_names
+        ]
+
+    @property
     def interpretation(self) -> Interpretation:
         """*@interpretation* attribute associated with the *signal*
         dataset of the NXdata group. ``None`` if no interpretation
@@ -738,48 +748,38 @@ class NXdata:
         if axis_name not in self.group:
             raise KeyError("group does not contain a dataset named '%s'" % axis_name)
 
-        len_axis = len(self.group[axis_name])
+        good_indices = _good_indices(self.group[axis_name])
+        # Try to find the errors dataset the standard way
+        error_dset = _get_errors(self.group, axis_name)
 
-        fg_idx = self.group[axis_name].attrs.get("first_good", 0)
-        lg_idx = self.group[axis_name].attrs.get("last_good", len_axis - 1)
+        if error_dset is not None:
+            return error_dset[good_indices] if good_indices is not None else error_dset
 
-        # case of axisname_errors dataset present
-        errors_name = axis_name + "_errors"
-        if errors_name in self.group and is_dataset(self.group[errors_name]):
-            if fg_idx != 0 or lg_idx != (len_axis - 1):
-                return self.group[errors_name][fg_idx : lg_idx + 1]
-            else:
-                return self.group[errors_name]
-        # case of uncertainties dataset name provided in @uncertainties
+        # Else, fallback on dataset name provided in @uncertainties
         uncertainties_names = get_attr_as_unicode(self.group, "uncertainties")
+        if uncertainties_names is None:
+            return None
         if isinstance(uncertainties_names, str):
             uncertainties_names = [uncertainties_names]
-        if uncertainties_names is not None:
-            # take the uncertainty with the same index as the axis in @axes
-            axes_ds_names = get_attr_as_unicode(self.group, "axes")
-            if axes_ds_names is None:
-                axes_ds_names = get_attr_as_unicode(self.signal, "axes")
-            if isinstance(axes_ds_names, str):
-                axes_ds_names = [axes_ds_names]
-            elif isinstance(axes_ds_names, numpy.ndarray):
-                # transform numpy.ndarray into list
-                axes_ds_names = list(axes_ds_names)
-            assert isinstance(axes_ds_names, list)
-            if hasattr(axes_ds_names[0], "decode"):
-                axes_ds_names = [ax_name.decode("utf-8") for ax_name in axes_ds_names]
-            if axis_name not in axes_ds_names:
-                raise KeyError(
-                    "group attr @axes does not mention a dataset "
-                    + "named '%s'" % axis_name
-                )
-            errors = self.group[
-                uncertainties_names[list(axes_ds_names).index(axis_name)]
-            ]
-            if fg_idx == 0 and lg_idx == (len_axis - 1):
-                return errors  # dataset
-            else:
-                return errors[fg_idx : lg_idx + 1]  # numpy array
-        return None
+        # take the uncertainty with the same index as the axis in @axes
+        axes_ds_names = get_attr_as_unicode(self.group, "axes")
+        if axes_ds_names is None:
+            axes_ds_names = get_attr_as_unicode(self.signal, "axes")
+        if isinstance(axes_ds_names, str):
+            axes_ds_names = [axes_ds_names]
+        elif isinstance(axes_ds_names, numpy.ndarray):
+            # transform numpy.ndarray into list
+            axes_ds_names = list(axes_ds_names)
+        assert isinstance(axes_ds_names, list)
+        if hasattr(axes_ds_names[0], "decode"):
+            axes_ds_names = [ax_name.decode("utf-8") for ax_name in axes_ds_names]
+        if axis_name not in axes_ds_names:
+            raise KeyError(
+                "group attr @axes does not mention a dataset "
+                + "named '%s'" % axis_name
+            )
+        errors = self.group[uncertainties_names[list(axes_ds_names).index(axis_name)]]
+        return errors[good_indices] if good_indices is not None else errors
 
     @property
     def errors(self) -> h5py.Dataset | None:
@@ -790,17 +790,14 @@ class NXdata:
         if not self.is_valid:
             raise InvalidNXdataError("Unable to parse invalid NXdata")
 
-        dataset_names = [
-            # From NXData:
-            "errors",
-            # Not Nexus (VARIABLE_errors is only for axes), but supported anyway
-            self.signal_dataset_name + "_errors",
-        ]
-        for name in dataset_names:
-            entity = self.group.get(name)
-            if entity is not None and is_dataset(entity):
-                return entity
+        errors = _get_errors(self.group, self.signal_dataset_name)
+        if errors is not None:
+            return errors
 
+        # Fallback on "errors" dataset: deprecated way of specifing errors (NIAC2018)
+        entity = self.group.get("errors")
+        if isinstance(entity, h5py.Dataset):
+            return entity
         return None
 
     @property
@@ -1104,3 +1101,27 @@ def get_default(group: Any, validate: bool = True) -> NXdata | None:
     :raise TypeError: if group is not a h5py-like group
     """
     return _get_default(group, validate, [])
+
+
+def _good_indices(dset: h5py.Dataset) -> slice | None:
+    first_good_index: int | None = dset.attrs.get("first_good")
+    last_good_index: int | None = dset.attrs.get("last_good")
+
+    if first_good_index is None and last_good_index is None:
+        return None
+
+    if last_good_index is None:
+        return slice(first_good_index, None)
+
+    return slice(first_good_index, last_good_index + 1)
+
+
+def _get_errors(group: h5py.Group, name: str) -> h5py.Dataset | None:
+    if name not in group:
+        raise KeyError(f"group does not contain a dataset named {name}")
+
+    errors = group.get(f"{name}_errors")
+    if not isinstance(errors, h5py.Dataset):
+        return None
+
+    return errors

--- a/src/silx/io/test/test_nxdata.py
+++ b/src/silx/io/test/test_nxdata.py
@@ -1,38 +1,11 @@
-# /*##########################################################################
-# Copyright (C) 2016-2022 European Synchrotron Radiation Facility
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
-#
-# ############################################################################*/
-"""Tests for NXdata parsing"""
-
-__authors__ = ["P. Knobel"]
-__license__ = "MIT"
-__date__ = "02/12/2025"
-
-
 import h5py
 import numpy
 import pytest
 
+
 from .. import nxdata
-from ..dictdump import dicttoh5
+from ..dictdump import dicttoh5, dicttonx
+
 
 text_dtype = h5py.special_dtype(vlen=str)
 
@@ -818,3 +791,59 @@ def test_empty_aux_signals(tmp_path):
         nxd = nxdata.NXdata(nxdata_grp)
         assert nxd.signal_name == "signal"
         assert nxd.auxiliary_signals_dataset_names == []
+
+
+def test_get_signal_errors(tmp_path):
+    nx_dict = {
+        "NXdata": {
+            "@NX_class": "NXdata",
+            "@signal": "signal",
+            "@auxiliary_signals": ["aux_signal_1", "aux_signal_2"],
+            "signal": numpy.linspace(0, 100, 11),
+            "signal_errors": numpy.linspace(0, 10, 11),
+            "aux_signal_1": numpy.linspace(-5, -5, 11),
+            "aux_signal_1_errors": numpy.linspace(0, 1, 11),
+            "aux_signal_2": numpy.linspace(-100, 0, 11),
+        }
+    }
+
+    dicttonx(nx_dict, tmp_path / "nx.h5")
+
+    with h5py.File(tmp_path / "nx.h5", "r") as h5file:
+        nxdata_grp = h5file["NXdata"]
+        signal_errors = nxdata_grp["signal_errors"]
+        aux_signal_errors = nxdata_grp["aux_signal_1_errors"]
+
+        nxd = nxdata.NXdata(nxdata_grp)
+        errors = nxd.errors
+        assert isinstance(errors, h5py.Dataset)
+        numpy.testing.assert_equal(signal_errors[()], errors[()])
+
+        aux_errors = nxd.auxiliary_signal_errors
+        assert aux_errors == [aux_signal_errors, None]
+
+
+def test_get_axis_errors(tmp_path):
+    with h5py.File(tmp_path / "nx.h5", "w") as h5file:
+        nxdata_grp = h5file.create_group("NXdata")
+        nxdata_grp.attrs["NX_class"] = "NXdata"
+        nxdata_grp.attrs["signal"] = "signal"
+        nxdata_grp.attrs["axes"] = ["x", "y", "z"]
+        nxdata_grp.create_dataset("signal", data=numpy.random.random((10, 3, 4)))
+        nxdata_grp.create_dataset("x", data=numpy.arange(0, 10, 10))
+        y_dset = nxdata_grp.create_dataset("y", data=[0, 1, 2])
+        y_dset.attrs["long_name"] = "Y"
+        y_errors = nxdata_grp.create_dataset("y_errors", data=[0.1, 0.2, 0.3])
+        z_dset = nxdata_grp.create_dataset("z", data=[0, 1, 2, 3])
+        z_dset.attrs["first_good"] = 1
+        z_dset.attrs["last_good"] = 2
+        z_dset_errors = nxdata_grp.create_dataset(
+            "z_errors", data=[0.01, 0.02, 0.03, 0.04]
+        )
+
+        nxd = nxdata.NXdata(nxdata_grp)
+        assert nxd.get_axis_errors("x") is None
+        # Check long_name works
+        assert nxd.get_axis_errors("Y") == y_errors
+        # Check good indices are applied
+        numpy.testing.assert_equal(nxd.get_axis_errors("z"), z_dset_errors[1:3])


### PR DESCRIPTION


- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

Address https://github.com/silx-kit/silx/pull/4646#discussion_r3461877000

I added a function `_get_errors` to get errors for any dataset. I use it to get the aux signal errors and in the function `get_axis_errors` (that has a bit more code to fallback on `uncertainties`). 

I also put the handling of the `first_good` and `last_good` in a reusable private helper. 

#### AI Disclosure
- [x] No AI used
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
