### PR TITLE
silx.gui.utils.testutils: Added `waitAsLongAs` helper to `qapp_utils` and `TestCaseQt` 

### DIFF
--- a/src/silx/conftest.py
+++ b/src/silx/conftest.py
@@ -210,10 +210,7 @@ def qWidgetFactory(qapp, qapp_utils):
     qapp.processEvents()
 
     # Wait some time for all widgets to be deleted
-    for _ in range(10):
-        validWidgets = [widget for widget in widgets if isValid(widget)]
-        if validWidgets:
-            qapp_utils.qWait(10)
+    qapp_utils.waitAsLongAs(lambda: any(isValid(w) for w in widgets))
 
     validWidgets = [widget for widget in widgets if isValid(widget)]
     assert not validWidgets, f"Some widgets were not destroyed: {validWidgets}"

--- a/src/silx/gui/dialog/test/test_datafiledialog.py
+++ b/src/silx/gui/dialog/test/test_datafiledialog.py
@@ -113,14 +113,6 @@ class _UtilsMixin:
             self._dialog = None
             self.qWaitForDestroy(ref)
 
-    def qWaitForPendingActions(self, dialog):
-        self.qapp.processEvents()
-        for _ in range(20):
-            if not dialog.hasPendingEvents():
-                return
-            self.qWait(100)
-        raise RuntimeError("Still have pending actions")
-
     def assertSamePath(self, path1, path2):
         self.assertEqual(
             os.path.normcase(os.path.realpath(path1)),
@@ -192,13 +184,13 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"
         dialog.selectFile(os.path.dirname(filename))
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         # select, then double click on the file
         index = browser.rootIndex().model().index(filename)
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         button = testutils.findChildren(dialog, qt.QPushButton, name="open")[0]
         self.assertTrue(button.isEnabled())
@@ -216,13 +208,13 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"
         dialog.selectFile(os.path.dirname(filename))
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         # select, then double click on the file
         index = browser.rootIndex().model().index(filename)
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         # select, then double click on the file
         index = (
@@ -232,7 +224,7 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         )
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         button = testutils.findChildren(dialog, qt.QPushButton, name="open")[0]
         self.assertTrue(button.isEnabled())
@@ -250,13 +242,13 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"
         dialog.selectFile(os.path.dirname(filename))
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         # select, then double click on the file
         index = browser.rootIndex().model().index(filename)
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         # select, then double click on the file
         index = (
@@ -266,7 +258,7 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         )
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         button = testutils.findChildren(dialog, qt.QPushButton, name="open")[0]
         self.assertTrue(button.isEnabled())
@@ -279,7 +271,7 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
     def testClickOnBackToParentTool(self):
         dialog = self.createDialog()
         dialog.show()
-        self.qWaitForWindowExposed(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         urlLineEdit = testutils.findChildren(dialog, qt.QLineEdit, name="url")[0]
         action = testutils.findChildren(dialog, qt.QAction, name="toParentAction")[0]
@@ -289,23 +281,23 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         # init state
         path = silx.io.url.DataUrl(file_path=filename, data_path="/group/image").path()
         dialog.selectUrl(path)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         url = silx.io.url.DataUrl(
             scheme="silx", file_path=filename, data_path="/group/image"
         )
         self.assertSameUrls(urlLineEdit.text(), url)
         # test
         self.mouseClick(toParentButton, qt.Qt.LeftButton)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         url = silx.io.url.DataUrl(scheme="silx", file_path=filename, data_path="/")
         self.assertSameUrls(urlLineEdit.text(), url)
 
         self.mouseClick(toParentButton, qt.Qt.LeftButton)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertSamePath(urlLineEdit.text(), _tmpDirectory + "/data")
 
         self.mouseClick(toParentButton, qt.Qt.LeftButton)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertSamePath(urlLineEdit.text(), _tmpDirectory)
 
     def testClickOnBackToRootTool(self):
@@ -323,12 +315,12 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
             scheme="silx", file_path=filename, data_path="/group/image"
         )
         dialog.selectUrl(url.path())
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertSameUrls(urlLineEdit.text(), url)
         self.assertTrue(button.isEnabled())
         # test
         self.mouseClick(button, qt.Qt.LeftButton)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         url = silx.io.url.DataUrl(scheme="silx", file_path=filename, data_path="/")
         self.assertSameUrls(urlLineEdit.text(), url)
         # self.assertFalse(button.isEnabled())
@@ -346,7 +338,7 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         # init state
         url = silx.io.url.DataUrl(file_path=filename, data_path="/group/image")
         dialog.selectUrl(url.path())
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         url = silx.io.url.DataUrl(
             scheme="silx", file_path=filename, data_path="/group/image"
         )
@@ -354,7 +346,7 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         self.assertTrue(button.isEnabled())
         # test
         self.mouseClick(button, qt.Qt.LeftButton)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertSamePath(urlLineEdit.text(), _tmpDirectory)
         self.assertFalse(button.isEnabled())
 
@@ -377,32 +369,32 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         filename = _tmpDirectory + "/data.h5"
 
         dialog.setDirectory(_tmpDirectory)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         # No way to use QTest.mouseDClick with QListView, QListWidget
         # Then we feed the history using selectPath
         dialog.selectUrl(filename)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         url = silx.io.url.DataUrl(scheme="silx", file_path=filename, data_path="/")
         dialog.selectUrl(url.path())
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         url2 = silx.io.url.DataUrl(
             scheme="silx", file_path=filename, data_path="/group"
         )
         dialog.selectUrl(url2.path())
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertFalse(forwardAction.isEnabled())
         self.assertTrue(backwardAction.isEnabled())
 
         button = testutils.getQToolButtonFromAction(backwardAction)
         self.mouseClick(button, qt.Qt.LeftButton)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertTrue(forwardAction.isEnabled())
         self.assertTrue(backwardAction.isEnabled())
         self.assertSameUrls(urlLineEdit.text(), url)
 
         button = testutils.getQToolButtonFromAction(forwardAction)
         self.mouseClick(button, qt.Qt.LeftButton)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertFalse(forwardAction.isEnabled())
         self.assertTrue(backwardAction.isEnabled())
         self.assertSameUrls(urlLineEdit.text(), url2)
@@ -463,7 +455,7 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         filename = _tmpDirectory + "/data.h5"
         uri = silx.io.url.DataUrl(scheme="silx", file_path=filename, data_path="/group")
         dialog.selectUrl(uri.path())
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         # test
         self.assertTrue(silx.io.is_group(dialog._selectedData()))
         self.assertSamePath(dialog.selectedFile(), filename)
@@ -479,7 +471,7 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         filename = _tmpDirectory + "/data.h5"
         uri = silx.io.url.DataUrl(scheme="silx", file_path=filename, data_path="/")
         dialog.selectUrl(uri.path())
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         # test
         self.assertTrue(silx.io.is_file(dialog._selectedData()))
         self.assertSamePath(dialog.selectedFile(), filename)
@@ -493,7 +485,7 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
 
         # init state
         dialog.selectUrl(_tmpDirectory)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         browser = testutils.findChildren(dialog, qt.QWidget, name="browser")[0]
         filename = _tmpDirectory + "/data.h5"
         url = silx.io.url.DataUrl(scheme="silx", file_path=filename, data_path="/")
@@ -502,7 +494,7 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         browser.selectIndex(index)
         # double click
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         # test
         self.assertSameUrls(dialog.selectedUrl(), url)
 
@@ -513,13 +505,13 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
 
         # init state
         dialog.selectUrl(_tmpDirectory)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         browser = testutils.findChildren(dialog, qt.QWidget, name="browser")[0]
         filename = _tmpDirectory + "/badformat.h5"
         index = browser.model().index(filename)
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         # test
         self.assertSamePath(dialog.selectedUrl(), filename)
 
@@ -539,7 +531,7 @@ class TestDataFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         dialog.show()
         self.qWaitForWindowExposed(dialog)
         dialog.selectUrl(_tmpDirectory)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertEqual(
             self._countSelectableItems(browser.model(), browser.rootIndex()), 4
         )
@@ -563,13 +555,13 @@ class TestDataFileDialog_FilterDataset(testutils.TestCaseQt, _UtilsMixin):
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"
         dialog.selectFile(os.path.dirname(filename))
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         # select, then double click on the file
         index = browser.rootIndex().model().index(filename)
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         # select, then double click on the file
         index = (
@@ -579,7 +571,7 @@ class TestDataFileDialog_FilterDataset(testutils.TestCaseQt, _UtilsMixin):
         )
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         button = testutils.findChildren(dialog, qt.QPushButton, name="open")[0]
         self.assertFalse(button.isEnabled())
@@ -592,13 +584,13 @@ class TestDataFileDialog_FilterDataset(testutils.TestCaseQt, _UtilsMixin):
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"
         dialog.selectFile(os.path.dirname(filename))
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         # select, then double click on the file
         index = browser.rootIndex().model().index(filename)
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         # select, then double click on the file
         index = (
@@ -608,7 +600,7 @@ class TestDataFileDialog_FilterDataset(testutils.TestCaseQt, _UtilsMixin):
         )
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         button = testutils.findChildren(dialog, qt.QPushButton, name="open")[0]
         self.assertTrue(button.isEnabled())
@@ -640,13 +632,13 @@ class TestDataFileDialog_FilterGroup(testutils.TestCaseQt, _UtilsMixin):
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"
         dialog.selectFile(os.path.dirname(filename))
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         # select, then double click on the file
         index = browser.rootIndex().model().index(filename)
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         # select, then double click on the file
         index = (
@@ -656,7 +648,7 @@ class TestDataFileDialog_FilterGroup(testutils.TestCaseQt, _UtilsMixin):
         )
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         button = testutils.findChildren(dialog, qt.QPushButton, name="open")[0]
         self.assertTrue(button.isEnabled())
@@ -676,13 +668,13 @@ class TestDataFileDialog_FilterGroup(testutils.TestCaseQt, _UtilsMixin):
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"
         dialog.selectFile(os.path.dirname(filename))
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         # select, then double click on the file
         index = browser.rootIndex().model().index(filename)
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         # select, then double click on the file
         index = (
@@ -692,7 +684,7 @@ class TestDataFileDialog_FilterGroup(testutils.TestCaseQt, _UtilsMixin):
         )
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         button = testutils.findChildren(dialog, qt.QPushButton, name="open")[0]
         self.assertFalse(button.isEnabled())
@@ -722,13 +714,13 @@ class TestDataFileDialog_FilterNXdata(testutils.TestCaseQt, _UtilsMixin):
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"
         dialog.selectFile(os.path.dirname(filename))
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         # select, then double click on the file
         index = browser.rootIndex().model().index(filename)
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         # select, then double click on the file
         index = (
@@ -738,7 +730,7 @@ class TestDataFileDialog_FilterNXdata(testutils.TestCaseQt, _UtilsMixin):
         )
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         button = testutils.findChildren(dialog, qt.QPushButton, name="open")[0]
         self.assertFalse(button.isEnabled())
@@ -753,13 +745,13 @@ class TestDataFileDialog_FilterNXdata(testutils.TestCaseQt, _UtilsMixin):
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/data.h5"
         dialog.selectFile(os.path.dirname(filename))
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         # select, then double click on the file
         index = browser.rootIndex().model().index(filename)
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         # select, then double click on the file
         index = (
@@ -769,7 +761,7 @@ class TestDataFileDialog_FilterNXdata(testutils.TestCaseQt, _UtilsMixin):
         )
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         button = testutils.findChildren(dialog, qt.QPushButton, name="open")[0]
         self.assertTrue(button.isEnabled())
@@ -792,7 +784,7 @@ class TestDataFileDialogApi(testutils.TestCaseQt, _UtilsMixin):
     def testSaveRestoreState(self):
         dialog = self.createDialog()
         dialog.setDirectory(_tmpDirectory)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         state = dialog.saveState()
         dialog = None
 
@@ -907,7 +899,7 @@ class TestDataFileDialogApi(testutils.TestCaseQt, _UtilsMixin):
         os.mkdir(directory)
         dialog = self.createDialog()
         dialog.setDirectory(directory)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         state = dialog.saveState()
         os.rmdir(directory)
         dialog = None
@@ -935,26 +927,26 @@ class TestDataFileDialogApi(testutils.TestCaseQt, _UtilsMixin):
 
     def testDirectory(self):
         dialog = self.createDialog()
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         dialog.selectUrl(_tmpDirectory)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertSamePath(dialog.directory(), _tmpDirectory)
 
     def testBadFileFormat(self):
         dialog = self.createDialog()
         dialog.selectUrl(_tmpDirectory + "/badformat.h5")
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertIsNone(dialog._selectedData())
 
     def testBadPath(self):
         dialog = self.createDialog()
         dialog.selectUrl("#$%/#$%")
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertIsNone(dialog._selectedData())
 
     def testBadSubpath(self):
         dialog = self.createDialog()
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         browser = testutils.findChildren(dialog, qt.QWidget, name="browser")[0]
 
@@ -963,7 +955,7 @@ class TestDataFileDialogApi(testutils.TestCaseQt, _UtilsMixin):
             scheme="silx", file_path=filename, data_path="/group/foobar"
         )
         dialog.selectUrl(url.path())
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertIsNotNone(dialog._selectedData())
 
         # an existing node is browsed, but the wrong path is selected
