### PR TITLE
silx.gui.plot: Fixed PlotWidget user interaction and limits for asinh scaled axes

### DIFF
--- a/src/silx/gui/plot/ImageView.py
+++ b/src/silx/gui/plot/ImageView.py
@@ -309,11 +309,23 @@ class _SideHistogram(PlotWidget):
         margins = self.getDataMargins()
         if self._direction == qt.Qt.Horizontal:
             _, _, vMin, vMax = _utils.addMarginsToLimits(
-                margins, False, False, 0, 0, vMin, vMax
+                margins,
+                self.getXAxis().getScale(),
+                self.getYAxis().getScale(),
+                0,
+                0,
+                vMin,
+                vMax,
             )
         elif self._direction == qt.Qt.Vertical:
             vMin, vMax, _, _ = _utils.addMarginsToLimits(
-                margins, False, False, vMin, vMax, 0, 0
+                margins,
+                self.getXAxis().getScale(),
+                self.getYAxis().getScale(),
+                vMin,
+                vMax,
+                0,
+                0,
             )
         else:
             assert False

--- a/src/silx/gui/plot/PlotInteraction.py
+++ b/src/silx/gui/plot/PlotInteraction.py
@@ -266,20 +266,24 @@ class Pan(_PlotInteractionWithClickEvents):
         previous: float,
     ) -> tuple[float, float]:
         axisScale = axis.getScale()
-        # TODO handle apply/revert errors
         currentScaled = axis_scale.apply(axisScale, current)
         previousScaled = axis_scale.apply(axisScale, previous)
         delta = currentScaled - previousScaled
 
         axisMin, axisMax = axis.getLimits()
-        newMin = axis_scale.revert(
-            axisScale, axis_scale.apply(axisScale, axisMin) - delta
-        )
-        newMax = axis_scale.revert(
-            axisScale, axis_scale.apply(axisScale, axisMax) - delta
-        )
+        try:
+            newMin = axis_scale.revert(
+                axisScale, axis_scale.apply(axisScale, axisMin) - delta
+            )
+            newMax = axis_scale.revert(
+                axisScale, axis_scale.apply(axisScale, axisMax) - delta
+            )
+        except (ValueError, OverflowError):
+            return newMin, newMax
 
-        if axis_scale.inSafeRange(newMin) and axis_scale.inSafeRange(newMax):
+        if axis_scale.inSafeRange(axisScale, newMin) and axis_scale.inSafeRange(
+            axisScale, newMax
+        ):
             return newMin, newMax
         else:
             return axisMin, axisMax

--- a/src/silx/gui/plot/PlotInteraction.py
+++ b/src/silx/gui/plot/PlotInteraction.py
@@ -60,14 +60,8 @@ from .backends.BackendBase import (
     CURSOR_SIZE_VER,
     CURSOR_SIZE_ALL,
 )
-
-from ._utils import (
-    FLOAT32_SAFE_MIN,
-    FLOAT32_MINPOS,
-    FLOAT32_SAFE_MAX,
-    applyZoomToPlot,
-    EnabledAxes,
-)
+from ._utils import applyZoomToPlot, EnabledAxes
+from ._utils import axis_scale
 
 # Base class ##################################################################
 
@@ -265,72 +259,45 @@ class Pan(_PlotInteractionWithClickEvents):
     def beginDrag(self, x, y, btn):
         self._previousDataPos = self._pixelToData(x, y)
 
+    def _axisDrag(
+        self,
+        axis,
+        current: float,
+        previous: float,
+    ) -> tuple[float, float]:
+        axisScale = axis.getScale()
+        # TODO handle apply/revert errors
+        currentScaled = axis_scale.apply(axisScale, current)
+        previousScaled = axis_scale.apply(axisScale, previous)
+        delta = currentScaled - previousScaled
+
+        axisMin, axisMax = axis.getLimits()
+        newMin = axis_scale.revert(
+            axisScale, axis_scale.apply(axisScale, axisMin) - delta
+        )
+        newMax = axis_scale.revert(
+            axisScale, axis_scale.apply(axisScale, axisMax) - delta
+        )
+
+        if axis_scale.inSafeRange(newMin) and axis_scale.inSafeRange(newMax):
+            return newMin, newMax
+        else:
+            return axisMin, axisMax
+
     def drag(self, x, y, btn):
-        xData, yData, y2Data = self._pixelToData(x, y)
-        lastX, lastY, lastY2 = self._previousDataPos
+        xData, yLeftData, yRightData = self._pixelToData(x, y)
+        lastX, lastYLeft, lastYRight = self._previousDataPos
 
