### PR TITLE
silx.gui.plot.PlotWidget: deprecate `histogram` arg from `addCurve` and add new args to `addHistogram`

### DIFF
--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -1123,17 +1123,7 @@ class PlotWidget(qt.QMainWindow):
                                 (Default: True)
         :param fill: True to fill the curve, False otherwise (default).
         :param resetzoom: True (the default) to reset the zoom.
-        :param histogram: if not None then the curve will be draw as an
-            histogram. The step for each values of the curve can be set to the
-            left, center or right of the original x curve values.
-            If histogram is not None and len(x) == len(y)+1 then x is directly
-            take as edges of the histogram.
-            Type of histogram::
-
-            - None (default)
-            - 'left'
-            - 'right'
-            - 'center'
+        :param histogram: DEPRECATED, use `addHistogram` with `align` instead.
         :param copy: True make a copy of the data (default),
                           False to use provided arrays.
         :param baseline: curve baseline
@@ -1141,6 +1131,13 @@ class PlotWidget(qt.QMainWindow):
         """
         # This is an histogram, use addHistogram
         if histogram is not None:
+            deprecated_warning(
+                type_="Argument",
+                name="histogram",
+                reason="histogram arg is deprecated. Use `addHistogram` to produce an histogram, setting the `align` argument instead.",
+                replacement="addHistogram",
+                since_version="3.0.2",
+            )
             histo = self.addHistogram(
                 histogram=y,
                 edges=x,
@@ -1149,21 +1146,16 @@ class PlotWidget(qt.QMainWindow):
                 fill=fill,
                 align=histogram,
                 copy=copy,
+                z=z,
+                info=info,
+                linewidth=linewidth,
+                linestyle=linestyle,
+                yaxis=yaxis,
             )
-
-            histo.setInfo(info)
-            if linewidth is not None:
-                histo.setLineWidth(linewidth)
-            if linestyle is not None:
-                histo.setLineStyle(linestyle)
             if xlabel is not None:
                 _logger.warning("addCurve: Histogram does not support xlabel argument")
             if ylabel is not None:
                 _logger.warning("addCurve: Histogram does not support ylabel argument")
-            if yaxis is not None:
-                histo.setYAxis(yaxis)
-            if z is not None:
-                histo.setZValue(z)
             if selectable is not None:
                 _logger.warning(
                     "addCurve: Histogram does not support selectable argument"
@@ -1279,6 +1271,10 @@ class PlotWidget(qt.QMainWindow):
         copy: bool = True,
         z: int | None = None,
         baseline: float | numpy.ndarray | None = None,
+        info: Any = None,
+        linewidth: float | None = None,
+        linestyle: str | None = None,
+        yaxis: Literal["left", "right"] | None = None,
     ) -> items.Histogram:
         """Add an histogram to the graph.
 
@@ -1312,6 +1308,18 @@ class PlotWidget(qt.QMainWindow):
                           False to use provided arrays.
         :param z: Layer on which to draw the histogram
         :param baseline: histogram baseline
+        :param info: User-defined information associated to the histogram
+        :param linewidth: The width of the histogram lines in pixels (Default: 1).
+        :param linestyle: Type of line::
+
+            - ' '  no line
+            - '-'  solid line
+            - '--' dashed line
+            - '-.' dash-dot line
+            - ':'  dotted line
+            - None (the default) to use default line style
+        :param yaxis: The Y axis this histogram is attached to.
+                      Either 'left' (the default) or 'right'
         :returns: The histogram item
         """
         legend = "Unnamed histogram" if legend is None else str(legend)
@@ -1354,6 +1362,15 @@ class PlotWidget(qt.QMainWindow):
             # if the user does not want that, autoscale of the different
             # axes has to be set to off.
             self.resetZoom()
+
+        if linewidth is not None:
+            histo.setLineWidth(linewidth)
+        if linestyle is not None:
+            histo.setLineStyle(linestyle)
+        if yaxis is not None:
+            histo.setYAxis(yaxis)
+        if info is not None:
+            histo.setInfo(info)
 
         return histo
 

--- a/src/silx/gui/plot/test/test_item.py
+++ b/src/silx/gui/plot/test/test_item.py
@@ -539,8 +539,9 @@ def testLineStyle(qapp_utils, plotWidget, linestyle):
     curve = plotWidget.addCurve((0, 1), (0, 1), linestyle=linestyle)
     assert curve.getLineStyle() == linestyle
 
-    histogram = plotWidget.addHistogram((0.25, 0.75, 0.25), (0.0, 0.33, 0.66, 1.0))
-    histogram.setLineStyle(linestyle)
+    histogram = plotWidget.addHistogram(
+        (0.25, 0.75, 0.25), (0.0, 0.33, 0.66, 1.0), linestyle=linestyle
+    )
     assert histogram.getLineStyle() == linestyle
 
     polylines = plotWidget.addShape(

--- a/src/silx/gui/plot/test/test_plotwidget.py
+++ b/src/silx/gui/plot/test/test_plotwidget.py
@@ -679,12 +679,12 @@ class TestPlotHistogram(PlotWidgetTestCase):
             edges=self.edges,
             legend="histogram1",
             color="blue",
+            linestyle=":",
         )
         histogram = self.plot.getItems()[0]
         assert histogram.getLineGapColor() is None
         histogram.setLineGapColor("red")
         assert histogram.getLineGapColor() == (1.0, 0.0, 0.0, 1.0)
-        histogram.setLineStyle(":")
 
 
 class TestPlotScatter(PlotWidgetTestCase, ParametricTestCase):


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

I noticed when working on #4651 that there are two ways of adding an histogram to a `PlotWidget`:
- use `addHistogram`
- use `addCurve` with the parameter `histogram` 

This is confusing and inconsistent for several reasons:
1. The level of functionality is not the same. For example, adding via `addCurve` allows to change the `yaxis` while adding via `addHistogram` does not
2. Some of the parameters of `addCurve` are ignored when using `histogram` since they do not apply to histograms. Some of them log warnings when they are unused but not all, since it is not really tractable to track all arguments of `addCurve`.
3. This makes the return type of `addCurve` needlessly inconsistent. If I don't use `histogram`, I know that `addCurve` will return a `Curve` but my IDE will still show an error as the return type is (rightly so) `Curve | Histogram`.

I propose therefore the deprecate the `histogram` parameter of `addCurve` in favour of using `addHistogram`.

In this PR, I deprecate the argument while also matching the functionality of `addHistogram` with what can be done by using `histogram` in `addCurve`. For this, I added several arguments to `addHistogram` (e.g. the `yaxis` mentionned above).

#### AI Disclosure
- [x] No AI used

