### PR TITLE
silx.gui.plot.PlotWidget: Fixed matplotlib backend wheel support

### DIFF
--- a/src/silx/gui/plot/backends/BackendMatplotlib.py
+++ b/src/silx/gui/plot/backends/BackendMatplotlib.py
@@ -1704,18 +1704,31 @@ class BackendMatplotlibQt(BackendMatplotlib, FigureCanvasQTAgg):
         # Fix here as we want to be able to use alt modifier in silx plot.
         # https://github.com/silx-kit/silx/pull/4631
         if event.angleDelta().y() == 0:
-            event = qt.QWheelEvent(
-                event.position(),
-                event.globalPosition(),
-                event.pixelDelta(),
-                qt.QPoint(0, event.angleDelta().x()),
-                event.buttons(),
-                event.modifiers(),
-                event.phase(),
-                event.isInverted(),
-                event.source(),
-                event.pointingDevice(),
-            )
+            if qt.BINDING == "PyQt5":
+                event = qt.QWheelEvent(
+                    event.position(),
+                    event.globalPosition(),
+                    event.pixelDelta(),
+                    qt.QPoint(0, event.angleDelta().x()),
+                    event.buttons(),
+                    event.modifiers(),
+                    event.phase(),
+                    event.inverted(),
+                    qt.Qt.MouseEventSynthesizedByApplication,
+                )
+            else:
+                event = qt.QWheelEvent(
+                    event.position(),
+                    event.globalPosition(),
+                    event.pixelDelta(),
+                    qt.QPoint(0, event.angleDelta().x()),
+                    event.buttons(),
+                    event.modifiers(),
+                    event.phase(),
+                    event.inverted(),
+                    qt.Qt.MouseEventSynthesizedByApplication,
+                    event.pointingDevice(),
+                )
             super().wheelEvent(event)
             return
 


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

This PR fixes issues with the use of  `QWheelEvent` event in the matplotlib backend with the different Qt bindings (see comments).

To reproduce: `QT_API=PyQt6 ipython` -> `from silx import sx, config; w = sx.plot([1, 2, 3], backend="mpl")`
and zoom in/out with the trackpad (or need to fall in the specific condition `if event.angleDelta().y() == 0:`)

Bug introduced in #4631

#### AI Disclosure
- [x] No AI used
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