-        xMin, xMax = self.plot.getXAxis().getLimits()
-        yMin, yMax = self.plot.getYAxis().getLimits()
-        y2Min, y2Max = self.plot.getYAxis(axis="right").getLimits()
-
-        if self.plot.getXAxis()._isLogarithmic():
-            try:
-                dx = math.log10(xData) - math.log10(lastX)
-                newXMin = pow(10.0, (math.log10(xMin) - dx))
-                newXMax = pow(10.0, (math.log10(xMax) - dx))
-            except (ValueError, OverflowError):
-                newXMin, newXMax = xMin, xMax
-
-            # Makes sure both values stays in positive float32 range
-            if newXMin < FLOAT32_MINPOS or newXMax > FLOAT32_SAFE_MAX:
-                newXMin, newXMax = xMin, xMax
-        else:
-            dx = xData - lastX
-            newXMin, newXMax = xMin - dx, xMax - dx
-
-            # Makes sure both values stays in float32 range
-            if newXMin < FLOAT32_SAFE_MIN or newXMax > FLOAT32_SAFE_MAX:
-                newXMin, newXMax = xMin, xMax
-
-        if self.plot.getYAxis()._isLogarithmic():
-            try:
-                dy = math.log10(yData) - math.log10(lastY)
-                newYMin = pow(10.0, math.log10(yMin) - dy)
-                newYMax = pow(10.0, math.log10(yMax) - dy)
-
-                dy2 = math.log10(y2Data) - math.log10(lastY2)
-                newY2Min = pow(10.0, math.log10(y2Min) - dy2)
-                newY2Max = pow(10.0, math.log10(y2Max) - dy2)
-            except (ValueError, OverflowError):
-                newYMin, newYMax = yMin, yMax
-                newY2Min, newY2Max = y2Min, y2Max
-
-            # Makes sure y and y2 stays in positive float32 range
-            if (
-                newYMin < FLOAT32_MINPOS
-                or newYMax > FLOAT32_SAFE_MAX
-                or newY2Min < FLOAT32_MINPOS
-                or newY2Max > FLOAT32_SAFE_MAX
-            ):
-                newYMin, newYMax = yMin, yMax
-                newY2Min, newY2Max = y2Min, y2Max
-        else:
-            dy = yData - lastY
-            dy2 = y2Data - lastY2
-            newYMin, newYMax = yMin - dy, yMax - dy
-            newY2Min, newY2Max = y2Min - dy2, y2Max - dy2
-
-            # Makes sure y and y2 stays in float32 range
-            if (
-                newYMin < FLOAT32_SAFE_MIN
-                or newYMax > FLOAT32_SAFE_MAX
-                or newY2Min < FLOAT32_SAFE_MIN
-                or newY2Max > FLOAT32_SAFE_MAX
-            ):
-                newYMin, newYMax = yMin, yMax
-                newY2Min, newY2Max = y2Min, y2Max
-
-        self.plot.setLimits(newXMin, newXMax, newYMin, newYMax, newY2Min, newY2Max)
+        newXMin, newXMax = self._axisDrag(self.plot.getXAxis(), xData, lastX)
+        newYLeftMin, newYLeftMax = self._axisDrag(
+            self.plot.getYAxis("left"), yLeftData, lastYLeft
+        )
+        newYRightMin, newYRightMax = self._axisDrag(
+            self.plot.getYAxis("right"), yRightData, lastYRight
+        )
+        self.plot.setLimits(
+            newXMin, newXMax, newYLeftMin, newYLeftMax, newYRightMin, newYRightMax
+        )
 
         self._previousDataPos = self._pixelToData(x, y)
 

--- a/src/silx/gui/plot/PlotInteraction.py
+++ b/src/silx/gui/plot/PlotInteraction.py
@@ -279,7 +279,7 @@ class Pan(_PlotInteractionWithClickEvents):
                 axisScale, axis_scale.apply(axisScale, axisMax) - delta
             )
         except (ValueError, OverflowError):
