### PR TITLE
silx.gui.plot: Refactor axis_scale helpers

### DIFF
--- a/src/silx/gui/plot/PlotInteraction.py
+++ b/src/silx/gui/plot/PlotInteraction.py
@@ -270,23 +270,14 @@ class Pan(_PlotInteractionWithClickEvents):
         previousScaled = axis_scale.apply(axisScale, previous)
         delta = currentScaled - previousScaled
 
-        axisMin, axisMax = axis.getLimits()
-        try:
-            newMin = axis_scale.revert(
-                axisScale, axis_scale.apply(axisScale, axisMin) - delta
-            )
-            newMax = axis_scale.revert(
-                axisScale, axis_scale.apply(axisScale, axisMax) - delta
-            )
-        except (ValueError, OverflowError):
-            return axisMin, axisMax
-
-        if axis_scale.inSafeRange(axisScale, newMin) and axis_scale.inSafeRange(
-            axisScale, newMax
-        ):
-            return newMin, newMax
+        axisLimits = axis.getLimits()
+        newRange = axis_scale.revert(
+            axisScale, axis_scale.apply(axisScale, axisLimits) - delta
+        )
+        if all(axis_scale.inSafeRange(axisScale, newRange)):
+            return tuple(newRange)
         else:
-            return axisMin, axisMax
+            return axisLimits
 
     def drag(self, x, y, btn):
         xData, yLeftData, yRightData = self._pixelToData(x, y)

