### PR TITLE
silx.io.nxdata.parse.NXdata: add support for asinh scale type in SILX_style

### DIFF
--- a/src/silx/io/nxdata/_utils.py
+++ b/src/silx/io/nxdata/_utils.py
@@ -1,26 +1,3 @@
-# /*##########################################################################
-#
-# Copyright (c) 2017-2023 European Synchrotron Radiation Facility
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
-#
-# ###########################################################################*/
 """Utility functions used by NXdata validation and parsing."""
 
 import copy
@@ -32,16 +9,13 @@ import numpy
 
 from silx.io import is_dataset
 
-__authors__ = ["P. Knobel"]
-__license__ = "MIT"
-__date__ = "17/04/2018"
-
 
 nxdata_logger = logging.getLogger("silx.io.nxdata")
 
 Interpretation = Literal[
     "scalar", "spectrum", "image", "rgb-image", "rgba-image", "vertex"
 ]
+ScaleType = Literal["linear", "log", "asinh"]
 
 
 INTERPDIM: dict[Interpretation, int] = {

--- a/src/silx/io/nxdata/parse.py
+++ b/src/silx/io/nxdata/parse.py
@@ -1,30 +1,7 @@
-# /*##########################################################################
-#
-# Copyright (c) 2017-2022 European Synchrotron Radiation Facility
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-# THE SOFTWARE.
-#
-# ###########################################################################*/
 """This package provides a collection of functions to work with h5py-like
 groups following the NeXus *NXdata* specification.
 
-See http://download.nexusformat.org/sphinx/classes/base_classes/NXdata.html
+See https://manual.nexusformat.org/classes/base_classes/NXdata.html
 
 The main class is :class:`NXdata`.
 You can also fetch the default NXdata in a NXroot or a NXentry with function
@@ -41,7 +18,7 @@ Other public functions:
 """
 
 import json
-from typing import Any
+from typing import Any, get_args
 
 import h5py
 import numpy
@@ -51,6 +28,7 @@ from silx.utils.deprecation import deprecated
 
 from ._utils import (
     Interpretation,
+    ScaleType,
     get_attr_as_unicode,
     INTERPDIM,
     get_dataset_name,
@@ -62,9 +40,7 @@ from ._utils import (
     validate_number_of_axes,
 )
 
-__authors__ = ["P. Knobel"]
-__license__ = "MIT"
-__date__ = "24/03/2020"
+_SCALES = get_args(ScaleType)
 
 
 class InvalidNXdataError(Exception):
@@ -80,8 +56,8 @@ class _SilxStyle:
 
     def __init__(self, nxdata):
         naxes = len(nxdata.axes)
-        self._axes_scale_types = [None] * naxes
-        self._signal_scale_type = None
+        self._axes_scale_types: tuple[ScaleType | None, ...] = tuple([None] * naxes)
+        self._signal_scale_type: ScaleType | None = None
 
         stylestr = get_attr_as_unicode(nxdata.group, "SILX_style")
         if stylestr is None:
@@ -107,10 +83,9 @@ class _SilxStyle:
                 nxdata_logger.error("Ignoring SILX_style:axes_scale_types, not a list")
             else:
                 for scale_type in axes_scale_types:
-                    if scale_type not in ("linear", "log"):
+                    if scale_type not in _SCALES:
                         nxdata_logger.error(
-                            "Ignoring SILX_style:axes_scale_types, invalid value: %s",
-                            str(scale_type),
+                            f"Ignoring SILX_style:axes_scale_types, invalid value: {scale_type} (supported values: {_SCALES})",
                         )
                         break
                 else:  # All values are valid
@@ -128,23 +103,20 @@ class _SilxStyle:
 
         if "signal_scale_type" in style:
             scale_type = style["signal_scale_type"]
-            if scale_type not in ("linear", "log"):
+            if scale_type not in _SCALES:
                 nxdata_logger.error(
-                    "Ignoring SILX_style:signal_scale_type, invalid value: %s",
-                    str(scale_type),
+                    f"Ignoring SILX_style:signal_scale_type, invalid value: {scale_type} (supported values: {_SCALES})",
                 )
             else:
                 self._signal_scale_type = scale_type
 
-    axes_scale_types = property(
-        lambda self: self._axes_scale_types,
-        doc="Tuple of NXdata axes scale types (None, 'linear' or 'log'). List[str]",
-    )
+    @property
+    def axes_scale_types(self) -> tuple[ScaleType | None, ...]:
+        return self._axes_scale_types
 
-    signal_scale_type = property(
-        lambda self: self._signal_scale_type,
-        doc="NXdata signal scale type (None, 'linear' or 'log'). str",
-    )
+    @property
+    def signal_scale_type(self) -> ScaleType | None:
+        return self._signal_scale_type
 
 
 class NXdata:

--- a/src/silx/io/test/test_nxdata.py
+++ b/src/silx/io/test/test_nxdata.py
@@ -1,7 +1,8 @@
 import h5py
 import numpy
 import pytest
-
+import json
+import logging
 
 from .. import nxdata
 from ..dictdump import dicttoh5, dicttonx
@@ -847,3 +848,60 @@ def test_get_axis_errors(tmp_path):
         assert nxd.get_axis_errors("Y") == y_errors
         # Check good indices are applied
         numpy.testing.assert_equal(nxd.get_axis_errors("z"), z_dset_errors[1:3])
+
+
+def test_valid_scale_types(tmp_path):
+    nx_dict = {
+        "NXdata": {
+            "@NX_class": "NXdata",
+            "@signal": "signal",
+            "signal": numpy.linspace(0, 100, 100).reshape(10, 10),
+            "x": numpy.linspace(0, 1, 10),
+            "y": numpy.linspace(1, 10, 10),
+            "@axes": ["y", "x"],
+            "@SILX_style": json.dumps(
+                {"axes_scale_types": ["log", "asinh"], "signal_scale_type": "linear"}
+            ),
+        }
+    }
+
+    dicttonx(nx_dict, tmp_path / "nx.h5")
+
+    with h5py.File(tmp_path / "nx.h5", "r") as h5file:
+        nxdata_grp = h5file["NXdata"]
+        nxd = nxdata.NXdata(nxdata_grp)
+        assert nxd.plot_style is not None
+        assert nxd.plot_style.axes_scale_types == ("log", "asinh")
+        assert nxd.plot_style.signal_scale_type == "linear"
+
+
+def test_invalid_scale_types(tmp_path, caplog):
+    nx_dict = {
+        "NXdata": {
+            "@NX_class": "NXdata",
+            "@signal": "signal",
+            "signal": numpy.linspace(0, 100, 100).reshape(10, 10),
+            "x": numpy.linspace(0, 1, 10),
+            "y": numpy.linspace(0, 1, 10),
+            "@axes": ["y", "x"],
+            "@SILX_style": json.dumps(
+                {
+                    "axes_scale_types": ["not_a_scale", "log"],
+                    "signal_scale_type": "not_a_scale",
+                }
+            ),
+        }
+    }
+
+    dicttonx(nx_dict, tmp_path / "nx.h5")
+
+    caplog.set_level(level=logging.ERROR, logger="silx.io.nxdata")
+    with h5py.File(tmp_path / "nx.h5", "r") as h5file:
+        nxdata_grp = h5file["NXdata"]
+        nxd = nxdata.NXdata(nxdata_grp)
+        assert nxd.plot_style is not None
+        assert nxd.plot_style.axes_scale_types == (None, None)
+        assert nxd.plot_style.signal_scale_type is None
+    assert len(caplog.messages) == 2
+    assert "Ignoring SILX_style:axes_scale_types" in caplog.messages[0]
+    assert "Ignoring SILX_style:signal_scale_type" in caplog.messages[1]


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

In https://github.com/silx-kit/silx/pull/4682#issuecomment-5131006726, I wanted to add checks in the NXdata parsing but it turns out that they are already there. I just needed to add support for the `asinh` scale type.

I also added related tests.

#### AI Disclosure
- [x] No AI used