@@ -975,9 +967,9 @@ class TestDataFileDialogApi(testutils.TestCaseQt, _UtilsMixin):
 
     def testUnsupportedSlicingPath(self):
         dialog = self.createDialog()
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         dialog.selectUrl(_tmpDirectory + "/data.h5?path=/cube&slice=0")
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         data = dialog._selectedData()
         if data is None:
             # Maybe nothing is selected

--- a/src/silx/gui/dialog/test/test_imagefiledialog.py
+++ b/src/silx/gui/dialog/test/test_imagefiledialog.py
@@ -120,14 +120,6 @@ class _UtilsMixin:
             self._dialog = None
             self.qWaitForDestroy(ref)
 
-    def qWaitForPendingActions(self, dialog):
-        self.qapp.processEvents()
-        for _ in range(20):
-            if not dialog.hasPendingEvents():
-                return
-            self.qWait(100)
-        raise RuntimeError("Still have pending actions")
-
     def assertSamePath(self, path1, path2):
         self.assertEqual(
             os.path.normcase(os.path.realpath(path1)),
@@ -205,7 +197,7 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         self.assertTrue(dialog.isVisible())
         filename = _tmpDirectory + "/singleimage.edf"
         dialog.selectFile(filename)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         button = testutils.findChildren(dialog, qt.QPushButton, name="open")[0]
         self.assertTrue(button.isEnabled())
@@ -225,7 +217,7 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         url = testutils.findChildren(dialog, qt.QLineEdit, name="url")[0]
         browser = testutils.findChildren(dialog, qt.QWidget, name="browser")[0]
         dialog.setDirectory(_tmpDirectory)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         self.assertSamePath(url.text(), _tmpDirectory)
 
@@ -241,7 +233,7 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         # self.mouseClick(sidebar, qt.Qt.LeftButton, pos=rect.center())
         # Using mouse click is not working, let's use the selection API
         sidebar.selectionModel().select(index, qt.QItemSelectionModel.ClearAndSelect)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         index = browser.rootIndex()
         if not index.isValid():
@@ -279,25 +271,25 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         # init state
         path = silx.io.url.DataUrl(file_path=filename, data_path="/group/image").path()
         dialog.selectUrl(path)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         path = silx.io.url.DataUrl(
             scheme="silx", file_path=filename, data_path="/group/image"
         ).path()
         self.assertSamePath(url.text(), path)
         # test
         self.mouseClick(toParentButton, qt.Qt.LeftButton)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         path = silx.io.url.DataUrl(
             scheme="silx", file_path=filename, data_path="/"
         ).path()
         self.assertSamePath(url.text(), path)
 
         self.mouseClick(toParentButton, qt.Qt.LeftButton)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertSamePath(url.text(), _tmpDirectory + "/data")
 
         self.mouseClick(toParentButton, qt.Qt.LeftButton)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertSamePath(url.text(), _tmpDirectory)
 
     def testClickOnBackToRootTool(self):
@@ -315,12 +307,12 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
             scheme="silx", file_path=filename, data_path="/group/image"
         ).path()
         dialog.selectUrl(path)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertSamePath(url.text(), path)
         self.assertTrue(button.isEnabled())
         # test
         self.mouseClick(button, qt.Qt.LeftButton)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         path = silx.io.url.DataUrl(
             scheme="silx", file_path=filename, data_path="/"
         ).path()