--- a/src/silx/gui/plot/_utils/__init__.py
+++ b/src/silx/gui/plot/_utils/__init__.py
@@ -54,15 +54,12 @@ def _addMargins(
     minScaled = axis_scale.apply(scale, minLimit)
     maxScaled = axis_scale.apply(scale, maxLimit)
     rangeLimit = maxScaled - minScaled
-    try:
-        min_ = axis_scale.revert(scale, minScaled - minMargin * rangeLimit)
-        max_ = axis_scale.revert(scale, maxScaled + maxMargin * rangeLimit)
-    except (ValueError, OverflowError):
-        return minLimit, maxLimit
-    else:
-        if axis_scale.inSafeRange(scale, min_) and axis_scale.inSafeRange(scale, max_):
-            return min_, max_
-        return minLimit, maxLimit
+
+    min_ = axis_scale.revert(scale, minScaled - minMargin * rangeLimit)
+    max_ = axis_scale.revert(scale, maxScaled + maxMargin * rangeLimit)
+    if all(axis_scale.inSafeRange(scale, (min_, max_))):
+        return min_, max_
+    return minLimit, maxLimit
 
 
 def addMarginsToLimits(

--- a/src/silx/gui/plot/_utils/axis_scale.py
+++ b/src/silx/gui/plot/_utils/axis_scale.py
@@ -1,6 +1,7 @@
-from math import sinh, asinh
+import numbers
 
 import numpy
+from numpy.typing import ArrayLike
 
 from ..items.types import AxisScaleType
 
@@ -28,27 +29,38 @@ def isValid(axisScale: AxisScaleType, value: float) -> bool:
         raise ValueError(f"Unsupported axis scale: {axisScale}")
 
 
-def apply(axisScale: AxisScaleType, value: float) -> float:
+def apply(axisScale: AxisScaleType, value: float | ArrayLike) -> float | numpy.ndarray:
+    if not isinstance(value, numbers.Real):
+        value = numpy.asarray(value)
+
     if axisScale == "linear":
         return value
     elif axisScale == "log":
-        if value > 0.0:
-            return numpy.log10(value)
+        if isinstance(value, numbers.Real):
+            return numpy.log10(value) if value > 0.0 else float("nan")
         else:
-            return float("nan")
+            with numpy.errstate(divide="ignore", invalid="ignore"):
+                scaled = numpy.log10(value)
+            scaled[~numpy.isfinite(scaled)] = numpy.nan
+            return scaled
     elif axisScale == "asinh":
-        return asinh(value)
+        return numpy.asinh(value)
     else:
         raise ValueError(f"Unsupported axis scale: {axisScale}")
 
 
-def revert(axisScale: AxisScaleType, value: float) -> float:
+def revert(axisScale: AxisScaleType, value: float | ArrayLike) -> float | numpy.ndarray:
+    if not isinstance(value, numbers.Real):
+        value = numpy.asarray(value)
+
     if axisScale == "linear":
         return value
     elif axisScale == "log":
-        return pow(10.0, value)
+        with numpy.errstate(over="ignore"):
+            return numpy.pow(10.0, value)
     elif axisScale == "asinh":
-        return sinh(value)
+        with numpy.errstate(over="ignore"):
+            return numpy.sinh(value)
     else:
         raise ValueError(f"Unsupported axis scale: {axisScale}")
 
@@ -65,11 +77,21 @@ def safeRange(axisScale: AxisScaleType) -> tuple[float, float]:
         raise ValueError(f"Unsupported axis scale: {axisScale}")
 
 
-def inSafeRange(axisScale: AxisScaleType, value: float) -> bool:
+def inSafeRange(
+    axisScale: AxisScaleType, value: float | ArrayLike
+) -> bool | numpy.ndarray:
+    if not isinstance(value, numbers.Real):
+        value = numpy.asarray(value)
+
     min_, max_ = safeRange(axisScale)
-    return min_ <= value <= max_
+    return (min_ <= value) & (value <= max_)
 
 
-def clipToSafeRange(axisScale: AxisScaleType, value: float) -> float:
+def clipToSafeRange(
+    axisScale: AxisScaleType, value: float | ArrayLike
+) -> float | numpy.ndarray:
+    if not isinstance(value, numbers.Real):
+        value = numpy.asarray(value)
+
     axisMin, axisMax = safeRange(axisScale)
     return numpy.clip(value, axisMin, axisMax)

--- a/src/silx/gui/plot/_utils/panzoom.py
+++ b/src/silx/gui/plot/_utils/panzoom.py
@@ -30,6 +30,9 @@ __date__ = "08/08/2017"
 
 import logging
 from typing import NamedTuple
+
+import numpy
+
 from .axis_scale import (
     FLOAT32_MINPOS,
     isValid,
@@ -100,15 +103,16 @@ def scale1DRange(
     range_ = (scaledMax - scaledMin) / scale
     newScaledMin = scaledCenter - offset * range_
     newScaledMax = scaledCenter + (1.0 - offset) * range_
-    try:
-        newMin = clipToSafeRange(axisScale, revert(axisScale, newScaledMin))
-        newMax = clipToSafeRange(axisScale, revert(axisScale, newScaledMax))
-    except (ValueError, OverflowError):
+
+    newRange = clipToSafeRange(
+        axisScale, revert(axisScale, (newScaledMin, newScaledMax))
+    )
+    if not all(numpy.isfinite(newRange)):
         # There should be no overflow as exponent is log10 of a float32
         # but better safe than sorry
         return scaledMin, scaledMax
 
-    return newMin, newMax
+    return tuple(newRange)
 
 
 class EnabledAxes(NamedTuple):
@@ -187,14 +191,11 @@ def applyPan(
     scaledMin = apply(axisScale, min_)
     scaledMax = apply(axisScale, max_)
     scaledOffset = panFactor * (scaledMax - scaledMin)
-    try:
-        newMin = revert(axisScale, scaledMin + scaledOffset)
-        newMax = revert(axisScale, scaledMax + scaledOffset)
-    except (ValueError, OverflowError):
-        return min_, max_
 
-    if isValid(axisScale, newMin) and isValid(axisScale, newMax):
-        return clipToSafeRange(axisScale, newMin), clipToSafeRange(axisScale, newMax)
+    newMin = revert(axisScale, scaledMin + scaledOffset)
+    newMax = revert(axisScale, scaledMax + scaledOffset)
+    if isValid(newMin) and isValid(newMax):
+        return tuple(clipToSafeRange(axisScale, (newMin, newMax)))
     else:
         return min_, max_
 

--- a/src/silx/gui/plot/_utils/test/test_axis_scale.py
+++ b/src/silx/gui/plot/_utils/test/test_axis_scale.py
@@ -53,7 +53,7 @@ def test_apply_asinh():
 def test_apply_linear_array():
     array = numpy.array([0.0, -5.0, 1e34])
     result = axis_scale.apply("linear", array)
-    assert assert_array_equal(result, array)
+    assert_array_equal(result, array)
 
 
 def test_apply_log_array():
@@ -78,14 +78,14 @@ def test_revert_linear():
 def test_revert_log():
     assert axis_scale.revert("log", 0.0) == approx(1.0)
     assert axis_scale.revert("log", 2.0) == approx(100.0)
-    assert axis_scale.revert("log", 310) == float("nan")
+    assert axis_scale.revert("log", 310) == float("inf")
 
 
 def test_revert_asinh():
     assert axis_scale.revert("asinh", 0.0) == approx(0.0)
     assert axis_scale.revert("asinh", 1.0) == approx(math.sinh(1.0))
     assert axis_scale.revert("asinh", -1.0) == approx(math.sinh(-1.0))
-    assert axis_scale.revert("asinh", 750) == float("nan")
+    assert axis_scale.revert("asinh", 750) == float("inf")
 
 
 def test_revert_linear_array():

--- a/src/silx/gui/plot/_utils/test/test_axis_scale.py
+++ b/src/silx/gui/plot/_utils/test/test_axis_scale.py
@@ -1,6 +1,7 @@
 import math
-import pytest
+import numpy
 
+from numpy.testing import assert_allclose, assert_array_equal
 from pytest import approx
 
 from silx.gui.plot._utils import axis_scale
@@ -49,6 +50,26 @@ def test_apply_asinh():
     assert axis_scale.apply("asinh", -1.0) == approx(math.asinh(-1.0))
 
 
+def test_apply_linear_array():
+    array = numpy.array([0.0, -5.0, 1e34])
+    result = axis_scale.apply("linear", array)
+    assert assert_array_equal(result, array)
+
+
+def test_apply_log_array():
+    array = numpy.array([1.0, 100.0, 0.0, -1.0])
+    result = axis_scale.apply("log", array)
+    assert isinstance(result, numpy.ndarray)
+    assert_allclose(result, [0.0, 2.0, numpy.nan, numpy.nan])
+
+
+def test_apply_asinh_array():
+    array = numpy.array([0.0, 1.0, -1.0])
+    result = axis_scale.apply("asinh", array)
+    assert isinstance(result, numpy.ndarray)
+    assert_allclose(result, [0.0, math.asinh(1.0), math.asinh(-1.0)])
+
+
 def test_revert_linear():
     assert axis_scale.revert("linear", 0.0) == approx(0.0)
     assert axis_scale.revert("linear", -5.0) == approx(-5.0)
@@ -57,19 +78,44 @@ def test_revert_linear():
 def test_revert_log():
     assert axis_scale.revert("log", 0.0) == approx(1.0)
     assert axis_scale.revert("log", 2.0) == approx(100.0)
-    with pytest.raises(OverflowError):
-        axis_scale.revert("log", 310)
+    assert axis_scale.revert("log", 310) == float("nan")
 
 
 def test_revert_asinh():
     assert axis_scale.revert("asinh", 0.0) == approx(0.0)
     assert axis_scale.revert("asinh", 1.0) == approx(math.sinh(1.0))
     assert axis_scale.revert("asinh", -1.0) == approx(math.sinh(-1.0))
-    with pytest.raises(OverflowError):
-        axis_scale.revert("asinh", 750)
+    assert axis_scale.revert("asinh", 750) == float("nan")
+
+
+def test_revert_linear_array():
+    array = numpy.array([0.0, -5.0])
+    result = axis_scale.revert("linear", array)
+    assert_array_equal(result, array)
+
+
+def test_revert_log_array():
+    array = numpy.array([0.0, 2.0, 310.0])
+    result = axis_scale.revert("log", array)
+    assert isinstance(result, numpy.ndarray)
+    assert_allclose(result, [1.0, 100.0, numpy.inf])
+
+
+def test_revert_asinh_array():
+    array = numpy.array([0.0, 1.0, -1.0, 750.0])
+    result = axis_scale.revert("asinh", array)
+    assert isinstance(result, numpy.ndarray)
+    assert_allclose(result, [0.0, math.sinh(1.0), math.sinh(-1.0), numpy.inf])
 
 
 def test_revert_nan():
     assert math.isnan(axis_scale.revert("linear", float("nan")))
     assert math.isnan(axis_scale.revert("log", float("nan")))
     assert math.isnan(axis_scale.revert("asinh", float("nan")))
+
+
+def test_revert_nan_array():
+    array = numpy.array([float("nan")])
+    assert math.isnan(axis_scale.revert("linear", array)[0])
+    assert math.isnan(axis_scale.revert("log", array)[0])
+    assert math.isnan(axis_scale.revert("asinh", array)[0])


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

The PR reworks axis_scale helpers to support arrays. As a side effect, `revert` no longer through exceptions so the places where this was used got updated.

This paves the way for PR #4681

#### AI Disclosure
- [x] No AI used
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
