### PR TITLE
4695 silx.gui.fit.FitWidget: fix usage of `qt.QFileDialog.getOpenFileName`

### DIFF
--- a/src/silx/gui/fit/FitWidget.py
+++ b/src/silx/gui/fit/FitWidget.py
@@ -594,19 +594,14 @@ class FitWidget(qt.QWidget):
         if bgtheory in self.fitmanager.bgtheories:
             self.fitmanager.setbackground(bgtheory)
         else:
-            functionsfile = qt.QFileDialog.getOpenFileName(
+            functionsfile, _ = qt.QFileDialog.getOpenFileName(
                 self,
                 "Select python module with your function(s)",
                 "",
                 "Python Files (*.py);;All Files (*)",
-functionsfile, _ = qt.QFileDialog.getOpenFileName(
-self,
-"Select python module with your function(s)",
-"",
-"Python Files (*.py);;All Files (*)",
             )
 
-            if functionsfile:
+            if functionsfile != "":
                 try:
                     self.fitmanager.loadbgtheories(functionsfile)
                 except ImportError:
@@ -640,19 +635,14 @@ self,
             self.fitmanager.settheory(theoryname)
         else:
             # open a load file dialog
-            functionsfile = qt.QFileDialog.getOpenFileName(
+            functionsfile, _ = qt.QFileDialog.getOpenFileName(
                 self,
                 "Select python module with your function(s)",
                 "",
                 "Python Files (*.py);;All Files (*)",
-functionsfile, _ = qt.QFileDialog.getOpenFileName(
-self,
-"Select python module with your function(s)",
-"",
-"Python Files (*.py);;All Files (*)",
             )
 
-            if functionsfile:
+            if functionsfile != "":
                 try:
                     self.fitmanager.loadtheories(functionsfile)
                 except ImportError:

--- a/src/silx/gui/fit/FitWidget.py
+++ b/src/silx/gui/fit/FitWidget.py
@@ -599,9 +599,9 @@ class FitWidget(qt.QWidget):
                 "Select python module with your function(s)",
                 "",
                 "Python Files (*.py);;All Files (*)",
-            )
+            )[0]
 
-            if len(functionsfile):
+            if functionsfile:
                 try:
                     self.fitmanager.loadbgtheories(functionsfile)
                 except ImportError:
@@ -640,9 +640,9 @@ class FitWidget(qt.QWidget):
                 "Select python module with your function(s)",
                 "",
                 "Python Files (*.py);;All Files (*)",
-            )
+            )[0]
 
-            if len(functionsfile):
+            if functionsfile:
                 try:
                     self.fitmanager.loadtheories(functionsfile)
                 except ImportError:

--- a/src/silx/gui/fit/FitWidget.py
+++ b/src/silx/gui/fit/FitWidget.py
@@ -599,7 +599,12 @@ class FitWidget(qt.QWidget):
                 "Select python module with your function(s)",
                 "",
                 "Python Files (*.py);;All Files (*)",
-            )[0]
+functionsfile, _ = qt.QFileDialog.getOpenFileName(
+self,
+"Select python module with your function(s)",
+"",
+"Python Files (*.py);;All Files (*)",
+            )
 
             if functionsfile:
                 try:

--- a/src/silx/gui/fit/FitWidget.py
+++ b/src/silx/gui/fit/FitWidget.py
@@ -645,7 +645,12 @@ self,
                 "Select python module with your function(s)",
                 "",
                 "Python Files (*.py);;All Files (*)",
-            )[0]
+functionsfile, _ = qt.QFileDialog.getOpenFileName(
+self,
+"Select python module with your function(s)",
+"",
+"Python Files (*.py);;All Files (*)",
+            )
 
             if functionsfile:
                 try:

--- a/src/silx/gui/fit/test/test_fitwidget.py
+++ b/src/silx/gui/fit/test/test_fitwidget.py
@@ -23,6 +23,10 @@
 # ###########################################################################*/
 """Basic tests for :class:`FitWidget`"""
 
+import os
+import tempfile
+from unittest import mock
+
 from silx.gui.utils.testutils import TestCaseQt
 
 from ... import qt
@@ -115,3 +119,41 @@ class TestFitWidget(TestCaseQt):
         # clove dialog
         # self.mouseClick(fw.configdialogs["foo"].ok, qt.Qt.LeftButton)
         # self.qapp.processEvents()
+
+    def testBkgEventFileDialogCancelled(self):
+        """Cancelling the file dialog must not attempt to import anything"""
+        bgtheories_before = set(self.fit_widget.fitmanager.bgtheories)
+        with mock.patch.object(
+            qt.QFileDialog, "getOpenFileName", return_value=("", "")
+        ):
+            self.fit_widget.bkgEvent("not_an_existing_bg_theory")
+
+        self.assertEqual(set(self.fit_widget.fitmanager.bgtheories), bgtheories_before)
+
+    def testBkgEventLoadCustomBackground(self):
+        """Selecting a valid python module must add its theories to bgtheories"""
+        module_content = (
+            "from silx.math.fit.fittheory import FitTheory\n"
+            "\n"
+            "def custom_bg_function(x, y0, a):\n"
+            "    return y0 + a\n"
+            "\n"
+            "THEORY = {\n"
+            "    'custom_bg': FitTheory(function=custom_bg_function, parameters=['a']),\n"
+            "}\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            module_path = os.path.join(tmp_dir, "custom_bg_theory_module.py")
+            with open(module_path, "w") as f:
+                f.write(module_content)
+
+            with (
+                mock.patch.object(
+                    qt.QFileDialog,
+                    "getOpenFileName",
+                    return_value=(module_path, "Python Files (*.py)"),
+                ),
+            ):
+                self.fit_widget.bkgEvent("custom_bg")
+
+            self.assertIn("custom_bg", self.fit_widget.fitmanager.bgtheories)


### PR DESCRIPTION
### PR summary

The PR fix the call of `qt.QFileDialog.getOpenFileName`. The call return ["(fileName, selectedFilter)"](https://doc.qt.io/qtforpython-6/PySide6/QtWidgets/QFileDialog.html#PySide6.QtWidgets.QFileDialog.getOpenFileName) - for PySide6, PySide2, PyQt5 and PyQt6 - which seems different from the [C++ API](https://doc.qt.io/qt-6/qfiledialog.html#getOpenFileName) :cry: 

Close #4695 

#### AI Disclosure
- [x] Claude used for adding the test.

Note: bug fix-release to be done.