### PR TITLE
CI: remove ignore of numpy 2.5 deprecation warnings

### DIFF
--- a/src/silx/conftest.py
+++ b/src/silx/conftest.py
@@ -80,8 +80,6 @@ _FILTERWARNINGS = (
     "ignore::DeprecationWarning:matplotlib._fontconfig_pattern",
     "ignore::DeprecationWarning:matplotlib._mathtext",
     "ignore::DeprecationWarning:pyparsing.util",
-    # Ignore numpy deprecation until fabio release with https://github.com/silx-kit/fabio/pull/641
-    "ignore:Setting the shape on a NumPy array has been deprecated in NumPy 2.5.:DeprecationWarning:fabio",
 )
 
 


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

Fix #4623


#### AI Disclosure
- [x] No AI used
