### PR TITLE
silx.gui.icons, silx view, silx compare: Fixed support of qt6<6.5

### DIFF
--- a/src/silx/app/compare/main.py
+++ b/src/silx/app/compare/main.py
@@ -28,6 +28,7 @@ import sys
 import logging
 import argparse
 import silx
+from packaging.version import Version
 from silx.gui import qt
 from silx.app.utils import parseutils
 from silx.app.compare.CompareImagesWindow import CompareImagesWindow
@@ -84,7 +85,7 @@ def mainQt(options):
         silx.config.DEFAULT_PLOT_BACKEND = "opengl"
 
     app = qt.QApplication([])
-    if qt.BINDING != "PyQt5":
+    if Version(qt.qVersion()) >= Version("6.8.0"):
         app.styleHints().setColorScheme(qt.Qt.ColorScheme.Light)
 
     window = CompareImagesWindow(backend=backend, settings=settings)

--- a/src/silx/app/view/main.py
+++ b/src/silx/app/view/main.py
@@ -33,6 +33,7 @@ import signal
 import sys
 import traceback
 
+from packaging.version import Version
 from silx.app.utils import parseutils
 
 _logger = logging.getLogger(__name__)
@@ -140,7 +141,7 @@ def mainQt(options):
     if app is None:
         app = qt.QApplication([])
     app.setDesktopFileName("org.silx.SilxView")
-    if qt.BINDING != "PyQt5":
+    if Version(qt.qVersion()) >= Version("6.8.0"):
         app.styleHints().setColorScheme(qt.Qt.ColorScheme.Light)
     qt.QLocale.setDefault(qt.QLocale.c())
 

--- a/src/silx/gui/icons.py
+++ b/src/silx/gui/icons.py
@@ -39,6 +39,10 @@ from . import qt
 import silx.resources
 from silx.utils import weakref as silxweakref
 
+from packaging.version import Version
+
+_QT_HAS_COLOR_SCHEME = Version(qt.qVersion()) >= Version("6.5.0")
+
 _logger = logging.getLogger(__name__)
 """Module logger"""
 
@@ -120,7 +124,7 @@ class _SvgIconEngine(qt.QIconEngine):
         # state does not seem to be handled by Qt default icon engines
         if qt.QGuiApplication.instance() is None:
             isDark = False
-        elif qt.BINDING != "PyQt5":
+        elif _QT_HAS_COLOR_SCHEME:
             isDark = (
                 qt.QApplication.styleHints().colorScheme() == qt.Qt.ColorScheme.Dark
             )


### PR DESCRIPTION
- [x] The PR title is formatted as: `<Module or Topic>: <Action> <Summary>` (see [contributing guidelines](https://github.com/silx-kit/silx/blob/main/doc/source/contribute/development.rst#pull-request-title-format))

### PR summary

<!-- Thank you for your pull request! Please, provide a description of the changes below -->

This PR avoids calling colorscheme API when the version of qt6 does not support it.

closes #4709

#### AI Disclosure
- [x] No AI used
<!-- 
If AI was used in this pull request, please write a quick sentence describing the tool(s) used and how they were used.

See our AI policy at https://github.com/silx-kit/silx/blob/main/doc/source/contribute/ai_policy.rst.
-->
