### PR TITLE
silx.gui.plot silx.gui.plot3d: Fixed support of matplotlib 3.11.1

### DIFF
--- a/src/silx/gui/utils/matplotlib.py
+++ b/src/silx/gui/utils/matplotlib.py
@@ -35,7 +35,6 @@ __license__ = "MIT"
 __date__ = "02/05/2018"
 
 
-import io
 import matplotlib
 import numpy
 
@@ -54,6 +53,7 @@ from matplotlib.font_manager import FontProperties
 from matplotlib.mathtext import MathTextParser
 from matplotlib.ticker import ScalarFormatter as _ScalarFormatter
 from matplotlib import figure, font_manager
+from matplotlib.backends.backend_agg import FigureCanvasAgg
 
 
 class DefaultTickFormatter(_ScalarFormatter):
@@ -147,13 +147,12 @@ def rasterMathText(
         verticalalignment="top",
     )
     text.set_linespacing(linespacing)
-    with io.BytesIO() as buffer:
-        fig.savefig(buffer, dpi=dotsPerInch, format="raw")
-        canvas_width, canvas_height = fig.get_window_extent().max
-        buffer.seek(0)
-        image = numpy.frombuffer(buffer.read(), dtype=numpy.uint8).reshape(
-            int(canvas_height), int(canvas_width), 4
-        )
+
+    canvas = FigureCanvasAgg(fig)
+    buffer, (canvas_width, canvas_height) = canvas.print_to_buffer()
+    image = numpy.frombuffer(buffer, dtype=numpy.uint8).reshape(
+        canvas_height, canvas_width, 4
+    )
 
     # RGB to inverted R channel
     array = 255 - image[:, :, 0]


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

This PR fixes support of matplotlib 3.11.1 for rendering text with opengl (both in silx.gui.plot and silx.gui.plot3d).
The OpenGL backend uses matplotlib to render text in textures and leverages its latex syntax support.

From what I tested, this works with matplotlib v3.6 (oldest supported version by silx), v3.11.0 and v3.11.1.

related to https://github.com/matplotlib/matplotlib/pull/32038

closes #4676

#### AI Disclosure
- [x] AI tool(s) claude/sonnet used for generating the patch

<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