@@ -340,7 +332,7 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         # init state
         path = silx.io.url.DataUrl(file_path=filename, data_path="/group/image").path()
         dialog.selectUrl(path)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         path = silx.io.url.DataUrl(
             scheme="silx", file_path=filename, data_path="/group/image"
         ).path()
@@ -348,7 +340,7 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         self.assertTrue(button.isEnabled())
         # test
         self.mouseClick(button, qt.Qt.LeftButton)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertSamePath(url.text(), _tmpDirectory)
         self.assertFalse(button.isEnabled())
 
@@ -371,34 +363,34 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         filename = _tmpDirectory + "/data.h5"
 
         dialog.setDirectory(_tmpDirectory)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         # No way to use QTest.mouseDClick with QListView, QListWidget
         # Then we feed the history using selectPath
         dialog.selectUrl(filename)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         path2 = silx.io.url.DataUrl(
             scheme="silx", file_path=filename, data_path="/"
         ).path()
         dialog.selectUrl(path2)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         path3 = silx.io.url.DataUrl(
             scheme="silx", file_path=filename, data_path="/group"
         ).path()
         dialog.selectUrl(path3)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertFalse(forwardAction.isEnabled())
         self.assertTrue(backwardAction.isEnabled())
 
         button = testutils.getQToolButtonFromAction(backwardAction)
         self.mouseClick(button, qt.Qt.LeftButton)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertTrue(forwardAction.isEnabled())
         self.assertTrue(backwardAction.isEnabled())
         self.assertSamePath(url.text(), path2)
 
         button = testutils.getQToolButtonFromAction(forwardAction)
         self.mouseClick(button, qt.Qt.LeftButton)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertFalse(forwardAction.isEnabled())
         self.assertTrue(backwardAction.isEnabled())
         self.assertSamePath(url.text(), path3)
