### PR TITLE
silx.opencl.common: Fixed allow 0 in get_platform() and get_device()

### DIFF
--- a/src/silx/opencl/common.py
+++ b/src/silx/opencl/common.py
@@ -302,7 +302,7 @@ class Platform:
                 if a_dev.name == key:
                     out = a_dev
         else:
-            if len(self.devices) > devid > 0:
+            if len(self.devices) > devid >= 0:
                 out = self.devices[devid]
         return out
 
@@ -555,7 +555,7 @@ class OpenCL:
                 if a_plat.name == key:
                     out = a_plat
         else:
-            if len(self.platforms) > platid > 0:
+            if len(self.platforms) > platid >= 0:
                 out = self.platforms[platid]
         return out
 


### PR DESCRIPTION
### PR summary

It appears that 0 is valid as a platform and device ID, but the `get_platform()` and `get_device()` methods check `> 0` and thus reject it. This changes `>` to `>=`.


#### AI Disclosure
- [x] No AI used
