### PR TITLE
silx view: Fixed copy name to clipboard for objects in sidebar.

### DIFF
--- a/src/silx/app/view/ApplicationContext.py
+++ b/src/silx/app/view/ApplicationContext.py
@@ -40,7 +40,7 @@ _logger = logging.getLogger(__name__)
 
 class ApplicationContext(DataViewHooks):
     """
-    Store the conmtext of the application
+    Store the context of the application
 
     It overwrites the DataViewHooks to custom the use of the DataViewer for
     the silx view application.

--- a/src/silx/app/view/Viewer.py
+++ b/src/silx/app/view/Viewer.py
@@ -987,7 +987,7 @@ class Viewer(qt.QMainWindow):
         model.createFromNxdata(h5nxdata)
 
     def _copyNameToClipboard(self, obj):
-        qt.Application.clipboard().setText(obj.name)
+        qt.QApplication.clipboard().setText(obj.name)
 
     def customContextMenu(self, event):
         """Called to populate the context menu


### PR DESCRIPTION
- [X] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

<!-- Thank you for your pull request! Please, provide a description of the changes below -->
Fixed typo in src/silx/app/view/Viewer.py in function _copyNameToClipboard() so the object names in the sidebar now can be copied to clipboard. Fixed typo in docstring in src/silx/app/view/ApplicationContext.py.

How to test? Open silx view, open h5-file, expand it, right click a dataset and copy the path of the dataset to clipboard. Verify copied path.

#### AI Disclosure
- [X] No AI used
- [ ] AI tool(s) ... used for ...
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