-            return newMin, newMax
+            return axisMin, axisMax
 
         if axis_scale.inSafeRange(axisScale, newMin) and axis_scale.inSafeRange(
             axisScale, newMax

--- a/src/silx/gui/plot/PlotWidget.py
+++ b/src/silx/gui/plot/PlotWidget.py
@@ -2218,23 +2218,21 @@ class PlotWidget(qt.QMainWindow):
             xFactor = factor if direction == "right" else -factor
             xMin, xMax = self._xAxis.getLimits()
 
-            xMin, xMax = _utils.applyPan(
-                xMin, xMax, xFactor, self._xAxis.getScale() == self._xAxis.LOGARITHMIC
-            )
+            xMin, xMax = _utils.applyPan(self._xAxis.getScale(), xMin, xMax, xFactor)
             self._xAxis.setLimits(xMin, xMax)
 
         else:  # direction in ('up', 'down')
             sign = -1.0 if self._yAxis.isInverted() else 1.0
             yFactor = sign * (factor if direction == "up" else -factor)
-            yMin, yMax = self._yAxis.getLimits()
-            yIsLog = self._yAxis.getScale() == self._yAxis.LOGARITHMIC
 
-            yMin, yMax = _utils.applyPan(yMin, yMax, yFactor, yIsLog)
+            yMin, yMax = self._yAxis.getLimits()
+            yMin, yMax = _utils.applyPan(self._yAxis.getScale(), yMin, yMax, yFactor)
             self._yAxis.setLimits(yMin, yMax)
 
             y2Min, y2Max = self._yRightAxis.getLimits()
-
-            y2Min, y2Max = _utils.applyPan(y2Min, y2Max, yFactor, yIsLog)
+            y2Min, y2Max = _utils.applyPan(
+                self._yRightAxis.getScale(), y2Min, y2Max, yFactor
+            )
             self._yRightAxis.setLimits(y2Min, y2Max)
 
     # Active Curve/Image
@@ -2735,8 +2733,8 @@ class PlotWidget(qt.QMainWindow):
             limits = list(
                 _utils.addMarginsToLimits(
                     self.getDataMargins() if margins is True else margins,
-                    self.getXAxis()._isLogarithmic(),
-                    self.getYAxis()._isLogarithmic(),
+                    self.getXAxis().getScale(),
+                    self.getYAxis().getScale(),
                     *limits,
                 )
             )

--- a/src/silx/gui/plot/_utils/__init__.py
+++ b/src/silx/gui/plot/_utils/__init__.py
@@ -28,19 +28,47 @@ __license__ = "MIT"
 __date__ = "21/03/2017"
 
 
-import numpy
-
-from .panzoom import FLOAT32_SAFE_MIN, FLOAT32_MINPOS, FLOAT32_SAFE_MAX  # noqa: F401
+from .axis_scale import FLOAT32_SAFE_MIN, FLOAT32_MINPOS, FLOAT32_SAFE_MAX  # noqa: F401
+from . import axis_scale
 from .panzoom import (  # noqa: F401
     applyZoomToPlot,
     applyPan,
     checkAxisLimits,
     EnabledAxes,
 )
+from ..items.types import AxisScaleType
+
+
+def _addMargins(
+    scale: AxisScaleType,
+    minMargin: float,
+    maxMargin: float,
+    minLimit: float,
+    maxLimit: float,
+):
+    if not axis_scale.isValid(scale, minLimit) or not axis_scale.isValid(
+        scale, maxLimit
+    ):
+        return minLimit, maxLimit
+
+    minScaled = axis_scale.apply(scale, minLimit)
+    maxScaled = axis_scale.apply(scale, maxLimit)
+    rangeLimit = maxScaled - minScaled
+    min_ = axis_scale.revert(scale, minScaled - minMargin * rangeLimit)
+    max_ = axis_scale.revert(scale, maxScaled + maxMargin * rangeLimit)
+    return min_, max_
 
 
 def addMarginsToLimits(
-    margins, isXLog, isYLog, xMin, xMax, yMin, yMax, y2Min=None, y2Max=None
+    margins,
+    xScale: AxisScaleType,
+    yScale: AxisScaleType,
+    xMin,
+    xMax,
+    yMin,
+    yMax,
+    y2Min=None,
+    y2Max=None,
 ):
     """Returns updated limits by extending them with margins.
 
@@ -56,46 +84,16 @@ def addMarginsToLimits(
     if margins is not None:
         xMinMargin, xMaxMargin, yMinMargin, yMaxMargin = margins
 
-        if not isXLog:
-            xRange = xMax - xMin
-            xMin -= xMinMargin * xRange
-            xMax += xMaxMargin * xRange
-
-        elif xMin > 0.0 and xMax > 0.0:  # Log scale
-            # Do not apply margins if limits < 0
-            xMinLog, xMaxLog = numpy.log10(xMin), numpy.log10(xMax)
-            xRangeLog = xMaxLog - xMinLog
-            xMin = pow(10.0, xMinLog - xMinMargin * xRangeLog)
-            xMax = pow(10.0, xMaxLog + xMaxMargin * xRangeLog)
-
-        if not isYLog:
-            yRange = yMax - yMin
-            yMin -= yMinMargin * yRange
-            yMax += yMaxMargin * yRange
-        elif yMin > 0.0 and yMax > 0.0:  # Log scale
-            # Do not apply margins if limits < 0
-            yMinLog, yMaxLog = numpy.log10(yMin), numpy.log10(yMax)
-            yRangeLog = yMaxLog - yMinLog
-            yMin = pow(10.0, yMinLog - yMinMargin * yRangeLog)
-            yMax = pow(10.0, yMaxLog + yMaxMargin * yRangeLog)
-
+        xMin, xMax = _addMargins(xScale, xMinMargin, xMaxMargin, xMin, xMax)
+        yMin, yMax = _addMargins(yScale, yMinMargin, yMaxMargin, yMin, yMax)
         if y2Min is not None and y2Max is not None:
-            if not isYLog:
-                yRange = y2Max - y2Min
-                y2Min -= yMinMargin * yRange
-                y2Max += yMaxMargin * yRange
-            elif y2Min > 0.0 and y2Max > 0.0:  # Log scale
-                # Do not apply margins if limits < 0
-                yMinLog, yMaxLog = numpy.log10(y2Min), numpy.log10(y2Max)
-                yRangeLog = yMaxLog - yMinLog
-                y2Min = pow(10.0, yMinLog - yMinMargin * yRangeLog)
-                y2Max = pow(10.0, yMaxLog + yMaxMargin * yRangeLog)
+            y2Min, y2Max = _addMargins(yScale, yMinMargin, yMaxMargin, y2Min, y2Max)
 
-    xMin, xMax = checkAxisLimits(xMin, xMax, "log" if isXLog else "linear")
-    yMin, yMax = checkAxisLimits(yMin, yMax, "log" if isYLog else "linear")
+    xMin, xMax = checkAxisLimits(xScale, xMin, xMax)
+    yMin, yMax = checkAxisLimits(yScale, yMin, yMax)
 
     if y2Min is None or y2Max is None:
         return xMin, xMax, yMin, yMax
     else:
-        y2Min, y2Max = checkAxisLimits(y2Min, y2Max, "log" if isYLog else "linear")
+        y2Min, y2Max = checkAxisLimits(yScale, y2Min, y2Max)
         return xMin, xMax, yMin, yMax, y2Min, y2Max

--- a/src/silx/gui/plot/_utils/__init__.py
+++ b/src/silx/gui/plot/_utils/__init__.py
@@ -91,11 +91,11 @@ def addMarginsToLimits(
                 y2Min = pow(10.0, yMinLog - yMinMargin * yRangeLog)
                 y2Max = pow(10.0, yMaxLog + yMaxMargin * yRangeLog)
 
-    xMin, xMax = checkAxisLimits(xMin, xMax, isXLog)
-    yMin, yMax = checkAxisLimits(yMin, yMax, isYLog)
+    xMin, xMax = checkAxisLimits(xMin, xMax, "log" if isXLog else "linear")
+    yMin, yMax = checkAxisLimits(yMin, yMax, "log" if isYLog else "linear")
 
     if y2Min is None or y2Max is None:
         return xMin, xMax, yMin, yMax
     else:
-        y2Min, y2Max = checkAxisLimits(y2Min, y2Max, isYLog)
+        y2Min, y2Max = checkAxisLimits(y2Min, y2Max, "log" if isYLog else "linear")
         return xMin, xMax, yMin, yMax, y2Min, y2Max

--- a/src/silx/gui/plot/_utils/__init__.py
+++ b/src/silx/gui/plot/_utils/__init__.py
@@ -54,9 +54,17 @@ def _addMargins(
     minScaled = axis_scale.apply(scale, minLimit)
     maxScaled = axis_scale.apply(scale, maxLimit)
     rangeLimit = maxScaled - minScaled
-    min_ = axis_scale.revert(scale, minScaled - minMargin * rangeLimit)
-    max_ = axis_scale.revert(scale, maxScaled + maxMargin * rangeLimit)
-    return min_, max_
+    try:
+        min_ = axis_scale.revert(scale, minScaled - minMargin * rangeLimit)
+        max_ = axis_scale.revert(scale, maxScaled + maxMargin * rangeLimit)
+    except (ValueError, OverflowError):
+        return minLimit, maxLimit
+    else:
+        if axis_scale.inSafeRange(axisScale, min_) and axis_scale.inSafeRange(
+            axisScale, max_
+        ):
+            return min_, max_
+        return min_, max_
 
 
 def addMarginsToLimits(

--- a/src/silx/gui/plot/_utils/__init__.py
+++ b/src/silx/gui/plot/_utils/__init__.py
@@ -60,9 +60,7 @@ def _addMargins(
     except (ValueError, OverflowError):
         return minLimit, maxLimit
     else:
-        if axis_scale.inSafeRange(axisScale, min_) and axis_scale.inSafeRange(
-            axisScale, max_
-        ):
+        if axis_scale.inSafeRange(scale, min_) and axis_scale.inSafeRange(scale, max_):
             return min_, max_
         return min_, max_
 

--- a/src/silx/gui/plot/_utils/__init__.py
+++ b/src/silx/gui/plot/_utils/__init__.py
@@ -62,7 +62,7 @@ def _addMargins(
     else:
         if axis_scale.inSafeRange(scale, min_) and axis_scale.inSafeRange(scale, max_):
             return min_, max_
-        return min_, max_
+        return minLimit, maxLimit
 
 
 def addMarginsToLimits(

--- a/src/silx/gui/plot/_utils/axis_scale.py
+++ b/src/silx/gui/plot/_utils/axis_scale.py
@@ -1,0 +1,74 @@
+import numpy
+from ..items.types import AxisScaleType
+
+
+# Float 32 info ###############################################################
+# Using min/max value below limits of float32
+# so operation with such value (e.g., max - min) do not overflow
+
+FLOAT32_SAFE_MIN = -1e37
+FLOAT32_MINPOS = numpy.finfo(numpy.float32).tiny
+FLOAT32_SAFE_MAX = 1e37
+
+
+def isValid(axisScale: AxisScaleType, value: float) -> bool:
+    if not numpy.isfinite(value):
+        return False
+
+    if axisScale == "linear":
+        return True
+    elif axisScale == "log":
+        return value > 0.0
+    elif axisScale == "asinh":
+        return True
+    else:
+        raise ValueError(f"Unsupported axis scale: {axisScale}")
+
+
+# TODO valueerror, overflowerror, warnings, safe range?
+def apply(axisScale: AxisScaleType, value: float) -> float:
+    if axisScale == "linear":
+        return value
+    elif axisScale == "log":
+        if value > 0.0:
+            return numpy.log10(value)
+        else:
+            return float("nan")
+    elif axisScale == "asinh":
+        return numpy.asinh(value)
+    else:
+        raise ValueError(f"Unsupported axis scale: {axisScale}")
+
+
+# TODO valueerror, overflowerror, warnings, safe range?
+def revert(axisScale: AxisScaleType, value: float) -> float:
+    if axisScale == "linear":
+        return value
+    elif axisScale == "log":
+        return pow(10.0, value)
+    elif axisScale == "asinh":
+        return numpy.sinh(value)
+    else:
+        raise ValueError(f"Unsupported axis scale: {axisScale}")
+
+
+def safeRange(axisScale: AxisScaleType) -> tuple[float, float]:
+    """Return axis range (min, max) below limits of float32 so that max - min does not overflow"""
+    if axisScale == "linear":
+        return FLOAT32_SAFE_MIN, FLOAT32_SAFE_MAX
+    elif axisScale == "log":
+        return FLOAT32_MINPOS, FLOAT32_SAFE_MAX
+    elif axisScale == "asinh":
+        return FLOAT32_SAFE_MIN, FLOAT32_SAFE_MAX
+    else:
+        raise ValueError(f"Unsupported axis scale: {axisScale}")
+
+
+def inSafeRange(axisScale: AxisScaleType, value: float) -> bool:
+    min_, max_ = safeRange(axisScale)
+    return min_ <= value <= max_
+
+
+def clipToSafeRange(axisScale: AxisScaleType, value: float) -> float:
+    axisMin, axisMax = safeRange(axisScale)
+    return numpy.clip(value, axisMin, axisMax)

--- a/src/silx/gui/plot/_utils/axis_scale.py
+++ b/src/silx/gui/plot/_utils/axis_scale.py
@@ -1,4 +1,7 @@
+from math import sinh, asinh
+
 import numpy
+
 from ..items.types import AxisScaleType
 
 
@@ -25,7 +28,6 @@ def isValid(axisScale: AxisScaleType, value: float) -> bool:
         raise ValueError(f"Unsupported axis scale: {axisScale}")
 
 
-# TODO valueerror, overflowerror, warnings, safe range?
 def apply(axisScale: AxisScaleType, value: float) -> float:
     if axisScale == "linear":
         return value
@@ -35,19 +37,18 @@ def apply(axisScale: AxisScaleType, value: float) -> float:
         else:
             return float("nan")
     elif axisScale == "asinh":
-        return numpy.asinh(value)
+        return asinh(value)
     else:
         raise ValueError(f"Unsupported axis scale: {axisScale}")
 
 
-# TODO valueerror, overflowerror, warnings, safe range?
 def revert(axisScale: AxisScaleType, value: float) -> float:
     if axisScale == "linear":
         return value
     elif axisScale == "log":
         return pow(10.0, value)
     elif axisScale == "asinh":
-        return numpy.sinh(value)
+        return sinh(value)
     else:
         raise ValueError(f"Unsupported axis scale: {axisScale}")
 

--- a/src/silx/gui/plot/_utils/panzoom.py
+++ b/src/silx/gui/plot/_utils/panzoom.py
@@ -29,34 +29,28 @@ __date__ = "08/08/2017"
 
 
 import logging
-import math
 from typing import NamedTuple
-import numpy
-from ..types import AxisScaleType
+from .axis_scale import (
+    FLOAT32_MINPOS,
+    isValid,
+    apply,
+    revert,
+    clipToSafeRange,
+)
+from ..items.types import AxisScaleType
 
 _logger = logging.getLogger(__name__)
 
 
-# Float 32 info ###############################################################
-# Using min/max value below limits of float32
-# so operation with such value (e.g., max - min) do not overflow
-
-FLOAT32_SAFE_MIN = -1e37
-FLOAT32_MINPOS = numpy.finfo(numpy.float32).tiny
-FLOAT32_SAFE_MAX = 1e37
-# TODO double support
-
-
 def checkAxisLimits(
-    vmin: float, vmax: float, axisScale: AxisScaleType = "linear", name: str = ""
+    axisScale: AxisScaleType, vmin: float, vmax: float, name: str = ""
 ) -> tuple[float, float]:
     """Makes sure axis range is not empty and within supported range.
 
     :return: (min, max) making sure min < max
     """
-    min_ = FLOAT32_MINPOS if axisScale == "log" else FLOAT32_SAFE_MIN
-    vmax = numpy.clip(vmax, min_, FLOAT32_SAFE_MAX)
-    vmin = numpy.clip(vmin, min_, FLOAT32_SAFE_MAX)
+    vmax = clipToSafeRange(axisScale, vmax)
+    vmin = clipToSafeRange(axisScale, vmin)
 
     if vmax < vmin:
         _logger.debug("%s axis: max < min, inverting limits.", name)
@@ -67,53 +61,48 @@ def checkAxisLimits(
             vmin, vmax = -0.1, 0.1
         elif vmin < 0:
             vmax *= 0.9
-            vmin = max(vmin * 1.1, FLOAT32_SAFE_MIN)  # Clip to range
+            vmin = clipToSafeRange(axisScale, vmin * 1.1)
         else:  # vmin > 0
-            vmax = min(vmin * 1.1, FLOAT32_SAFE_MAX)  # Clip to range
+            vmax = clipToSafeRange(axisScale, vmin * 1.1)
             vmin *= 0.9
 
     return vmin, vmax
 
 
 def scale1DRange(
-    min_: float, max_: float, center: float, scale: float, isLog: bool
+    axisScale: AxisScaleType, min_: float, max_: float, center: float, scale: float
 ) -> tuple[float, float]:
     """Scale a 1D range given a scale factor and an center point.
 
     Keeps the values in a smaller range than float32.
 
+    :param axisScale:
     :param min_: The current min value of the range.
     :param max_: The current max value of the range.
     :param center: The center of the zoom (i.e., invariant point).
-    :param scale: The scale to use for zoom
-    :param isLog: Whether using log scale or not.
+    :param scale: The scaling factor to apply for zoom
     :return: The zoomed range (min, max)
     """
-    if isLog:
-        # Min and center can be < 0 when
-        # autoscale is off and switch to log scale
-        # max_ < 0 should not happen
-        min_ = numpy.log10(min_) if min_ > 0.0 else FLOAT32_MINPOS
-        center = numpy.log10(center) if center > 0.0 else FLOAT32_MINPOS
-        max_ = numpy.log10(max_) if max_ > 0.0 else FLOAT32_MINPOS
+    # Min and center can be < 0 when
+    # autoscale is off and switch to log scale
+    # max_ < 0 should not happen
+    # TODO better and weird previous behavior
+    scaledMin = apply(axisScale, min_) if isValid(axisScale, min_) else FLOAT32_MINPOS
+    scaledCenter = (
+        apply(axisScale, center) if isValid(axisScale, center) else FLOAT32_MINPOS
+    )
+    scaledMax = apply(axisScale, max_) if isValid(axisScale, max_) else FLOAT32_MINPOS
 
-    if min_ == max_:
-        return min_, max_
+    if scaledMin == scaledMax:
+        return scaledMin, scaledMax
 
-    offset = (center - min_) / (max_ - min_)
-    range_ = (max_ - min_) / scale
-    newMin = center - offset * range_
-    newMax = center + (1.0 - offset) * range_
+    offset = (scaledCenter - scaledMin) / (scaledMax - scaledMin)
+    range_ = (scaledMax - scaledMin) / scale
+    newScaledMin = scaledCenter - offset * range_
+    newScaledMax = scaledCenter + (1.0 - offset) * range_
 
-    if isLog:
-        # No overflow as exponent is log10 of a float32
-        newMin = pow(10.0, newMin)
-        newMax = pow(10.0, newMax)
-        newMin = numpy.clip(newMin, FLOAT32_MINPOS, FLOAT32_SAFE_MAX)
-        newMax = numpy.clip(newMax, FLOAT32_MINPOS, FLOAT32_SAFE_MAX)
-    else:
-        newMin = numpy.clip(newMin, FLOAT32_SAFE_MIN, FLOAT32_SAFE_MAX)
-        newMax = numpy.clip(newMax, FLOAT32_SAFE_MIN, FLOAT32_SAFE_MAX)
+    newMin = clipToSafeRange(axisScale, revert(axisScale, newScaledMin))
+    newMax = clipToSafeRange(axisScale, revert(axisScale, newScaledMax))
     return newMin, newMax
 
 
@@ -157,12 +146,12 @@ def applyZoomToPlot(
 
     if enabled.xaxis:
         xMin, xMax = scale1DRange(
-            xMin, xMax, dataCenterPos[0], scale, plot.getXAxis()._isLogarithmic()
+            plot.getXAxis().getScale(), xMin, xMax, dataCenterPos[0], scale
         )
 
     if enabled.yaxis:
         yMin, yMax = scale1DRange(
-            yMin, yMax, dataCenterPos[1], scale, plot.getYAxis()._isLogarithmic()
+            plot.getYAxis("left").getScale(), yMin, yMax, dataCenterPos[1], scale
         )
 
     if enabled.y2axis:
@@ -170,45 +159,35 @@ def applyZoomToPlot(
         assert dataPos is not None
         y2Center = dataPos[1]
         y2Min, y2Max = scale1DRange(
-            y2Min, y2Max, y2Center, scale, plot.getYAxis()._isLogarithmic()
+            plot.getYAxis("right").getScale(), y2Min, y2Max, y2Center, scale
         )
 
     plot.setLimits(xMin, xMax, yMin, yMax, y2Min, y2Max)
 
 
-def applyPan(min_, max_, panFactor, isLog10):
+def applyPan(
+    axisScale: AxisScaleType, min_: float, max_: float, panFactor: float
+) -> tuple[float, float]:
     """Returns a new range with applied panning.
 
-    Moves the range according to panFactor.
-    If isLog10 is True, converts to log10 before moving.
+    Moves the range according to panFactor after applying axis scale.
 
-    :param float min_: Min value of the data range to pan.
-    :param float max_: Max value of the data range to pan.
-                       Must be >= min.
-    :param float panFactor: Signed proportion of the range to use for pan.
-    :param bool isLog10: True if log10 scale, False if linear scale.
+    :param min_: Min value of the data range to pan.
+    :param max_: Max value of the data range to pan.
+                 Must be >= min.
+    :param panFactor: Signed proportion of the range to use for pan.
+    :param axisScale:
     :return: New min and max value with pan applied.
-    :rtype: 2-tuple of float.
     """
-    if isLog10 and min_ > 0.0:
-        # Negative range and log scale can happen with matplotlib
-        logMin, logMax = math.log10(min_), math.log10(max_)
-        logOffset = panFactor * (logMax - logMin)
-        newMin = pow(10.0, logMin + logOffset)
-        newMax = pow(10.0, logMax + logOffset)
-
-        # Takes care of out-of-range values
-        if newMin > 0.0 and newMax < float("inf"):
-            min_, max_ = newMin, newMax
-
+    scaledMin = apply(axisScale, min_)
+    scaledMax = apply(axisScale, max_)
+    scaledOffset = panFactor * (scaledMax - scaledMin)
+    newMin = revert(axisScale, scaledMin + scaledOffset)
+    newMax = revert(axisScale, scaledMax + scaledOffset)
+    if isValid(axisScale, newMin) and isValid(axisScale, newMax):
+        return newMin, newMax
     else:
-        offset = panFactor * (max_ - min_)
-        newMin, newMax = min_ + offset, max_ + offset
-
-        # Takes care of out-of-range values
-        if newMin > -float("inf") and newMax < float("inf"):
-            min_, max_ = newMin, newMax
-    return min_, max_
+        return min_, max_
 
 
 class _Unset:

--- a/src/silx/gui/plot/_utils/panzoom.py
+++ b/src/silx/gui/plot/_utils/panzoom.py
@@ -100,9 +100,14 @@ def scale1DRange(
     range_ = (scaledMax - scaledMin) / scale
     newScaledMin = scaledCenter - offset * range_
     newScaledMax = scaledCenter + (1.0 - offset) * range_
+    try:
+        newMin = clipToSafeRange(axisScale, revert(axisScale, newScaledMin))
+        newMax = clipToSafeRange(axisScale, revert(axisScale, newScaledMax))
+    except (ValueError, OverflowError):
+        # There should be no overflow as exponent is log10 of a float32
+        # but better safe than sorry
+        return scaledMin, scaledMax
 
-    newMin = clipToSafeRange(axisScale, revert(axisScale, newScaledMin))
-    newMax = clipToSafeRange(axisScale, revert(axisScale, newScaledMax))
     return newMin, newMax
 
 
@@ -182,10 +187,14 @@ def applyPan(
     scaledMin = apply(axisScale, min_)
     scaledMax = apply(axisScale, max_)
     scaledOffset = panFactor * (scaledMax - scaledMin)
-    newMin = revert(axisScale, scaledMin + scaledOffset)
-    newMax = revert(axisScale, scaledMax + scaledOffset)
+    try:
+        newMin = revert(axisScale, scaledMin + scaledOffset)
+        newMax = revert(axisScale, scaledMax + scaledOffset)
+    except (ValueError, OverflowError):
+        return min_, max_
+
     if isValid(axisScale, newMin) and isValid(axisScale, newMax):
-        return newMin, newMax
+        return clipToSafeRange(axisScale, newMin), clipToSafeRange(axisScale, newMax)
     else:
         return min_, max_
 

--- a/src/silx/gui/plot/_utils/panzoom.py
+++ b/src/silx/gui/plot/_utils/panzoom.py
@@ -32,6 +32,7 @@ import logging
 import math
 from typing import NamedTuple
 import numpy
+from ..types import AxisScaleType
 
 _logger = logging.getLogger(__name__)
 
@@ -46,15 +47,14 @@ FLOAT32_SAFE_MAX = 1e37
 # TODO double support
 
 
-def checkAxisLimits(vmin: float, vmax: float, isLog: bool = False, name: str = ""):
+def checkAxisLimits(
+    vmin: float, vmax: float, axisScale: AxisScaleType = "linear", name: str = ""
+) -> tuple[float, float]:
     """Makes sure axis range is not empty and within supported range.
 
-    :param vmin: Min axis value
-    :param vmax: Max axis value
     :return: (min, max) making sure min < max
-    :rtype: 2-tuple of float
     """
-    min_ = FLOAT32_MINPOS if isLog else FLOAT32_SAFE_MIN
+    min_ = FLOAT32_MINPOS if axisScale == "log" else FLOAT32_SAFE_MIN
     vmax = numpy.clip(vmax, min_, FLOAT32_SAFE_MAX)
     vmin = numpy.clip(vmin, min_, FLOAT32_SAFE_MAX)
 

--- a/src/silx/gui/plot/_utils/panzoom.py
+++ b/src/silx/gui/plot/_utils/panzoom.py
@@ -177,11 +177,11 @@ def applyPan(
 
     Moves the range according to panFactor after applying axis scale.
 
+    :param axisScale:
     :param min_: Min value of the data range to pan.
     :param max_: Max value of the data range to pan.
                  Must be >= min.
     :param panFactor: Signed proportion of the range to use for pan.
-    :param axisScale:
     :return: New min and max value with pan applied.
     """
     scaledMin = apply(axisScale, min_)

--- a/src/silx/gui/plot/_utils/test/test_axis_scale.py
+++ b/src/silx/gui/plot/_utils/test/test_axis_scale.py
@@ -1,0 +1,75 @@
+import math
+import pytest
+
+from pytest import approx
+
+from silx.gui.plot._utils import axis_scale
+
+
+def test_is_valid_linear():
+    assert axis_scale.isValid("linear", 0.0)
+    assert axis_scale.isValid("linear", 1e34)
+    assert axis_scale.isValid("linear", -1e34)
+    assert not axis_scale.isValid("linear", float("nan"))
+    assert not axis_scale.isValid("linear", float("inf"))
+    assert not axis_scale.isValid("linear", float("-inf"))
+
+
+def test_is_valid_log():
+    assert axis_scale.isValid("log", 1.0)
+    assert axis_scale.isValid("log", 1e34)
+    assert not axis_scale.isValid("log", -1)
+    assert not axis_scale.isValid("log", float("nan"))
+    assert not axis_scale.isValid("log", float("inf"))
+
+
+def test_is_valid_asinh():
+    assert axis_scale.isValid("asinh", 0.0)
+    assert axis_scale.isValid("asinh", 1e34)
+    assert axis_scale.isValid("asinh", -1e34)
+    assert not axis_scale.isValid("asinh", float("nan"))
+    assert not axis_scale.isValid("asinh", float("inf"))
+
+
+def test_apply_linear():
+    assert axis_scale.apply("linear", 0.0) == approx(0.0)
+    assert axis_scale.apply("linear", -5.0) == approx(-5.0)
+
+
+def test_apply_log():
+    assert axis_scale.apply("log", 1.0) == approx(0.0)
+    assert axis_scale.apply("log", 100.0) == approx(2.0)
+    assert math.isnan(axis_scale.apply("log", 0.0))
+    assert math.isnan(axis_scale.apply("log", -1.0))
+
+
+def test_apply_asinh():
+    assert axis_scale.apply("asinh", 0.0) == approx(0.0)
+    assert axis_scale.apply("asinh", 1.0) == approx(math.asinh(1.0))
+    assert axis_scale.apply("asinh", -1.0) == approx(math.asinh(-1.0))
+
+
+def test_revert_linear():
+    assert axis_scale.revert("linear", 0.0) == approx(0.0)
+    assert axis_scale.revert("linear", -5.0) == approx(-5.0)
+
+
+def test_revert_log():
+    assert axis_scale.revert("log", 0.0) == approx(1.0)
+    assert axis_scale.revert("log", 2.0) == approx(100.0)
+    with pytest.raises(OverflowError):
+        axis_scale.revert("log", 310)
+
+
+def test_revert_asinh():
+    assert axis_scale.revert("asinh", 0.0) == approx(0.0)
+    assert axis_scale.revert("asinh", 1.0) == approx(math.sinh(1.0))
+    assert axis_scale.revert("asinh", -1.0) == approx(math.sinh(-1.0))
+    with pytest.raises(OverflowError):
+        axis_scale.revert("asinh", 750)
+
+
+def test_revert_nan():
+    assert math.isnan(axis_scale.revert("linear", float("nan")))
+    assert math.isnan(axis_scale.revert("log", float("nan")))
+    assert math.isnan(axis_scale.revert("asinh", float("nan")))

--- a/src/silx/gui/plot/backends/BackendBase.py
+++ b/src/silx/gui/plot/backends/BackendBase.py
@@ -35,8 +35,8 @@ __date__ = "21/12/2018"
 from collections.abc import Callable
 import weakref
 from silx.gui.colors import RGBAColorType
-from typing import Literal
 
+from ..items.types import AxisScaleType
 from ... import qt
 
 # Names for setCursor
@@ -487,10 +487,10 @@ class BackendBase:
         """
         self.__xAxisTimeSeries = bool(isTimeSeries)
 
-    def setXAxisScale(self, scale: Literal["linear", "log", "asinh"]):
+    def setXAxisScale(self, scale: AxisScaleType):
         pass
 
-    def setYAxisScale(self, scale: Literal["linear", "log", "asinh"]):
+    def setYAxisScale(self, scale: AxisScaleType):
         pass
 
     def setXAxisInverted(self, flag: bool):

--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -57,6 +57,7 @@ from matplotlib import path as mpath
 
 from . import BackendBase
 from .. import items
+from ..items.types import AxisScaleType
 from .._utils import FLOAT32_MINPOS
 from .._utils.dtime_ticklayout import (
     calcTicks,
@@ -1303,7 +1304,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
         self._isXAxisTimeSeries = isTimeSeries
         self.__initXAxisFormatterAndLocator()
 
-    def setXAxisScale(self, scale):
+    def setXAxisScale(self, scale: AxisScaleType):
         if scale == "log":
             # Workaround for matplotlib 2.1.0 when one tries to set an axis
             # to log scale with both limits <= 0
@@ -1316,7 +1317,7 @@ class BackendMatplotlib(BackendBase.BackendBase):
         self.ax.set_xscale(scale)
         self.__initXAxisFormatterAndLocator()
 
-    def setYAxisScale(self, scale):
+    def setYAxisScale(self, scale: AxisScaleType):
         if scale == "log":
             # Workaround for matplotlib 2.0 issue with negative bounds
             # before switching to log scale

--- a/src/silx/gui/plot/backends/BackendOpenGL.py
+++ b/src/silx/gui/plot/backends/BackendOpenGL.py
@@ -35,6 +35,7 @@ import numpy
 
 from .. import items
 from .._utils import FLOAT32_MINPOS
+from ..items.types import AxisScaleType
 from . import BackendBase
 from ... import colors
 from ... import qt
@@ -1558,7 +1559,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
     def setXAxisTimeSeries(self, isTimeSeries):
         self._plotFrame.xAxis.isTimeSeries = isTimeSeries
 
-    def setXAxisScale(self, scale):
+    def setXAxisScale(self, scale: AxisScaleType):
         if scale == "asinh":
             raise NotImplementedError(
                 f"Plot OpenGL backend does not support {scale} X axis"
@@ -1571,7 +1572,7 @@ class BackendOpenGL(BackendBase.BackendBase, glu.OpenGLWidget):
 
             self._plotFrame.xAxis.isLog = is_log
 
-    def setYAxisScale(self, scale):
+    def setYAxisScale(self, scale: AxisScaleType):
         if scale == "asinh":
             raise NotImplementedError(
                 f"Plot OpenGL backend does not support {scale} Y axis"

--- a/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -1039,17 +1039,17 @@ class GLPlotFrame2D(GLPlotFrame):
         """
         if x is not None:
             self._dataRanges["x"] = checkAxisLimits(
-                x[0], x[1], "log" if self.xAxis.isLog else "linear", name="x"
+                "log" if self.xAxis.isLog else "linear", x[0], x[1], name="x"
             )
 
         if y is not None:
             self._dataRanges["y"] = checkAxisLimits(
-                y[0], y[1], "log" if self.yAxis.isLog else "linear", name="y"
+                "log" if self.yAxis.isLog else "linear", y[0], y[1], name="y"
             )
 
         if y2 is not None:
             self._dataRanges["y2"] = checkAxisLimits(
-                y2[0], y2[1], "log" if self.y2Axis.isLog else "linear", name="y2"
+                "log" if self.y2Axis.isLog else "linear", y2[0], y2[1], name="y2"
             )
 
         self.xAxis.dataRange = self._dataRanges["x"]

--- a/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
+++ b/src/silx/gui/plot/backends/glutils/GLPlotFrame.py
@@ -1039,17 +1039,17 @@ class GLPlotFrame2D(GLPlotFrame):
         """
         if x is not None:
             self._dataRanges["x"] = checkAxisLimits(
-                x[0], x[1], self.xAxis.isLog, name="x"
+                x[0], x[1], "log" if self.xAxis.isLog else "linear", name="x"
             )
 
         if y is not None:
             self._dataRanges["y"] = checkAxisLimits(
-                y[0], y[1], self.yAxis.isLog, name="y"
+                y[0], y[1], "log" if self.yAxis.isLog else "linear", name="y"
             )
 
         if y2 is not None:
             self._dataRanges["y2"] = checkAxisLimits(
-                y2[0], y2[1], self.y2Axis.isLog, name="y2"
+                y2[0], y2[1], "log" if self.y2Axis.isLog else "linear", name="y2"
             )
 
         self.xAxis.dataRange = self._dataRanges["x"]

--- a/src/silx/gui/plot/items/axis.py
+++ b/src/silx/gui/plot/items/axis.py
@@ -149,7 +149,7 @@ class Axis(qt.QObject):
         :return: (min, max) making sure min < max
         """
         return _utils.checkAxisLimits(
-            vmin, vmax, isLog=self._isLogarithmic(), name=self._defaultLabel
+            vmin, vmax, axisScale=self.getScale(), name=self._defaultLabel
         )
 
     def _getDataRange(self) -> tuple[float, float] | None:

--- a/src/silx/gui/plot/items/axis.py
+++ b/src/silx/gui/plot/items/axis.py
@@ -149,7 +149,7 @@ class Axis(qt.QObject):
         :return: (min, max) making sure min < max
         """
         return _utils.checkAxisLimits(
-            vmin, vmax, axisScale=self.getScale(), name=self._defaultLabel
+            self.getScale(), vmin, vmax, name=self._defaultLabel
         )
 
     def _getDataRange(self) -> tuple[float, float] | None:


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

This PR is a follow-up of #4529 which left user interaction and axes limits unmanaged for asinh axis scale.
It refactors the previously hard-coded plot axis scale `if isLog: ... else: # linear` by using some `apply/revert` helpers taking the scale as argument.

TODO:
- [x] Check handling of erroneous values in `apply/revert`
- [x] Fix negative min limit issue
- [x] More testing

attn @loichuder 


Related to  #4233

#### AI Disclosure
- [x] Claude Code used to generate tests
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
