### PR TITLE
silx.gui.colors: Added matplotlib "headless" support

### DIFF
--- a/src/silx/gui/colors.py
+++ b/src/silx/gui/colors.py
@@ -47,11 +47,10 @@ from silx.utils.deprecation import deprecated_warning
 _logger = logging.getLogger(__name__)
 
 try:
-    import silx.gui.utils.matplotlib  # noqa  Initalize matplotlib
-    from matplotlib import colormaps as _matplotlib_colormaps
+    import matplotlib as _matplotlib
 except ImportError:
     _logger.info("matplotlib not available, only embedded colormaps available")
-    _matplotlib_colormaps = None
+    _matplotlib = None
 
 
 _COLORDICT = {}
@@ -224,7 +223,7 @@ def _registerColormapFromMatplotlib(
     cursor_color: str = "black",
     preferred: bool = False,
 ):
-    colormap = _matplotlib_colormaps[name]
+    colormap = _matplotlib.colormaps[name]
     lut = colormap(numpy.linspace(0, 1, colormap.N, endpoint=True))
     colors = _colormap.array_to_rgba8888(lut)
     registerLUT(name, colors, cursor_color, preferred)
@@ -943,8 +942,8 @@ class Colormap(qt.QObject):
         """
         registered_colormaps = _colormap.get_registered_colormaps()
         colormaps = set(registered_colormaps)
-        if _matplotlib_colormaps is not None:
-            colormaps.update(_matplotlib_colormaps())
+        if _matplotlib is not None:
+            colormaps.update(_matplotlib.colormaps())
 
         # Put registered_colormaps first
         colormaps = tuple(


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

This PR removes the init of matplotlib from `silx.gui.colors` setting usage of Qt to allow headless usage:
This init is not needed since `colormaps` is available in the [top `matplotlib` import](https://github.com/matplotlib/matplotlib/blob/522cfa3000de008daddec8a6f6b0d6ce3056177f/lib/matplotlib/__init__.py#L1580), so there is no side effect using it it does not set the mpl backend.

`matplotlib` is still initialized in `PlotWidget.py` where it is needed.
Other usage of matplotlib (matplotlib.tri and matplotlib.font_manager) also do not init matplotlib backend.

closes #4697

#### AI Disclosure
- [x] No AI used
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
