### PR TITLE
Deprecation warnings: fix double punctuation

### DIFF
--- a/src/silx/utils/deprecation.py
+++ b/src/silx/utils/deprecation.py
@@ -124,10 +124,7 @@ def deprecated_warning(
         msg += " Reason: %s%s" % (reason, _sentence_suffix(reason))
 
     if replacement is not None:
-        msg += " Use '%s' instead%s" % (
-            replacement,
-            _sentence_suffix(replacement),
-        )
+        msg += " Use '%s' instead." % replacement
 
     msg += "\n%s"
     limit = 2 + skip_backtrace_count

--- a/src/silx/utils/deprecation.py
+++ b/src/silx/utils/deprecation.py
@@ -119,10 +119,16 @@ def deprecated_warning(
     if since_version is not None:
         msg += " since silx version %s" % since_version
     msg += "."
+
     if reason is not None:
-        msg += " Reason: %s." % reason
+        msg += " Reason: %s%s" % (reason, _sentence_suffix(reason))
+
     if replacement is not None:
-        msg += " Use '%s' instead." % replacement
+        msg += " Use '%s' instead%s" % (
+            replacement,
+            _sentence_suffix(replacement),
+        )
+
     msg += "\n%s"
     limit = 2 + skip_backtrace_count
     backtrace = "".join(traceback.format_stack(limit=limit)[0])
@@ -134,3 +140,9 @@ def deprecated_warning(
         else:
             deprecache.add(data)
     depreclog.warning(msg, type_, name, backtrace)
+
+
+def _sentence_suffix(text):
+    if text.endswith((".", "!", "?")):
+        return ""
+    return "."


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

Deprecation warnings were adding punctuation's without checking that there was already one.

#### AI Disclosure
- [x] No AI used
- [ ] AI tool(s) ... used for ...
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
