### PR TITLE
CI: do not install Cython 3.3.0a1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 build-backend = 'mesonpy'
 requires = [
     'meson-python',
-    'Cython',
+    'Cython!=3.3.0a1',
 ]
 
 


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

Lots of segfaults in the CI lately. It seems to be related to the new Cython alpha release.

In this PR, I exclude Cython 3.3.0a1 from the requirements and it seemed to fix the CI (failure is due to the infamous polygon test).

Of course, this is a temp fix. We should review Cython changes and see what is the real issue: https://github.com/cython/cython/blob/master/CHANGES.rst#330a1-2026-06-24


#### AI Disclosure
- [x] No AI used
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