@@ -423,7 +415,7 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
 
         # init state
         dialog.selectUrl(_tmpDirectory)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         browser = testutils.findChildren(dialog, qt.QWidget, name="browser")[0]
         filename = _tmpDirectory + "/singleimage.edf"
         url = silx.io.url.DataUrl(scheme="fabio", file_path=filename).path()
@@ -432,7 +424,7 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         browser.selectIndex(index)
         # double click
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         # test
         self.assertEqual(dialog.selectedImage().shape, (100, 100))
         self.assertSamePath(dialog.selectedFile(), filename)
@@ -489,7 +481,7 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
 
         # init state
         dialog.selectUrl(_tmpDirectory)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         browser = testutils.findChildren(dialog, qt.QWidget, name="browser")[0]
         filename = _tmpDirectory + "/data.h5"
         url = silx.io.url.DataUrl(scheme="silx", file_path=filename, data_path="/")
@@ -498,7 +490,7 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         browser.selectIndex(index)
         # double click
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         # test
         self.assertSameUrls(dialog.selectedUrl(), url)
 
@@ -546,13 +538,13 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
 
         # init state
         dialog.selectUrl(_tmpDirectory)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         browser = testutils.findChildren(dialog, qt.QWidget, name="browser")[0]
         filename = _tmpDirectory + "/badformat.edf"
         index = browser.model().index(filename)
         browser.selectIndex(index)
         browser.activated.emit(index)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         # test
         self.assertSameUrls(dialog.selectedUrl(), filename)
 
@@ -573,7 +565,7 @@ class TestImageFileDialogInteraction(testutils.TestCaseQt, _UtilsMixin):
         dialog.show()
         self.qWaitForWindowExposed(dialog)
         dialog.selectUrl(_tmpDirectory)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertEqual(
             self._countSelectableItems(browser.model(), browser.rootIndex()), 6
         )
@@ -607,13 +599,13 @@ class TestImageFileDialogApi(testutils.TestCaseQt, _UtilsMixin):
         dialog.setDirectory(_tmpDirectory)
         colormap = Colormap(normalization=Colormap.LOGARITHM)
         dialog.setColormap(colormap)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         state = dialog.saveState()
         dialog = None
 
         dialog2 = self.createDialog()
         result = dialog2.restoreState(state)
-        self.qWaitForPendingActions(dialog2)
+        self.waitAsLongAs(dialog2.hasPendingEvents)
         self.assertTrue(result)
         self.assertEqual(dialog2.colormap().getNormalization(), "log")
 
