### PR TITLE
Doc: fix warning when sphinx-autodoc-typehints parses `numpy.trapezoid`

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -82,8 +82,6 @@ if importlib.util.find_spec("sphinx_autodoc_typehints"):
 
     always_document_param_types = True
 
-# Ignore warnings about type hints that numpy's stubs can't resolve (e.g. trapezoid's ScalarT).
-suppress_warnings = ["sphinx_autodoc_typehints.forward_reference"]
 
 autodoc_member_order = "bysource"
 

--- a/src/silx/gui/plot/CurvesROIWidget.py
+++ b/src/silx/gui/plot/CurvesROIWidget.py
@@ -39,10 +39,12 @@ import functools
 import numpy
 from typing import Union
 
+# `sphinx-autodoc-typehints` can't parse the trapezoid signature for recent numpy versions (2.5+)
+# So don't expose it so it is not picked up by `sphinx-autodoc-typehints`
 try:
-    from numpy import trapezoid
+    from numpy import trapezoid as _trapezoid
 except ImportError:  # numpy v1 compatibility
-    from numpy import trapz as trapezoid
+    from numpy import trapz as _trapezoid
 from numpy.typing import ArrayLike
 
 from silx.io import dictdump
@@ -1243,13 +1245,13 @@ class ROI(_RegionOfInterestBase):
         if x.size == 0:
             return 0.0, 0.0
 
-        rawArea = trapezoid(y, x=x)
+        rawArea = _trapezoid(y, x=x)
         # to speed up and avoid an intersection calculation we are taking the
         # closest index to the ROI
         closestXLeftIndex = (numpy.abs(x - self.getFrom())).argmin()
         closestXRightIndex = (numpy.abs(x - self.getTo())).argmin()
         yBackground = y[closestXLeftIndex], y[closestXRightIndex]
-        background = trapezoid(yBackground, x=x)
+        background = _trapezoid(yBackground, x=x)
         netArea = rawArea - background
         return rawArea, netArea
 


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

Latest documentation build had a new warning (that get treated as an error):

```
 /opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/numpy/lib/_function_base_impl.py:4922: WARNING: Cannot resolve forward reference in type annotations of "silx.gui.plot.CurvesROIWidget.trapezoid" (module numpy.lib._function_base_impl): name 'ScalarT' is not defined [sphinx_autodoc_typehints.forward_reference]
```

It seems `sphinx_autodoc_typehints` cannot parse properly the new typing of `numpy.trapezoid`. Both libraries are dependencies so this is not something we can fix ourselves.

What we can do, however, is to avoid exposing `trapezoid` when importing it in `silx.gui.plot.CurvesROIWidget.`. This way, it stays invisible to `sphinx_autodoc_typehints` and does not try to parse it. 

#### AI Disclosure
- [x] Claude code used to investigate the issue and produce the solution