### PR TITLE
silx.gui.data.NXdataWidgets.ArrayImagePlot: fix ValueError for images with irregular axes

### DIFF
--- a/src/silx/gui/data/NXdataWidgets.py
+++ b/src/silx/gui/data/NXdataWidgets.py
@@ -352,13 +352,11 @@ class ArrayImagePlot(BaseImagePlot):
             if self._axesScales:
                 xAxisIndex, yAxisIndex = self._getXYIndices()
                 xAxisScale = self._axesScales[xAxisIndex]
+                if xAxisScale is not None:
+                    self._plot.getXAxis().setScale(xAxisScale)
                 yAxisScale = self._axesScales[yAxisIndex]
-            else:
-                xAxisScale = None
-                yAxisScale = None
-
-            self._plot.getXAxis().setScale(xAxisScale)
-            self._plot.getYAxis().setScale(yAxisScale)
+                if yAxisScale is not None:
+                    self._plot.getYAxis().setScale(yAxisScale)
 
             xScatter, yScatter = numpy.meshgrid(xAxis, yAxis)
             self._plot.addScatter(

--- a/src/silx/gui/data/test/test_nexus_dataviewer.py
+++ b/src/silx/gui/data/test/test_nexus_dataviewer.py
@@ -65,6 +65,26 @@ def test_rgb_image_with_interpretation(qapp, qWidgetFactory, tmp_path):
         assert isinstance(plot.getImage("rgb"), ImageRgba)
 
 
+def test_image_with_non_affine_axis_becomes_scatter(qapp, qWidgetFactory, tmp_path):
+    widget: DataViewer = qWidgetFactory(DataViewer)
+    with h5py.File(tmp_path / "test.h5", "w") as h5file:
+        h5file.attrs["NX_class"] = "NXdata"
+        h5file.attrs["signal"] = "signal"
+        h5file.create_dataset(name="signal", data=numpy.random.random((10, 10)))
+        h5file.create_dataset(name="non_affine_x", data=numpy.logspace(0, 1, 10))
+        h5file.create_dataset(name="y", data=numpy.arange(10))
+        h5file.attrs["axes"] = ["y", "non_affine_x"]
+
+        widget.setData(h5file["/"])
+
+        qapp.processEvents()
+
+        imageView = widget.currentAvailableViews()[0]
+        plot: Plot2D = imageView.getWidget().getPlot()
+        assert plot.getImage() is None
+        assert plot.getScatter() is not None
+
+
 @pytest.mark.skipif(
     sys.version_info.major == 3 and sys.version_info.minor == 14,
     reason="Triggers segfault on Python 3.14. To be fixed",


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

Fix #4701 

This comes from an untested conditional branch of `ArrayImagePlot` when the image has defined but non-affine axes. In this case, the image get plotted as a scatter and the scales get applied to the X and Y axes. Since I was not testing if the scales were `None`, it raised a `ValueError` in case the scales were not defined.

I added a check for `None` and a non-regression test. 

#### AI Disclosure
- [x] Claude code used to generate an early version of the regression test that I tuned by hand.