@@ -732,7 +724,7 @@ class TestImageFileDialogApi(testutils.TestCaseQt, _UtilsMixin):
         os.mkdir(directory)
         dialog = self.createDialog()
         dialog.setDirectory(directory)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         state = dialog.saveState()
         os.rmdir(directory)
         dialog = None
@@ -768,38 +760,38 @@ class TestImageFileDialogApi(testutils.TestCaseQt, _UtilsMixin):
 
     def testDirectory(self):
         dialog = self.createDialog()
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         dialog.selectUrl(_tmpDirectory)
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertSamePath(dialog.directory(), _tmpDirectory)
 
     def testBadDataType(self):
         dialog = self.createDialog()
         dialog.selectUrl(_tmpDirectory + "/data.h5::/complex_image")
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertIsNone(dialog._selectedData())
 
     def testBadDataShape(self):
         dialog = self.createDialog()
         dialog.selectUrl(_tmpDirectory + "/data.h5::/unknown")
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertIsNone(dialog._selectedData())
 
     def testBadDataFormat(self):
         dialog = self.createDialog()
         dialog.selectUrl(_tmpDirectory + "/badformat.edf")
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertIsNone(dialog._selectedData())
 
     def testBadPath(self):
         dialog = self.createDialog()
         dialog.selectUrl("#$%/#$%")
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertIsNone(dialog._selectedData())
 
     def testBadSubpath(self):
         dialog = self.createDialog()
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
 
         browser = testutils.findChildren(dialog, qt.QWidget, name="browser")[0]
 
@@ -808,7 +800,7 @@ class TestImageFileDialogApi(testutils.TestCaseQt, _UtilsMixin):
             scheme="silx", file_path=filename, data_path="/group/foobar"
         )
         dialog.selectUrl(url.path())
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertIsNone(dialog._selectedData())
 
         # an existing node is browsed, but the wrong path is selected
@@ -820,7 +812,7 @@ class TestImageFileDialogApi(testutils.TestCaseQt, _UtilsMixin):
 
     def testBadSlicingPath(self):
         dialog = self.createDialog()
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         dialog.selectUrl(_tmpDirectory + "/data.h5::/cube[a;45,-90]")
-        self.qWaitForPendingActions(dialog)
+        self.waitAsLongAs(dialog.hasPendingEvents)
         self.assertIsNone(dialog._selectedData())

--- a/src/silx/gui/hdf5/test/test_hdf5.py
+++ b/src/silx/gui/hdf5/test/test_hdf5.py
@@ -63,15 +63,6 @@ def create_NXentry(group, name):
     return node
 
 
-def waitForPendingOperations(qapp_utils: TestCaseQt, model):
-    for _ in range(20):
-        if not model.hasPendingOperations():
-            break
-        qapp_utils.qWait(200)
-    else:
-        raise RuntimeError("Still waiting for a pending operation")
-
-
 def testErrorInInsertFilenameAsync(tmp_path, caplog, qapp_utils):
     filename = str(tmp_path / "corrupt.h5")
     with open(filename, "wb") as h5file:
@@ -82,7 +73,7 @@ def testErrorInInsertFilenameAsync(tmp_path, caplog, qapp_utils):
     model.insertFileAsync(filename)
 
     assert qt.silxGlobalThreadPool().waitForDone(2000)  # Needed for PySide6
-    waitForPendingOperations(qapp_utils, model)
+    qapp_utils.waitAsLongAs(model.hasPendingOperations)
     assert len(caplog.records) == 1
     assert "can't be read as HDF5" in caplog.records[0].getMessage()
 
@@ -148,7 +139,7 @@ class TestHdf5TreeModel(TestCaseQt):
             self.assertIsInstance(
                 model.nodeFromIndex(index), hdf5.Hdf5LoadingItem.Hdf5LoadingItem
             )
-            waitForPendingOperations(self, model)
+            self.waitAsLongAs(model.hasPendingOperations)
             index = model.index(0, 0, qt.QModelIndex())
             self.assertIsInstance(model.nodeFromIndex(index), hdf5.Hdf5Item.Hdf5Item)
         finally:
@@ -180,7 +171,7 @@ class TestHdf5TreeModel(TestCaseQt):
         index = model.index(0, 0, qt.QModelIndex())
         node1 = model.nodeFromIndex(index)
         model.synchronizeH5pyObject(h5)
-        waitForPendingOperations(self, model)
+        self.waitAsLongAs(model.hasPendingOperations)
         # Now h5 was loaded from it's filename
         # Another ref is owned by the model
         h5.close()
@@ -270,7 +261,7 @@ class TestHdf5TreeModel(TestCaseQt):
         model.dropMimeData(mimeData, qt.Qt.CopyAction, 0, 0, qt.QModelIndex())
         self.assertEqual(model.rowCount(qt.QModelIndex()), 1)
         # after sync
-        waitForPendingOperations(self, model)
+        self.waitAsLongAs(model.hasPendingOperations)
         index = model.index(0, 0, qt.QModelIndex())
         self.assertIsInstance(model.nodeFromIndex(index), hdf5.Hdf5Item.Hdf5Item)
         # clean up
@@ -455,14 +446,6 @@ class TestHdf5TreeModelSignals(TestCaseQt):
         self.h5 = None
         TestCaseQt.tearDown(self)
 
