### PR TITLE
silx.gui.plot.items.Axis: raise ValueError if the scale is invalid

### DIFF
--- a/src/silx/gui/plot/items/axis.py
+++ b/src/silx/gui/plot/items/axis.py
@@ -220,7 +220,10 @@ class Axis(qt.QObject):
 
     def setScale(self, scale: types.AxisScaleType):
         """Set the scale to be used by this axis."""
-        assert scale in self._SCALES
+        if scale not in self._SCALES:
+            raise ValueError(
+                f"{scale} is not one of the supported scales: {self._SCALES}"
+            )
         if self._scale == scale:
             return
 

--- a/src/silx/gui/plot/test/test_axis.py
+++ b/src/silx/gui/plot/test/test_axis.py
@@ -1,32 +1,4 @@
-# /*##########################################################################
-#
-# Copyright (c) 2023 European Synchrotron Radiation Facility
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
-#
-# ###########################################################################*/
-"""Tests of PlotWidget Axis items"""
-
-__authors__ = ["T. Vincent"]
-__license__ = "MIT"
-__date__ = "15/06/2023"
-
+import pytest
 
 from silx.gui.plot import PlotWidget
 
@@ -157,3 +129,11 @@ def testInvertedAxis(qWidgetFactory):
     yaxis = plotWidget.getYAxis()
     yaxis.setInverted(True)
     assert yaxis.isInverted()
+
+
+def testWrongScale(qWidgetFactory):
+    plotWidget = qWidgetFactory(PlotWidget)
+
+    xaxis = plotWidget.getXAxis()
+    with pytest.raises(ValueError):
+        xaxis.setScale("not_a_scale")


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

https://github.com/silx-kit/silx/pull/4682#issuecomment-5131006726

#### AI Disclosure
- [x] No AI used