-    def waitForPendingOperations(self, model):
-        for _ in range(20):
-            if not model.hasPendingOperations():
-                break
-            self.qWait(200)
-        else:
-            raise RuntimeError("Still waiting for a pending operation")
-
     def testInsert(self):
         h5 = h5py.File(self.filename, mode="r")
         self.model.insertH5pyObject(h5)
@@ -495,7 +478,7 @@ class TestHdf5TreeModelSignals(TestCaseQt):
 
     def testSynchonized(self):
         self.model.synchronizeH5pyObject(self.h5)
-        waitForPendingOperations(self, self.model)
+        self.waitAsLongAs(self.model.hasPendingOperations)
         self.assertEqual(self.listener.callCount(), 1)
         self.assertEqual(
             self.listener.karguments(argumentName="signal")[0], "synchronized"

--- a/src/silx/gui/plot/test/test_imagestack.py
+++ b/src/silx/gui/plot/test/test_imagestack.py
@@ -214,22 +214,18 @@ class TestImageStack(TestCaseQt):
         # make sure if all urls are removed nothing is plot anymore
         self.widget.getPlotWidget().getActiveImage() is None
 
-    def _waitUntilUrlLoaded(self, timeout=2.0):
+    def _waitUntilUrlLoaded(self):
         """Wait until all image urls are loaded"""
-        loop_duration = 0.2
-        remaining_duration = timeout
-        while len(self.widget._loadingThreads) > 0 and remaining_duration > 0:
-            remaining_duration -= loop_duration
-            time.sleep(loop_duration)
-            self.qapp.processEvents()
-
-        if remaining_duration <= 0.0:
-            remaining_urls = []
-            for thread_ in self.widget._loadingThreads:
-                remaining_urls.append(thread_.url.path())
+        try:
+            self.waitAsLongAs(
+                lambda: len(self.widget._loadingThreads) > 0, msecs=0.2, nretries=10
+            )
+        except RuntimeError:
+            remaining_urls = [
+                thread_.url.path() for thread_ in self.widget._loadingThreads
+            ]
             mess = (
                 "All images are not loaded after the time out. "
                 "Remaining urls are: " + str(remaining_urls)
             )
             raise TimeoutError(mess)
-        return True

--- a/src/silx/gui/plot/test/utils.py
+++ b/src/silx/gui/plot/test/utils.py
@@ -68,12 +68,7 @@ class PlotWidgetTestCase(TestCaseQt):
         self.plot.destroyed.connect(self.__onPlotDestroyed)
         self.plot.close()
         del self.plot
-        for _ in range(100):
-            if not self.plotAlive:
-                break
-            self.qWait(10)
-        else:
-            logger.error("Plot is still alive")
+        self.waitAsLongAs(lambda: self.plotAlive)
 
     def tearDown(self):
         if not self._currentTestSucceeded():

--- a/src/silx/gui/plot/tools/test/test_profile.py
+++ b/src/silx/gui/plot/tools/test/test_profile.py
@@ -3,7 +3,7 @@ import logging
 import pytest
 
 from silx.gui import qt
-from silx.gui.utils.testutils import qWaitForWindowExposedAndActivate, QTest
+from silx.gui.utils.testutils import qWaitForWindowExposedAndActivate
 
 from silx.gui.plot import PlotWindow, Plot1D, Plot2D, Profile
 from silx.gui.plot.StackView import StackView
@@ -67,13 +67,6 @@ class TestInteractions:
         widget.show()
         yield widget.getPlotWidget()
 
-    def waitPendingOperations(self, profile, qapp_utils):
-        for _ in range(10):
-            if not profile.hasPendingOperations():
-                return
-            qapp_utils.qWait(100)
-        _logger.error("The profile manager still have pending operations")
-
     def genericRoiTest(self, plot, roiClass, qapp_utils):
         profileManager = manager.ProfileManager(plot, plot)
         profileManager.setItemType(image=True, scatter=True)
@@ -93,7 +86,7 @@ class TestInteractions:
                 qapp_utils.mouseMove(widget, pos=pos2)
                 qapp_utils.mouseClick(widget, qt.Qt.LeftButton, pos=pos2)
 
-            self.waitPendingOperations(profileManager, qapp_utils)
+            qapp_utils.waitAsLongAs(profileManager.hasPendingOperations)
 
             # Test that something was computed
             if issubclass(roiClass, rois._ProfileCrossROI):
@@ -302,10 +295,7 @@ class TestProfileToolBar:
                         qapp_utils.mouseClick(widget, qt.Qt.LeftButton)
 
                         manager = toolBar.getProfileManager()
-                        for _ in range(20):
-                            qapp_utils.qWait(200)
-                            if not manager.hasPendingOperations():
-                                break
+                        qapp_utils.waitAsLongAs(manager.hasPendingOperations)
 
     def testDiagonalProfile(
         self, plotAndToolBar, subtests: pytest.Subtests, qapp_utils
@@ -339,20 +329,14 @@ class TestProfileToolBar:
 
                 manager = toolBar.getProfileManager()
 
-                for _ in range(20):
-                    qapp_utils.qWait(200)
-                    if not manager.hasPendingOperations():
-                        break
+                qapp_utils.waitAsLongAs(manager.hasPendingOperations)
 
                 roi = manager.getCurrentRoi()
                 assert roi is not None
                 roi.setProfileLineWidth(3)
                 roi.setProfileMethod(method)
 
-                for _ in range(20):
-                    qapp_utils.qWait(200)
-                    if not manager.hasPendingOperations():
-                        break
+                qapp_utils.waitAsLongAs(manager.hasPendingOperations)
 
                 curveItem = (
                     roi.getProfileWindow().getCurrentPlotWidget().getAllCurves()[0]
@@ -404,10 +388,7 @@ class TestProfile3DToolBar:
         roi.setProfileType("2D")
         roi.setProfileLineWidth(3)
 
-        for _ in range(20):
-            qapp_utils.qWait(200)
-            if not manager.hasPendingOperations():
-                break
+        qapp_utils.waitAsLongAs(manager.hasPendingOperations)
 
         # check 2D 'mean' profile
         profilePlot = roi.getProfileWindow().getCurrentPlotWidget()
@@ -435,10 +416,7 @@ class TestProfile3DToolBar:
         roi.setProfileType("2D")
         roi.setProfileLineWidth(3)
 
-        for _ in range(20):
-            qapp_utils.qWait(200)
-            if not manager.hasPendingOperations():
-                break
+        qapp_utils.waitAsLongAs(manager.hasPendingOperations)
 
         # check 2D 'sum' profile
         profilePlot = roi.getProfileWindow().getCurrentPlotWidget()
@@ -448,7 +426,7 @@ class TestProfile3DToolBar:
 
 
 @pytest.mark.parametrize("with_mask", (True, False))
-def testProfile1D(qWidgetFactory, with_mask):
+def testProfile1D(qWidgetFactory, with_mask, qapp_utils):
     """Test that the profile plot associated to a Plot2D is a 1D plot and that mask is take into account.
 
     Note: the mask; when applied; is at the center. As we have an od number of elements the expected result remains the same.
@@ -474,10 +452,7 @@ def testProfile1D(qWidgetFactory, with_mask):
     roiManager.addRoi(roi)
     roiManager.setCurrentRoi(roi)
 
-    for _ in range(20):
-        QTest.qWait(200)
-        if not manager.hasPendingOperations():
-            break
+    qapp_utils.waitAsLongAs(manager.hasPendingOperations)
 
     profileWindow = roi.getProfileWindow()
     assert isinstance(roi.getProfileWindow(), ProfileWindow)
@@ -492,7 +467,7 @@ def testProfile1D(qWidgetFactory, with_mask):
 
 
 @pytest.mark.parametrize("with_mask", (True, False))
-def testProfile2D(qWidgetFactory, with_mask):
+def testProfile2D(qWidgetFactory, with_mask, qapp_utils):
     """Test that the profile plot associated to a stack view is either a
     Plot1D or a plot 2D instance.
     Make sure also that the mask is take into account.
@@ -526,10 +501,7 @@ def testProfile2D(qWidgetFactory, with_mask):
     roiManager.addRoi(roi)
     roiManager.setCurrentRoi(roi)
 
-    for _ in range(20):
-        QTest.qWait(200)
-        if not manager.hasPendingOperations():
-            break
+    qapp_utils.waitAsLongAs(manager.hasPendingOperations)
 
     profileWindow = roi.getProfileWindow()
     assert isinstance(roi.getProfileWindow(), ProfileWindow)
@@ -544,10 +516,7 @@ def testProfile2D(qWidgetFactory, with_mask):
 
     roi.setProfileType("1D")
 
-    for _ in range(20):
-        QTest.qWait(200)
-        if not manager.hasPendingOperations():
-            break
+    qapp_utils.waitAsLongAs(manager.hasPendingOperations)
 
     profileWindow = roi.getProfileWindow()
     assert isinstance(roi.getProfileWindow(), ProfileWindow)

--- a/src/silx/gui/plot/tools/test/test_scatterprofiletoolbar.py
+++ b/src/silx/gui/plot/tools/test/test_scatterprofiletoolbar.py
@@ -78,11 +78,7 @@ class TestScatterProfileToolBar(TestCaseQt, ParametricTestCase):
         roiManager.addRoi(roi)
 
         # Wait for async interpolator init
-        for _ in range(20):
-            self.qWait(200)
-            if not self.manager.hasPendingOperations():
-                break
-        self.qapp.processEvents()
+        self.waitAsLongAs(self.manager.hasPendingOperations)
 
         window = roi.getProfileWindow()
         self.assertIsNotNone(window)
@@ -119,10 +115,7 @@ class TestScatterProfileToolBar(TestCaseQt, ParametricTestCase):
         roiManager.addRoi(roi)
 
         # Wait for async interpolator init
-        for _ in range(10):
-            self.qWait(200)
-            if not self.manager.hasPendingOperations():
-                break
+        self.waitAsLongAs(self.manager.hasPendingOperations)
 
         window = roi.getProfileWindow()
         self.assertIsNotNone(window)
@@ -139,10 +132,7 @@ class TestScatterProfileToolBar(TestCaseQt, ParametricTestCase):
         self.plot.getYAxis().setLimits(yLimits[0] + 1, yLimits[1] + 10)
 
         # Wait for async interpolator init
-        for _ in range(10):
-            self.qWait(200)
-            if not self.manager.hasPendingOperations():
-                break
+        self.waitAsLongAs(self.manager.hasPendingOperations)
 
         yLimits = self.plot.getYAxis().getLimits()
         data = window.getProfile()
@@ -173,10 +163,7 @@ class TestScatterProfileToolBar(TestCaseQt, ParametricTestCase):
         roiManager.addRoi(roi)
 
         # Wait for async interpolator init
-        for _ in range(10):
-            self.qWait(200)
-            if not self.manager.hasPendingOperations():
-                break
+        self.waitAsLongAs(self.manager.hasPendingOperations)
 
         window = roi.getProfileWindow()
         self.assertIsNotNone(window)

--- a/src/silx/gui/utils/test/test_async.py
+++ b/src/silx/gui/utils/test/test_async.py
@@ -89,13 +89,7 @@ class TestSubmitToQtThread(TestCaseQt):
         """Call submitToQtMainThread from a Python thread"""
         thread = threading.Thread(target=self._threadedTest)
         thread.start()
-        for i in range(100):  # Loop over for 10 seconds
-            self.qapp.processEvents()
-            thread.join(0.1)
-            if not thread.is_alive():
-                break
-        else:
-            self.fail("Thread task still running")
+        self.waitAsLongAs(thread.is_alive)
 
     def testFromQtThread(self):
         """Call submitToQtMainThread from a Qt thread pool"""
@@ -114,10 +108,4 @@ class TestSubmitToQtThread(TestCaseQt):
         threadPool = qt.silxGlobalThreadPool()
         runner = Runner(self._threadedTest)
         threadPool.start(runner)
-        for i in range(100):  # Loop over for 10 seconds
-            self.qapp.processEvents()
-            done = threadPool.waitForDone(100)
-            if done:
-                break
-        else:
-            self.fail("Thread pool task still running")
+        self.waitAsLongAs(lambda: not threadPool.waitForDone(10))

--- a/src/silx/gui/utils/testutils.py
+++ b/src/silx/gui/utils/testutils.py
@@ -34,6 +34,7 @@ import unittest
 import functools
 import sys
 import os
+from collections.abc import Callable
 
 from silx.gui import qt
 from silx.gui.qt import inspect as _inspect
@@ -408,6 +409,18 @@ class TestCaseQt(unittest.TestCase):
         pixmap = screen.grabWindow(0)
         pixmap.save(filename)
         _logger.log(level, "Screenshot saved at %s", filename)
+
+    def waitAsLongAs(
+        self, callable: Callable[[], bool], msecs: int | None = None, nretries: int = 20
+    ) -> None:
+        if msecs is None:
+            msecs = self.DEFAULT_TIMEOUT_WAIT
+        for _ in range(nretries):
+            if not callable():
+                return
+            self.qWait(msecs)
+        else:
+            raise RuntimeError("Still waiting for a pending operation")
 
 
 class SignalListener:

--- a/src/silx/gui/widgets/test/test_threadpoolpushbutton.py
+++ b/src/silx/gui/widgets/test/test_threadpoolpushbutton.py
@@ -13,26 +13,13 @@ def button(qWidgetFactory):
 
 
 @pytest.fixture()
-def waitForPendingOperations(button, qapp_utils):
-    def _waitForPendingOperations():
-        for i in range(50):
-            if not button.hasPendingOperations():
-                break
-            qapp_utils.qWait(10)
-        else:
-            raise RuntimeError("Still waiting for a pending operation")
-
-    return _waitForPendingOperations
-
-
-@pytest.fixture()
 def listener():
     listener = SignalListener()
     yield listener
     listener.clear()
 
 
-def testExecute(button, waitForPendingOperations):
+def testExecute(button, qapp_utils):
     result = []
 
     def appendToResult(name):
@@ -40,11 +27,11 @@ def testExecute(button, waitForPendingOperations):
 
     button.setCallable(appendToResult, "a")
     button.executeCallable()
-    waitForPendingOperations()
+    qapp_utils.waitAsLongAs(button.hasPendingOperations)
     assert result == ["a"]
 
 
-def testMultiExecution(button, waitForPendingOperations):
+def testMultiExecution(button, qapp_utils):
     result = []
 
     def appendToResult(name):
@@ -54,11 +41,11 @@ def testMultiExecution(button, waitForPendingOperations):
     numberOfCalls = qt.silxGlobalThreadPool().maxThreadCount()
     for _ in range(numberOfCalls):
         button.executeCallable()
-    waitForPendingOperations()
+    qapp_utils.waitAsLongAs(button.hasPendingOperations)
     assert result == ["a"] * numberOfCalls
 
 
-def testSaturateThreadPool(button, waitForPendingOperations):
+def testSaturateThreadPool(button, qapp_utils):
     result = []
 
     def appendToResult(name):
@@ -69,7 +56,7 @@ def testSaturateThreadPool(button, waitForPendingOperations):
     numberOfCalls = qt.silxGlobalThreadPool().maxThreadCount() * 2
     for _ in range(numberOfCalls):
         button.executeCallable()
-    waitForPendingOperations()
+    qapp_utils.waitAsLongAs(button.hasPendingOperations)
     assert result == ["a"] * numberOfCalls
 
 


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

! Merge PR #4666 first !

Move `waitForPendingOperations` to a more general helper in `qapp_utils`.

#### AI Disclosure
- [x] No AI used
- [ ] AI tool(s) ... used for ...
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
